### PR TITLE
Release 2019-05-03-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 ### Removed 
 ### Security
 
+# 2019-05-03-1
+### Added 
+### Changed
+### Fixed
+- Allow Org Owners to create Facility Groups
+- Fix the duplication of appointments in the Overdue tab
+### Deprecated 
+### Removed 
+### Security
+
+
 # 2019-04-30-1
 ## Portal
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Added 
 ### Changed
 ### Fixed
+- Fix `appointment type` syncing issues with API v1 and v2. 
 - Allow Org Owners to create Facility Groups
 - Fix the duplication of appointments in the Overdue tab
 ### Deprecated 


### PR DESCRIPTION
- Fix `appointment type` syncing issues with API v1 and v2. 
- Allow Org Owners to create Facility Groups 
- Fix the duplication of appointments in the Overdue tab 