### PR TITLE
Fix `appointment type` syncing issues with API v1 and v2.

### DIFF
--- a/app/controllers/api/current/appointments_controller.rb
+++ b/app/controllers/api/current/appointments_controller.rb
@@ -9,12 +9,6 @@ class Api::Current::AppointmentsController < Api::Current::SyncController
     __sync_to_user__('appointments')
   end
 
-  def set_default_appointment_type(appointment_params)
-    if !appointment_params.key?('appointment_type') && Appointment.compute_merge_status(appointment_params) == :new
-      appointment_params['appointment_type'] = Appointment.appointment_types[:manual]
-    end
-  end
-
   private
 
   def merge_if_valid(appointment_params)
@@ -25,7 +19,6 @@ class Api::Current::AppointmentsController < Api::Current::SyncController
       { errors_hash: validator.errors_hash }
     else
       record_params = Api::Current::Transformer.from_request(appointment_params)
-      set_default_appointment_type(record_params)
       appointment = Appointment.merge(record_params)
       { record: appointment }
     end

--- a/app/controllers/api/v2/appointments_controller.rb
+++ b/app/controllers/api/v2/appointments_controller.rb
@@ -1,2 +1,39 @@
 class Api::V2::AppointmentsController < Api::Current::AppointmentsController
+  private
+
+  def set_default_appointment_type(appointment_params)
+    if !appointment_params.key?('appointment_type') && Appointment.compute_merge_status(appointment_params) == :new
+      appointment_params['appointment_type'] = Appointment.appointment_types[:manual]
+    end
+  end
+
+  def merge_if_valid(appointment_params)
+    validator = Api::V2::AppointmentPayloadValidator.new(appointment_params)
+    logger.debug "Follow Up Schedule had errors: #{validator.errors_hash}" if validator.invalid?
+    if validator.invalid?
+      NewRelic::Agent.increment_metric('Merge/Appointment/schema_invalid')
+      { errors_hash: validator.errors_hash }
+    else
+      record_params = Api::Current::Transformer.from_request(appointment_params)
+      set_default_appointment_type(record_params)
+      appointment = Appointment.merge(record_params)
+      { record: appointment }
+    end
+  end
+
+  def appointments_params
+    params.require(:appointments).map do |appointment_params|
+      appointment_params.permit(
+        :id,
+        :patient_id,
+        :facility_id,
+        :scheduled_date,
+        :status,
+        :cancel_reason,
+        :remind_on,
+        :agreed_to_visit,
+        :created_at,
+        :updated_at)
+    end
+  end
 end

--- a/app/validators/api/v1/appointment_payload_validator.rb
+++ b/app/validators/api/v1/appointment_payload_validator.rb
@@ -1,2 +1,20 @@
 class Api::V1::AppointmentPayloadValidator < Api::Current::AppointmentPayloadValidator
+  attr_accessor(
+    :id,
+    :patient_id,
+    :facility_id,
+    :scheduled_date,
+    :status,
+    :cancel_reason,
+    :remind_on,
+    :agreed_to_visit,
+    :created_at,
+    :updated_at
+  )
+
+  validate :validate_schema
+
+  def schema
+    Api::V1::Models.appointment
+  end
 end

--- a/app/validators/api/v1/appointment_payload_validator.rb
+++ b/app/validators/api/v1/appointment_payload_validator.rb
@@ -1,19 +1,4 @@
-class Api::V1::AppointmentPayloadValidator < Api::Current::AppointmentPayloadValidator
-  attr_accessor(
-    :id,
-    :patient_id,
-    :facility_id,
-    :scheduled_date,
-    :status,
-    :cancel_reason,
-    :remind_on,
-    :agreed_to_visit,
-    :created_at,
-    :updated_at
-  )
-
-  validate :validate_schema
-
+class Api::V1::AppointmentPayloadValidator < Api::V2::AppointmentPayloadValidator
   def schema
     Api::V1::Models.appointment
   end

--- a/app/validators/api/v1/appointment_payload_validator.rb
+++ b/app/validators/api/v1/appointment_payload_validator.rb
@@ -1,5 +1,2 @@
 class Api::V1::AppointmentPayloadValidator < Api::V2::AppointmentPayloadValidator
-  def schema
-    Api::V1::Models.appointment
-  end
 end

--- a/app/validators/api/v2/appointment_payload_validator.rb
+++ b/app/validators/api/v2/appointment_payload_validator.rb
@@ -1,2 +1,21 @@
 class Api::V2::AppointmentPayloadValidator < Api::Current::AppointmentPayloadValidator
+  attr_accessor(
+    :id,
+    :patient_id,
+    :facility_id,
+    :scheduled_date,
+    :status,
+    :cancel_reason,
+    :remind_on,
+    :agreed_to_visit,
+    :created_at,
+    :updated_at
+  )
+
+  validate :validate_schema
+
+  def schema
+    Api::V2::Models.appointment
+  end
+
 end

--- a/spec/controllers/api/v2/appointments_controller_spec.rb
+++ b/spec/controllers/api/v2/appointments_controller_spec.rb
@@ -34,6 +34,54 @@ RSpec.describe Api::V2::AppointmentsController, type: :controller do
   describe 'POST sync: send data from device to server;' do
     it_behaves_like 'a working sync controller creating records'
     it_behaves_like 'a working sync controller updating records'
+
+    context 'appointment_type' do
+      before :each do
+        set_authentication_headers
+      end
+
+      describe 'Appointments without appointment_type are compatible with v2' do
+        let(:request_key) { model.to_s.underscore.pluralize }
+
+        it 'sets appointment_type to manual if field is not set in the sync payload' do
+          new_records = (1..5).map { build_payload.call.except(:appointment_type) }
+          new_records_payload = Hash[request_key, new_records]
+
+          post(:sync_from_user, params: new_records_payload, as: :json)
+
+          expect(response).to have_http_status(200)
+          after_post_appointments = Appointment.all
+          after_post_appointments_ids = after_post_appointments.map(&:id)
+
+          new_records.each do |record|
+            expect(after_post_appointments_ids.include? record[:id]).to be true
+          end
+
+          after_post_appointments.each do |appointment|
+            expect(appointment.appointment_type).to eq Appointment.appointment_types[:manual]
+          end
+        end
+
+        it 'sets appointment_type to manual even if appointment_type explicitly provided' do
+          new_records = (1..5).map { build_payload.call }
+          new_records_payload = Hash[request_key, new_records]
+
+          post(:sync_from_user, params: new_records_payload, as: :json)
+
+          expect(response).to have_http_status(200)
+          after_post_appointments = Appointment.all
+          after_post_appointments_ids = after_post_appointments.map(&:id)
+
+          new_records.each do |record|
+            expect(after_post_appointments_ids.include? record[:id]).to be true
+          end
+
+          after_post_appointments.each do |appointment|
+            expect(appointment.appointment_type).to eq Appointment.appointment_types[:manual]
+          end
+        end
+      end
+    end
   end
 
   describe 'GET sync: send data from server to device;' do


### PR DESCRIPTION
Story for bug: https://github.com/simpledotorg/simple-server/pull/381

Changes:
- Moved `set_default_appointment_type` from `current` to `v2` to ensure transformers applied for v1 and v2 and not for current,
- Fixed `attr_accessors` in `v1` and `v2` to exclude `appointment_type`.