### PR TITLE
Speed up tests (~35% on a single thread)

### DIFF
--- a/spec/api/current/analytics_spec.rb
+++ b/spec/api/current/analytics_spec.rb
@@ -12,7 +12,7 @@ describe 'Analytics Current API', swagger_doc: 'current/swagger.json' do
       before :each do
         4.times do |w|
           Timecop.travel(w.weeks.ago) do
-            FactoryBot.create_list(:patient, 5 + Random.rand(10))
+            FactoryBot.create_list(:patient, 3)
           end
         end
       end
@@ -41,7 +41,7 @@ describe 'Analytics Current API', swagger_doc: 'current/swagger.json' do
       before :each do
         4.times do |w|
           Timecop.travel(w.weeks.ago) do
-            FactoryBot.create_list(:patient, 5 + Random.rand(10))
+            FactoryBot.create_list(:patient, 3)
           end
         end
       end

--- a/spec/api/current/appointments_spec.rb
+++ b/spec/api/current/appointments_spec.rb
@@ -17,7 +17,7 @@ describe 'Appointment Current API', swagger_doc: 'current/swagger.json' do
         let(:HTTP_X_FACILITY_ID) { request_facility.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:appointments) { { appointments: (1..10).map { build_appointment_payload } } }
+        let(:appointments) { { appointments: (1..3).map { build_appointment_payload } } }
 
         run_test!
       end
@@ -29,7 +29,7 @@ describe 'Appointment Current API', swagger_doc: 'current/swagger.json' do
         let(:HTTP_X_FACILITY_ID) { request_facility.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:appointments) { { appointments: (1..10).map { build_invalid_appointment_payload } } }
+        let(:appointments) { { appointments: (1..3).map { build_invalid_appointment_payload } } }
         run_test!
       end
     end
@@ -45,7 +45,7 @@ describe 'Appointment Current API', swagger_doc: 'current/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:appointment, 10)
+          FactoryBot.create_list(:appointment, 3)
         end
       end
 

--- a/spec/api/current/blood_pressures_spec.rb
+++ b/spec/api/current/blood_pressures_spec.rb
@@ -17,7 +17,7 @@ describe 'BloodPressures Current API', swagger_doc: 'current/swagger.json' do
         let(:HTTP_X_FACILITY_ID) { request_facility.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:blood_pressures) { { blood_pressures: (1..10).map { build_blood_pressure_payload } } }
+        let(:blood_pressures) { { blood_pressures: (1..3).map { build_blood_pressure_payload } } }
 
         run_test!
       end
@@ -30,7 +30,7 @@ describe 'BloodPressures Current API', swagger_doc: 'current/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::Current::Schema.sync_from_user_errors
-        let(:blood_pressures) { { blood_pressures: (1..10).map { build_invalid_blood_pressure_payload } } }
+        let(:blood_pressures) { { blood_pressures: (1..3).map { build_invalid_blood_pressure_payload } } }
         run_test!
       end
     end
@@ -46,7 +46,7 @@ describe 'BloodPressures Current API', swagger_doc: 'current/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:blood_pressure, 10)
+          FactoryBot.create_list(:blood_pressure, 3)
         end
       end
 

--- a/spec/api/current/medical_histories_spec.rb
+++ b/spec/api/current/medical_histories_spec.rb
@@ -17,7 +17,7 @@ describe 'Medical History Current API', swagger_doc: 'current/swagger.json' do
         let(:HTTP_X_FACILITY_ID) { request_facility.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:medical_histories) { { medical_histories: (1..10).map { build_medical_history_payload_current } } }
+        let(:medical_histories) { { medical_histories: (1..3).map { build_medical_history_payload_current } } }
 
         run_test!
       end
@@ -30,7 +30,7 @@ describe 'Medical History Current API', swagger_doc: 'current/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::Current::Schema.sync_from_user_errors
-        let(:medical_histories) { { medical_histories: (1..10).map { build_invalid_medical_history_payload_current } } }
+        let(:medical_histories) { { medical_histories: (1..3).map { build_invalid_medical_history_payload_current } } }
         run_test!
       end
     end
@@ -46,7 +46,7 @@ describe 'Medical History Current API', swagger_doc: 'current/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:medical_history, 10)
+          FactoryBot.create_list(:medical_history, 3)
         end
       end
 

--- a/spec/api/current/patients_spec.rb
+++ b/spec/api/current/patients_spec.rb
@@ -17,7 +17,7 @@ describe 'Patients Current API', swagger_doc: 'current/swagger.json' do
         let(:HTTP_X_FACILITY_ID) { request_facility.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:patients) { { patients: (1..10).map { build_patient_payload } } }
+        let(:patients) { { patients: (1..3).map { build_patient_payload } } }
         run_test!
       end
 
@@ -29,7 +29,7 @@ describe 'Patients Current API', swagger_doc: 'current/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::Current::Schema.sync_from_user_errors
-        let(:patients) { { patients: (1..10).map { build_invalid_patient_payload } } }
+        let(:patients) { { patients: (1..3).map { build_invalid_patient_payload } } }
         run_test!
       end
     end
@@ -45,7 +45,7 @@ describe 'Patients Current API', swagger_doc: 'current/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:patient, 10)
+          FactoryBot.create_list(:patient, 3)
         end
       end
 

--- a/spec/api/current/prescription_drugs_spec.rb
+++ b/spec/api/current/prescription_drugs_spec.rb
@@ -17,7 +17,7 @@ describe 'PrescriptionDrugs Current API', swagger_doc: 'current/swagger.json' do
         let(:HTTP_X_FACILITY_ID) { request_facility.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:prescription_drugs) { { prescription_drugs: (1..10).map { build_prescription_drug_payload } } }
+        let(:prescription_drugs) { { prescription_drugs: (1..3).map { build_prescription_drug_payload } } }
         run_test!
       end
 
@@ -29,7 +29,7 @@ describe 'PrescriptionDrugs Current API', swagger_doc: 'current/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::Current::Schema.sync_from_user_errors
-        let(:prescription_drugs) { { prescription_drugs: (1..10).map { build_invalid_prescription_drug_payload } } }
+        let(:prescription_drugs) { { prescription_drugs: (1..3).map { build_invalid_prescription_drug_payload } } }
         run_test!
       end
     end
@@ -45,7 +45,7 @@ describe 'PrescriptionDrugs Current API', swagger_doc: 'current/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:prescription_drug, 10)
+          FactoryBot.create_list(:prescription_drug, 3)
         end
       end
 

--- a/spec/api/current/protocols_spec.rb
+++ b/spec/api/current/protocols_spec.rb
@@ -11,7 +11,7 @@ describe 'Protocols Current API', swagger_doc: 'current/swagger.json' do
       before :each do
         Timecop.travel(10.minutes.ago) do
           protocol = FactoryBot.create(:protocol)
-          FactoryBot.create_list(:protocol_drug, 10, protocol: protocol)
+          FactoryBot.create_list(:protocol_drug, 3, protocol: protocol)
         end
       end
 

--- a/spec/api/v1/appointments_spec.rb
+++ b/spec/api/v1/appointments_spec.rb
@@ -14,7 +14,7 @@ describe 'Appointment V1 API', swagger_doc: 'v1/swagger.json' do
         let(:HTTP_X_USER_ID) { request_user.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:appointments) { { appointments: (1..10).map { build_appointment_payload } } }
+        let(:appointments) { { appointments: (1..3).map { build_appointment_payload } } }
 
         run_test!
       end
@@ -25,7 +25,7 @@ describe 'Appointment V1 API', swagger_doc: 'v1/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::V1::Schema.sync_from_user_errors
-        let(:appointments) { { appointments: (1..10).map { build_invalid_appointment_payload } } }
+        let(:appointments) { { appointments: (1..3).map { build_invalid_appointment_payload } } }
         run_test!
       end
     end
@@ -40,7 +40,7 @@ describe 'Appointment V1 API', swagger_doc: 'v1/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:appointment, 10)
+          FactoryBot.create_list(:appointment, 3)
         end
       end
 

--- a/spec/api/v1/blood_pressures_spec.rb
+++ b/spec/api/v1/blood_pressures_spec.rb
@@ -14,7 +14,7 @@ describe 'BloodPressures V1 API', swagger_doc: 'v1/swagger.json' do
         let(:HTTP_X_USER_ID) { request_user.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:blood_pressures) { { blood_pressures: (1..10).map { build_blood_pressure_payload } } }
+        let(:blood_pressures) { { blood_pressures: (1..3).map { build_blood_pressure_payload } } }
 
         run_test!
       end
@@ -25,7 +25,7 @@ describe 'BloodPressures V1 API', swagger_doc: 'v1/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::V1::Schema.sync_from_user_errors
-        let(:blood_pressures) { { blood_pressures: (1..10).map { build_invalid_blood_pressure_payload } } }
+        let(:blood_pressures) { { blood_pressures: (1..3).map { build_invalid_blood_pressure_payload } } }
         run_test!
       end
     end

--- a/spec/api/v1/communications_spec.rb
+++ b/spec/api/v1/communications_spec.rb
@@ -14,7 +14,7 @@ describe 'Communication V1 API', swagger_doc: 'v1/swagger.json' do
         let(:HTTP_X_USER_ID) { request_user.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:communications) { { communications: (1..10).map { build_communication_payload } } }
+        let(:communications) { { communications: (1..3).map { build_communication_payload } } }
 
         run_test!
       end
@@ -25,7 +25,7 @@ describe 'Communication V1 API', swagger_doc: 'v1/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::V1::Schema.sync_from_user_errors
-        let(:communications) { { communications: (1..10).map { build_invalid_communication_payload } } }
+        let(:communications) { { communications: (1..3).map { build_invalid_communication_payload } } }
         run_test!
       end
     end
@@ -40,7 +40,7 @@ describe 'Communication V1 API', swagger_doc: 'v1/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:communication, 10)
+          FactoryBot.create_list(:communication, 3)
         end
       end
 

--- a/spec/api/v1/medical_histories_spec.rb
+++ b/spec/api/v1/medical_histories_spec.rb
@@ -14,7 +14,7 @@ describe 'Medical History V1 API', swagger_doc: 'v1/swagger.json' do
         let(:HTTP_X_USER_ID) { request_user.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:medical_histories) { { medical_histories: (1..10).map { build_medical_history_payload_v1 } } }
+        let(:medical_histories) { { medical_histories: (1..3).map { build_medical_history_payload_v1 } } }
 
         run_test!
       end
@@ -25,7 +25,7 @@ describe 'Medical History V1 API', swagger_doc: 'v1/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::V1::Schema.sync_from_user_errors
-        let(:medical_histories) { { medical_histories: (1..10).map { build_invalid_medical_history_payload_v1 } } }
+        let(:medical_histories) { { medical_histories: (1..3).map { build_invalid_medical_history_payload_v1 } } }
         run_test!
       end
     end
@@ -40,7 +40,7 @@ describe 'Medical History V1 API', swagger_doc: 'v1/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:medical_history, 10)
+          FactoryBot.create_list(:medical_history, 3)
         end
       end
 

--- a/spec/api/v1/patients_spec.rb
+++ b/spec/api/v1/patients_spec.rb
@@ -14,7 +14,7 @@ describe 'Patients V1 API', swagger_doc: 'v1/swagger.json' do
         let(:HTTP_X_USER_ID) { request_user.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:patients) { { patients: (1..10).map { build_patient_payload } } }
+        let(:patients) { { patients: (1..3).map { build_patient_payload } } }
         run_test!
       end
 
@@ -24,7 +24,7 @@ describe 'Patients V1 API', swagger_doc: 'v1/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::V1::Schema.sync_from_user_errors
-        let(:patients) { { patients: (1..10).map { build_invalid_patient_payload } } }
+        let(:patients) { { patients: (1..3).map { build_invalid_patient_payload } } }
         run_test!
       end
     end
@@ -39,7 +39,7 @@ describe 'Patients V1 API', swagger_doc: 'v1/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:patient, 10)
+          FactoryBot.create_list(:patient, 3)
         end
       end
 

--- a/spec/api/v1/prescription_drugs_spec.rb
+++ b/spec/api/v1/prescription_drugs_spec.rb
@@ -14,7 +14,7 @@ describe 'PrescriptionDrugs V1 API', swagger_doc: 'v1/swagger.json' do
         let(:HTTP_X_USER_ID) { request_user.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:prescription_drugs) { { prescription_drugs: (1..10).map { build_prescription_drug_payload } } }
+        let(:prescription_drugs) { { prescription_drugs: (1..3).map { build_prescription_drug_payload } } }
         run_test!
       end
 
@@ -24,7 +24,7 @@ describe 'PrescriptionDrugs V1 API', swagger_doc: 'v1/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::V1::Schema.sync_from_user_errors
-        let(:prescription_drugs) { { prescription_drugs: (1..10).map { build_invalid_prescription_drug_payload } } }
+        let(:prescription_drugs) { { prescription_drugs: (1..3).map { build_invalid_prescription_drug_payload } } }
         run_test!
       end
     end
@@ -39,7 +39,7 @@ describe 'PrescriptionDrugs V1 API', swagger_doc: 'v1/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:prescription_drug, 10)
+          FactoryBot.create_list(:prescription_drug, 3)
         end
       end
 

--- a/spec/api/v1/protocols_spec.rb
+++ b/spec/api/v1/protocols_spec.rb
@@ -11,7 +11,7 @@ describe 'Protocols V1 API', swagger_doc: 'v1/swagger.json' do
       before :each do
         Timecop.travel(10.minutes.ago) do
           protocol = FactoryBot.create(:protocol)
-          FactoryBot.create_list(:protocol_drug, 10, protocol: protocol)
+          FactoryBot.create_list(:protocol_drug, 3, protocol: protocol)
         end
       end
 

--- a/spec/api/v2/analytics_spec.rb
+++ b/spec/api/v2/analytics_spec.rb
@@ -12,7 +12,7 @@ describe 'Analytics V2 API', swagger_doc: 'v2/swagger.json' do
       before :each do
         4.times do |w|
           Timecop.travel(w.weeks.ago) do
-            FactoryBot.create_list(:patient, 5 + Random.rand(10))
+            FactoryBot.create_list(:patient, 3)
           end
         end
       end
@@ -41,7 +41,7 @@ describe 'Analytics V2 API', swagger_doc: 'v2/swagger.json' do
       before :each do
         4.times do |w|
           Timecop.travel(w.weeks.ago) do
-            FactoryBot.create_list(:patient, 5 + Random.rand(10))
+            FactoryBot.create_list(:patient, 3)
           end
         end
       end

--- a/spec/api/v2/appointments_spec.rb
+++ b/spec/api/v2/appointments_spec.rb
@@ -17,7 +17,7 @@ describe 'Appointment V2 API', swagger_doc: 'v2/swagger.json' do
         let(:HTTP_X_FACILITY_ID) { request_facility.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:appointments) { { appointments: (1..10).map { build_appointment_payload } } }
+        let(:appointments) { { appointments: (1..3).map { build_appointment_payload } } }
 
         run_test!
       end
@@ -29,7 +29,7 @@ describe 'Appointment V2 API', swagger_doc: 'v2/swagger.json' do
         let(:HTTP_X_FACILITY_ID) { request_facility.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:appointments) { { appointments: (1..10).map { build_invalid_appointment_payload } } }
+        let(:appointments) { { appointments: (1..3).map { build_invalid_appointment_payload } } }
         run_test!
       end
     end
@@ -45,7 +45,7 @@ describe 'Appointment V2 API', swagger_doc: 'v2/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:appointment, 10)
+          FactoryBot.create_list(:appointment, 3)
         end
       end
 

--- a/spec/api/v2/blood_pressures_spec.rb
+++ b/spec/api/v2/blood_pressures_spec.rb
@@ -17,7 +17,7 @@ describe 'BloodPressures V2 API', swagger_doc: 'v2/swagger.json' do
         let(:HTTP_X_FACILITY_ID) { request_facility.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:blood_pressures) { { blood_pressures: (1..10).map { build_blood_pressure_payload } } }
+        let(:blood_pressures) { { blood_pressures: (1..3).map { build_blood_pressure_payload } } }
 
         run_test!
       end
@@ -30,7 +30,7 @@ describe 'BloodPressures V2 API', swagger_doc: 'v2/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::V2::Schema.sync_from_user_errors
-        let(:blood_pressures) { { blood_pressures: (1..10).map { build_invalid_blood_pressure_payload } } }
+        let(:blood_pressures) { { blood_pressures: (1..3).map { build_invalid_blood_pressure_payload } } }
         run_test!
       end
     end
@@ -46,7 +46,7 @@ describe 'BloodPressures V2 API', swagger_doc: 'v2/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:blood_pressure, 10)
+          FactoryBot.create_list(:blood_pressure, 3)
         end
       end
 

--- a/spec/api/v2/communications_spec.rb
+++ b/spec/api/v2/communications_spec.rb
@@ -17,7 +17,7 @@ describe 'Communication V2 API', swagger_doc: 'v2/swagger.json' do
         let(:HTTP_X_FACILITY_ID) { request_facility.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:communications) { { communications: (1..10).map { build_communication_payload } } }
+        let(:communications) { { communications: (1..3).map { build_communication_payload } } }
 
         run_test!
       end
@@ -30,7 +30,7 @@ describe 'Communication V2 API', swagger_doc: 'v2/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::V2::Schema.sync_from_user_errors
-        let(:communications) { { communications: (1..10).map { build_invalid_communication_payload } } }
+        let(:communications) { { communications: (1..3).map { build_invalid_communication_payload } } }
         run_test!
       end
     end
@@ -46,7 +46,7 @@ describe 'Communication V2 API', swagger_doc: 'v2/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:communication, 10)
+          FactoryBot.create_list(:communication, 3)
         end
       end
 

--- a/spec/api/v2/medical_histories_spec.rb
+++ b/spec/api/v2/medical_histories_spec.rb
@@ -17,7 +17,7 @@ describe 'Medical History V2 API', swagger_doc: 'v2/swagger.json' do
         let(:HTTP_X_FACILITY_ID) { request_facility.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:medical_histories) { { medical_histories: (1..10).map { build_medical_history_payload_v2 } } }
+        let(:medical_histories) { { medical_histories: (1..3).map { build_medical_history_payload_v2 } } }
 
         run_test!
       end
@@ -30,7 +30,7 @@ describe 'Medical History V2 API', swagger_doc: 'v2/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::V2::Schema.sync_from_user_errors
-        let(:medical_histories) { { medical_histories: (1..10).map { build_invalid_medical_history_payload_v2 } } }
+        let(:medical_histories) { { medical_histories: (1..3).map { build_invalid_medical_history_payload_v2 } } }
         run_test!
       end
     end
@@ -46,7 +46,7 @@ describe 'Medical History V2 API', swagger_doc: 'v2/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:medical_history, 10)
+          FactoryBot.create_list(:medical_history, 3)
         end
       end
 

--- a/spec/api/v2/patients_spec.rb
+++ b/spec/api/v2/patients_spec.rb
@@ -17,7 +17,7 @@ describe 'Patients V2 API', swagger_doc: 'v2/swagger.json' do
         let(:HTTP_X_FACILITY_ID) { request_facility.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:patients) { { patients: (1..10).map { build_patient_payload } } }
+        let(:patients) { { patients: (1..3).map { build_patient_payload } } }
         run_test!
       end
 
@@ -29,7 +29,7 @@ describe 'Patients V2 API', swagger_doc: 'v2/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::V2::Schema.sync_from_user_errors
-        let(:patients) { { patients: (1..10).map { build_invalid_patient_payload } } }
+        let(:patients) { { patients: (1..3).map { build_invalid_patient_payload } } }
         run_test!
       end
     end
@@ -45,7 +45,7 @@ describe 'Patients V2 API', swagger_doc: 'v2/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:patient, 10)
+          FactoryBot.create_list(:patient, 3)
         end
       end
 

--- a/spec/api/v2/prescription_drugs_spec.rb
+++ b/spec/api/v2/prescription_drugs_spec.rb
@@ -17,7 +17,7 @@ describe 'PrescriptionDrugs V2 API', swagger_doc: 'v2/swagger.json' do
         let(:HTTP_X_FACILITY_ID) { request_facility.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
-        let(:prescription_drugs) { { prescription_drugs: (1..10).map { build_prescription_drug_payload } } }
+        let(:prescription_drugs) { { prescription_drugs: (1..3).map { build_prescription_drug_payload } } }
         run_test!
       end
 
@@ -29,7 +29,7 @@ describe 'PrescriptionDrugs V2 API', swagger_doc: 'v2/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::V2::Schema.sync_from_user_errors
-        let(:prescription_drugs) { { prescription_drugs: (1..10).map { build_invalid_prescription_drug_payload } } }
+        let(:prescription_drugs) { { prescription_drugs: (1..3).map { build_invalid_prescription_drug_payload } } }
         run_test!
       end
     end
@@ -45,7 +45,7 @@ describe 'PrescriptionDrugs V2 API', swagger_doc: 'v2/swagger.json' do
 
       before :each do
         Timecop.travel(10.minutes.ago) do
-          FactoryBot.create_list(:prescription_drug, 10)
+          FactoryBot.create_list(:prescription_drug, 3)
         end
       end
 

--- a/spec/api/v2/protocols_spec.rb
+++ b/spec/api/v2/protocols_spec.rb
@@ -11,7 +11,7 @@ describe 'Protocols V2 API', swagger_doc: 'v2/swagger.json' do
       before :each do
         Timecop.travel(10.minutes.ago) do
           protocol = FactoryBot.create(:protocol)
-          FactoryBot.create_list(:protocol_drug, 10, protocol: protocol)
+          FactoryBot.create_list(:protocol_drug, 3, protocol: protocol)
         end
       end
 

--- a/spec/controllers/api/current/blood_pressures_controller_spec.rb
+++ b/spec/controllers/api/current/blood_pressures_controller_spec.rb
@@ -44,12 +44,12 @@ RSpec.describe Api::Current::BloodPressuresController, type: :controller do
 
       it 'creates new blood pressures with associated patient' do
         patient = FactoryBot.create(:patient)
-        blood_pressures = (1..10).map do
+        blood_pressures = (1..3).map do
           build_blood_pressure_payload(FactoryBot.build(:blood_pressure, patient: patient))
         end
         post(:sync_from_user, params: { blood_pressures: blood_pressures }, as: :json)
-        expect(BloodPressure.count).to eq 10
-        expect(patient.blood_pressures.count).to eq 10
+        expect(BloodPressure.count).to eq 3
+        expect(patient.blood_pressures.count).to eq 3
         expect(response).to have_http_status(200)
       end
 
@@ -131,28 +131,28 @@ RSpec.describe Api::Current::BloodPressuresController, type: :controller do
     describe 'current facility prioritisation' do
       it "syncs request facility's records first" do
         request_2_facility = FactoryBot.create(:facility, facility_group: request_user.facility.facility_group)
-        FactoryBot.create_list(:blood_pressure, 5, facility: request_facility, updated_at: 3.minutes.ago)
-        FactoryBot.create_list(:blood_pressure, 5, facility: request_facility, updated_at: 5.minutes.ago)
-        FactoryBot.create_list(:blood_pressure, 5, facility: request_2_facility, updated_at: 7.minutes.ago)
-        FactoryBot.create_list(:blood_pressure, 5, facility: request_2_facility, updated_at: 10.minutes.ago)
+        FactoryBot.create_list(:blood_pressure, 2, facility: request_facility, updated_at: 3.minutes.ago)
+        FactoryBot.create_list(:blood_pressure, 2, facility: request_facility, updated_at: 5.minutes.ago)
+        FactoryBot.create_list(:blood_pressure, 2, facility: request_2_facility, updated_at: 7.minutes.ago)
+        FactoryBot.create_list(:blood_pressure, 2, facility: request_2_facility, updated_at: 10.minutes.ago)
 
         # GET request 1
         set_authentication_headers
-        get :sync_to_user, params: { limit: 10 }
+        get :sync_to_user, params: { limit: 4 }
         response_1_body = JSON(response.body)
 
         record_ids = response_1_body['blood_pressures'].map { |r| r['id'] }
         records = model.where(id: record_ids)
-        expect(records.count).to eq 10
+        expect(records.count).to eq 4
         expect(records.map(&:facility).to_set).to eq Set[request_facility]
 
         # GET request 2
-        get :sync_to_user, params: { limit: 10, process_token: response_1_body['process_token'] }
+        get :sync_to_user, params: { limit: 4, process_token: response_1_body['process_token'] }
         response_2_body = JSON(response.body)
 
         record_ids = response_2_body['blood_pressures'].map { |r| r['id'] }
         records = model.where(id: record_ids)
-        expect(records.count).to eq 10
+        expect(records.count).to eq 4
         expect(records.map(&:facility).to_set).to eq Set[request_facility, request_2_facility]
       end
     end
@@ -163,18 +163,18 @@ RSpec.describe Api::Current::BloodPressuresController, type: :controller do
 
       before :each do
         set_authentication_headers
-        FactoryBot.create_list(:blood_pressure, 5, facility: facility_in_another_group, updated_at: 3.minutes.ago)
-        FactoryBot.create_list(:blood_pressure, 5, facility: facility_in_same_group, updated_at: 5.minutes.ago)
-        FactoryBot.create_list(:blood_pressure, 5, facility: request_facility, updated_at: 7.minutes.ago)
+        FactoryBot.create_list(:blood_pressure, 2, facility: facility_in_another_group, updated_at: 3.minutes.ago)
+        FactoryBot.create_list(:blood_pressure, 2, facility: facility_in_same_group, updated_at: 5.minutes.ago)
+        FactoryBot.create_list(:blood_pressure, 2, facility: request_facility, updated_at: 7.minutes.ago)
       end
 
       it "only sends data for facilities belonging in the sync group of user's registration facility" do
-        get :sync_to_user, params: { limit: 15 }
+        get :sync_to_user, params: { limit: 6 }
 
         response_blood_pressures = JSON(response.body)['blood_pressures']
         response_facilities = response_blood_pressures.map { |blood_pressure| blood_pressure['facility_id'] }.to_set
 
-        expect(response_blood_pressures.count).to eq 10
+        expect(response_blood_pressures.count).to eq 4
         expect(response_facilities).to match_array([request_facility.id, facility_in_same_group.id])
         expect(response_facilities).not_to include(facility_in_another_group.id)
       end

--- a/spec/controllers/api/current/facilities_controller_spec.rb
+++ b/spec/controllers/api/current/facilities_controller_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Api::Current::FacilitiesController, type: :controller do
   describe 'a working Current sync controller sending records' do
     before :each do
       Timecop.travel(15.minutes.ago) do
-        create_record_list(5)
+        create_record_list(2)
       end
       Timecop.travel(14.minutes.ago) do
-        create_record_list(5)
+        create_record_list(2)
       end
     end
 
@@ -31,7 +31,7 @@ RSpec.describe Api::Current::FacilitiesController, type: :controller do
       end
 
       it 'only sends facilities that belong to a facility group' do
-        facilities_without_group = FactoryBot.create_list(:facility, 5, facility_group: nil)
+        facilities_without_group = FactoryBot.create_list(:facility, 2, facility_group: nil)
         get :sync_to_user
 
         response_body = JSON(response.body)
@@ -40,11 +40,11 @@ RSpec.describe Api::Current::FacilitiesController, type: :controller do
       end
 
       it 'Returns new records added since last sync' do
-        expected_records = create_record_list(5, updated_at: 5.minutes.ago)
+        expected_records = create_record_list(2, updated_at: 5.minutes.ago)
         get :sync_to_user, params: { process_token: make_process_token({ other_facilities_processed_since: 10.minutes.ago }) }
 
         response_body = JSON(response.body)
-        expect(response_body[response_key].count).to eq 5
+        expect(response_body[response_key].count).to eq 2
 
         expect(response_body[response_key].map { |record| record['id'] }.to_set)
           .to eq(expected_records.map(&:id).to_set)
@@ -76,14 +76,14 @@ RSpec.describe Api::Current::FacilitiesController, type: :controller do
         it 'Returns all the records on server over multiple small batches' do
           get :sync_to_user, params: {
             process_token: make_process_token({ other_facilities_processed_since: 20.minutes.ago }),
-            limit: 7
+            limit: 2
           }
 
           response_1 = JSON(response.body)
 
           get :sync_to_user, params: {
             process_token: response_1['process_token'],
-            limit: 8
+            limit: 5
           }
           response_2 = JSON(response.body)
 

--- a/spec/controllers/api/current/medical_histories_controller_spec.rb
+++ b/spec/controllers/api/current/medical_histories_controller_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe Api::Current::MedicalHistoriesController, type: :controller do
     before :each do
       set_authentication_headers
 
-      FactoryBot.create_list(:medical_history, 5, patient: patient_in_request_facility, updated_at: 7.minutes.ago)
-      FactoryBot.create_list(:medical_history, 5, patient: patient_in_same_group, updated_at: 5.minutes.ago)
-      FactoryBot.create_list(:medical_history, 5, patient: patient_in_another_group, updated_at: 3.minutes.ago)
+      FactoryBot.create_list(:medical_history, 2, patient: patient_in_request_facility, updated_at: 7.minutes.ago)
+      FactoryBot.create_list(:medical_history, 2, patient: patient_in_same_group, updated_at: 5.minutes.ago)
+      FactoryBot.create_list(:medical_history, 2, patient: patient_in_another_group, updated_at: 3.minutes.ago)
     end
 
     it "only sends data for facilities belonging in the sync group of user's registration facility" do
@@ -64,7 +64,7 @@ RSpec.describe Api::Current::MedicalHistoriesController, type: :controller do
       response_medical_histories = JSON(response.body)['medical_histories']
       response_patients = response_medical_histories.map { |medical_history| medical_history['patient_id'] }.to_set
 
-      expect(response_medical_histories.count).to eq 10
+      expect(response_medical_histories.count).to eq 4
       expect(response_patients).not_to include(patient_in_another_group.id)
     end
   end

--- a/spec/controllers/api/current/patients_controller_spec.rb
+++ b/spec/controllers/api/current/patients_controller_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe Api::Current::PatientsController, type: :controller do
       end
 
       it 'creates new patients' do
-        patients = (1..10).map { build_patient_payload }
+        patients = (1..3).map { build_patient_payload }
         post(:sync_from_user, params: { patients: patients }, as: :json)
-        expect(Patient.count).to eq 10
-        expect(Address.count).to eq 10
+        expect(Patient.count).to eq 3
+        expect(Address.count).to eq 3
         expect(PatientPhoneNumber.count).to eq(patients.sum { |patient| patient['phone_numbers'].count })
         expect(response).to have_http_status(200)
       end
@@ -124,7 +124,7 @@ RSpec.describe Api::Current::PatientsController, type: :controller do
         request.env['HTTP_AUTHORIZATION'] = "Bearer #{request_user.access_token}"
       end
 
-      let(:existing_patients) { FactoryBot.create_list(:patient, 10) }
+      let(:existing_patients) { FactoryBot.create_list(:patient, 3) }
       let(:updated_patients_payload) { existing_patients.map { |patient| updated_patient_payload patient } }
 
       it 'with only updated patient attributes' do
@@ -160,7 +160,7 @@ RSpec.describe Api::Current::PatientsController, type: :controller do
         sync_time = Time.now
         post :sync_from_user, params: { patients: patients_payload }, as: :json
 
-        expect(PatientPhoneNumber.updated_on_server_since(sync_time).count).to eq 10
+        expect(PatientPhoneNumber.updated_on_server_since(sync_time).count).to eq 3
         patients_payload.each do |updated_patient|
           updated_phone_number = updated_patient['phone_numbers'].first
           db_phone_number = PatientPhoneNumber.find(updated_phone_number['id'])
@@ -201,7 +201,7 @@ RSpec.describe Api::Current::PatientsController, type: :controller do
         end
 
         it 'updates phone numbers' do
-          expect(PatientPhoneNumber.updated_on_server_since(sync_time).count).to eq 10
+          expect(PatientPhoneNumber.updated_on_server_since(sync_time).count).to eq 3
 
           patients_payload.each do |updated_patient|
             updated_patient.with_int_timestamps
@@ -214,7 +214,7 @@ RSpec.describe Api::Current::PatientsController, type: :controller do
         end
 
         it 'updates business identifiers' do
-          expect(PatientBusinessIdentifier.updated_on_server_since(sync_time).count).to eq 10
+          expect(PatientBusinessIdentifier.updated_on_server_since(sync_time).count).to eq 3
 
           patients_payload.each do |updated_patient|
             updated_patient.with_int_timestamps
@@ -258,28 +258,28 @@ RSpec.describe Api::Current::PatientsController, type: :controller do
     describe 'current facility prioritisation' do
       it "syncs request facility's records first" do
         request_2_facility = FactoryBot.create(:facility, facility_group: request_user.facility.facility_group)
-        FactoryBot.create_list(:patient, 5, registration_facility: request_2_facility, updated_at: 3.minutes.ago)
-        FactoryBot.create_list(:patient, 5, registration_facility: request_2_facility, updated_at: 5.minutes.ago)
-        FactoryBot.create_list(:patient, 5, registration_facility: request_facility, updated_at: 7.minutes.ago)
-        FactoryBot.create_list(:patient, 5, registration_facility: request_facility, updated_at: 10.minutes.ago)
+        FactoryBot.create_list(:patient, 2, registration_facility: request_2_facility, updated_at: 3.minutes.ago)
+        FactoryBot.create_list(:patient, 2, registration_facility: request_2_facility, updated_at: 5.minutes.ago)
+        FactoryBot.create_list(:patient, 2, registration_facility: request_facility, updated_at: 7.minutes.ago)
+        FactoryBot.create_list(:patient, 2, registration_facility: request_facility, updated_at: 10.minutes.ago)
 
         # GET request 1
         set_authentication_headers
-        get :sync_to_user, params: { limit: 10 }
+        get :sync_to_user, params: { limit: 4 }
         response_1_body = JSON(response.body)
 
         record_ids = response_1_body['patients'].map { |r| r['id'] }
         records = model.where(id: record_ids)
-        expect(records.count).to eq 10
+        expect(records.count).to eq 4
         expect(records.map(&:registration_facility).to_set).to eq Set[request_facility]
 
         # GET request 2
-        get :sync_to_user, params: { limit: 10, process_token: response_1_body['process_token'] }
+        get :sync_to_user, params: { limit: 4, process_token: response_1_body['process_token'] }
         response_2_body = JSON(response.body)
 
         record_ids = response_2_body['patients'].map { |r| r['id'] }
         records = model.where(id: record_ids)
-        expect(records.count).to eq 10
+        expect(records.count).to eq 4
         expect(records.map(&:registration_facility).to_set).to eq Set[request_facility, request_2_facility]
       end
     end
@@ -288,12 +288,12 @@ RSpec.describe Api::Current::PatientsController, type: :controller do
       let(:facility_in_same_group) { FactoryBot.create(:facility, facility_group: request_user.facility.facility_group) }
       let(:facility_in_another_group) { FactoryBot.create(:facility) }
 
-      let(:patients_in_another_group) { FactoryBot.create_list(:patient, 5, registration_facility: facility_in_another_group, updated_at: 3.minutes.ago) }
+      let(:patients_in_another_group) { FactoryBot.create_list(:patient, 2, registration_facility: facility_in_another_group, updated_at: 3.minutes.ago) }
 
       before :each do
         set_authentication_headers
-        FactoryBot.create_list(:patient, 5, registration_facility: request_facility, updated_at: 7.minutes.ago)
-        FactoryBot.create_list(:patient, 5, registration_facility: facility_in_same_group, updated_at: 5.minutes.ago)
+        FactoryBot.create_list(:patient, 2, registration_facility: request_facility, updated_at: 7.minutes.ago)
+        FactoryBot.create_list(:patient, 2, registration_facility: facility_in_same_group, updated_at: 5.minutes.ago)
       end
 
       it "only sends data for facilities belonging in the sync group of user's registration facility" do
@@ -302,7 +302,7 @@ RSpec.describe Api::Current::PatientsController, type: :controller do
         response_patients = JSON(response.body)['patients']
         response_ids = response_patients.map { |patient| patient['id'] }.to_set
 
-        expect(response_ids.count).to eq 10
+        expect(response_ids.count).to eq 4
         patients_in_another_group.map(&:id).each do |patient_in_another_group_id|
           expect(response_ids).not_to include(patient_in_another_group_id)
         end

--- a/spec/controllers/api/current/prescription_drugs_controller_spec.rb
+++ b/spec/controllers/api/current/prescription_drugs_controller_spec.rb
@@ -37,15 +37,15 @@ RSpec.describe Api::Current::PrescriptionDrugsController, type: :controller do
 
         patient = FactoryBot.create(:patient)
         facility = FactoryBot.create(:facility)
-        prescription_drugs = (1..10).map do
+        prescription_drugs = (1..3).map do
           build_prescription_drug_payload(FactoryBot.build(:prescription_drug,
                                                            patient: patient,
                                                            facility: facility))
         end
         post(:sync_from_user, params: { prescription_drugs: prescription_drugs }, as: :json)
-        expect(PrescriptionDrug.count).to eq 10
-        expect(patient.prescription_drugs.count).to eq 10
-        expect(facility.prescription_drugs.count).to eq 10
+        expect(PrescriptionDrug.count).to eq 3
+        expect(patient.prescription_drugs.count).to eq 3
+        expect(facility.prescription_drugs.count).to eq 3
         expect(response).to have_http_status(200)
       end
     end
@@ -57,28 +57,28 @@ RSpec.describe Api::Current::PrescriptionDrugsController, type: :controller do
     describe 'current facility prioritisation' do
       it "syncs request facility's records first" do
         request_2_facility = FactoryBot.create(:facility, facility_group: request_user.facility.facility_group)
-        FactoryBot.create_list(:prescription_drug, 5, facility: request_facility, updated_at: 3.minutes.ago)
-        FactoryBot.create_list(:prescription_drug, 5, facility: request_facility, updated_at: 5.minutes.ago)
-        FactoryBot.create_list(:prescription_drug, 5, facility: request_2_facility, updated_at: 7.minutes.ago)
-        FactoryBot.create_list(:prescription_drug, 5, facility: request_2_facility, updated_at: 10.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: request_facility, updated_at: 3.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: request_facility, updated_at: 5.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: request_2_facility, updated_at: 7.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: request_2_facility, updated_at: 10.minutes.ago)
 
         # GET request 1
         set_authentication_headers
-        get :sync_to_user, params: { limit: 10 }
+        get :sync_to_user, params: { limit: 4 }
         response_1_body = JSON(response.body)
 
         record_ids = response_1_body['prescription_drugs'].map { |r| r['id'] }
         records = model.where(id: record_ids)
-        expect(records.count).to eq 10
+        expect(records.count).to eq 4
         expect(records.map(&:facility).to_set).to eq Set[request_facility]
 
         # GET request 2
-        get :sync_to_user, params: { limit: 10, process_token: response_1_body['process_token'] }
+        get :sync_to_user, params: { limit: 4, process_token: response_1_body['process_token'] }
         response_2_body = JSON(response.body)
 
         record_ids = response_2_body['prescription_drugs'].map { |r| r['id'] }
         records = model.where(id: record_ids)
-        expect(records.count).to eq 10
+        expect(records.count).to eq 4
         expect(records.map(&:facility).to_set).to eq Set[request_facility, request_2_facility]
       end
     end
@@ -89,9 +89,9 @@ RSpec.describe Api::Current::PrescriptionDrugsController, type: :controller do
 
       before :each do
         set_authentication_headers
-        FactoryBot.create_list(:prescription_drug, 5, facility: facility_in_another_group, updated_at: 3.minutes.ago)
-        FactoryBot.create_list(:prescription_drug, 5, facility: facility_in_same_group, updated_at: 5.minutes.ago)
-        FactoryBot.create_list(:prescription_drug, 5, facility: request_facility, updated_at: 7.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: facility_in_another_group, updated_at: 3.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: facility_in_same_group, updated_at: 5.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: request_facility, updated_at: 7.minutes.ago)
       end
 
       it "only sends data for facilities belonging in the sync group of user's registration facility" do
@@ -100,7 +100,7 @@ RSpec.describe Api::Current::PrescriptionDrugsController, type: :controller do
         response_prescription_drugs = JSON(response.body)['prescription_drugs']
         response_facilities = response_prescription_drugs.map { |prescription_drug| prescription_drug['facility_id']}.to_set
 
-        expect(response_prescription_drugs.count).to eq 10
+        expect(response_prescription_drugs.count).to eq 4
         expect(response_facilities).to match_array([request_facility.id, facility_in_same_group.id])
         expect(response_facilities).not_to include(facility_in_another_group.id)
       end

--- a/spec/controllers/api/current/users_controller_spec.rb
+++ b/spec/controllers/api/current/users_controller_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Api::Current::UsersController, type: :controller do
   describe '#find' do
     let(:phone_number) { Faker::PhoneNumber.phone_number }
     let(:facility) { FactoryBot.create(:facility) }
-    let!(:db_users) { FactoryBot.create_list(:user, 10, registration_facility_id: facility.id) }
+    let!(:db_users) { FactoryBot.create_list(:user, 3, registration_facility_id: facility.id) }
     let!(:user) { FactoryBot.create(:user, phone_number: phone_number, registration_facility_id: facility.id) }
 
     it 'lists the users with the given phone number' do

--- a/spec/controllers/api/v1/blood_pressures_controller_spec.rb
+++ b/spec/controllers/api/v1/blood_pressures_controller_spec.rb
@@ -50,12 +50,12 @@ RSpec.describe Api::V1::BloodPressuresController, type: :controller do
     describe 'creates new blood pressures' do
       it 'creates new blood pressures with associated patient' do
         patient = FactoryBot.create(:patient)
-        blood_pressures = (1..10).map do
+        blood_pressures = (1..3).map do
           build_blood_pressure_payload_v1(FactoryBot.build(:blood_pressure, patient: patient))
         end
         post(:sync_from_user, params: { blood_pressures: blood_pressures }, as: :json)
-        expect(BloodPressure.count).to eq 10
-        expect(patient.blood_pressures.count).to eq 10
+        expect(BloodPressure.count).to eq 3
+        expect(patient.blood_pressures.count).to eq 3
         expect(response).to have_http_status(200)
       end
 
@@ -112,8 +112,8 @@ RSpec.describe Api::V1::BloodPressuresController, type: :controller do
 
     before :each do
       set_authentication_headers
-      FactoryBot.create_list(:blood_pressure, 5, facility: facility_in_another_group, updated_at: 3.minutes.ago)
-      FactoryBot.create_list(:blood_pressure, 5, facility: facility_in_same_group, updated_at: 5.minutes.ago)
+      FactoryBot.create_list(:blood_pressure, 2, facility: facility_in_another_group, updated_at: 3.minutes.ago)
+      FactoryBot.create_list(:blood_pressure, 2, facility: facility_in_same_group, updated_at: 5.minutes.ago)
     end
 
     it "only sends data for facilities belonging in the sync group of user's registration facility" do
@@ -122,7 +122,7 @@ RSpec.describe Api::V1::BloodPressuresController, type: :controller do
       response_blood_pressures = JSON(response.body)['blood_pressures']
       response_facilities = response_blood_pressures.map { |blood_pressure| blood_pressure['facility_id']}.to_set
 
-      expect(response_blood_pressures.count).to eq 5
+      expect(response_blood_pressures.count).to eq 2
       expect(response_facilities).not_to include(facility_in_another_group.id)
     end
   end

--- a/spec/controllers/api/v1/facilities_controller_spec.rb
+++ b/spec/controllers/api/v1/facilities_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::FacilitiesController, type: :controller do
   describe 'a working V1 sync controller sending records' do
     before :each do
       Timecop.travel(15.minutes.ago) do
-        create_record_list(10)
+        create_record_list(2)
       end
     end
 
@@ -28,7 +28,7 @@ RSpec.describe Api::V1::FacilitiesController, type: :controller do
       end
 
       it 'only sends facilities that belong to a facility group' do
-        facilities_without_group = FactoryBot.create_list(:facility, 5, facility_group: nil)
+        facilities_without_group = FactoryBot.create_list(:facility, 2, facility_group: nil)
         get :sync_to_user
 
         response_body = JSON(response.body)
@@ -37,11 +37,11 @@ RSpec.describe Api::V1::FacilitiesController, type: :controller do
       end
 
       it 'Returns new records added since last sync' do
-        expected_records = create_record_list(5, updated_at: 5.minutes.ago)
+        expected_records = create_record_list(2, updated_at: 5.minutes.ago)
         get :sync_to_user, params: { processed_since: 10.minutes.ago }
 
         response_body = JSON(response.body)
-        expect(response_body[response_key].count).to eq 5
+        expect(response_body[response_key].count).to eq 2
 
         expect(response_body[response_key].map { |record| record['id'] }.to_set)
           .to eq(expected_records.map(&:id).to_set)
@@ -71,7 +71,7 @@ RSpec.describe Api::V1::FacilitiesController, type: :controller do
         it 'Returns all the records on server over multiple small batches' do
           get :sync_to_user, params: {
             processed_since: 20.minutes.ago,
-            limit: 7
+            limit: 2
           }
           response_1 = JSON(response.body)
 

--- a/spec/controllers/api/v1/medical_histories_controller_spec.rb
+++ b/spec/controllers/api/v1/medical_histories_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Api::V1::MedicalHistoriesController, type: :controller do
 
     describe 'updates records' do
       let(:existing_records) do
-        FactoryBot.create_list(:medical_history, 10)
+        FactoryBot.create_list(:medical_history, 3)
       end
       let(:record_updates) { MedicalHistory::MEDICAL_HISTORY_QUESTIONS.map { |key| [key.to_s, %w(unknown yes).sample] }.to_h }
       let(:updated_records) { existing_records.map { |record| build_medical_history_payload_current(record).merge(record_updates).merge(updated_at: 10.minutes.from_now) } }
@@ -104,8 +104,8 @@ RSpec.describe Api::V1::MedicalHistoriesController, type: :controller do
       let(:false_medical_history_questions) { medical_history_questions.map { |key| [key, false] }.to_h }
       before :each do
         set_authentication_headers
-        FactoryBot.create_list(:medical_history, 10, :unknown)
-        FactoryBot.create_list(:medical_history, 10)
+        FactoryBot.create_list(:medical_history, 2, :unknown)
+        FactoryBot.create_list(:medical_history, 2)
       end
 
       it 'converts :unknown and :no to false in the response' do
@@ -129,8 +129,8 @@ RSpec.describe Api::V1::MedicalHistoriesController, type: :controller do
     before :each do
       set_authentication_headers
 
-      FactoryBot.create_list(:medical_history, 5, patient: patient_in_same_group, updated_at: 5.minutes.ago)
-      FactoryBot.create_list(:medical_history, 5, patient: patient_in_another_group, updated_at: 3.minutes.ago)
+      FactoryBot.create_list(:medical_history, 2, patient: patient_in_same_group, updated_at: 5.minutes.ago)
+      FactoryBot.create_list(:medical_history, 2, patient: patient_in_another_group, updated_at: 3.minutes.ago)
     end
 
     it "only sends data for facilities belonging in the sync group of user's registration facility" do
@@ -139,7 +139,7 @@ RSpec.describe Api::V1::MedicalHistoriesController, type: :controller do
       response_medical_histories = JSON(response.body)['medical_histories']
       response_patients = response_medical_histories.map { |medical_history| medical_history['patient_id'] }.to_set
 
-      expect(response_medical_histories.count).to eq 5
+      expect(response_medical_histories.count).to eq 2
       expect(response_patients).not_to include(patient_in_another_group.id)
     end
   end

--- a/spec/controllers/api/v1/prescription_drugs_controller_spec.rb
+++ b/spec/controllers/api/v1/prescription_drugs_controller_spec.rb
@@ -35,15 +35,15 @@ RSpec.describe Api::V1::PrescriptionDrugsController, type: :controller do
         
         patient            = FactoryBot.create(:patient)
         facility           = FactoryBot.create(:facility)
-        prescription_drugs = (1..10).map do
+        prescription_drugs = (1..3).map do
           build_prescription_drug_payload(FactoryBot.build(:prescription_drug,
                                                            patient:  patient,
                                                            facility: facility))
         end
         post(:sync_from_user, params: { prescription_drugs: prescription_drugs }, as: :json)
-        expect(PrescriptionDrug.count).to eq 10
-        expect(patient.prescription_drugs.count).to eq 10
-        expect(facility.prescription_drugs.count).to eq 10
+        expect(PrescriptionDrug.count).to eq 3
+        expect(patient.prescription_drugs.count).to eq 3
+        expect(facility.prescription_drugs.count).to eq 3
         expect(response).to have_http_status(200)
       end
     end
@@ -58,8 +58,8 @@ RSpec.describe Api::V1::PrescriptionDrugsController, type: :controller do
 
       before :each do
         set_authentication_headers
-        FactoryBot.create_list(:prescription_drug, 5, facility: facility_in_another_group, updated_at: 3.minutes.ago)
-        FactoryBot.create_list(:prescription_drug, 5, facility: facility_in_same_group, updated_at: 5.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: facility_in_another_group, updated_at: 3.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: facility_in_same_group, updated_at: 5.minutes.ago)
       end
 
       it "only sends data for facilities belonging in the sync group of user's registration facility" do
@@ -68,7 +68,7 @@ RSpec.describe Api::V1::PrescriptionDrugsController, type: :controller do
         response_prescription_drugs = JSON(response.body)['prescription_drugs']
         response_facilities = response_prescription_drugs.map { |prescription_drug| prescription_drug['facility_id']}.to_set
 
-        expect(response_prescription_drugs.count).to eq 5
+        expect(response_prescription_drugs.count).to eq 2
         expect(response_facilities).not_to include(facility_in_another_group.id)
       end
     end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
   describe '#find' do
     let(:phone_number) { Faker::PhoneNumber.phone_number }
     let(:facility) { FactoryBot.create(:facility) }
-    let!(:db_users) { FactoryBot.create_list(:user, 10, registration_facility_id: facility.id) }
+    let!(:db_users) { FactoryBot.create_list(:user, 3, registration_facility_id: facility.id) }
     let!(:user) { FactoryBot.create(:user, phone_number: phone_number, registration_facility_id: facility.id) }
 
     it 'lists the users with the given phone number' do

--- a/spec/controllers/api/v2/blood_pressures_controller_spec.rb
+++ b/spec/controllers/api/v2/blood_pressures_controller_spec.rb
@@ -58,12 +58,12 @@ RSpec.describe Api::V2::BloodPressuresController, type: :controller do
     describe 'creates new blood pressures' do
       it 'creates new blood pressures with associated patient' do
         patient = FactoryBot.create(:patient)
-        blood_pressures = (1..10).map do
+        blood_pressures = (1..3).map do
           build_blood_pressure_payload_v2(FactoryBot.build(:blood_pressure, patient: patient))
         end
         post(:sync_from_user, params: { blood_pressures: blood_pressures }, as: :json)
-        expect(BloodPressure.count).to eq 10
-        expect(patient.blood_pressures.count).to eq 10
+        expect(BloodPressure.count).to eq 3
+        expect(patient.blood_pressures.count).to eq 3
         expect(response).to have_http_status(200)
       end
 
@@ -115,28 +115,28 @@ RSpec.describe Api::V2::BloodPressuresController, type: :controller do
     describe 'v2 facility prioritisation' do
       it "syncs request facility's records first" do
         request_2_facility = FactoryBot.create(:facility, facility_group: request_user.facility.facility_group)
-        FactoryBot.create_list(:blood_pressure, 5, facility: request_facility, updated_at: 3.minutes.ago)
-        FactoryBot.create_list(:blood_pressure, 5, facility: request_facility, updated_at: 5.minutes.ago)
-        FactoryBot.create_list(:blood_pressure, 5, facility: request_2_facility, updated_at: 7.minutes.ago)
-        FactoryBot.create_list(:blood_pressure, 5, facility: request_2_facility, updated_at: 10.minutes.ago)
+        FactoryBot.create_list(:blood_pressure, 2, facility: request_facility, updated_at: 3.minutes.ago)
+        FactoryBot.create_list(:blood_pressure, 2, facility: request_facility, updated_at: 5.minutes.ago)
+        FactoryBot.create_list(:blood_pressure, 2, facility: request_2_facility, updated_at: 7.minutes.ago)
+        FactoryBot.create_list(:blood_pressure, 2, facility: request_2_facility, updated_at: 10.minutes.ago)
 
         # GET request 1
         set_authentication_headers
-        get :sync_to_user, params: { limit: 10 }
+        get :sync_to_user, params: { limit: 4 }
         response_1_body = JSON(response.body)
 
         record_ids = response_1_body['blood_pressures'].map { |r| r['id'] }
         records = model.where(id: record_ids)
-        expect(records.count).to eq 10
+        expect(records.count).to eq 4
         expect(records.map(&:facility).to_set).to eq Set[request_facility]
 
         # GET request 2
-        get :sync_to_user, params: { limit: 10, process_token: response_1_body['process_token'] }
+        get :sync_to_user, params: { limit: 4, process_token: response_1_body['process_token'] }
         response_2_body = JSON(response.body)
 
         record_ids = response_2_body['blood_pressures'].map { |r| r['id'] }
         records = model.where(id: record_ids)
-        expect(records.count).to eq 10
+        expect(records.count).to eq 4
         expect(records.map(&:facility).to_set).to eq Set[request_facility, request_2_facility]
       end
     end
@@ -147,18 +147,18 @@ RSpec.describe Api::V2::BloodPressuresController, type: :controller do
 
       before :each do
         set_authentication_headers
-        FactoryBot.create_list(:blood_pressure, 5, facility: facility_in_another_group, updated_at: 3.minutes.ago)
-        FactoryBot.create_list(:blood_pressure, 5, facility: facility_in_same_group, updated_at: 5.minutes.ago)
-        FactoryBot.create_list(:blood_pressure, 5, facility: request_facility, updated_at: 7.minutes.ago)
+        FactoryBot.create_list(:blood_pressure, 2, facility: facility_in_another_group, updated_at: 3.minutes.ago)
+        FactoryBot.create_list(:blood_pressure, 2, facility: facility_in_same_group, updated_at: 5.minutes.ago)
+        FactoryBot.create_list(:blood_pressure, 2, facility: request_facility, updated_at: 7.minutes.ago)
       end
 
       it "only sends data for facilities belonging in the sync group of user's registration facility" do
-        get :sync_to_user, params: { limit: 15 }
+        get :sync_to_user, params: { limit: 6 }
 
         response_blood_pressures = JSON(response.body)['blood_pressures']
         response_facilities = response_blood_pressures.map { |blood_pressure| blood_pressure['facility_id']}.to_set
 
-        expect(response_blood_pressures.count).to eq 10
+        expect(response_blood_pressures.count).to eq 4
         expect(response_facilities).to match_array([request_facility.id, facility_in_same_group.id])
         expect(response_facilities).not_to include(facility_in_another_group.id)
       end

--- a/spec/controllers/api/v2/facilities_controller_spec.rb
+++ b/spec/controllers/api/v2/facilities_controller_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Api::V2::FacilitiesController, type: :controller do
   describe 'a working V2 sync controller sending records' do
     before :each do
       Timecop.travel(15.minutes.ago) do
-        create_record_list(5)
+        create_record_list(2)
       end
       Timecop.travel(14.minutes.ago) do
-        create_record_list(5)
+        create_record_list(2)
       end
     end
 
@@ -31,7 +31,7 @@ RSpec.describe Api::V2::FacilitiesController, type: :controller do
       end
 
       it 'only sends facilities that belong to a facility group' do
-        facilities_without_group = FactoryBot.create_list(:facility, 5, facility_group: nil)
+        facilities_without_group = FactoryBot.create_list(:facility, 2, facility_group: nil)
         get :sync_to_user
 
         response_body = JSON(response.body)
@@ -40,11 +40,11 @@ RSpec.describe Api::V2::FacilitiesController, type: :controller do
       end
 
       it 'Returns new records added since last sync' do
-        expected_records = create_record_list(5, updated_at: 5.minutes.ago)
+        expected_records = create_record_list(2, updated_at: 5.minutes.ago)
         get :sync_to_user, params: { process_token: make_process_token({ other_facilities_processed_since: 10.minutes.ago }) }
 
         response_body = JSON(response.body)
-        expect(response_body[response_key].count).to eq 5
+        expect(response_body[response_key].count).to eq 2
 
         expect(response_body[response_key].map { |record| record['id'] }.to_set)
           .to eq(expected_records.map(&:id).to_set)
@@ -76,7 +76,7 @@ RSpec.describe Api::V2::FacilitiesController, type: :controller do
         it 'Returns all the records on server over multiple small batches' do
           get :sync_to_user, params: {
             process_token: make_process_token({ other_facilities_processed_since: 20.minutes.ago }),
-            limit: 7
+            limit: 2
           }
 
           response_1 = JSON(response.body)

--- a/spec/controllers/api/v2/medical_histories_controller_spec.rb
+++ b/spec/controllers/api/v2/medical_histories_controller_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe Api::V2::MedicalHistoriesController, type: :controller do
     before :each do
       set_authentication_headers
 
-      FactoryBot.create_list(:medical_history, 5, patient: patient_in_request_facility, updated_at: 7.minutes.ago)
-      FactoryBot.create_list(:medical_history, 5, patient: patient_in_same_group, updated_at: 5.minutes.ago)
-      FactoryBot.create_list(:medical_history, 5, patient: patient_in_another_group, updated_at: 3.minutes.ago)
+      FactoryBot.create_list(:medical_history, 2, patient: patient_in_request_facility, updated_at: 7.minutes.ago)
+      FactoryBot.create_list(:medical_history, 2, patient: patient_in_same_group, updated_at: 5.minutes.ago)
+      FactoryBot.create_list(:medical_history, 2, patient: patient_in_another_group, updated_at: 3.minutes.ago)
     end
 
     it "only sends data for facilities belonging in the sync group of user's registration facility" do
@@ -64,7 +64,7 @@ RSpec.describe Api::V2::MedicalHistoriesController, type: :controller do
       response_medical_histories = JSON(response.body)['medical_histories']
       response_patients = response_medical_histories.map { |medical_history| medical_history['patient_id'] }.to_set
 
-      expect(response_medical_histories.count).to eq 10
+      expect(response_medical_histories.count).to eq 4
       expect(response_patients).not_to include(patient_in_another_group.id)
     end
   end

--- a/spec/controllers/api/v2/prescription_drugs_controller_spec.rb
+++ b/spec/controllers/api/v2/prescription_drugs_controller_spec.rb
@@ -37,15 +37,15 @@ RSpec.describe Api::V2::PrescriptionDrugsController, type: :controller do
 
         patient = FactoryBot.create(:patient)
         facility = FactoryBot.create(:facility)
-        prescription_drugs = (1..10).map do
+        prescription_drugs = (1..3).map do
           build_prescription_drug_payload(FactoryBot.build(:prescription_drug,
                                                            patient: patient,
                                                            facility: facility))
         end
         post(:sync_from_user, params: { prescription_drugs: prescription_drugs }, as: :json)
-        expect(PrescriptionDrug.count).to eq 10
-        expect(patient.prescription_drugs.count).to eq 10
-        expect(facility.prescription_drugs.count).to eq 10
+        expect(PrescriptionDrug.count).to eq 3
+        expect(patient.prescription_drugs.count).to eq 3
+        expect(facility.prescription_drugs.count).to eq 3
         expect(response).to have_http_status(200)
       end
     end
@@ -57,28 +57,28 @@ RSpec.describe Api::V2::PrescriptionDrugsController, type: :controller do
     describe 'v2 facility prioritisation' do
       it "syncs request facility's records first" do
         request_2_facility = FactoryBot.create(:facility, facility_group: request_user.facility.facility_group)
-        FactoryBot.create_list(:prescription_drug, 5, facility: request_facility, updated_at: 3.minutes.ago)
-        FactoryBot.create_list(:prescription_drug, 5, facility: request_facility, updated_at: 5.minutes.ago)
-        FactoryBot.create_list(:prescription_drug, 5, facility: request_2_facility, updated_at: 7.minutes.ago)
-        FactoryBot.create_list(:prescription_drug, 5, facility: request_2_facility, updated_at: 10.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: request_facility, updated_at: 3.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: request_facility, updated_at: 5.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: request_2_facility, updated_at: 7.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: request_2_facility, updated_at: 10.minutes.ago)
 
         # GET request 1
         set_authentication_headers
-        get :sync_to_user, params: { limit: 10 }
+        get :sync_to_user, params: { limit: 4 }
         response_1_body = JSON(response.body)
 
         record_ids = response_1_body['prescription_drugs'].map { |r| r['id'] }
         records = model.where(id: record_ids)
-        expect(records.count).to eq 10
+        expect(records.count).to eq 4
         expect(records.map(&:facility).to_set).to eq Set[request_facility]
 
         # GET request 2
-        get :sync_to_user, params: { limit: 10, process_token: response_1_body['process_token'] }
+        get :sync_to_user, params: { limit: 4, process_token: response_1_body['process_token'] }
         response_2_body = JSON(response.body)
 
         record_ids = response_2_body['prescription_drugs'].map { |r| r['id'] }
         records = model.where(id: record_ids)
-        expect(records.count).to eq 10
+        expect(records.count).to eq 4
         expect(records.map(&:facility).to_set).to eq Set[request_facility, request_2_facility]
       end
     end
@@ -89,9 +89,9 @@ RSpec.describe Api::V2::PrescriptionDrugsController, type: :controller do
 
       before :each do
         set_authentication_headers
-        FactoryBot.create_list(:prescription_drug, 5, facility: facility_in_another_group, updated_at: 3.minutes.ago)
-        FactoryBot.create_list(:prescription_drug, 5, facility: facility_in_same_group, updated_at: 5.minutes.ago)
-        FactoryBot.create_list(:prescription_drug, 5, facility: request_facility, updated_at: 7.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: facility_in_another_group, updated_at: 3.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: facility_in_same_group, updated_at: 5.minutes.ago)
+        FactoryBot.create_list(:prescription_drug, 2, facility: request_facility, updated_at: 7.minutes.ago)
       end
 
       it "only sends data for facilities belonging in the sync group of user's registration facility" do
@@ -100,7 +100,7 @@ RSpec.describe Api::V2::PrescriptionDrugsController, type: :controller do
         response_prescription_drugs = JSON(response.body)['prescription_drugs']
         response_facilities = response_prescription_drugs.map { |prescription_drug| prescription_drug['facility_id']}.to_set
 
-        expect(response_prescription_drugs.count).to eq 10
+        expect(response_prescription_drugs.count).to eq 4
         expect(response_facilities).to match_array([request_facility.id, facility_in_same_group.id])
         expect(response_facilities).not_to include(facility_in_another_group.id)
       end

--- a/spec/controllers/api/v2/users_controller_spec.rb
+++ b/spec/controllers/api/v2/users_controller_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Api::V2::UsersController, type: :controller do
   describe '#find' do
     let(:phone_number) { Faker::PhoneNumber.phone_number }
     let(:facility) { FactoryBot.create(:facility) }
-    let!(:db_users) { FactoryBot.create_list(:user, 10, registration_facility_id: facility.id) }
+    let!(:db_users) { FactoryBot.create_list(:user, 3, registration_facility_id: facility.id) }
     let!(:user) { FactoryBot.create(:user, phone_number: phone_number, registration_facility_id: facility.id) }
 
     it 'lists the users with the given phone number' do

--- a/spec/controllers/appointments_controller_spec.rb
+++ b/spec/controllers/appointments_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AppointmentsController, type: :controller do
 
     let!(:facility_1) { create(:facility, facility_group: facility_group) }
     let!(:overdue_appointments_in_facility_1) do
-      appointments = create_list(:appointment, 10, :overdue, facility: facility_1)
+      appointments = create_list(:appointment, 3, :overdue, facility: facility_1)
       appointments.each do |appointment|
         create(:blood_pressure, patient: appointment.patient, facility: facility_1)
         create(:blood_pressure, patient: appointment.patient, facility: facility_1)
@@ -23,7 +23,7 @@ RSpec.describe AppointmentsController, type: :controller do
 
     let!(:facility_2) { create(:facility, facility_group: facility_group) }
     let!(:overdue_appointments_in_facility_2) do
-      appointments = create_list(:appointment, 10, :overdue, facility: facility_2)
+      appointments = create_list(:appointment, 3, :overdue, facility: facility_2)
       appointments.each do |appointment|
         create(:blood_pressure, patient: appointment.patient, facility: facility_2)
         create(:blood_pressure, patient: appointment.patient, facility: facility_2)
@@ -63,16 +63,18 @@ RSpec.describe AppointmentsController, type: :controller do
     end
 
     describe 'pagination' do
-      it 'shows 20 records per page by default' do
+      it 'shows "Pagination::DEFAULT_PAGE_SIZE" records per page' do
+        stub_const("Pagination::DEFAULT_PAGE_SIZE", 5)
         get :index, params: {}
 
-        expect(response.body.scan(/recorded at/).length).to be(20)
+        expect(response.body.scan(/recorded at/).length).to be(5)
       end
 
       it 'shows the selected number of records per page' do
+        stub_const("Pagination::DEFAULT_PAGE_SIZE", 5)
         get :index, params: { per_page: 50 }
 
-        expect(response.body.scan(/recorded at/).length).to be(20)
+        expect(response.body.scan(/recorded at/).length).to be(6)
       end
 
       it 'shows all records if All is selected' do

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PatientsController, type: :controller do
 
     let!(:facility_1) { create(:facility, facility_group: facility_group) }
     let!(:patients_to_followup_in_facility_1) do
-      patients = create_list(:patient, 50,
+      patients = create_list(:patient, 3,
                              registration_facility: facility_1,
                              device_created_at: 10.days.ago)
       patients.each do |patient|
@@ -24,7 +24,7 @@ RSpec.describe PatientsController, type: :controller do
 
     let!(:facility_2) { create(:facility, facility_group: facility_group) }
     let!(:patients_to_followup_in_facility_2) do
-      patients = create_list(:patient, 50,
+      patients = create_list(:patient, 3,
                              registration_facility: facility_2,
                              device_created_at: 10.days.ago)
       patients.each do |patient|
@@ -59,16 +59,18 @@ RSpec.describe PatientsController, type: :controller do
     end
 
     describe 'pagination' do
-      it 'shows 20 records per page by default' do
+      it 'shows "Pagination::DEFAULT_PAGE_SIZE" records per page by default' do
+        stub_const("Pagination::DEFAULT_PAGE_SIZE", 5)
         get :index, params: {}
 
-        expect(response.body.scan(/recorded at/).length).to be(20)
+        expect(response.body.scan(/recorded at/).length).to be(5)
       end
 
       it 'shows the selected number of records per page' do
+        stub_const("Pagination::DEFAULT_PAGE_SIZE", 5)
         get :index, params: { per_page: 50 }
 
-        expect(response.body.scan(/recorded at/).length).to be(50)
+        expect(response.body.scan(/recorded at/).length).to be(6)
       end
 
       it 'shows all records if All is selected' do

--- a/spec/models/analytics/patient_set_analytics_spec.rb
+++ b/spec/models/analytics/patient_set_analytics_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Analytics::PatientSetAnalytics do
   before do
     # old patients recorded as hypertensive
     old_patients = Timecop.travel(one_year_ago) do
-      old_patients = create_list(:patient, 5)
+      old_patients = create_list(:patient, 3)
       old_patients.each { |patient| create(:blood_pressure, :high, patient: patient) }
       old_patients
     end
@@ -29,7 +29,7 @@ RSpec.describe Analytics::PatientSetAnalytics do
     # newly enrolled patients each month
     [first_jan, first_feb, first_mar].each do |first_of_month|
       Timecop.travel(first_of_month) do
-        patients = create_list(:patient, 5)
+        patients = create_list(:patient, 2)
         patients.each do |patient|
           create(:blood_pressure,
                  :under_control,
@@ -51,13 +51,13 @@ RSpec.describe Analytics::PatientSetAnalytics do
 
   describe '#unique_patients_count' do
     it 'returns the number of unique patients in the list' do
-      expect(analytics.unique_patients_count).to eq(20)
+      expect(analytics.unique_patients_count).to eq(9)
     end
   end
 
   describe '#newly_enrolled_patients_count' do
     it 'returns the number of patients newly enrolled in the period' do
-      expect(analytics.newly_enrolled_patients_count).to eq(15)
+      expect(analytics.newly_enrolled_patients_count).to eq(6)
     end
   end
 
@@ -65,9 +65,9 @@ RSpec.describe Analytics::PatientSetAnalytics do
     it 'returns the number of patients newly enrolled per month' do
       expect(analytics.newly_enrolled_patients_count_per_month(4))
         .to include(first_dec_prev_year => 0,
-                    first_jan => 5,
-                    first_feb => 5,
-                    first_mar => 5)
+                    first_jan => 2,
+                    first_feb => 2,
+                    first_mar => 2)
     end
   end
 
@@ -79,17 +79,17 @@ RSpec.describe Analytics::PatientSetAnalytics do
 
   describe '#non_returning_hypertensive_patients_count' do
     it 'return the number of patients enrolled as hypertensives that have not had a BP recorded in the period' do
-      expect(analytics.non_returning_hypertensive_patients_count).to eq(3)
+      expect(analytics.non_returning_hypertensive_patients_count).to eq(1)
     end
   end
 
   describe '#non_returning_hypertensive_patients_count_per_month' do
     it 'return the number of patients enrolled as hypertensives that have not had a BP recorded per month' do
       expect(analytics.non_returning_hypertensive_patients_count_per_month(4))
-        .to eq(first_dec_prev_year => 3,
-               first_jan => 3,
-               first_feb => 4,
-               first_mar => 4)
+        .to eq(first_dec_prev_year => 1,
+               first_jan => 1,
+               first_feb => 2,
+               first_mar => 2)
     end
   end
 
@@ -100,11 +100,11 @@ RSpec.describe Analytics::PatientSetAnalytics do
         Date.new(2019, 1, 06) => 0,
         Date.new(2019, 1, 13) => 0,
         Date.new(2019, 1, 20) => 0,
-        Date.new(2019, 1, 27) => 5,
+        Date.new(2019, 1, 27) => 2,
         Date.new(2019, 2, 03) => 0,
         Date.new(2019, 2, 10) => 0,
         Date.new(2019, 2, 17) => 0,
-        Date.new(2019, 2, 24) => 5,
+        Date.new(2019, 2, 24) => 2,
         Date.new(2019, 3, 03) => 0,
         Date.new(2019, 3, 10) => 0,
         Date.new(2019, 3, 17) => 0,
@@ -122,7 +122,7 @@ RSpec.describe Analytics::PatientSetAnalytics do
 
       Timecop.travel(from_time - ControlRateQuery::COHORT_DELTA) do
         # newly enrolled patients in the cohort
-        cohort_patients = create_list(:patient, 5)
+        cohort_patients = create_list(:patient, 3)
         cohort_patients.each { |patient| create(:blood_pressure, :high, patient: patient) }
       end
 
@@ -137,20 +137,20 @@ RSpec.describe Analytics::PatientSetAnalytics do
       context 'number of patients now under control / number of hypertensives patients recorded in cohort' do
         it 'returns the control rate for the set of patients in the period' do
           expect(analytics.control_rate)
-            .to eq(control_rate: 20,
-                   hypertensive_patients_in_cohort: 5,
+            .to eq(control_rate: 33,
+                   hypertensive_patients_in_cohort: 3,
                    patients_under_control_in_period: 1)
         end
       end
     end
 
     describe '#control_rate_per_month' do
-      it 'returns the number of blood pressures recorded per week for a group of patients' do
+      it 'returns the control rate per month for a group of patients' do
         expected_counts = {
           Date.new(2018, 10, 1) => 0,
           Date.new(2018, 11, 1) => 0,
           Date.new(2018, 12, 1) => 0,
-          Date.new(2019, 1, 1) => 20,
+          Date.new(2019, 1, 1) => 33,
           Date.new(2019, 2, 1) => 0,
           Date.new(2019, 3, 1) => 0,
         }

--- a/spec/models/analytics/user_analytics_spec.rb
+++ b/spec/models/analytics/user_analytics_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe Analytics::UserAnalytics do
   describe '#registered_patients_count' do
     it 'returns the number of patients registered by the user during the period' do
       Timecop.travel(from_time) do
-        create_list(:patient, 10, registration_user: user, registration_facility: facility)
+        create_list(:patient, 2, registration_user: user, registration_facility: facility)
       end
 
-      expect(user_analytics.registered_patients_count).to eq(10)
+      expect(user_analytics.registered_patients_count).to eq(2)
     end
   end
 

--- a/spec/policies/audit_log_policy_spec.rb
+++ b/spec/policies/audit_log_policy_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe AuditLogPolicy::Scope do
   let(:subject) { described_class }
 
   before :each do
-    FactoryBot.create_list(:audit_log, 20)
+    FactoryBot.create_list(:audit_log, 3)
   end
 
   describe "owner" do

--- a/spec/requests/api/current/patient_sync_spec.rb
+++ b/spec/requests/api/current/patient_sync_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe 'Patients sync', type: :request do
 
   include_examples 'current API sync requests'
 
-  it 'pushes 10 new patients, updates only address or phone numbers, and pulls updated ones' do
-    first_patients_payload = (1..10).map { build_payload.call }
+  it 'pushes 3 new patients, updates only address or phone numbers, and pulls updated ones' do
+    first_patients_payload = (1..3).map { build_payload.call }
     post sync_route, params: { patients: first_patients_payload }.to_json, headers: headers
     get sync_route, params: {}, headers: headers
     process_token = JSON(response.body)['process_token']

--- a/spec/requests/api/v1/patient_sync_spec.rb
+++ b/spec/requests/api/v1/patient_sync_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe 'Patients sync', type: :request do
 
   include_examples 'sync requests'
 
-  it 'pushes 10 new patients, updates only address or phone numbers, and pulls updated ones' do
-    first_patients_payload = (1..10).map { build_payload.call }
+  it 'pushes 3 new patients, updates only address or phone numbers, and pulls updated ones' do
+    first_patients_payload = (1..3).map { build_payload.call }
     post sync_route, params: { patients: first_patients_payload }.to_json, headers: headers
     get sync_route, params: {}, headers: headers
     processed_since = JSON(response.body)['processed_since']

--- a/spec/requests/api/v2/patient_sync_spec.rb
+++ b/spec/requests/api/v2/patient_sync_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe 'Patients sync', type: :request do
 
   include_examples 'v2 API sync requests'
 
-  it 'pushes 10 new patients, updates only address or phone numbers, and pulls updated ones' do
-    first_patients_payload = (1..10).map { build_payload.call }
+  it 'pushes 3 new patients, updates only address or phone numbers, and pulls updated ones' do
+    first_patients_payload = (1..3).map { build_payload.call }
     post sync_route, params: { patients: first_patients_payload }.to_json, headers: headers
     get sync_route, params: {}, headers: headers
     process_token = JSON(response.body)['process_token']

--- a/spec/requests/shared_examples/api/current/shared_spec_for_sync_requests.rb
+++ b/spec/requests/shared_examples/api/current/shared_spec_for_sync_requests.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples 'current API sync requests' do
   let(:response_key) { model.to_s.underscore.pluralize }
   let(:empty_payload) { Hash[response_key.to_sym, []] }
   let(:valid_payload) { Hash[response_key.to_sym, [build_payload.call]] }
-  let(:created_records) { (1..10).map { build_payload.call } }
+  let(:created_records) { (1..5).map { build_payload.call } }
   let(:many_valid_records) { Hash[response_key.to_sym, created_records] }
   let(:expected_response) do
     valid_payload[response_key.to_sym].map do |payload|
@@ -27,7 +27,7 @@ RSpec.shared_examples 'current API sync requests' do
   let(:updated_records) do
     model
       .find(created_records.map { |record| record['id'] })
-      .take(5)
+      .take(2)
       .map(&update_payload)
   end
   let(:updated_payload) { Hash[response_key.to_sym, updated_records] }
@@ -77,7 +77,7 @@ RSpec.shared_examples 'current API sync requests' do
     expect(response_process_token[:current_facility_processed_since].to_time.to_i).to eq(model.first.updated_at.to_i)
   end
 
-  it 'pushes 10 new records, updates 5, and pulls only updated ones' do
+  it 'pushes 5 new records, updates 2, and pulls only updated ones' do
     post sync_route, params: many_valid_records.to_json, headers: headers
     get sync_route, params: {}, headers: headers
     process_token = JSON(response.body)['process_token']
@@ -102,7 +102,7 @@ RSpec.shared_examples 'current API sync requests' do
       get sync_route, params: { process_token: process_token_without_resync }, headers: headers_with_resync_token
       response_body = JSON(response.body)
 
-      expect(response_body[response_key].count).to eq(10)
+      expect(response_body[response_key].count).to eq(5)
       expect(parse_process_token(response_body)[:resync_token]).to eq(resync_token)
     end
 
@@ -114,7 +114,7 @@ RSpec.shared_examples 'current API sync requests' do
           headers: headers_with_resync_token
       response_body = JSON(response.body)
 
-      expect(response_body[response_key].count).to eq(10)
+      expect(response_body[response_key].count).to eq(5)
       expect(parse_process_token(response_body)[:resync_token]).to eq(resync_token)
     end
 
@@ -150,7 +150,7 @@ RSpec.shared_examples 'current API sync requests' do
       get sync_route, params: { process_token: process_token_without_resync }, headers: headers
       response_body = JSON(response.body)
 
-      expect(response_body[response_key].count).to eq(10)
+      expect(response_body[response_key].count).to eq(5)
       expect(parse_process_token(response_body)[:resync_token]).to eq(nil)
 
       get sync_route, params: { process_token: JSON(response.body)['process_token'] }, headers: headers

--- a/spec/requests/shared_examples/api/v1/shared_spec_for_sync_requests.rb
+++ b/spec/requests/shared_examples/api/v1/shared_spec_for_sync_requests.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples 'sync requests' do
   let(:response_key) { model.to_s.underscore.pluralize }
   let(:empty_payload) { Hash[response_key.to_sym, []] }
   let(:valid_payload) { Hash[response_key.to_sym, [build_payload.call]] }
-  let(:created_records) { (1..10).map { build_payload.call } }
+  let(:created_records) { (1..5).map { build_payload.call } }
   let(:many_valid_records) { Hash[response_key.to_sym, created_records] }
   let(:expected_response) do
     valid_payload[response_key.to_sym].map do |payload|
@@ -27,7 +27,7 @@ RSpec.shared_examples 'sync requests' do
   let(:updated_records) do
     model
       .find(created_records.map { |record| record['id'] })
-      .take(5)
+      .take(2)
       .map(&update_payload)
   end
   let(:updated_payload) { Hash[response_key.to_sym, updated_records] }
@@ -72,7 +72,7 @@ RSpec.shared_examples 'sync requests' do
     expect(response_body['processed_since'].to_time.to_i).to eq(model.first.updated_at.to_i)
   end
 
-  it 'pushes 10 new blood_pressures, updates 5, and pulls only updated ones' do
+  it 'pushes 5 new blood_pressures, updates 2, and pulls only updated ones' do
     post sync_route, params: many_valid_records.to_json, headers: headers
     get sync_route, params: {}, headers: headers
     processed_since = JSON(response.body)['processed_since']

--- a/spec/requests/shared_examples/api/v2/shared_spec_for_sync_requests.rb
+++ b/spec/requests/shared_examples/api/v2/shared_spec_for_sync_requests.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples 'v2 API sync requests' do
   let(:response_key) { model.to_s.underscore.pluralize }
   let(:empty_payload) { Hash[response_key.to_sym, []] }
   let(:valid_payload) { Hash[response_key.to_sym, [build_payload.call]]}
-  let(:created_records) { (1..10).map { build_payload.call } }
+  let(:created_records) { (1..5).map { build_payload.call } }
   let(:many_valid_records) { Hash[response_key.to_sym, created_records] }
   let(:expected_response) do
     valid_payload[response_key.to_sym].map do |payload|
@@ -27,7 +27,7 @@ RSpec.shared_examples 'v2 API sync requests' do
   let(:updated_records) do
     model
       .find(created_records.map { |record| record['id'] })
-      .take(5)
+      .take(2)
       .map(&update_payload)
   end
   let(:updated_payload) { Hash[response_key.to_sym, updated_records] }
@@ -77,7 +77,7 @@ RSpec.shared_examples 'v2 API sync requests' do
     expect(response_process_token[:current_facility_processed_since].to_time.to_i).to eq(model.first.updated_at.to_i)
   end
 
-  it 'pushes 10 new blood_pressures, updates 5, and pulls only updated ones' do
+  it 'pushes 5 new blood_pressures, updates 2, and pulls only updated ones' do
     post sync_route, params: many_valid_records.to_json, headers: headers
     get sync_route, params: {}, headers: headers
     process_token = JSON(response.body)['process_token']
@@ -102,7 +102,7 @@ RSpec.shared_examples 'v2 API sync requests' do
       get sync_route, params: { process_token: process_token_without_resync }, headers: headers_with_resync_token
       response_body = JSON(response.body)
 
-      expect(response_body[response_key].count).to eq(10)
+      expect(response_body[response_key].count).to eq(5)
       expect(parse_process_token(response_body)[:resync_token]).to eq(resync_token)
     end
 
@@ -138,7 +138,7 @@ RSpec.shared_examples 'v2 API sync requests' do
       get sync_route, params: { process_token: process_token_without_resync }, headers: headers
       response_body = JSON(response.body)
 
-      expect(response_body[response_key].count).to eq(10)
+      expect(response_body[response_key].count).to eq(5)
       expect(parse_process_token(response_body)[:resync_token]).to eq(nil)
 
       get sync_route, params: { process_token: JSON(response.body)['process_token'] }, headers: headers

--- a/spec/services/appointment_notification_service_spec.rb
+++ b/spec/services/appointment_notification_service_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe AppointmentNotificationService do
     let!(:user) { create(:user) }
     let!(:facility_1) { create(:facility) }
     let!(:facility_2) { create(:facility) }
-    let!(:overdue_appointments_from_facility_1) { create_list(:appointment, 10, :overdue, facility: facility_1) }
-    let!(:overdue_appointments_from_facility_2) { create_list(:appointment, 10, :overdue, facility: facility_2) }
+    let!(:overdue_appointments_from_facility_1) { create_list(:appointment, 4, :overdue, facility: facility_1) }
+    let!(:overdue_appointments_from_facility_2) { create_list(:appointment, 4, :overdue, facility: facility_2) }
     let!(:overdue_appointments) { overdue_appointments_from_facility_1 + overdue_appointments_from_facility_2 }
     let!(:recently_overdue_appointments) do
       create_list(:appointment,
-                  10,
+                  2,
                   facility: facility_1,
                   scheduled_date: 1.day.ago,
                   status: :scheduled)
@@ -36,7 +36,7 @@ RSpec.describe AppointmentNotificationService do
       AppointmentNotification::Worker.drain
 
       eligible_appointments = overdue_appointments.select { |a| a.communications.present? }
-      expect(eligible_appointments.count).to eq(20)
+      expect(eligible_appointments.count).to eq(8)
     end
 
     it 'should ignore appointments which are recently overdue (< 3 days)' do
@@ -80,7 +80,7 @@ RSpec.describe AppointmentNotificationService do
       AppointmentNotification::Worker.drain
 
       eligible_appointments = overdue_appointments.select { |a| a.communications.present? }
-      expect(eligible_appointments.count).to eq(10)
+      expect(eligible_appointments.count).to eq(4)
     end
 
     it 'should only send reminder of half the appointments if the rollout percentage is 50%' do
@@ -91,7 +91,7 @@ RSpec.describe AppointmentNotificationService do
       AppointmentNotification::Worker.drain
 
       eligible_appointments = overdue_appointments.select { |a| a.communications.present? }
-      expect(eligible_appointments.count).to eq(5)
+      expect(eligible_appointments.count).to eq(2)
     end
   end
 end


### PR DESCRIPTION
https://semaphoreci.com/docs/running-rspec-specs-in-threads.html

Need to re-run in single threaded mode once on SemaphoreCI with KNAPSACK_GENERATE_REPORT=true to split into equal sized jobs.

Subsequent runs can be parallel