### PR TITLE
Fix time-sensitive analytics (and/or specs)

### DIFF
--- a/spec/models/analytics/patient_set_analytics_spec.rb
+++ b/spec/models/analytics/patient_set_analytics_spec.rb
@@ -104,8 +104,9 @@ RSpec.describe Analytics::PatientSetAnalytics do
     end
   end
 
-  describe '#blood_pressure_recored_per_week' do
+  describe '#blood_pressure_recorded_per_week' do
     it 'returns the number of blood pressures recorded per week for a group of patients' do
+      Timecop.travel(Date.new(2019, 3, 21))
       expected_counts = {
         Date.new(2018, 12, 30) => 7,
         Date.new(2019, 1, 06) => 0,


### PR DESCRIPTION
The current `patient_set_analytics` specs are incomplete and broken. The class requires a `from_time` and `to_time`, but the methods that report analytics for months and weeks previous don't pay attention to these times.

As a result, the specs only work on a given date. We can fix the specs by time traveling to that date, but the better answer is to update the analytics classes to respect the `to_time` or at least be more explicit in what they're returning.

Also, there is no spec for `control_rate_per_month` so we should add that.

cc @govindkrjoshi (this was introduced in #278)