### PR TITLE
Fix warmup for quarterly analytics

### DIFF
--- a/app/jobs/warm_up_analytics_cache_job.rb
+++ b/app/jobs/warm_up_analytics_cache_job.rb
@@ -6,7 +6,7 @@ class WarmUpAnalyticsCacheJob < ApplicationJob
     record = record_type.constantize.find(record_id)
 
     from_time = from_time_string.to_time
-    to_time = from_time_string.to_time
+    to_time = to_time_string.to_time
 
     Rails.cache.delete(record.analytics_cache_key(from_time, to_time))
     record.patient_set_analytics(from_time, to_time)

--- a/app/jobs/warm_up_analytics_cache_job.rb
+++ b/app/jobs/warm_up_analytics_cache_job.rb
@@ -8,7 +8,7 @@ class WarmUpAnalyticsCacheJob < ApplicationJob
     from_time = from_time_string.to_time
     to_time = from_time_string.to_time
 
-    Rails.cache.delete(record.analytics_cache_key(from_time), record.analytics_cache_key(to_time))
-    record.patient_set_analytics(from_time_string.to_time, to_time_string.to_time)
+    Rails.cache.delete(record.analytics_cache_key(from_time, to_time))
+    record.patient_set_analytics(from_time, to_time)
   end
 end

--- a/app/jobs/warm_up_analytics_cache_job.rb
+++ b/app/jobs/warm_up_analytics_cache_job.rb
@@ -4,6 +4,11 @@ class WarmUpAnalyticsCacheJob < ApplicationJob
 
   def perform(record_type, record_id, from_time_string, to_time_string)
     record = record_type.constantize.find(record_id)
+
+    from_time = from_time_string.to_time
+    to_time = from_time_string.to_time
+
+    Rails.cache.delete(record.analytics_cache_key(from_time), record.analytics_cache_key(to_time))
     record.patient_set_analytics(from_time_string.to_time, to_time_string.to_time)
   end
 end

--- a/app/models/concerns/patient_set_analytics_reportable.rb
+++ b/app/models/concerns/patient_set_analytics_reportable.rb
@@ -13,7 +13,8 @@ module PatientSetAnalyticsReportable
         non_returning_hypertensive_patients: analytics.non_returning_hypertensive_patients_count,
         control_rate: analytics.control_rate,
         unique_patients_enrolled: analytics.unique_patients_count,
-        blood_pressures_recorded_per_week: analytics.blood_pressures_recorded_per_week(WEEKS_PREVIOUS)
+        blood_pressures_recorded_per_week: analytics.blood_pressures_recorded_per_week(WEEKS_PREVIOUS),
+        cache_updated_at: Time.now
       }
     end
   end

--- a/app/views/analytics/facilities/show.html.erb
+++ b/app/views/analytics/facilities/show.html.erb
@@ -23,7 +23,7 @@
     <h1><%= @facility.name %></h1>
     <%= string_for_range(@from_time, @to_time) %>
     <p class="text-muted">
-      <% if @facility_analyics[:cache_updated_at].present? %>
+      <% if @facility_analytics[:cache_updated_at].present? %>
         <small>Last updated: <%= @facility_analytics[:cache_updated_at].strftime("%B %d, %Y") %></small>
       <% end %>
     </p>

--- a/app/views/analytics/facilities/show.html.erb
+++ b/app/views/analytics/facilities/show.html.erb
@@ -23,7 +23,7 @@
     <h1><%= @facility.name %></h1>
     <%= string_for_range(@from_time, @to_time) %>
     <p class="text-muted">
-      <% if @facility_analyics[:cache_updated_at] %>
+      <% if @facility_analyics[:cache_updated_at].present? %>
         <small>Last updated: <%= @facility_analytics[:cache_updated_at].strftime("%B %d, %Y") %></small>
       <% end %>
     </p>

--- a/app/views/analytics/facilities/show.html.erb
+++ b/app/views/analytics/facilities/show.html.erb
@@ -22,9 +22,10 @@
 
     <h1><%= @facility.name %></h1>
     <%= string_for_range(@from_time, @to_time) %>
-    <%= string_for_range(@from_time, @to_time) %>
     <p class="text-muted">
-      <small>Last updated: <%= Time.now.strftime("%B %d, %Y") %></small>
+      <% if @facility_analyics[:cache_updated_at] %>
+        <small>Last updated: <%= @facility_analytics[:cache_updated_at].strftime("%B %d, %Y") %></small>
+      <% end %>
     </p>
   </div>
 

--- a/app/views/analytics/facility_groups/show.html.erb
+++ b/app/views/analytics/facility_groups/show.html.erb
@@ -6,9 +6,8 @@
   <div class="dashboard">
     <h1><%= @facility_group.name %></h1>
     <%= string_for_range(@from_time, @to_time) %>
-    <p class="text-muted"><small>Last updated: <%= Time.now.strftime("%B %d, %Y") %></small></p>
+    <small>Last updated: <%= @facility_group_analytics[:cache_updated_at].strftime("%B %d, %Y") %></small>
   </div>
-
 
   <%= render 'facility_table' %>
 

--- a/app/views/analytics/facility_groups/show.html.erb
+++ b/app/views/analytics/facility_groups/show.html.erb
@@ -6,14 +6,17 @@
   <div class="dashboard">
     <h1><%= @facility_group.name %></h1>
     <%= string_for_range(@from_time, @to_time) %>
-    <small>Last updated: <%= @facility_group_analytics[:cache_updated_at].strftime("%B %d, %Y") %></small>
+    <% if @facility_group_analytics[:cached_updated_at].present? %>
+      <small>Last updated: <%= @facility_group_analytics[:cache_updated_at].strftime("%B %d, %Y") %></small>
+    <% end %>
   </div>
 
   <%= render 'facility_table' %>
 
   <section>
     <h4>Notes</h4>
-    <p class="footnote"><strong>Didn't attend</strong> patients are enrolled hypertensives that have not had a BP recorded
+    <p class="footnote"><strong>Didn't attend</strong> patients are enrolled hypertensives that have not had a BP
+      recorded
       in the past 3 months.</p>
     <p class="footnote">
       <strong><%= t('analytics.control_rate') %></strong>

--- a/app/views/analytics/facility_groups/show.html.erb
+++ b/app/views/analytics/facility_groups/show.html.erb
@@ -15,8 +15,7 @@
 
   <section>
     <h4>Notes</h4>
-    <p class="footnote"><strong>Didn't attend</strong> patients are enrolled hypertensives that have not had a BP
-      recorded
+    <p class="footnote"><strong>Didn't attend</strong> patients are enrolled hypertensives that have not had a BP recorded
       in the past 3 months.</p>
     <p class="footnote">
       <strong><%= t('analytics.control_rate') %></strong>

--- a/app/views/analytics/facility_groups/show.html.erb
+++ b/app/views/analytics/facility_groups/show.html.erb
@@ -6,7 +6,7 @@
   <div class="dashboard">
     <h1><%= @facility_group.name %></h1>
     <%= string_for_range(@from_time, @to_time) %>
-    <% if @facility_group_analytics[:cached_updated_at].present? %>
+    <% if @facility_group_analytics[:cache_updated_at].present? %>
       <small>Last updated: <%= @facility_group_analytics[:cache_updated_at].strftime("%B %d, %Y") %></small>
     <% end %>
   </div>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -17,6 +17,6 @@ every :day, at: local('2:00 am').utc do
   rake 'appointment_notification:three_days_after_missed_visit'
 end
 
-every :month, at: local('1:00 am').utc do
+every :day, at: local('1:00 am').utc do
   rake 'analytics:warm_up_last_four_quarters'
 end


### PR DESCRIPTION
We discovered two issues with warmup up quarterly caches for a facilities and facility groups. 

- The cache key for a quarterly period will not get refreshed if the key is already present
- There can be discrepancies when displaying all time patients counts between the different time periods depending on when the cache was updated. 
- Adds a `cache_updated_at` timestamp to track when a cache was updated. 