### PR TITLE
Fix issues with user registration and login

### DIFF
--- a/app/controllers/api/current/users_controller.rb
+++ b/app/controllers/api/current/users_controller.rb
@@ -90,15 +90,14 @@ class Api::Current::UsersController < APIController
   end
 
   def registration_params
-    params.require(:user)
-      .permit(
-        :id,
-        :full_name,
-        :phone_number,
-        :password_digest,
-        :updated_at,
-        :created_at,
-        :registration_facility_id)
+    params.permit(
+      :id,
+      :full_name,
+      :phone_number,
+      :password_digest,
+      :updated_at,
+      :created_at,
+      :registration_facility_id)
   end
 
   def find_params

--- a/app/models/old_user.rb
+++ b/app/models/old_user.rb
@@ -108,7 +108,7 @@ class OldUser < ApplicationRecord
     self.sync_approval_requested(I18n.t('reset_password'))
   end
 
-  def registered_at_facility
+  def registration_facility
     self.facility
   end
 end

--- a/app/transformers/api/current/user_transformer.rb
+++ b/app/transformers/api/current/user_transformer.rb
@@ -5,7 +5,7 @@ class Api::Current::UserTransformer
         .merge('registration_facility_id' => user.registration_facility.id,
                'phone_number' => user.phone_number,
                'password_digest' => user.phone_number_authentication.password_digest)
-        .except('sync_approval_status', 'sync_approval_status_reason', 'otp', 'otp_valid_until', 'access_token', 'logged_in_at')
+        .except('otp', 'otp_valid_until', 'access_token', 'logged_in_at')
     end
   end
 end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -28,13 +28,13 @@
             <td class="sync_approval_status_reason"><%= user.sync_approval_status_reason %></td>
             <td class="nowrap"><a href="tel:<%= user.phone_number %>"><%= user.phone_number %></a></td>
             <td>
-              <% if user.registered_at_facility.present? %>
-                <% facility = user.registered_at_facility %>
+              <% if user.registration_facility.present? %>
+                <% facility = user.registration_facility %>
 
                 <% if policy(facility).show? %>
                   <%= link_to facility.name, [:admin, facility.facility_group, facility] %>
                 <% else %>
-                  <%= user.registered_at_facility.name %>
+                  <%= user.registration_facility.name %>
                 <% end %>
               <% end %>
             </td>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -233,7 +233,6 @@ ActiveRecord::Schema.define(version: 20190623191212) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
-    t.string "role"
   end
 
   create_table "medical_histories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -390,17 +389,6 @@ ActiveRecord::Schema.define(version: 20190623191212) do
     t.datetime "deleted_at"
     t.index ["user_id", "authenticatable_type", "authenticatable_id"], name: "user_authentications_master_users_authenticatable_uniq_index", unique: true
     t.index ["user_id"], name: "index_user_authentications_on_user_id"
-  end
-
-  create_table "user_permissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "user_id", null: false
-    t.string "permission_slug"
-    t.string "resource_type"
-    t.uuid "resource_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "deleted_at"
-    t.index ["resource_type", "resource_id"], name: "index_user_permissions_on_resource_type_and_resource_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/api/current/users_spec.rb
+++ b/spec/api/current/users_spec.rb
@@ -43,26 +43,26 @@ describe 'Users Current API', swagger_doc: 'current/swagger.json' do
       let(:phone_number) { Faker::PhoneNumber.phone_number }
 
       response '200', 'user is registered' do
-        let(:user) { { user: register_user_request_params(registration_facility_id: facility.id) } }
+        let(:user) { register_user_request_params(registration_facility_id: facility.id) }
 
         schema Api::Current::Schema.user_registration_response
         run_test!
       end
 
       response '400', 'returns bad request for invalid params' do
-        let(:user) { { user: register_user_request_params(full_name: nil) } }
+        let(:user) { register_user_request_params(full_name: nil) }
         run_test!
       end
 
       response '400', 'returns bad request if phone number already exists' do
         let(:used_phone_number) { Faker::PhoneNumber.phone_number }
         let!(:existing_user) { FactoryBot.create(:user, phone_number: used_phone_number) }
-        let(:user) { { user: register_user_request_params(phone_number: used_phone_number, registration_facility_id: facility.id) } }
+        let(:user) { register_user_request_params(phone_number: used_phone_number, registration_facility_id: facility.id) }
         run_test!
       end
 
       response '404', 'returns not found if  facility id is not known' do
-        let(:user) { { user: register_user_request_params(phone_number: phone_number, registration_facility_id: SecureRandom.uuid) } }
+        let(:user) { register_user_request_params(phone_number: phone_number, registration_facility_id: SecureRandom.uuid) }
         run_test!
       end
     end

--- a/spec/api/v2/users_spec.rb
+++ b/spec/api/v2/users_spec.rb
@@ -43,26 +43,26 @@ describe 'Users V2 API', swagger_doc: 'v2/swagger.json' do
       let(:phone_number) { Faker::PhoneNumber.phone_number }
 
       response '200', 'user is registered' do
-        let(:user) { { user: register_user_request_params(registration_facility_id: facility.id) } }
+        let(:user) { register_user_request_params(registration_facility_id: facility.id) }
 
         schema Api::V2::Schema.user_registration_response
         run_test!
       end
 
       response '400', 'returns bad request for invalid params' do
-        let(:user) { { user: register_user_request_params(full_name: nil) } }
+        let(:user) { register_user_request_params(full_name: nil) }
         run_test!
       end
 
       response '400', 'returns bad request if phone number already exists' do
         let(:used_phone_number) { Faker::PhoneNumber.phone_number }
         let!(:existing_user) { FactoryBot.create(:user, phone_number: used_phone_number) }
-        let(:user) { { user: register_user_request_params(phone_number: used_phone_number, registration_facility_id: facility.id) } }
+        let(:user) { register_user_request_params(phone_number: used_phone_number, registration_facility_id: facility.id) }
         run_test!
       end
 
       response '404', 'returns not found if  facility id is not known' do
-        let(:user) { { user: register_user_request_params(phone_number: phone_number, registration_facility_id: SecureRandom.uuid) } }
+        let(:user) { register_user_request_params(phone_number: phone_number, registration_facility_id: SecureRandom.uuid) }
         run_test!
       end
     end

--- a/spec/controllers/api/v2/users_controller_spec.rb
+++ b/spec/controllers/api/v2/users_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Api::V2::UsersController, type: :controller do
       let(:password_digest) { user_params[:password_digest] }
 
       it 'creates a user, and responds with the created user object and their access token' do
-        post :register, params: { user: user_params }
+        post :register, params: user_params
         parsed_response = JSON(response.body)
 
         created_user = User.find_by(full_name: user_params[:full_name])
@@ -45,9 +45,7 @@ RSpec.describe Api::V2::UsersController, type: :controller do
                      'device_updated_at',
                      'device_created_at',
                      'created_at',
-                     'updated_at',
-                     'sync_approval_status',
-                     'sync_approval_status_reason')
+                     'updated_at')
                    .merge('registration_facility_id' => facility.id, 'phone_number' => phone_number, 'password_digest' => password_digest)
                    .as_json
                    .with_int_timestamps)
@@ -57,7 +55,7 @@ RSpec.describe Api::V2::UsersController, type: :controller do
       end
 
       it 'sets the user status to requested' do
-        post :register, params: { user: user_params }
+        post :register, params: user_params
         created_user = User.find_by(full_name: user_params[:full_name])
         expect(created_user.sync_approval_status).to eq(User.sync_approval_statuses[:requested])
         expect(created_user.sync_approval_status_reason).to eq(I18n.t('registration'))
@@ -68,13 +66,13 @@ RSpec.describe Api::V2::UsersController, type: :controller do
         allow(FeatureToggle).to receive(:enabled?).with('FIXED_OTP_ON_REQUEST_FOR_QA').and_return(false)
         allow(FeatureToggle).to receive(:enabled?).with('AUTO_APPROVE_USER_FOR_QA').and_return(true)
 
-        post :register, params: { user: user_params }
+        post :register, params: user_params
         created_user = User.find_by(full_name: user_params[:full_name])
         expect(created_user.sync_approval_status).to eq(User.sync_approval_statuses[:allowed])
       end
 
       it 'sends an email to a list of owners and supervisors' do
-        post :register, params: { user: user_params }
+        post :register, params: user_params
         approval_email = ActionMailer::Base.deliveries.last
         expect(approval_email.to).to include(supervisor.email)
         expect(approval_email.cc).to include(organization_owner.email)
@@ -82,13 +80,13 @@ RSpec.describe Api::V2::UsersController, type: :controller do
       end
 
       it 'sends an email with owners in the bcc list' do
-        post :register, params: { user: user_params }
+        post :register, params: user_params
         approval_email = ActionMailer::Base.deliveries.last
         expect(approval_email.bcc).to include(owner.email)
       end
 
       it 'sends an approval email with list of accessible facilities' do
-        post :register, params: { user: user_params }
+        post :register, params: user_params
         approval_email = ActionMailer::Base.deliveries.last
         facility.facility_group.facilities.each do |facility|
           expect(approval_email.body.to_s).to match(Regexp.quote(facility.name))


### PR DESCRIPTION
Rails only adds the `User` model attributes under the `user` key in params. 
This slightly changes the way the params are permitted in the controller and passed in the specs.