### PR TITLE
Adding non-null constraint on appointment_type 

### DIFF
--- a/db/migrate/20190402050907_mark_appointment_type_non_null.rb
+++ b/db/migrate/20190402050907_mark_appointment_type_non_null.rb
@@ -1,0 +1,5 @@
+class MarkAppointmentTypeNonNull < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :appointments, :appointment_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190322071636) do
+ActiveRecord::Schema.define(version: 20190402050907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,7 +90,7 @@ ActiveRecord::Schema.define(version: 20190322071636) do
     t.date "remind_on"
     t.boolean "agreed_to_visit"
     t.datetime "deleted_at"
-    t.string "appointment_type"
+    t.string "appointment_type", null: false
     t.index ["appointment_type"], name: "index_appointments_on_appointment_type"
     t.index ["deleted_at"], name: "index_appointments_on_deleted_at"
     t.index ["facility_id"], name: "index_appointments_on_facility_id"


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/n/projects/2184102/stories/164570825
Task: 3 (Create a migration to mark the `appointment_type` column as non-nullable.)

Dependent on: https://github.com/simpledotorg/simple-server/pull/315