### PR TITLE
Count unique patients per day instead of BPs

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -11,14 +11,13 @@ class Admin::DashboardController < AdminController
     @days_previous = 20
     @months_previous = 8
 
-    @bps_by_facility          = bps_by_facility
-    @bps_by_facility_user     = bps_by_facility_user
-    @bps_by_facility_user_day = bps_by_facility_user_day
+    @visits_by_facility          = visits_by_facility
+    @visits_by_facility_user     = visits_by_facility_user
+    @visits_by_facility_user_day = visits_by_facility_user_day
+    @visits_by_facility_month    = visits_by_facility_month
 
     @new_patients_by_facility       = new_patients_by_facility
     @new_patients_by_facility_month = new_patients_by_facility_month
-
-    @visits_by_facility_month = visits_by_facility_month
 
     @control_rate_by_facility = control_rate_by_facility
 
@@ -28,16 +27,20 @@ class Admin::DashboardController < AdminController
 
   private
 
-  def bps_by_facility
-    BloodPressure.group(:facility_id).count
+  def visits_by_facility
+    BloodPressure.group(:facility_id).count("distinct patient_id")
   end
 
-  def bps_by_facility_user
-    BloodPressure.group(:facility_id, :user_id).count
+  def visits_by_facility_user
+    BloodPressure.group(:facility_id, :user_id).count("distinct patient_id")
   end
 
-  def bps_by_facility_user_day
-    BloodPressure.group(:facility_id, :user_id).group_by_day(:device_created_at, last: @days_previous + 1).count
+  def visits_by_facility_user_day
+    BloodPressure.group(:facility_id, :user_id).group_by_day(:device_created_at, last: @days_previous + 1).count("distinct patient_id")
+  end
+
+  def visits_by_facility_month
+    BloodPressure.group(:facility_id).group_by_month(:device_created_at, last: @months_previous + 1).count("distinct patient_id")
   end
 
   def new_patients_by_facility
@@ -46,10 +49,6 @@ class Admin::DashboardController < AdminController
 
   def new_patients_by_facility_month
     Facility.joins(:patients).group("facilities.id").distinct('patients.id').group_by_month("patients.device_created_at", last: @months_previous + 1).count("patients.id")
-  end
-
-  def visits_by_facility_month
-    BloodPressure.group(:facility_id).group_by_month(:device_created_at, last: @months_previous + 1).distinct(:patient_id).count(:patient_id)
   end
 
   def control_rate_by_facility

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -45,9 +45,9 @@
     <thead class="thead-light">
       <tr>
 
-        <th><h3>BPs recorded</h3></th>
+        <th><h3>Patients recorded</h3></th>
 
-        <th class="text-center">Total BPs</th>
+        <th class="text-center">Total Patients</th>
         <% @days_previous.downto(0).map { |since| since.days.ago }.each do |day| %>
           <th class="text-center <%= "holiday" if day.sunday? %>">
             <small><strong><%= day.strftime("%b") %><br><%= day.strftime("%d") %></strong></small>
@@ -57,11 +57,11 @@
     </thead>
     <tbody>
       <% @facilities.sort_by(&:name).each do |facility| %>
-        <% next if @bps_by_facility.fetch(facility.id, 0)  == 0 %>
+        <% next if @visits_by_facility.fetch(facility.id, 0)  == 0 %>
 
         <tr class="table-info table-row-small">
           <td class="row-title"><strong><%= facility.name %></strong></td>
-          <td class="text-center"><%= lighten_if_zero(@bps_by_facility[facility.id] || 0) %></td>
+          <td class="text-center"><%= lighten_if_zero(@visits_by_facility[facility.id] || 0) %></td>
           <% @days_previous.downto(0).map { |since| since.days.ago }.each do |day| %>
             <td class="text-center <%= "holiday" if day.sunday? %>"></td>
           <% end %>
@@ -71,11 +71,11 @@
           <tr class="table-row-small">
             <td class="pl-lg-4"><%= user.full_name %></td>
             <td class="text-center">
-              <%= lighten_if_zero(@bps_by_facility_user[[facility.id, user.id]] || 0) %>
+              <%= lighten_if_zero(@visits_by_facility_user[[facility.id, user.id]] || 0) %>
             </td>
             <% @days_previous.downto(0).map { |since| since.days.ago }.each do |day| %>
               <td class="text-center <%= "holiday" if day.sunday? %>">
-                <%= lighten_if_zero(@bps_by_facility_user_day[[facility.id, user.id, day.in_time_zone("New Delhi").to_date]] || 0) %>
+                <%= lighten_if_zero(@visits_by_facility_user_day[[facility.id, user.id, day.in_time_zone("New Delhi").to_date]] || 0) %>
               </td>
             <% end %>
           </tr>
@@ -104,7 +104,7 @@
     </thead>
     <tbody>
       <% @facilities.sort_by(&:name).each do |facility| %>
-        <% next if @bps_by_facility.fetch(facility.id, 0) == 0 %>
+        <% next if @visits_by_facility.fetch(facility.id, 0) == 0 %>
 
         <tr class="table-light">
 
@@ -112,7 +112,7 @@
           <td class="text-center"><%= lighten_if_zero(@new_patients_by_facility[facility.id] || 0) %></td>
           <% @months_previous.downto(0).each do |since| %>
             <td class="text-center">
-              <%= lighten_if_zero(@new_patients_by_facility_month[[facility.id, since.months.ago.in_time_zone("New Delhi").beginning_of_month.to_date]] || 0) %> 
+              <%= lighten_if_zero(@new_patients_by_facility_month[[facility.id, since.months.ago.in_time_zone("New Delhi").beginning_of_month.to_date]] || 0) %>
             </td>
           <% end %>
         </tr>
@@ -128,7 +128,7 @@
   <table class="table table-sm">
     <thead class="thead-light">
       <tr>
-        <th><h3>Unique patients seen</h3></th>
+        <th><h3>Unique patients recorded</h3></th>
         <% @months_previous.downto(0).each do |since| %>
           <th class="text-center">
             <%= since.months.ago.in_time_zone("New Delhi").strftime("%b") %><br>
@@ -139,7 +139,7 @@
     </thead>
     <tbody>
       <% @facilities.sort_by(&:name).each do |facility| %>
-        <% next if @bps_by_facility.fetch(facility.id, 0) == 0 %>
+        <% next if @visits_by_facility.fetch(facility.id, 0) == 0 %>
 
         <tr class="table-light">
 

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -7,15 +7,15 @@
       <div class="card-body">
         <div class="row">
           <div class="col-lg-3">
-            
+
               <strong><%= link_to user.full_name, [:admin, user] %></strong>
               (<small><%= user.sync_approval_status_reason %></small>)
-            
+
           </div>
           <div class="col">
             <div class="row tight">
               <div class="col">
-                
+
                 <small>Ph: <a href="tel:<%= user.phone_number %>"><%= user.phone_number %></a></small>
               </div>
               <div class="col tight">
@@ -92,7 +92,7 @@
   <table class="table table-sm">
     <thead class="thead-light">
       <tr>
-        <th><h3>Patients registered</h3></th>
+        <th><h3>New patients registered</h3></th>
         <th class="text-center">Total</th>
         <% @months_previous.downto(0).each do |since| %>
           <th class="text-center">

--- a/spec/features/admin/dashboards_spec.rb
+++ b/spec/features/admin/dashboards_spec.rb
@@ -14,8 +14,8 @@ RSpec.feature "Dashboards", type: :feature do
 
   it "shows a basic dashboard" do
 
-    expect(page).to have_content("BPs recorded")
-    expect(page).to have_content("Patients registered")
+    expect(page).to have_content("Patients recorded")
+    expect(page).to have_content("New patients registered")
   end
 
   context "outstanding approval requests" do


### PR DESCRIPTION
Using unique patient visits is more clear to all of the dashboard users we've spoken to.