### PR TITLE
Track invalid phone numbers

### DIFF
--- a/app/models/patient_phone_number.rb
+++ b/app/models/patient_phone_number.rb
@@ -21,6 +21,7 @@ class PatientPhoneNumber < ApplicationRecord
   def self.require_whitelisting
     self.left_outer_joins(:exotel_phone_number_detail)
       .where(patient_phone_numbers: { dnd_status: true })
+      .where.not(patient_phone_numbers: { phone_type: 'invalid' })
       .where(%Q(
         (exotel_phone_number_details.whitelist_status is null) OR
         (exotel_phone_number_details.whitelist_status = 'neutral') OR

--- a/app/models/patient_phone_number.rb
+++ b/app/models/patient_phone_number.rb
@@ -1,7 +1,11 @@
 class PatientPhoneNumber < ApplicationRecord
   include Mergeable
 
-  PHONE_TYPE = %w[mobile landline].freeze
+  enum phone_type: {
+    mobile: 'mobile',
+    landline: 'landline',
+    invalid: 'invalid'
+  }, _prefix: true
 
   belongs_to :patient
 

--- a/app/schema/api/current/models.rb
+++ b/app/schema/api/current/models.rb
@@ -72,7 +72,8 @@ class Api::Current::Models
         properties: {
           id: { '$ref' => '#/definitions/uuid' },
           number: { '$ref' => '#/definitions/non_empty_string' },
-          phone_type: { type: :string, enum: PatientPhoneNumber::PHONE_TYPE },
+          # TODO: Client only handles `mobile` and `landline` phone_types. Allow `invalid` when mobile supports it
+          phone_type: { type: :string, enum: PatientPhoneNumber.phone_types.slice(:mobile, :landline).keys },
           active: { type: :boolean },
           deleted_at: { '$ref' => '#/definitions/nullable_timestamp' },
           created_at: { '$ref' => '#/definitions/timestamp' },

--- a/app/services/exotel_api_service.rb
+++ b/app/services/exotel_api_service.rb
@@ -35,18 +35,23 @@ class ExotelAPIService
 
     {
       dnd_status: EXOTEL_TRUTHY_STRINGS.include?(phone_number_details_response.dig('Numbers', 'DND')),
-      phone_type: phone_number_details_response.dig('Numbers', 'Type').downcase.to_sym,
-      whitelist_status: exotel_whitelist_details_response.dig('Result', 'Status').downcase.to_sym,
+      phone_type: parse_response_field(phone_number_details_response.dig('Numbers', 'Type'), :invalid),
+      whitelist_status: parse_response_field(exotel_whitelist_details_response.dig('Result', 'Status'), nil),
       whitelist_status_valid_until: parse_exotel_whitelist_expiry(exotel_whitelist_details_response.dig('Result', 'Expiry'))
     }
   end
 
   def parse_exotel_whitelist_expiry(expiry_time)
-    return if expiry_time < 0
+    return if expiry_time.blank? || expiry_time < 0
     Time.now + expiry_time.seconds
   end
 
   private
+
+  def parse_response_field(field, default)
+    return default if field.blank?
+    field.downcase.to_sym
+  end
 
   def execute_get(url)
     begin

--- a/app/transformers/api/current/patient_phone_number_transformer.rb
+++ b/app/transformers/api/current/patient_phone_number_transformer.rb
@@ -1,0 +1,22 @@
+class Api::Current::PatientPhoneNumberTransformer
+  class << self
+    def to_response(phone_number)
+      response = Api::Current::Transformer
+                   .to_response(phone_number)
+                   .except('patient_id', 'dnd_status')
+
+      # TODO: Forcing phone_type to send `mobile` instead of `invalid`. Remove when client supports `invalid`
+      unless ['mobile', 'landline'].include?(response['phone_type'])
+        response['phone_type'] = 'mobile'
+      end
+
+      response
+    end
+
+    def from_request(phone_number)
+      Api::Current::Transformer
+        .from_request(phone_number)
+        .except('dnd_status', 'phone_type')
+    end
+  end
+end

--- a/app/transformers/api/current/patient_transformer.rb
+++ b/app/transformers/api/current/patient_transformer.rb
@@ -27,7 +27,7 @@ class Api::Current::PatientTransformer
       address_attributes = Api::Current::Transformer.from_request(address) if address.present?
 
       phone_numbers_attributes = phone_numbers.map do |phone_number|
-        Api::Current::Transformer.from_request(phone_number)
+        Api::Current::PatientPhoneNumberTransformer.from_request(phone_number)
       end if phone_numbers.present?
 
       business_identifiers_attributes = business_identifiers.map do |business_identifier|
@@ -52,7 +52,7 @@ class Api::Current::PatientTransformer
         .merge(
           'address' => Api::Current::Transformer.to_response(patient.address),
           'phone_numbers' => patient.phone_numbers.map do |phone_number|
-            Api::Current::Transformer.to_response(phone_number).except('patient_id', 'dnd_status')
+            Api::Current::PatientPhoneNumberTransformer.to_response(phone_number)
           end,
           'business_identifiers' => patient.business_identifiers.map do |business_identifier|
             Api::Current::PatientBusinessIdentifierTransformer.to_response(business_identifier)

--- a/spec/factories/patient_phone_numbers.rb
+++ b/spec/factories/patient_phone_numbers.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :patient_phone_number do
     id { SecureRandom.uuid }
     number { Faker::PhoneNumber.phone_number }
-    phone_type { PatientPhoneNumber.phone_types.values.sample }
+    phone_type { 'mobile' }
     active { [true, false].sample }
     device_created_at { Time.now }
     device_updated_at { Time.now }

--- a/spec/factories/patient_phone_numbers.rb
+++ b/spec/factories/patient_phone_numbers.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :patient_phone_number do
     id { SecureRandom.uuid }
     number { Faker::PhoneNumber.phone_number }
-    phone_type { PatientPhoneNumber::PHONE_TYPE.sample }
+    phone_type { PatientPhoneNumber.phone_types.values.sample }
     active { [true, false].sample }
     device_created_at { Time.now }
     device_updated_at { Time.now }

--- a/spec/factories/patient_phone_numbers.rb
+++ b/spec/factories/patient_phone_numbers.rb
@@ -10,3 +10,7 @@ FactoryBot.define do
     patient
   end
 end
+
+def build_patient_phone_number_payload(phone_number = FactoryBot.build(:patient_phone_number))
+  Api::Current::PatientPhoneNumberTransformer.to_response(phone_number)
+end

--- a/spec/models/patient_phone_number_spec.rb
+++ b/spec/models/patient_phone_number_spec.rb
@@ -33,34 +33,36 @@ RSpec.describe PatientPhoneNumber, type: :model do
   end
 
   describe 'require_whitelisting' do
-    let(:patient) { create(:patient) }
-    let(:non_dnd_phone) { create(:patient_phone_number, patient: patient, dnd_status: false) }
+    let!(:patient) { create(:patient) }
+    let!(:non_dnd_phone) { create(:patient_phone_number, patient: patient, dnd_status: false) }
 
-    let(:dnd_phone) { create(:patient_phone_number, patient: patient, dnd_status: true) }
+    let!(:dnd_phone) { create(:patient_phone_number, patient: patient, dnd_status: true) }
 
-    let(:blackist_phone) do
+    let!(:blackist_phone) do
       phone_number = create(:patient_phone_number, patient: patient, dnd_status: true)
       create(:exotel_phone_number_detail, patient_phone_number: phone_number, whitelist_status: 'blacklist')
       phone_number
     end
 
-    let(:neutral_phone) do
+    let!(:neutral_phone) do
       phone_number = create(:patient_phone_number, patient: patient, dnd_status: true)
       create(:exotel_phone_number_detail, patient_phone_number: phone_number, whitelist_status: 'neutral')
       phone_number
     end
 
-    let(:valid_whitelist_phone) do
+    let!(:valid_whitelist_phone) do
       phone_number = create(:patient_phone_number, patient: patient, dnd_status: true)
       create(:exotel_phone_number_detail, patient_phone_number: phone_number, whitelist_status: 'whitelist', whitelist_status_valid_until: 3.days.from_now)
       phone_number
     end
 
-    let(:expired_whitelist_phone) do
+    let!(:expired_whitelist_phone) do
       phone_number = create(:patient_phone_number, patient: patient, dnd_status: true)
       create(:exotel_phone_number_detail, patient_phone_number: phone_number, whitelist_status: 'whitelist', whitelist_status_valid_until: 3.days.ago)
       phone_number
     end
+
+    let!(:invalid_phone) { create(:patient_phone_number, patient: patient, phone_type: :invalid) }
 
     it 'returns all the numbers that require whitelisting' do
       expect(PatientPhoneNumber.require_whitelisting)
@@ -71,7 +73,8 @@ RSpec.describe PatientPhoneNumber, type: :model do
       expect(PatientPhoneNumber.require_whitelisting)
         .not_to include(non_dnd_phone,
                         blackist_phone,
-                        valid_whitelist_phone)
+                        valid_whitelist_phone,
+                        invalid_phone)
     end
   end
 

--- a/spec/services/exotel_api_service_spec.rb
+++ b/spec/services/exotel_api_service_spec.rb
@@ -112,6 +112,11 @@ describe ExotelAPIService, type: :model do
   end
 
   describe 'parse_exotel_whitelist_expiry' do
+    it 'returns nil if expiry time is nil' do
+      expect(service.parse_exotel_whitelist_expiry(nil)).to be_nil
+    end
+
+
     it 'returns nil if expiry time is less than 0' do
       expect(service.parse_exotel_whitelist_expiry(-1)).to be_nil
     end

--- a/spec/transformers/api/current/patient_phone_number_transformer_spec.rb
+++ b/spec/transformers/api/current/patient_phone_number_transformer_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Api::Current::PatientPhoneNumberTransformer do
+  describe 'to_response' do
+    let(:phone_number) { build(:patient_phone_number) }
+
+    it 'removes patient_id and dnd_status' do
+      transformed_phone_number = Api::Current::PatientPhoneNumberTransformer.to_response(phone_number)
+
+      expect(transformed_phone_number).not_to include('patient_id', 'dnd_status')
+    end
+
+    it 'replaces phone_types other than mobile and landline with mobile' do
+      phone_number = build(:patient_phone_number, phone_type: :invalid)
+      transformed_phone_number = Api::Current::PatientPhoneNumberTransformer.to_response(phone_number)
+      expect(transformed_phone_number['phone_type']).to eq('mobile')
+    end
+  end
+
+  describe 'from_request' do
+    let(:phone_number_payload) { build_patient_phone_number_payload }
+
+    it 'removes dnd_status and phone_type from the request' do
+      transformed_payload = Api::Current::PatientPhoneNumberTransformer.from_request(phone_number_payload)
+
+      expect(transformed_payload).not_to include('dnd_status', 'phone_type')
+    end
+  end
+end


### PR DESCRIPTION
We now have more information about phones from the exotel apis. This includes phone_type `mobile` and `landline`. When we get back an empty response for this field, we can mark the phone number as invalid since it isn't recognized as a phone number by exotel.

Since the Mobile client can only handle `mobile` and `landline` phone types, the PatientPhoneNumberTransformer replaces other phone types with `mobile`  