### PR TITLE
Fix audit log fickle test

### DIFF
--- a/app/jobs/create_audit_logs_worker.rb
+++ b/app/jobs/create_audit_logs_worker.rb
@@ -1,6 +1,7 @@
-class CreateAuditLogsJob < ApplicationJob
-  queue_as :default
-  self.queue_adapter = :sidekiq
+class CreateAuditLogsWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :audit_log_queue
 
   def perform(user_id, record_class, record_ids, action)
     user = User.find(user_id)

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -46,7 +46,7 @@ class AuditLog < ApplicationRecord
     records_by_class = records.group_by { |record| record.class.to_s }
 
     records_by_class.each do |record_class, records_for_class|
-      CreateAuditLogsJob.perform_later(user.id, record_class, records_for_class.map(&:id), action)
+      CreateAuditLogsWorker.perform_async(user.id, record_class, records_for_class.map(&:id), action)
     end
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,3 +6,5 @@
   - default
   - [analytics_warmup, 2]
   - [high, 3]
+  - [phone_number_details_queue, 1]
+  - [audit_log_queue, 1]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,5 +6,4 @@
   - default
   - [analytics_warmup, 2]
   - [high, 3]
-  - [phone_number_details_queue, 1]
   - [audit_log_queue, 1]

--- a/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
+++ b/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
@@ -439,17 +439,16 @@ RSpec.shared_examples 'a sync controller that audits the data access' do
   describe 'creates an audit log for data synced to user' do
     let!(:records) { create_record_list(5) }
     it 'creates an audit log for data fetched by the user' do
-      perform_enqueued_jobs do
+      Sidekiq::Testing.inline! do
         get :sync_to_user, params: {
           processed_since: 20.minutes.ago,
           limit: 5
         }, as: :json
+        audit_logs = AuditLog.where(user_id: request_user.id, auditable_type: auditable_type)
+        expect(audit_logs.count).to eq(5)
+        expect(audit_logs.map(&:auditable_id).to_set).to eq(records.map(&:id).to_set)
+        expect(audit_logs.map(&:action).to_set).to eq(['fetch'].to_set)
       end
-
-      audit_logs = AuditLog.where(user_id: request_user.id, auditable_type: auditable_type)
-      expect(audit_logs.count).to be 5
-      expect(audit_logs.map(&:auditable_id).to_set).to eq(records.map(&:id).to_set)
-      expect(audit_logs.map(&:action).to_set).to eq(['fetch'].to_set)
     end
   end
 end

--- a/spec/jobs/create_audit_logs_worker_spec.rb
+++ b/spec/jobs/create_audit_logs_worker_spec.rb
@@ -1,27 +1,24 @@
 require 'rails_helper'
 
-RSpec.describe CreateAuditLogsJob, type: :job do
+RSpec.describe CreateAuditLogsWorker, type: :job do
   include ActiveJob::TestHelper
 
   describe '#perform_later' do
-    let(:user) { create :user }
+    let!(:user) { create :user }
     let(:record_class) { 'Patient' }
     let(:record_ids) { create_list(record_class.underscore.to_sym, 3).pluck(:id) }
     let(:action) { 'fetch' }
-    let(:job) { CreateAuditLogsJob.perform_later(user.id, 'Patient', record_ids, action) }
 
-    it 'queues the job' do
-      assert_enqueued_jobs 1 do
-        job
-      end
-    end
-
-    it 'queues the job on the default queue' do
-      expect(job.queue_name).to eq('default')
+    it 'queues the job on audit_log_queue' do
+      expect {
+        CreateAuditLogsWorker.perform_async(user.id, 'Patient', record_ids, action)
+      }.to change(Sidekiq::Queues['audit_log_queue'], :size).by(1)
+      CreateAuditLogsWorker.clear
     end
 
     it 'updates the cache for the facility group with analytics for the given time' do
-      perform_enqueued_jobs { job }
+      CreateAuditLogsWorker.perform_async(user.id, 'Patient', record_ids, action)
+      CreateAuditLogsWorker.drain
       user_audit_logs = AuditLog.where(user: user)
       expect(user_audit_logs.count).to eq(3)
       expect(user_audit_logs.pluck(:auditable_id)).to match_array(record_ids)


### PR DESCRIPTION
Audit logs specs would randomly fail when the tests are run in parallel. This PR attempts to fix this. 