### PR TITLE
Update sprockets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
Sprockets version 3.7.1 has a security vulenerability
https://blog.heroku.com/rails-asset-pipeline-vulnerability