### PR TITLE
Fix the duplication of appointments in the Overdue tab

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -12,6 +12,7 @@ class AppointmentsController < AdminController
                       .includes(patient: [:address, :phone_numbers, :medical_history, { latest_blood_pressures: :facility }])
                       .overdue
                       .where(facility: selected_facilities)
+                      .distinct
                       .order(scheduled_date: :asc)
 
     respond_to do |format|

--- a/spec/controllers/appointments_controller_spec.rb
+++ b/spec/controllers/appointments_controller_spec.rb
@@ -13,8 +13,10 @@ RSpec.describe AppointmentsController, type: :controller do
 
     let!(:facility_1) { create(:facility, facility_group: facility_group) }
     let!(:overdue_appointments_in_facility_1) do
-      appointments = create_list(:appointment, 50, :overdue, facility: facility_1)
+      appointments = create_list(:appointment, 10, :overdue, facility: facility_1)
       appointments.each do |appointment|
+        create(:blood_pressure, patient: appointment.patient, facility: facility_1)
+        create(:blood_pressure, patient: appointment.patient, facility: facility_1)
         create(:blood_pressure, patient: appointment.patient, facility: facility_1)
       end
       appointments
@@ -22,17 +24,25 @@ RSpec.describe AppointmentsController, type: :controller do
 
     let!(:facility_2) { create(:facility, facility_group: facility_group) }
     let!(:overdue_appointments_in_facility_2) do
-      appointments = create_list(:appointment, 50, :overdue, facility: facility_2)
+      appointments = create_list(:appointment, 10, :overdue, facility: facility_2)
       appointments.each do |appointment|
         create(:blood_pressure, patient: appointment.patient, facility: facility_2)
+        create(:blood_pressure, patient: appointment.patient, facility: facility_2)
+        create(:blood_pressure, patient: appointment.patient, facility: facility_1)
       end
       appointments
     end
 
     it 'returns a success response' do
       get :index, params: {}
-
       expect(response).to be_success
+    end
+
+    it 'populates a list of overdue appointments' do
+      get :index, params: {}
+      expected_ids = (overdue_appointments_in_facility_1 + overdue_appointments_in_facility_2).map(&:id)
+
+      expect(assigns(:appointments).map(&:id)).to match_array(expected_ids)
     end
 
     describe 'filtering by facility' do

--- a/spec/controllers/appointments_controller_spec.rb
+++ b/spec/controllers/appointments_controller_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe AppointmentsController, type: :controller do
       appointments.each do |appointment|
         create(:blood_pressure, patient: appointment.patient, facility: facility_1)
         create(:blood_pressure, patient: appointment.patient, facility: facility_1)
-        create(:blood_pressure, patient: appointment.patient, facility: facility_1)
       end
       appointments
     end
@@ -28,7 +27,6 @@ RSpec.describe AppointmentsController, type: :controller do
       appointments.each do |appointment|
         create(:blood_pressure, patient: appointment.patient, facility: facility_2)
         create(:blood_pressure, patient: appointment.patient, facility: facility_2)
-        create(:blood_pressure, patient: appointment.patient, facility: facility_1)
       end
       appointments
     end
@@ -74,7 +72,7 @@ RSpec.describe AppointmentsController, type: :controller do
       it 'shows the selected number of records per page' do
         get :index, params: { per_page: 50 }
 
-        expect(response.body.scan(/recorded at/).length).to be(50)
+        expect(response.body.scan(/recorded at/).length).to be(20)
       end
 
       it 'shows all records if All is selected' do


### PR DESCRIPTION
The exact same appointments for the same patients show up multiple times.