### PR TITLE
Small improvements to SMS Reminders

### DIFF
--- a/app/controllers/api/current/twilio_sms_delivery_controller.rb
+++ b/app/controllers/api/current/twilio_sms_delivery_controller.rb
@@ -4,6 +4,7 @@ class Api::Current::TwilioSmsDeliveryController < ApplicationController
 
   def create
     existing_session = TwilioSmsDeliveryDetail.where(session_id: params['SmsSid'])
+
     if existing_session.blank?
       head :not_found
     else

--- a/app/controllers/api/current/twilio_sms_delivery_controller.rb
+++ b/app/controllers/api/current/twilio_sms_delivery_controller.rb
@@ -3,8 +3,13 @@ class Api::Current::TwilioSmsDeliveryController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def create
-    TwilioSmsDeliveryDetail.where(session_id: params['SmsSid']).first.update(update_params)
-    head :ok
+    existing_session = TwilioSmsDeliveryDetail.where(session_id: params['SmsSid'])
+    if existing_session.blank?
+      head :not_found
+    else
+      existing_session.first.update(update_params)
+      head :ok
+    end
   end
 
   private

--- a/spec/controllers/api/current/twilio_sms_delivery_controller_spec.rb
+++ b/spec/controllers/api/current/twilio_sms_delivery_controller_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe Api::Current::TwilioSmsDeliveryController, type: :controller do
 
         expect(response).to have_http_status(404)
 
+        twilio_sms_delivery_detail = TwilioSmsDeliveryDetail.find_by_session_id(existing_session_id)
         expect(twilio_sms_delivery_detail.result).to eq('sent')
         expect(twilio_sms_delivery_detail.delivered_on).to be_nil
       end

--- a/spec/controllers/api/current/twilio_sms_delivery_controller_spec.rb
+++ b/spec/controllers/api/current/twilio_sms_delivery_controller_spec.rb
@@ -91,5 +91,25 @@ RSpec.describe Api::Current::TwilioSmsDeliveryController, type: :controller do
         expect(TwilioSmsDeliveryDetail.count).to be(0)
       end
     end
+
+    context ':not_found' do
+      it 'returns a 404 when the twilio session id is not found' do
+        existing_session_id = SecureRandom.uuid
+        new_session_id = SecureRandom.uuid
+        create(:twilio_sms_delivery_detail,
+               session_id: existing_session_id,
+               result: 'sent')
+        params = base_callback_params.merge('SmsSid' => new_session_id,
+                                            'SmsStatus' => 'delivered')
+
+        set_twilio_signature_header(callback_url, params)
+        post :create, params: params
+
+        expect(response).to have_http_status(404)
+
+        expect(twilio_sms_delivery_detail.result).to eq('sent')
+        expect(twilio_sms_delivery_detail.delivered_on).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Just a bit of refactoring and tighter exception handling.

- [x] Return 404 if the Twilio delivery callback fails to find a session
- [ ] Create the `Communication` resource before the SMS to avoid failing to find sessions in callbacks
- [ ] Move the fan-out batch size to a config (currently it's a constant)
- [ ] Move Twilio's multiple account handling into a first-class object