### PR TITLE
Add user_facilities table

### DIFF
--- a/app/models/user_facility.rb
+++ b/app/models/user_facility.rb
@@ -1,0 +1,4 @@
+class UserFacility < ApplicationRecord
+  belongs_to :user
+  belongs_to :facility
+end

--- a/db/migrate/20180807101604_create_user_facilities.rb
+++ b/db/migrate/20180807101604_create_user_facilities.rb
@@ -1,0 +1,10 @@
+class CreateUserFacilities < ActiveRecord::Migration[5.1]
+  def change
+    create_table :user_facilities, id: :uuid do |t|
+      t.belongs_to :user, index: true, type: :uuid, null: false
+      t.belongs_to :facility, index: true, type: :uuid, null: false
+      t.timestamps
+    end
+    add_index :user_facilities, [:user_id, :facility_id], unique: true
+  end
+end

--- a/db/migrate/20180807101604_create_user_facilities.rb
+++ b/db/migrate/20180807101604_create_user_facilities.rb
@@ -6,5 +6,7 @@ class CreateUserFacilities < ActiveRecord::Migration[5.1]
       t.timestamps
     end
     add_index :user_facilities, [:user_id, :facility_id], unique: true
+    add_foreign_key :user_facilities, :users
+    add_foreign_key :user_facilities, :facilities
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180730082447) do
+ActiveRecord::Schema.define(version: 20180807101604) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,6 +142,16 @@ ActiveRecord::Schema.define(version: 20180730082447) do
     t.integer "follow_up_days"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "user_facilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.uuid "facility_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["facility_id"], name: "index_user_facilities_on_facility_id"
+    t.index ["user_id", "facility_id"], name: "index_user_facilities_on_user_id_and_facility_id", unique: true
+    t.index ["user_id"], name: "index_user_facilities_on_user_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -187,4 +187,6 @@ ActiveRecord::Schema.define(version: 20180807101604) do
   add_foreign_key "patient_phone_numbers", "patients"
   add_foreign_key "patients", "addresses"
   add_foreign_key "protocol_drugs", "protocols"
+  add_foreign_key "user_facilities", "facilities"
+  add_foreign_key "user_facilities", "users"
 end

--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -9,4 +9,16 @@ namespace :data_migration do
 
     puts "Updated sync approval status to approved for users created before #{now}"
   end
+
+  desc "Populate user facilities table from users table"
+  task create_user_facility_records_for_users: :environment do
+    ActiveRecord::Base.transaction do
+      users = User.all
+      puts "Creating UserFacility records fors #{users.count} users"
+      users.each do |user|
+        UserFacility.create(user_id: user.id, facility_id: user.facility.id)
+      end
+      puts "Created UserFacility records fors #{users.count} users"
+    end
+  end
 end


### PR DESCRIPTION
Create user_facilities table in a seperate PR, so that the table can be created and the data can be migrated to the new table before we drop facility_id from users table. 