### PR TITLE
[Security] Upgrade bootstrap gem to fix vulnerability issue.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'devise', '~> 4.4.3'
 gem 'devise_invitable', '~> 1.7.0'
 gem 'twilio-ruby', '~> 5.10', '>= 5.10.3'
 gem 'pundit'
-gem 'bootstrap', '~> 4.1.1'
+gem 'bootstrap', '~> 4.1.2'
 gem 'jquery-rails'
 gem "bootstrap_form", ">= 4.0.0.alpha1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,11 +43,11 @@ GEM
     airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (8.0.0)
-    autoprefixer-rails (9.0.0)
+    autoprefixer-rails (9.1.4)
       execjs
     bcrypt (3.1.12)
     bindex (0.5.0)
-    bootstrap (4.1.1)
+    bootstrap (4.1.3)
       autoprefixer-rails (>= 6.0.3)
       popper_js (>= 1.12.9, < 2)
       sass (>= 3.5.2)
@@ -155,7 +155,7 @@ GEM
       rack
       rake (>= 0.8.1)
     pg (1.0.0)
-    popper_js (1.12.9)
+    popper_js (1.14.3)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -290,7 +290,7 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt (~> 3.1, >= 3.1.11)
-  bootstrap (~> 4.1.1)
+  bootstrap (~> 4.1.2)
   bootstrap_form (>= 4.0.0.alpha1)
   byebug
   capistrano (~> 3.10)


### PR DESCRIPTION
Details: https://nvd.nist.gov/vuln/detail/CVE-2018-14042