### PR TITLE
Handle a few edge-cases while building overdue report

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -3,7 +3,7 @@ class AppointmentsController < AdminController
 
   def index
     authorize Appointment, :index?
-    @appointments_per_facility = policy_scope(Appointment).overdue.group_by(&:facility)
+    @appointments_per_facility = policy_scope(Appointment).overdue_appointments_report
   end
 
   def edit

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,12 +1,13 @@
 class Patient < ApplicationRecord
   include Mergeable
 
-  GENDERS  = %w[male female transgender].freeze
+  GENDERS = %w[male female transgender].freeze
   STATUSES = %w[active dead migrated unresponsive inactive].freeze
 
   belongs_to :address, optional: true
   has_many :phone_numbers, class_name: 'PatientPhoneNumber'
   has_many :blood_pressures
+  has_many :latest_blood_pressures, -> { order(device_created_at: :desc) }, class_name: 'BloodPressure'
   has_many :prescription_drugs
   has_many :facilities, -> { distinct }, through: :blood_pressures
   has_many :users, -> { distinct }, through: :blood_pressures
@@ -36,7 +37,7 @@ class Patient < ApplicationRecord
   end
 
   def latest_blood_pressure
-    blood_pressures.order(device_created_at: :desc).first
+    latest_blood_pressures.first
   end
 
   def current_age

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -17,9 +17,9 @@
           <tr>
             <td>Last BP:</td>
             <td>
-              <%= appointment.patient.latest_blood_pressure.systolic %>/<%= appointment.patient.latest_blood_pressure.diastolic %>
+              <%= appointment.patient.latest_blood_pressure&.systolic %>/<%= appointment.patient.latest_blood_pressure&.diastolic %>
               &nbsp;
-              <%= appointment.patient.latest_blood_pressure.recorded_days_ago %> days ago
+              <%= appointment.patient.latest_blood_pressure&.recorded_days_ago %> days ago
             </td>
           </tr>
           <tr>

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -27,4 +27,29 @@ describe Appointment, type: :model do
       expect(Appointment.overdue).not_to include(upcoming_appointment)
     end
   end
+
+  describe '.overdue_appointments_report' do
+    let(:facility) { create(:facility) }
+
+    it "should group overdue appointments by facility" do
+      overdue_appointment = create(:appointment, :overdue, facility: facility)
+
+      expected = {}
+      expected[facility] = [overdue_appointment]
+      expect(Appointment.overdue_appointments_report).to eq(expected)
+    end
+
+    it "should exclude overdue appointments that don't have patients" do
+      overdue_appointment = create(:appointment, :overdue, facility: facility)
+      create(:appointment, facility: facility)
+
+      expected = {}
+      expected[facility] = [overdue_appointment]
+      expect(Appointment.overdue_appointments_report).to eq(expected)
+    end
+
+    it "should be empty if there are no overdue appointments" do
+      expect(Appointment.overdue_appointments_report).to eq({})
+    end
+  end
 end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -34,4 +34,19 @@ describe Patient, type: :model do
   describe 'Behavior' do
     it_behaves_like 'a record that is deletable'
   end
+
+  describe 'Associations' do
+    it { should have_many(:blood_pressures) }
+    it { should have_many(:latest_blood_pressures) }
+
+    it 'should sort blood pressures by the latest one first' do
+      patient = FactoryBot.create(:patient)
+      facility = FactoryBot.create(:facility)
+      blood_pressures = FactoryBot.create_list(:blood_pressure, 5, patient: patient, facility: facility)
+
+      expected_blood_pressures = blood_pressures.sort_by(&:device_created_at).reverse
+
+      expect(patient.latest_blood_pressures).to eq(expected_blood_pressures)
+    end
+  end
 end


### PR DESCRIPTION
* Remove appointments which don’t have patients
* Don’t display BP if BP is not present for a patient
* Eager-load the patient tree while generating the report