### PR TITLE
Update swagger.json + handle user registration errors better

### DIFF
--- a/app/controllers/api/current/users_controller.rb
+++ b/app/controllers/api/current/users_controller.rb
@@ -14,7 +14,10 @@ class Api::Current::UsersController < APIController
       }, status: :bad_request
     end
 
-    send_approval_notification_email(user)
+    ApprovalNotifierMailer
+      .with(user: user)
+      .registration_approval_email
+      .deliver_later if approve_and_save(user)
 
     render json: {
       user: user_to_response(user),
@@ -53,15 +56,12 @@ class Api::Current::UsersController < APIController
 
   private
 
-  def send_approval_notification_email(user)
-    if FeatureToggle.auto_approve_for_qa?
-      user.sync_approval_allowed
-      user.save
-    else
+  def approve_and_save(user)
+    FeatureToggle.auto_approve_for_qa? ?
+      user.sync_approval_allowed :
       user.sync_approval_requested(I18n.t('registration'))
-      user.save
-      ApprovalNotifierMailer.with(user: user).registration_approval_email.deliver_later
-    end
+
+    user.save
   end
 
   def find_user(params)

--- a/app/controllers/api/current/users_controller.rb
+++ b/app/controllers/api/current/users_controller.rb
@@ -8,7 +8,7 @@ class Api::Current::UsersController < APIController
     user = User.build_with_phone_number_authentication(user_from_request)
     return head :not_found unless user.registration_facility.present?
 
-    if user.invalid? || user.phone_number_authentication.invalid?
+    if user.phone_number_authentication.invalid?
       return render json: {
         errors: user.phone_number_authentication.errors
       }, status: :bad_request

--- a/app/validators/api/v1/payload_validator.rb
+++ b/app/validators/api/v1/payload_validator.rb
@@ -1,2 +1,5 @@
-class Api::V1::PayloadValidator < Api::Current::PayloadValidator
+class Api::V1::PayloadValidator < Api::V2::PayloadValidator
+  def schema_with_definitions
+    schema.merge(definitions: Api::V1::Schema.all_definitions)
+  end
 end

--- a/app/validators/api/v1/user_registration_payload_validator.rb
+++ b/app/validators/api/v1/user_registration_payload_validator.rb
@@ -9,6 +9,8 @@ class Api::V1::UserRegistrationPayloadValidator < Api::V1::PayloadValidator
     :updated_at
   )
 
+  validate :validate_schema
+
   def schema
     Api::V1::Models.user
   end

--- a/app/validators/api/v2/payload_validator.rb
+++ b/app/validators/api/v2/payload_validator.rb
@@ -1,2 +1,5 @@
 class Api::V2::PayloadValidator < Api::Current::PayloadValidator
+  def schema_with_definitions
+    schema.merge(definitions: Api::V2::Schema.all_definitions)
+  end
 end

--- a/spec/api/current/users_spec.rb
+++ b/spec/api/current/users_spec.rb
@@ -38,7 +38,7 @@ describe 'Users Current API', swagger_doc: 'current/swagger.json' do
   path '/users/register' do
     post 'Register a new user' do
       tags 'User'
-      parameter name: :user, in: :body, schema: { '$ref' => '#/definitions/user' }
+      parameter name: :user, in: :body, schema: Api::Current::Schema.user_registration_request
 
       let(:phone_number) { Faker::PhoneNumber.phone_number }
 

--- a/spec/api/v1/users_spec.rb
+++ b/spec/api/v1/users_spec.rb
@@ -38,7 +38,7 @@ describe 'Users V1 API', swagger_doc: 'v1/swagger.json' do
   path '/users/register' do
     post 'Register a new user' do
       tags 'User'
-      parameter name: :user, in: :body, schema: { '$ref' => '#/definitions/user' }
+      parameter name: :user, in: :body, schema: Api::V1::Schema.user_registration_request
 
       let(:phone_number) { Faker::PhoneNumber.phone_number }
 

--- a/spec/api/v1/users_spec.rb
+++ b/spec/api/v1/users_spec.rb
@@ -38,7 +38,7 @@ describe 'Users V1 API', swagger_doc: 'v1/swagger.json' do
   path '/users/register' do
     post 'Register a new user' do
       tags 'User'
-      parameter name: :user, in: :body, schema: Api::V1::Schema.user_registration_request
+      parameter name: :user, in: :body, schema: { '$ref' => '#/definitions/user' }
 
       let(:phone_number) { Faker::PhoneNumber.phone_number }
 
@@ -99,12 +99,12 @@ describe 'Users V1 API', swagger_doc: 'v1/swagger.json' do
 
     post 'Request for reset password' do
       tags 'User'
-      security [ basic: [] ]
+      security [basic: []]
       parameter name: :password_digest, in: :body, schema: Api::V1::Schema.user_reset_password_request
       let(:user) { FactoryBot.create(:user, registration_facility: facility) }
       let(:HTTP_X_USER_ID) { user.id }
       let(:Authorization) { "Bearer #{user.access_token}" }
-      let(:password_digest) { { password_digest:  BCrypt::Password.create('1234') } }
+      let(:password_digest) { { password_digest: BCrypt::Password.create('1234') } }
 
       response '200', 'user password reset request is received' do
         schema Api::V1::Schema.user_registration_response

--- a/spec/api/v2/users_spec.rb
+++ b/spec/api/v2/users_spec.rb
@@ -38,7 +38,7 @@ describe 'Users V2 API', swagger_doc: 'v2/swagger.json' do
   path '/users/register' do
     post 'Register a new user' do
       tags 'User'
-      parameter name: :user, in: :body, schema: { '$ref' => '#/definitions/user' }
+      parameter name: :user, in: :body, schema: Api::V2::Schema.user_registration_request
 
       let(:phone_number) { Faker::PhoneNumber.phone_number }
 

--- a/swagger/current/swagger.json
+++ b/swagger/current/swagger.json
@@ -887,7 +887,15 @@
             "name": "user",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/user"
+              "type": "object",
+              "properties": {
+                "user": {
+                  "$ref": "#/definitions/user"
+                }
+              },
+              "required": [
+                "user"
+              ]
             }
           }
         ],
@@ -1142,7 +1150,6 @@
         "full_name",
         "created_at",
         "updated_at",
-        "recorded_at",
         "status"
       ]
     },
@@ -1306,7 +1313,6 @@
         "full_name",
         "created_at",
         "updated_at",
-        "recorded_at",
         "status"
       ],
       "description": "Patient with address, phone numbers and business identifiers nested."
@@ -1359,7 +1365,6 @@
         "diastolic",
         "created_at",
         "updated_at",
-        "recorded_at",
         "patient_id",
         "facility_id",
         "user_id"

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -857,7 +857,15 @@
             "name": "user",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/user"
+              "type": "object",
+              "properties": {
+                "user": {
+                  "$ref": "#/definitions/user"
+                }
+              },
+              "required": [
+                "user"
+              ]
             }
           }
         ],

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -857,15 +857,7 @@
             "name": "user",
             "in": "body",
             "schema": {
-              "type": "object",
-              "properties": {
-                "user": {
-                  "$ref": "#/definitions/user"
-                }
-              },
-              "required": [
-                "user"
-              ]
+              "$ref": "#/definitions/user"
             }
           }
         ],

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -1000,7 +1000,15 @@
             "name": "user",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/user"
+              "type": "object",
+              "properties": {
+                "user": {
+                  "$ref": "#/definitions/user"
+                }
+              },
+              "required": [
+                "user"
+              ]
             }
           }
         ],


### PR DESCRIPTION
The idea is this,

* The user validation check during `users/register` via `user.invalid?` was mostly superfluous since the User object is not saved to the DB yet. The kinds of validations we have:
   * The necessary user validations are already handled via the schema
   * The User ID being duplicated across registration requests can only be handled on `save` (and throw a 500 subsequently)
   * The rest, `full_name`, `device_created_at` and `device_updated_at` are validated on the model level at the moment, but are not handled explicitly in the controller (which they might have been previously... but not _really_ since they are also validated in the schema)

To simplify all this, the controller simply checks for the validity of PhoneNumberAuthentication and returns errors around those as necessary.