### PR TITLE
Allow editing counsellor facilities

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -46,4 +46,8 @@ class Admin < ApplicationRecord
     return User.all if owner?
     facility_groups.flat_map(&:users)
   end
+
+  def access_controllable_ids
+    admin_access_controls.map(&:access_controllable_id)
+  end
 end

--- a/app/views/admins/_form.html.erb
+++ b/app/views/admins/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-6">
-    <%= bootstrap_form_with(model: admin, local: true, autocomplete: "off", label_errors: true) do |form| %>
+    <%= bootstrap_form_for(admin, autocomplete: "off", label_errors: true) do |form| %>
       <%= form.text_field :email, id: :admin_email, required: true, autocomplete: "off" %>
       <%= form.text_field :role, value: admin.role, readonly: true %>
       <%= form.hidden_field :access_controllable_type, value: AdminAccessControl::ACCESS_CONTROLLABLE_TYPE_FOR_ROLE[admin.role.to_sym] %>
@@ -14,7 +14,7 @@
 
       <% if admin.has_role?(:organanization_owner) %>
         <h3>Select Organizations</h3>
-        <%= form.collection_check_boxes :access_controllable_ids, policy_scope(Organization), :id, :name, label: 'Organizations', size: 1 %>
+        <%= form.collection_check_boxes :access_controllable_ids, policy_scope(Organization), :id, :name %>
       <% end %>
 
       <%= form.primary %>

--- a/app/views/admins/_form.html.erb
+++ b/app/views/admins/_form.html.erb
@@ -5,15 +5,16 @@
       <%= form.text_field :role, value: admin.role, readonly: true %>
       <%= form.hidden_field :access_controllable_type, value: AdminAccessControl::ACCESS_CONTROLLABLE_TYPE_FOR_ROLE[admin.role.to_sym] %>
 
-      <% if admin.supervisor? || admin.analyst? %>
-        <h3>Facility groups</h3>
-        <%= form.collection_check_boxes :access_controllable_ids, admin.facility_groups, :id, :name, label: 'Facility Groups', checked_value: 1 %>
-        <%= form.collection_check_boxes :access_controllable_ids, policy_scope(FacilityGroup).where.not(id: admin.facility_groups.pluck(:id)), :id, :name, label: 'Other Facility Groups' %>
+      <% if admin.has_role?(:supervisor, :analyst, :counsellor) %>
+        <h3>Select facility groups</h3>
+        <% policy_scope(FacilityGroup).group_by(&:organization).each do |organization, facility_groups| %>
+          <%= form.collection_check_boxes :access_controllable_ids, facility_groups, :id, :name, label: "Organization: #{organization.name}" %>
+        <% end %>
       <% end %>
 
-      <% if admin.organization_owner? %>
-        <%= form.collection_check_boxes :access_controllable_ids, admin.organizations, :id, :name, label: 'Organizations', checked_value: 1 %>
-        <%= form.collection_check_boxes :access_controllable_ids, policy_scope(Organization).where.not(id: admin.organizations.pluck(:id)), :id, :name, label: 'Other Organizations' %>
+      <% if admin.has_role?(:organanization_owner) %>
+        <h3>Select Organizations</h3>
+        <%= form.collection_check_boxes :access_controllable_ids, policy_scope(Organization), :id, :name, label: 'Organizations', size: 1 %>
       <% end %>
 
       <%= form.primary %>

--- a/app/views/admins/invitations/new.html.erb
+++ b/app/views/admins/invitations/new.html.erb
@@ -12,13 +12,13 @@
       <% if [:supervisor, :analyst, :counsellor].include?(@role) %>
         <h3>Select facility groups</h3>
         <% policy_scope(FacilityGroup).group_by(&:organization).each do |organization, facility_groups| %>
-          <%= f.collection_check_boxes :access_controllable_ids, facility_groups, :id, :name, checked: true, label: "Organization: #{organization.name}" %>
+          <%= f.collection_check_boxes :access_controllable_ids, facility_groups, :id, :name, label: "Organization: #{organization.name}" %>
         <% end %>
       <% end %>
 
       <% if @role == :organization_owner %>
         <h3>Select Organizations</h3>
-        <%= f.collection_check_boxes :access_controllable_ids, policy_scope(Organization), :id, :name, checked: true, label: 'Organizations', size: 1 %>
+        <%= f.collection_check_boxes :access_controllable_ids, policy_scope(Organization), :id, :name, label: 'Organizations', size: 1 %>
       <% end %>
 
       <%= f.primary t("devise.invitations.new.submit_button") %>

--- a/spec/features/admins_spec.rb
+++ b/spec/features/admins_spec.rb
@@ -25,12 +25,7 @@ RSpec.feature "Admins", type: :feature do
   describe "editing admins" do
     let!(:facility_group) { create(:facility_group, name: "CHC Buccho") }
     let!(:other_facility_group) { create(:facility_group, name: "PHC Ubha") }
-    let!(:counsellor) {
-      create(
-        :admin,
-        :counsellor,
-      )
-    }
+    let!(:counsellor) { create( :admin, :counsellor) }
 
     before do
       sign_in(owner)
@@ -42,6 +37,7 @@ RSpec.feature "Admins", type: :feature do
       click_button "Update Admin"
 
       expect(counsellor.reload.facility_groups).to include(facility_group)
+      expect(counsellor.facility_groups).not_to include(other_facility_group)
     end
   end
 

--- a/spec/features/admins_spec.rb
+++ b/spec/features/admins_spec.rb
@@ -22,6 +22,29 @@ RSpec.feature "Admins", type: :feature do
     end
   end
 
+  describe "editing admins" do
+    let!(:facility_group) { create(:facility_group, name: "CHC Buccho") }
+    let!(:other_facility_group) { create(:facility_group, name: "PHC Ubha") }
+    let!(:counsellor) {
+      create(
+        :admin,
+        :counsellor,
+      )
+    }
+
+    before do
+      sign_in(owner)
+      visit edit_admin_path(counsellor)
+    end
+
+    it "should allow changing facility groups" do
+      check "CHC Buccho"
+      click_button "Update Admin"
+
+      expect(counsellor.reload.facility_groups).to include(facility_group)
+    end
+  end
+
   describe "sending invitations to supervisors" do
     let(:email) { "new@example.com" }
     let(:new_supervisor) { Admin.find_by(email: email) }


### PR DESCRIPTION
This allows owners and organization owners to edit the facility groups for counsellors.

Quick note: `form_with` does not automatically add `id=` attributes to inputs. This is fixed in Rails 5.2; we should upgrade when we can.