### PR TITLE
Admin fixes for PATH release

### DIFF
--- a/app/controllers/admins/invitations_controller.rb
+++ b/app/controllers/admins/invitations_controller.rb
@@ -10,12 +10,14 @@ class Admins::InvitationsController < Devise::InvitationsController
   def create
     authorize :invitation, :create?
     @role = params.require(:admin).require(:role).downcase.to_sym
-    admin_access_controls = access_controllable_ids.reject(&:empty?).map do |access_controllable_id|
-      AdminAccessControl.new(
-        access_controllable_type: access_controllable_type,
-        access_controllable_id: access_controllable_id)
+    unless @role == :owner
+      admin_access_controls = access_controllable_ids.reject(&:empty?).map do |access_controllable_id|
+        AdminAccessControl.new(
+          access_controllable_type: access_controllable_type,
+          access_controllable_id: access_controllable_id)
+      end
+      invite_resource.admin_access_controls = admin_access_controls
     end
-    invite_resource.admin_access_controls = admin_access_controls
     super
   end
 

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -31,6 +31,10 @@ class Admin < ApplicationRecord
     facility_groups.map(&:protocol).uniq
   end
 
+  def facilities
+    facility_groups.flat_map(&:facilities)
+  end
+
   def users
     facility_groups.flat_map(&:users)
   end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -15,7 +15,7 @@ class Admin < ApplicationRecord
 
   def facility_groups
     return admin_access_controls.map(&:access_controllable) if (supervisor? || analyst?)
-    return admin_access_controls.map(&:access_controllable).flat_map(&:facility_groups) if organization_owner?
+    return organizations.flat_map(&:facility_groups) if organization_owner?
     return FacilityGroup.all if owner?
     []
   end

--- a/app/policies/facility_group_policy.rb
+++ b/app/policies/facility_group_policy.rb
@@ -4,7 +4,33 @@ class FacilityGroupPolicy < ApplicationPolicy
   end
 
   def show?
-    index?
+    user.owner? || admin_can_access?(:organization_owner)
+  end
+
+  def create?
+    user.owner? || admin_can_access?(:organization_owner)
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    user.owner? || admin_can_access?(:organization_owner)
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    user.owner? || admin_can_access?(:organization_owner)
+  end
+
+  private
+
+  def admin_can_access?(role)
+    user.role == role.to_s && user.facility_groups.include?(record)
   end
 
   class Scope

--- a/app/policies/facility_policy.rb
+++ b/app/policies/facility_policy.rb
@@ -4,7 +4,33 @@ class FacilityPolicy < ApplicationPolicy
   end
 
   def show?
-    index?
+    user.owner? || admin_can_access?(:organization_owner) || admin_can_access?(:supervisor)
+  end
+
+  def create?
+    user.owner? || admin_can_access?(:organization_owner)
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    user.owner? || admin_can_access?(:organization_owner)
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    user.owner? || admin_can_access?(:organization_owner)
+  end
+
+  private
+
+  def admin_can_access?(role)
+    user.role == role.to_s && user.facilities.include?(record)
   end
 
   class Scope

--- a/app/policies/invitation_policy.rb
+++ b/app/policies/invitation_policy.rb
@@ -12,7 +12,7 @@ class InvitationPolicy < Struct.new(:user, :invitaion)
   end
 
   def invite_organization_owner?
-    user.owner?
+    user.owner? || user.organization_owner?
   end
 
   def invite_supervisor?

--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -18,7 +18,7 @@ class OrganizationPolicy < ApplicationPolicy
   private
 
   def admin_can_access?(role)
-    user.role == role && user.organizations.include?(record)
+    user.role == role.to_s && user.organizations.include?(record)
   end
 
   class Scope

--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -4,7 +4,21 @@ class OrganizationPolicy < ApplicationPolicy
   end
 
   def show?
-    index?
+    user.owner? || admin_can_access?(:organization_owner)
+  end
+
+  def update?
+    show?
+  end
+
+  def edit?
+    update?
+  end
+
+  private
+
+  def admin_can_access?(role)
+    user.role == role && user.organizations.include?(record)
   end
 
   class Scope

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -8,19 +8,27 @@ class UserPolicy < ApplicationPolicy
   end
 
   def show?
-    index? && user_belongs_to_admin?
+    user.owner? || user_belongs_to_admin?
+  end
+
+  def update?
+    show?
+  end
+
+  def edit?
+    update?
   end
 
   def disable_access?
-    show?
+    update?
   end
 
   def enable_access?
-    show?
+    update?
   end
 
   def reset_otp?
-    show?
+    update?
   end
 
   class Scope

--- a/spec/policies/invitation_policy_spec.rb
+++ b/spec/policies/invitation_policy_spec.rb
@@ -18,13 +18,26 @@ RSpec.describe InvitationPolicy do
     end
   end
 
-  permissions :invite_owner?, :invite_organization_owner? do
+  permissions :invite_owner? do
     it "permits owners" do
       expect(subject).to permit(owner)
     end
 
     it "doesn't permit any other admin" do
       expect(subject).not_to permit(organization_owner)
+      expect(subject).not_to permit(supervisor)
+      expect(subject).not_to permit(analyst)
+    end
+
+  end
+
+  permissions :invite_organization_owner? do
+    it "permits owners and organization owners" do
+      expect(subject).to permit(owner)
+      expect(subject).to permit(organization_owner)
+    end
+
+    it "doesn't permit other admins" do
       expect(subject).not_to permit(supervisor)
       expect(subject).not_to permit(analyst)
     end

--- a/spec/policies/organization_policy_spec.rb
+++ b/spec/policies/organization_policy_spec.rb
@@ -3,11 +3,32 @@ require "rails_helper"
 RSpec.describe OrganizationPolicy do
   subject { described_class }
 
+  let(:organization) { FactoryBot.create(:organization) }
+
   let(:owner) { create(:admin, :owner) }
-  let(:supervisor) { create(:admin, :supervisor) }
+  let(:organization_owner) { FactoryBot.create(:admin, :organization_owner, admin_access_controls: [AdminAccessControl.new(access_controllable: organization)]) }
+  let(:supervisor) { FactoryBot.create(:admin, :supervisor) }
   let(:analyst) { create(:admin, :analyst) }
 
-  permissions :index?, :show?, :new?, :create?, :update?, :edit?, :destroy? do
+  permissions :index? do
+    it "permits owners" do
+      expect(subject).to permit(owner, Organization)
+    end
+
+    it "permits organization owners" do
+      expect(subject).to permit(organization_owner, Organization)
+    end
+
+    it "denies supervisors" do
+      expect(subject).not_to permit(supervisor, Organization)
+    end
+
+    it "denies analysts" do
+      expect(subject).not_to permit(analyst, Organization)
+    end
+  end
+
+  permissions :show?, :new?, :create?, :update?, :edit?, :destroy? do
     it "permits owners" do
       expect(subject).to permit(owner, Organization)
     end
@@ -20,6 +41,14 @@ RSpec.describe OrganizationPolicy do
       expect(subject).not_to permit(analyst, Organization)
     end
   end
+
+  permissions :show?, :update?, :edit? do
+    it "permits organization owners only for their organizations" do
+      other_organization = FactoryBot.create(:organization)
+      expect(subject).to permit(organization_owner, organization)
+      expect(subject).not_to permit(organization_owner, other_organization)
+    end
+  end
 end
 
 RSpec.describe OrganizationPolicy::Scope do
@@ -27,8 +56,8 @@ RSpec.describe OrganizationPolicy::Scope do
   let(:organization_1) { create(:organization) }
   let(:organization_2) { create(:organization) }
 
-  let(:facility_group_1) { create(:facility_group, organization: organization_1)}
-  let(:facility_group_2) { create(:facility_group, organization: organization_2)}
+  let(:facility_group_1) { create(:facility_group, organization: organization_1) }
+  let(:facility_group_2) { create(:facility_group, organization: organization_2) }
 
   describe "owner" do
     let(:owner) { create(:admin, :owner) }


### PR DESCRIPTION
Organization Owners can:
- access/edit all entities within their organizations
- invite new admins to their organizations