### PR TITLE
Add pagination to the AuditLogs index view

### DIFF
--- a/app/controllers/admin/audit_logs_controller.rb
+++ b/app/controllers/admin/audit_logs_controller.rb
@@ -4,14 +4,14 @@ class Admin::AuditLogsController < AdminController
 
   def index
     authorize AuditLog
-    @audit_logs = policy_scope(AuditLog).none
+    audit_logs = policy_scope(AuditLog).none
 
     if params[:user_name].present?
       users = policy_scope(User).where('full_name ilike ?', "%#{params[:user_name]}%")
-      @audit_logs = paginate(policy_scope(AuditLog)
-                               .where(user_id: users.pluck(:id))
-                               .order(created_at: :desc))
+      audit_logs = policy_scope(AuditLog).where(user_id: users.pluck(:id)).order(created_at: :desc)
     end
+
+    @audit_logs = paginate(audit_logs)
   end
 
   def show

--- a/app/controllers/admin/audit_logs_controller.rb
+++ b/app/controllers/admin/audit_logs_controller.rb
@@ -1,12 +1,16 @@
 class Admin::AuditLogsController < AdminController
+  include Pagination
   before_action :set_audit_log, only: [:show]
 
   def index
     authorize AuditLog
     @audit_logs = policy_scope(AuditLog).none
+
     if params[:user_name].present?
       users = policy_scope(User).where('full_name ilike ?', "%#{params[:user_name]}%")
-      @audit_logs = policy_scope(AuditLog).where(user_id: users.pluck(:id)).order(created_at: :desc)
+      @audit_logs = paginate(policy_scope(AuditLog)
+                               .where(user_id: users.pluck(:id))
+                               .order(created_at: :desc))
     end
   end
 

--- a/app/views/admin/audit_logs/index.html.erb
+++ b/app/views/admin/audit_logs/index.html.erb
@@ -41,3 +41,5 @@
     <p>No audit logs found for "<%= params[:user_name] %>"</p>
   <% end %>
 <% end %>
+
+<%= paginate @audit_logs %>


### PR DESCRIPTION
Not having pagination on the AuditLog index page causes our server instance to OOM because it loads too many records.