### PR TITLE
P0 Fix: Only send one invitation email for new admins

### DIFF
--- a/app/controllers/admins/invitations_controller.rb
+++ b/app/controllers/admins/invitations_controller.rb
@@ -10,15 +10,18 @@ class Admins::InvitationsController < Devise::InvitationsController
   def create
     authorize :invitation, :create?
     @role = params.require(:admin).require(:role).downcase.to_sym
+
+    super
+
     unless @role == :owner
       admin_access_controls = access_controllable_ids.reject(&:empty?).map do |access_controllable_id|
         AdminAccessControl.new(
           access_controllable_type: access_controllable_type,
           access_controllable_id: access_controllable_id)
       end
-      invite_resource.admin_access_controls = admin_access_controls
+
+      resource.update(admin_access_controls: admin_access_controls)
     end
-    super
   end
 
   protected


### PR DESCRIPTION
*Bug:* https://www.pivotaltracker.com/story/show/164040599

Previously we were accidentally sending an invitation email by calling `invite_resource`, which itself creates the new `Admin` and sends the invitation, and then called `super` which does the same thing.

I fixed this by calling `super` first to take care of invitations and model creation, then making use of the instance's `resource` to set access controls.