### PR TITLE
Fix: ApplicationHelper#rounded_time_ago_in_words test

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,9 +18,9 @@ describe ApplicationHelper, type: :helper do
     end
 
     it 'should return date in number of ago if date is less than a year ago' do
-      expect(helper.rounded_time_ago_in_words(31.days.ago.to_date)).to eq("about 1 month ago")
-      expect(helper.rounded_time_ago_in_words(2.months.ago.to_date)).to eq("about 2 months ago")
-      expect(helper.rounded_time_ago_in_words(11.months.ago.to_date)).to eq("11 months ago")
+      expect(helper.rounded_time_ago_in_words(31.days.ago.to_date)).to match(/1 month ago/)
+      expect(helper.rounded_time_ago_in_words(2.months.ago.to_date)).to match(/2 months ago/)
+      expect(helper.rounded_time_ago_in_words(11.months.ago.to_date)).to match(/11 months ago/)
     end
   end
 


### PR DESCRIPTION
Make it a regex match instead of an exact match due to the varied behavior between months.