### PR TITLE
Feature flag off the Overdue Appointments button

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,7 @@
               <li class="nav-item">
                 <%= link_to "Dashboard", admin_root_path, class: "nav-link #{active_controller?("organizations", "facility_groups")}" %>
               </li>
-              <% if policy(Appointment).index? %>
+              <% if policy(Appointment).index? && FeatureToggle.enabled?('PATIENT_FOLLOWUPS') %>
                 <li class="nav-item">
                   <%= link_to "Overdue Appointments", appointments_path, class: "nav-link #{active_controller?("patient_details")}" %>
                 </li>


### PR DESCRIPTION
Don't show the button if `PATIENT_FOLLOWUPS` is set to false.