### PR TITLE
[HOTFIX] Hide BPs with orphaned User associations

### DIFF
--- a/app/views/facility_groups/show.html.erb
+++ b/app/views/facility_groups/show.html.erb
@@ -32,7 +32,7 @@
           <% end %>
         </tr>
 
-        <% @users_by_facility[facility].sort_by(&:full_name).each do |user| %>
+        <% @users_by_facility[facility].compact.sort_by(&:full_name).each do |user| %>
           <tr class="table-row-small">
             <td class="pl-lg-4"><%= user.full_name %></td>
             <td class="text-center">


### PR DESCRIPTION
Right now, if a blood pressure belongs to a user record that was deleted, the dashboard crashes.

This hotfix fixes the crash. (We still need to fix the data.)