### PR TITLE
FIX: Removing the last BP for a patient should decrement follow-up count

### DIFF
--- a/app/queries/facility_analytics_query.rb
+++ b/app/queries/facility_analytics_query.rb
@@ -37,6 +37,7 @@ class FacilityAnalyticsQuery
         .left_outer_joins(:patient)
         .joins(:facility)
         .where(facility: @facility)
+        .where(deleted_at: nil)
         .group('master_users.id', date_truncate_string)
         .where("patients.recorded_at < #{date_truncate_string}")
         .order('master_users.id')

--- a/spec/factories/blood_pressures.rb
+++ b/spec/factories/blood_pressures.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
     device_created_at { Time.now }
     device_updated_at { Time.now }
     recorded_at { device_created_at }
-    deleted_at { [nil, Time.now].sample }
     association :facility, strategy: :build
     association :patient, strategy: :build
     user

--- a/spec/queries/facility_analytics_query_spec.rb
+++ b/spec/queries/facility_analytics_query_spec.rb
@@ -116,6 +116,38 @@ RSpec.describe FacilityAnalyticsQuery do
     end
   end
 
+  context 'edge cases' do
+    describe '#follow_up_patients_by_month' do
+      it 'should discount counting as follow-up if the last BP is removed' do
+        patient = Timecop.travel(first_feb) do
+          create(:patient, registration_facility: facility, registration_user: users.first)
+        end
+
+        _mar_bp = Timecop.travel(first_mar) do
+          create(:blood_pressure, patient: patient, facility: facility, user: users.first)
+        end
+
+        apr_bp = Timecop.travel(first_apr) do
+          create(:blood_pressure, patient: patient, facility: facility, user: users.first)
+        end
+
+        # simulate soft-deleting a blood_pressure
+        apr_bp.discard
+
+        expected_result =
+          { users.first.id =>
+              { :follow_up_patients_by_month =>
+                  {
+                    first_mar => 1
+                  }
+              }
+          }
+
+        expect(analytics.follow_up_patients_by_month).to eq(expected_result)
+      end
+    end
+  end
+
   context 'when there is no data available' do
     it 'returns nil for all analytics queries' do
       expect(analytics.registered_patients_by_month).to eq(nil)


### PR DESCRIPTION
Fixes: https://www.pivotaltracker.com/story/show/167312089