### PR TITLE
[WIP] Correctly display BP counts for users who switch facilities

### DIFF
--- a/app/controllers/facility_groups_controller.rb
+++ b/app/controllers/facility_groups_controller.rb
@@ -13,6 +13,7 @@ class FacilityGroupsController < AdminController
     @months_previous = 8
 
     @facilities = @facility_group.facilities
+    @users_by_facility = users_by_facility(@facility_group)
     @visits_by_facility = visits_by_facility(@facility_group)
     @visits_by_facility_user = visits_by_facility_user(@facility_group)
     @visits_by_facility_user_day = visits_by_facility_user_day(@facility_group)
@@ -29,6 +30,16 @@ class FacilityGroupsController < AdminController
 
   def blood_pressures_in_facility_group(facility_group)
     BloodPressure.where(facility: @facilities)
+  end
+
+  def users_by_facility(facility_group)
+    facility_users = Hash.new { |hash, key| hash[key] = Array.new }
+
+    blood_pressures_in_facility_group(facility_group).select(:facility_id, :user_id).distinct.each do |bp|
+      facility_users[bp.facility] << bp.user
+    end
+
+    facility_users
   end
 
   def visits_by_facility(facility_group)

--- a/app/views/facility_groups/show.html.erb
+++ b/app/views/facility_groups/show.html.erb
@@ -1,4 +1,5 @@
 <%= render "shared/user_approvals" %>
+<%= console %>
 
 <h1>
   <small><%= @organization.name %></small><br>
@@ -22,7 +23,7 @@
     </thead>
     <tbody>
       <% @facilities.sort_by(&:name).each do |facility| %>
-        <% next if @visits_by_facility.fetch(facility.id, 0)  == 0 %>
+        <% next if @visits_by_facility.fetch(facility.id, 0) == 0 %>
 
         <tr class="table-info table-row-small">
           <td class="row-title"><strong><%= facility.name %></strong></td>
@@ -32,7 +33,7 @@
           <% end %>
         </tr>
 
-        <% facility.users.sort_by(&:full_name).each do |user| %>
+        <% @users_by_facility[facility].sort_by(&:full_name).each do |user| %>
           <tr class="table-row-small">
             <td class="pl-lg-4"><%= user.full_name %></td>
             <td class="text-center">

--- a/app/views/facility_groups/show.html.erb
+++ b/app/views/facility_groups/show.html.erb
@@ -1,5 +1,4 @@
 <%= render "shared/user_approvals" %>
-<%= console %>
 
 <h1>
   <small><%= @organization.name %></small><br>


### PR DESCRIPTION
**Story:** https://www.pivotaltracker.com/n/projects/2184102/stories/162240967

The dashboard currently has a bug where users are only displayed in the facility where they are registered, not where they record BPs. This means that if users switch facilities, their BP counts never appear on the dashboard.

This is fixed by looping through the list of all users who have **ever** recorded a BP in each facility, not just the users registered there.

Example of the fix in action:
![image](https://user-images.githubusercontent.com/612212/53540547-fc83e400-3ae3-11e9-9003-302ae4ef8cf3.png)
(Notice how "Rosanna Ratke" appears in two places, as she has recorded BPs in two clinics)