### PR TITLE
Avoid runtime errors when reading ENV

### DIFF
--- a/app/controllers/api/v1/sync_controller.rb
+++ b/app/controllers/api/v1/sync_controller.rb
@@ -74,7 +74,7 @@ class Api::V1::SyncController < APIController
     if params[:limit].present?
       params[:limit].to_i
     else
-      ENV.fetch('DEFAULT_NUMBER_OF_RECORDS').to_i
+      ENV['DEFAULT_NUMBER_OF_RECORDS'].to_i
     end
   end
 end

--- a/app/controllers/qa/purges_controller.rb
+++ b/app/controllers/qa/purges_controller.rb
@@ -17,7 +17,7 @@ class Qa::PurgesController < APIController
   end
 
   def validate_access
-    purge_access_token = ENV.fetch('PURGE_URL_ACCESS_TOKEN')
+    purge_access_token = ENV['PURGE_URL_ACCESS_TOKEN']
     authenticate_or_request_with_http_token do |token, _options|
       ActiveSupport::SecurityUtils.secure_compare(token, purge_access_token)
     end

--- a/app/helpers/feature_toggle.rb
+++ b/app/helpers/feature_toggle.rb
@@ -1,11 +1,11 @@
 module FeatureToggle
   def self.enabled?(feature_name)
     toggle_name = "ENABLE_#{feature_name}"
-    ENV.fetch(toggle_name) == 'true'
+    ENV[toggle_name] == 'true'
   end
 
   def self.enabled_for_regex?(regex_name, feature_name)
     feature_list_name = "ENABLE_REGEX_#{regex_name}"
-    Regexp.new(ENV.fetch(feature_list_name)).match(feature_name)
+    Regexp.new(ENV[feature_list_name]).match(feature_name)
   end
 end

--- a/app/mailers/approval_notifier_mailer.rb
+++ b/app/mailers/approval_notifier_mailer.rb
@@ -2,11 +2,11 @@ class ApprovalNotifierMailer < ApplicationMailer
   default :from => 'help@simple.org'
 
   def supervisor_emails
-    ENV.fetch('SUPERVISOR_EMAILS')
+    ENV['SUPERVISOR_EMAILS']
   end
 
   def owner_emails
-    ENV.fetch('OWNER_EMAILS')
+    ENV['OWNER_EMAILS']
   end
 
   def approval_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,7 @@ class User < ApplicationRecord
     6.times do
       otp += digits.sample.to_s
     end
-    otp_valid_until = Time.now + ENV.fetch('USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES').to_i.minutes
+    otp_valid_until = Time.now + ENV['USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES'].to_i.minutes
 
     { otp: otp, otp_valid_until: otp_valid_until }
   end

--- a/app/services/sms_notification_service.rb
+++ b/app/services/sms_notification_service.rb
@@ -10,7 +10,7 @@ class SmsNotificationService
   end
 
   def send_request_otp_sms
-    app_signature = ENV.fetch('SIMPLE_APP_SIGNATURE')
+    app_signature = ENV['SIMPLE_APP_SIGNATURE']
     send_sms(I18n.t('sms.request_otp', otp: user.otp, app_signature: app_signature))
   end
 
@@ -25,7 +25,7 @@ class SmsNotificationService
     end
 
     client.messages.create(
-      from: ENV.fetch('TWILIO_PHONE_NUMBER'),
+      from: ENV['TWILIO_PHONE_NUMBER'],
       to: user.phone_number.prepend(I18n.t('sms.country_code')),
       body: body
     )

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Admin::UsersController, type: :controller do
 
       it 'adds otp and otp_valid_until to the user' do
         Timecop.freeze do
-          timedelta = ENV.fetch('USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES').to_i.minutes
+          timedelta = ENV['USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES'].to_i.minutes
           post :create, params: { user: valid_attributes, facility_id: facility.id }
 
           user = User.find_by(phone_number: valid_attributes[:phone_number])

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       it 'sends an email to a list of owners and supervisors' do
         post :register, params: { user: user_params }
         approval_email = ActionMailer::Base.deliveries.last
-        expect(ENV.fetch('SUPERVISOR_EMAILS')).to match(/#{Regexp.quote(approval_email.to.first)}/)
-        expect(ENV.fetch('OWNER_EMAILS')).to match(/#{Regexp.quote(approval_email.cc.first)}/)
+        expect(ENV['SUPERVISOR_EMAILS']).to match(/#{Regexp.quote(approval_email.to.first)}/)
+        expect(ENV['OWNER_EMAILS']).to match(/#{Regexp.quote(approval_email.cc.first)}/)
         expect(approval_email.body.to_s).to match(Regexp.quote(user_params[:phone_number]))
       end
     end


### PR DESCRIPTION
- The service should not start up if a required config is not present in ENV.