### PR TITLE
HOTFIX: Cache facilities and facility_groups view cache by ID rather than slug

### DIFF
--- a/app/controllers/analytics/facilities_controller.rb
+++ b/app/controllers/analytics/facilities_controller.rb
@@ -38,7 +38,7 @@ class Analytics::FacilitiesController < AnalyticsController
   def set_cache_key
     @cache_key = [
       "analytics/facilities",
-      @facility.slug,
+      @facility.id,
       @from_time.strftime("%Y-%m-%d"),
       @to_time.strftime("%Y-%m-%d")
     ]

--- a/app/controllers/analytics/facility_groups_controller.rb
+++ b/app/controllers/analytics/facility_groups_controller.rb
@@ -36,7 +36,7 @@ class Analytics::FacilityGroupsController < AnalyticsController
   def set_cache_key
     @cache_key = [
       "analytics/facility_groups",
-      @facility_group.slug,
+      @facility_group.id,
       @from_time.strftime("%Y-%m-%d"),
       @to_time.strftime("%Y-%m-%d")
     ]

--- a/app/views/analytics/facility_groups/show.html.erb
+++ b/app/views/analytics/facility_groups/show.html.erb
@@ -2,7 +2,7 @@
            from_time: @from_time,
            to_time: @to_time %>
 
-<% cache ["analytics/facility_groups", @facility_group.slug, @from_time.strftime("%Y-%m-%d"), @to_time.strftime("%Y-%m-%d")] do %>
+<% cache @cache_key do %>
   <div class="dashboard">
     <h1><%= @facility_group.name %></h1>
     <%= string_for_range(@from_time, @to_time) %>


### PR DESCRIPTION
A lot of facility slugs (friendly IDs) are `nil`. This means that the page cache would cache all of the facilities within the same time frame as the same page since the cache key depends on the `slug` rather than the ID.

This changes the view caching to be on the ID rather than the slug.