### PR TITLE
Fixing failing current_age spec

### DIFF
--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -120,8 +120,6 @@ describe Patient, type: :model do
       end
 
       it "returns age based on age_updated_at if date of birth is not present" do
-        patient = create(:patient, has_date_of_birth?: false)
-
         patient.age = 30
         patient.age_updated_at = 2.years.ago
 

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -67,7 +67,7 @@ describe Patient, type: :model do
   end
 
   context "Utility methods" do
-    let(:patient) { create(:patient, has_date_of_birth?: false) }
+    let(:patient) { create(:patient) }
 
     describe '#risk_priority' do
       it 'should return no priority for patients recently overdue' do
@@ -120,8 +120,7 @@ describe Patient, type: :model do
       end
 
       it "returns age based on age_updated_at if date of birth is not present" do
-        patient.age = 30
-        patient.age_updated_at = 2.years.ago
+        patient = create(:patient, age: 30, age_updated_at: 2.years.ago, date_of_birth: nil)
 
         expect(patient.current_age).to eq(32)
       end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -67,16 +67,16 @@ describe Patient, type: :model do
   end
 
   context "Utility methods" do
+    let(:patient) { create(:patient, has_date_of_birth?: false) }
+
     describe '#risk_priority' do
       it 'should return no priority for patients recently overdue' do
-        patient = create(:patient)
         create(:appointment, scheduled_date: 29.days.ago, status: :scheduled, patient: patient)
 
         expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:NONE])
       end
 
       it 'should return highest priority for patients overdue with critical bp' do
-        patient = create(:patient)
         create(:blood_pressure, :critical, patient: patient)
         create(:appointment, scheduled_date: 31.days.ago, status: :scheduled, patient: patient)
 
@@ -84,7 +84,6 @@ describe Patient, type: :model do
       end
 
       it 'should return very high priority for patients overdue with medical risk history' do
-        patient = create(:patient)
         create(:medical_history, :prior_risk_history, patient: patient)
         create(:appointment, :overdue, patient: patient)
 
@@ -92,7 +91,6 @@ describe Patient, type: :model do
       end
 
       it 'should return high priority for patients overdue with very high bp' do
-        patient = create(:patient)
         create(:blood_pressure, :very_high, patient: patient)
         create(:appointment, :overdue, patient: patient)
 
@@ -100,7 +98,6 @@ describe Patient, type: :model do
       end
 
       it 'should return regular priority for patients overdue with high bp' do
-        patient = create(:patient)
         create(:blood_pressure, :high, patient: patient)
         create(:appointment, :overdue, patient: patient)
 
@@ -108,7 +105,6 @@ describe Patient, type: :model do
       end
 
       it 'should return low priority for patients overdue with low risk' do
-        patient = create(:patient)
         create(:blood_pressure, :under_control, patient: patient)
         create(:appointment, scheduled_date: 2.years.ago, status: :scheduled, patient: patient)
 
@@ -118,8 +114,6 @@ describe Patient, type: :model do
 
     describe "#current_age" do
       it "returns age based on date of birth year if present" do
-        patient = create(:patient)
-
         patient.date_of_birth = Date.parse("1980-01-01")
 
         expect(patient.current_age).to eq(Date.today.year - 1980)
@@ -135,8 +129,6 @@ describe Patient, type: :model do
       end
 
       it "returns 0 if age is 0" do
-        patient = create(:patient)
-
         patient.age = 0
         patient.age_updated_at = 2.years.ago
 

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -118,19 +118,28 @@ describe Patient, type: :model do
 
     describe "#current_age" do
       it "returns age based on date of birth year if present" do
+        patient = create(:patient)
+
         patient.date_of_birth = Date.parse("1980-01-01")
+
         expect(patient.current_age).to eq(Date.today.year - 1980)
       end
 
       it "returns age based on age_updated_at if date of birth is not present" do
+        patient = create(:patient, has_date_of_birth?: false)
+
         patient.age = 30
         patient.age_updated_at = 2.years.ago
+
         expect(patient.current_age).to eq(32)
       end
 
       it "returns 0 if age is 0" do
+        patient = create(:patient)
+
         patient.age = 0
         patient.age_updated_at = 2.years.ago
+
         expect(patient.current_age).to eq(0)
       end
     end


### PR DESCRIPTION
For the chore https://www.pivotaltracker.com/n/projects/2184102/stories/164597712, specifically, the error shown below:

```
Failures:

  1) Patient Utility methods #current_age returns age based on age_updated_at if date of birth is not present
     Failure/Error: expect(patient.current_age).to eq(32)

       expected: 32
            got: 0

       (compared using ==)
     # ./spec/models/patient_spec.rb:128:in `block (4 levels) in <top (required)>'
```