### PR TITLE
FIX: Disable sending request OTP SMSes for QA env

### DIFF
--- a/app/controllers/api/current/users_controller.rb
+++ b/app/controllers/api/current/users_controller.rb
@@ -8,7 +8,7 @@ class Api::Current::UsersController < APIController
     user = User.new(user_from_request)
     return head :not_found unless user.facility.present?
     return render json: { errors: user.errors }, status: :bad_request if user.invalid?
-    if FeatureToggle.auto_approve?
+    if FeatureToggle.auto_approve_for_qa?
       user.sync_approval_allowed
       user.save
     else
@@ -33,7 +33,11 @@ class Api::Current::UsersController < APIController
     user = User.find(request_user_id)
     user.set_otp
     user.save
-    SmsNotificationService.new(user.phone_number).send_request_otp_sms(user.otp)
+
+    SmsNotificationService
+      .new(user.phone_number)
+      .send_request_otp_sms(user.otp) unless FeatureToggle.auto_approve_for_qa?
+
     head :ok
   end
 

--- a/app/helpers/feature_toggle.rb
+++ b/app/helpers/feature_toggle.rb
@@ -9,7 +9,7 @@ module FeatureToggle
     Regexp.new(ENV[feature_list_name]).match(feature_name)
   end
 
-  def self.auto_approve?
+  def self.auto_approve_for_qa?
     enabled?('AUTO_APPROVE_USER_FOR_QA')
   end
 end


### PR DESCRIPTION
This was turned on due the removal of `SMS_NOTIFICATION_FOR_OTP` config. This PR clubs the behavior of auto approval with SMS sending instead of maintaining another feature flag.