### PR TITLE
Make sync_to_user audit log creation async

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'connection_pool'
 gem 'whenever', require: false
 gem 'redis'
 gem 'redis-rails'
+gem 'activerecord-import'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,8 @@ GEM
       activemodel (= 5.1.6.2)
       activesupport (= 5.1.6.2)
       arel (~> 8.0)
+    activerecord-import (1.0.1)
+      activerecord (>= 3.2)
     activesupport (5.1.6.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -386,6 +388,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import
   bcrypt (~> 3.1, >= 3.1.11)
   bootstrap (~> 4.3.1)
   bootstrap_form (>= 4.1.0)

--- a/app/controllers/api/current/facilities_controller.rb
+++ b/app/controllers/api/current/facilities_controller.rb
@@ -9,6 +9,10 @@ class Api::Current::FacilitiesController < Api::Current::SyncController
 
   private
 
+  def disable_audit_logs?
+    true
+  end
+
   def transform_to_response(facility)
     facility.as_json
       .merge(protocol_id: facility.protocol.try(:id))

--- a/app/controllers/api/current/protocols_controller.rb
+++ b/app/controllers/api/current/protocols_controller.rb
@@ -13,6 +13,10 @@ class Api::Current::ProtocolsController < Api::Current::SyncController
 
   private
 
+  def disable_audit_logs?
+    true
+  end
+
   def transform_to_response(protocol)
     protocol.as_json(include: :protocol_drugs)
   end

--- a/app/controllers/api/current/sync_controller.rb
+++ b/app/controllers/api/current/sync_controller.rb
@@ -19,7 +19,7 @@ class Api::Current::SyncController < APIController
   end
 
   def __sync_to_user__(response_key)
-    AuditLog.create_logs_async(current_user, records_to_sync, 'fetch')
+    AuditLog.create_logs_async(current_user, records_to_sync, 'fetch') unless disable_audit_logs?
     render(
       json: {
         response_key => records_to_sync.map { |record| transform_to_response(record) },
@@ -30,6 +30,10 @@ class Api::Current::SyncController < APIController
   end
 
   private
+
+  def disable_audit_logs?
+    false
+  end
 
   def check_disabled_api
     return if sync_api_toggled_on?

--- a/app/controllers/api/current/sync_controller.rb
+++ b/app/controllers/api/current/sync_controller.rb
@@ -19,7 +19,7 @@ class Api::Current::SyncController < APIController
   end
 
   def __sync_to_user__(response_key)
-    records_to_sync.each { |record| AuditLog.fetch_log(current_user, record) }
+    AuditLog.create_logs_async(current_user, records_to_sync, 'fetch')
     render(
       json: {
         response_key => records_to_sync.map { |record| transform_to_response(record) },

--- a/app/controllers/concerns/api/v1/sync_controller_overrides.rb
+++ b/app/controllers/concerns/api/v1/sync_controller_overrides.rb
@@ -4,7 +4,7 @@ module Api::V1::SyncControllerOverrides
   included do
     def __sync_to_user__(response_key)
       records_to_sync = find_records_to_sync(processed_since, limit)
-      records_to_sync.each { |record| AuditLog.fetch_log(current_user, record) }
+      AuditLog.create_logs_async(current_user, records_to_sync, 'fetch') unless disable_audit_logs?
       render(
         json: {
           response_key => records_to_sync.map { |record| transform_to_response(record) },

--- a/app/jobs/create_audit_logs_job.rb
+++ b/app/jobs/create_audit_logs_job.rb
@@ -4,12 +4,12 @@ class CreateAuditLogsJob < ApplicationJob
 
   def perform(user_id, record_class, record_ids, action)
     user = User.find(user_id)
-    audit_logs_attributes = record_ids.map do |record_id|
-      { user: user,
-        auditable_type: record_class,
-        auditable_id: record_id,
-        action: action }
+    audit_logs = record_ids.map do |record_id|
+      AuditLog.new({ user: user,
+                     auditable_type: record_class,
+                     auditable_id: record_id,
+                     action: action })
     end
-    AuditLog.create!(audit_logs_attributes)
+    AuditLog.import!(audit_logs, validate: true)
   end
 end

--- a/app/jobs/create_audit_logs_job.rb
+++ b/app/jobs/create_audit_logs_job.rb
@@ -1,0 +1,15 @@
+class CreateAuditLogsJob < ApplicationJob
+  queue_as :default
+  self.queue_adapter = :sidekiq
+
+  def perform(user_id, record_class, record_ids, action)
+    user = User.find(user_id)
+    audit_logs_attributes = record_ids.map do |record_id|
+      { user: user,
+        auditable_type: record_class,
+        auditable_id: record_id,
+        action: action }
+    end
+    AuditLog.create!(audit_logs_attributes)
+  end
+end

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -7,7 +7,6 @@ class AuditLog < ApplicationRecord
     old:     'touch'
   }.freeze
 
-
   belongs_to :user
   belongs_to :auditable, polymorphic: true
 
@@ -42,12 +41,12 @@ class AuditLog < ApplicationRecord
       action:         'login')
   end
 
+  # ActiveRecord callbacks will not be run (if any)
   def self.create_logs_async(user, records, action)
     records_by_class = records.group_by { |record| record.class.to_s }
 
     records_by_class.each do |record_class, records_for_class|
       CreateAuditLogsJob.perform_later(user.id, record_class, records_for_class.map(&:id), action)
     end
-
   end
 end

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -41,4 +41,13 @@ class AuditLog < ApplicationRecord
       auditable_id:   user.id,
       action:         'login')
   end
+
+  def self.create_logs_async(user, records, action)
+    records_by_class = records.group_by { |record| record.class.to_s }
+
+    records_by_class.each do |record_class, records_for_class|
+      CreateAuditLogsJob.perform_later(user.id, record_class, records_for_class.map(&:id), action)
+    end
+
+  end
 end

--- a/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
+++ b/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
@@ -302,6 +302,8 @@ RSpec.shared_examples 'a working Current sync controller sending records' do
   end
 end
 RSpec.shared_examples 'a sync controller that audits the data access' do
+  include ActiveJob::TestHelper
+
   before :each do
     set_authentication_headers
   end
@@ -351,12 +353,13 @@ RSpec.shared_examples 'a sync controller that audits the data access' do
   describe 'creates an audit log for data synced to user' do
     let!(:records) { create_record_list(5) }
     it 'creates an audit log for data fetched by the user' do
-      get :sync_to_user, params: {
-        processed_since: 20.minutes.ago,
-        limit: 5
-      }, as: :json
+      perform_enqueued_jobs do
+        get :sync_to_user, params: {
+          processed_since: 20.minutes.ago,
+          limit: 5
+        }, as: :json
+      end
 
-      perform_enqueued_jobs
       audit_logs = AuditLog.where(user_id: request_user.id, auditable_type: auditable_type)
       expect(audit_logs.count).to be 5
       expect(audit_logs.map(&:auditable_id).to_set).to eq(records.map(&:id).to_set)

--- a/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
+++ b/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
@@ -356,6 +356,7 @@ RSpec.shared_examples 'a sync controller that audits the data access' do
         limit: 5
       }, as: :json
 
+      perform_enqueued_jobs
       audit_logs = AuditLog.where(user_id: request_user.id, auditable_type: auditable_type)
       expect(audit_logs.count).to be 5
       expect(audit_logs.map(&:auditable_id).to_set).to eq(records.map(&:id).to_set)

--- a/spec/jobs/create_audit_logs_job_spec.rb
+++ b/spec/jobs/create_audit_logs_job_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe CreateAuditLogsJob, type: :job do
+  include ActiveJob::TestHelper
+
+  describe '#perform_later' do
+    let(:user) { create :user }
+    let(:record_class) { 'Patient' }
+    let(:record_ids) { create_list(record_class.underscore.to_sym, 3).pluck(:id) }
+    let(:action) { 'fetch' }
+    let(:job) { CreateAuditLogsJob.perform_later(user.id, 'Patient', record_ids, action) }
+
+    it 'queues the job' do
+      assert_enqueued_jobs 1 do
+        job
+      end
+    end
+
+    it 'queues the job on the default queue' do
+      expect(job.queue_name).to eq('default')
+    end
+
+    it 'updates the cache for the facility group with analytics for the given time' do
+      perform_enqueued_jobs { job }
+      user_audit_logs = AuditLog.where(user: user)
+      expect(user_audit_logs.count).to eq(3)
+      expect(user_audit_logs.pluck(:auditable_id)).to match_array(record_ids)
+    end
+  end
+end

--- a/spec/models/audit_log_spec.rb
+++ b/spec/models/audit_log_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+describe AuditLog, type: :model do
+  include ActiveJob::TestHelper
+
+  let(:user) { create :user }
+  let(:record) { create :patient }
+
+  describe 'Associations' do
+    it { should belong_to(:user) }
+    it { should belong_to(:auditable) }
+  end
+
+  context 'Validations' do
+    it { validate_presence_of(:action) }
+    it { validate_presence_of(:auditable) }
+  end
+
+  describe '.merge_log' do
+    it 'creates a merge log for the user and record' do
+      record.merge_status = :new
+      expect {
+        AuditLog.merge_log(user, record)
+      }.to change(AuditLog, :count).by(1)
+      audit_log = AuditLog.find_by(user: user, auditable: record)
+      expect(audit_log).to be_present
+      expect(audit_log.action).to eq(AuditLog::MERGE_STATUS_TO_ACTION[:new])
+    end
+  end
+
+  describe '.fetch_log' do
+    it 'creates a fetch log for the user and record' do
+      expect {
+        AuditLog.fetch_log(user, record)
+      }.to change(AuditLog, :count).by(1)
+      audit_log = AuditLog.find_by(user: user, auditable: record)
+      expect(audit_log).to be_present
+      expect(audit_log.action).to eq('fetch')
+    end
+  end
+
+  describe '.login_log' do
+    it 'creates a fetch log for the user and record' do
+      expect {
+        AuditLog.login_log(user)
+      }.to change(AuditLog, :count).by(1)
+      audit_log = AuditLog.find_by(user: user, auditable: user)
+      expect(audit_log).to be_present
+      expect(audit_log.action).to eq('login')
+    end
+  end
+
+  describe '.create_logs_async' do
+    let(:record_type) { 'Patient' }
+    let(:records) { create_list(record_type.underscore.to_sym, 3) }
+    let(:action) { 'fetch' }
+
+    it 'schedules a job to create audit logs in the background' do
+      assert_enqueued_jobs 1, only: CreateAuditLogsJob do
+        AuditLog.create_logs_async(user, records, action)
+      end
+    end
+
+    it 'creates audit logs for user and records when the job is completed' do
+      perform_enqueued_jobs do
+        AuditLog.create_logs_async(user, records, action)
+      end
+
+      records.each do |record|
+        expect(AuditLog.find_by(user: user, auditable: record, action: action)).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Create audit logs during fetch asynchronously.
- Does not change the behavior of merge or login audit logs
- Disable audit logs for facility sync and protocol apis. They are public APIs, most cases there will be no user to create an audit log for.  