### PR TITLE
Don't auto-increment age if age is 0

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -87,6 +87,8 @@ class Patient < ApplicationRecord
     if date_of_birth.present?
       Date.today.year - date_of_birth.year
     elsif age.present?
+      return 0 if age == 0
+
       years_since_update = Date.today.year - age_updated_at.year
       age + years_since_update
     end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -23,6 +23,10 @@ describe Patient, type: :model do
     it { should belong_to(:registration_user).class_name("User") }
   end
 
+  describe 'Associations' do
+    it { should have_many(:blood_pressures) }
+  end
+
   describe 'Validations' do
     it_behaves_like 'a record that validates device timestamps'
 
@@ -37,84 +41,103 @@ describe Patient, type: :model do
     it_behaves_like 'a record that is deletable'
   end
 
-  describe '.not_contacted' do
-    let(:patient_to_followup) { create(:patient, device_created_at: 5.days.ago) }
-    let(:patient_to_not_followup) { create(:patient, device_created_at: 1.day.ago) }
-    let(:patient_contacted) { create(:patient, contacted_by_counsellor: true) }
-    let(:patient_could_not_be_contacted) { create(:patient, could_not_contact_reason: 'dead') }
+  context "Scopes" do
+    describe '.not_contacted' do
+      let(:patient_to_followup) { create(:patient, device_created_at: 5.days.ago) }
+      let(:patient_to_not_followup) { create(:patient, device_created_at: 1.day.ago) }
+      let(:patient_contacted) { create(:patient, contacted_by_counsellor: true) }
+      let(:patient_could_not_be_contacted) { create(:patient, could_not_contact_reason: 'dead') }
 
-    it 'includes uncontacted patients registered 2 days ago or earlier' do
-      expect(Patient.not_contacted).to include(patient_to_followup)
-    end
+      it 'includes uncontacted patients registered 2 days ago or earlier' do
+        expect(Patient.not_contacted).to include(patient_to_followup)
+      end
 
-    it 'excludes uncontacted patients registered less than 2 days ago' do
-      expect(Patient.not_contacted).not_to include(patient_to_not_followup)
-    end
+      it 'excludes uncontacted patients registered less than 2 days ago' do
+        expect(Patient.not_contacted).not_to include(patient_to_not_followup)
+      end
 
-    it 'excludes already contacted patients' do
-      expect(Patient.not_contacted).not_to include(patient_contacted)
-    end
+      it 'excludes already contacted patients' do
+        expect(Patient.not_contacted).not_to include(patient_contacted)
+      end
 
-    it 'excludes patients who could not be contacted' do
-      expect(Patient.not_contacted).not_to include(patient_could_not_be_contacted)
+      it 'excludes patients who could not be contacted' do
+        expect(Patient.not_contacted).not_to include(patient_could_not_be_contacted)
+      end
     end
   end
 
-  describe 'Associations' do
-    it { should have_many(:blood_pressures) }
-  end
+  context "Utility methods" do
+    describe '#risk_priority' do
+      it 'should return no priority for patients recently overdue' do
+        patient = create(:patient)
+        create(:appointment, scheduled_date: 29.days.ago, status: :scheduled, patient: patient)
 
-  describe '#risk_priority' do
-    it 'should return no priority for patients recently overdue' do
-      patient = create(:patient)
-      create(:appointment, scheduled_date: 29.days.ago, status: :scheduled, patient: patient)
+        expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:NONE])
+      end
 
-      expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:NONE])
+      it 'should return highest priority for patients overdue with critical bp' do
+        patient = create(:patient)
+        create(:blood_pressure, :critical, patient: patient)
+        create(:appointment, scheduled_date: 31.days.ago, status: :scheduled, patient: patient)
+
+        expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:HIGHEST])
+      end
+
+      it 'should return very high priority for patients overdue with medical risk history' do
+        patient = create(:patient)
+        create(:medical_history, :prior_risk_history, patient: patient)
+        create(:appointment, :overdue, patient: patient)
+
+        expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:VERY_HIGH])
+      end
+
+      it 'should return high priority for patients overdue with very high bp' do
+        patient = create(:patient)
+        create(:blood_pressure, :very_high, patient: patient)
+        create(:appointment, :overdue, patient: patient)
+
+        expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:HIGH])
+      end
+
+      it 'should return regular priority for patients overdue with high bp' do
+        patient = create(:patient)
+        create(:blood_pressure, :high, patient: patient)
+        create(:appointment, :overdue, patient: patient)
+
+        expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:REGULAR])
+      end
+
+      it 'should return low priority for patients overdue with low risk' do
+        patient = create(:patient)
+        create(:blood_pressure, :under_control, patient: patient)
+        create(:appointment, scheduled_date: 2.years.ago, status: :scheduled, patient: patient)
+
+        expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:LOW])
+      end
     end
 
-    it 'should return highest priority for patients overdue with critical bp' do
-      patient = create(:patient)
-      create(:blood_pressure, :critical, patient: patient)
-      create(:appointment, scheduled_date: 31.days.ago, status: :scheduled, patient: patient)
+    describe "#current_age" do
+      it "returns age based on date of birth year if present" do
+        patient.date_of_birth = Date.parse("1980-01-01")
+        expect(patient.current_age).to eq(Date.today.year - 1980)
+      end
 
-      expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:HIGHEST])
-    end
+      it "returns age based on age_updated_at if date of birth is not present" do
+        patient.age = 30
+        patient.age_updated_at = 2.years.ago
+        expect(patient.current_age).to eq(32)
+      end
 
-    it 'should return very high priority for patients overdue with medical risk history' do
-      patient = create(:patient)
-      create(:medical_history, :prior_risk_history, patient: patient)
-      create(:appointment, :overdue, patient: patient)
-
-      expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:VERY_HIGH])
-    end
-
-    it 'should return high priority for patients overdue with very high bp' do
-      patient = create(:patient)
-      create(:blood_pressure, :very_high, patient: patient)
-      create(:appointment, :overdue, patient: patient)
-
-      expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:HIGH])
-    end
-
-    it 'should return regular priority for patients overdue with high bp' do
-      patient = create(:patient)
-      create(:blood_pressure, :high, patient: patient)
-      create(:appointment, :overdue, patient: patient)
-
-      expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:REGULAR])
-    end
-
-    it 'should return low priority for patients overdue with low risk' do
-      patient = create(:patient)
-      create(:blood_pressure, :under_control, patient: patient)
-      create(:appointment, scheduled_date: 2.years.ago, status: :scheduled, patient: patient)
-
-      expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:LOW])
+      it "returns 0 if age is 0" do
+        patient.age = 0
+        patient.age_updated_at = 2.years.ago
+        expect(patient.current_age).to eq(0)
+      end
     end
   end
 
   context 'Virtual params' do
-    describe '.call_result' do
+    describe '#call_result' do
       it 'correctly records successful contact' do
         patient.call_result = 'contacted'
 


### PR DESCRIPTION
Allows us to import records from cardreader if they are missing ages, as we will set the age to zero.