### PR TITLE
Fix analyst permissions

### DIFF
--- a/app/policies/facility_policy.rb
+++ b/app/policies/facility_policy.rb
@@ -1,11 +1,6 @@
 class FacilityPolicy < ApplicationPolicy
   def index?
-    user.has_role?(
-      :owner,
-      :organization_owner,
-      :supervisor,
-      :analyst
-    )
+    user.has_role?(:owner, :organization_owner, :supervisor, :analyst)
   end
 
   def show?

--- a/app/policies/facility_policy.rb
+++ b/app/policies/facility_policy.rb
@@ -1,10 +1,15 @@
 class FacilityPolicy < ApplicationPolicy
   def index?
-    user.owner? || user.organization_owner? || user.supervisor?
+    user.has_role?(
+      :owner,
+      :organization_owner,
+      :supervisor,
+      :analyst
+    )
   end
 
   def show?
-    user.owner? || admin_can_access?(:organization_owner) || admin_can_access?(:supervisor)
+    user.owner? || (user.has_role?(:organization_owner, :analyst, :supervisor) && belongs_to_admin?)
   end
 
   def share_anonymized_data?
@@ -24,7 +29,7 @@ class FacilityPolicy < ApplicationPolicy
   end
 
   def update?
-    user.owner? || admin_can_access?(:organization_owner)
+    user.owner? || (user.organization_owner? && belongs_to_admin?)
   end
 
   def edit?
@@ -32,21 +37,11 @@ class FacilityPolicy < ApplicationPolicy
   end
 
   def destroy?
-    destroyable? && (user.owner? || admin_can_access?(:organization_owner))
+    destroyable? && (user.owner? || (user.organization_owner? && belongs_to_admin?))
   end
 
   def upload?
     user.owner?
-  end
-
-  private
-
-  def destroyable?
-    record.registered_patients.none? && record.blood_pressures.none?
-  end
-
-  def admin_can_access?(role)
-    user.role == role.to_s && user.facilities.include?(record)
   end
 
   class Scope
@@ -61,4 +56,15 @@ class FacilityPolicy < ApplicationPolicy
       scope.where(facility_group: user.facility_groups)
     end
   end
+
+  private
+
+  def destroyable?
+    record.registered_patients.none? && record.blood_pressures.none?
+  end
+
+  def belongs_to_admin?
+    user.facilities.include?(record)
+  end
+
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,10 +1,10 @@
 class UserPolicy < ApplicationPolicy
   def index?
-    user.has_role?(:owner, :organization_owner, :supervisor)
+    user.has_role?(:owner, :organization_owner, :supervisor, :analyst)
   end
 
   def show?
-    user.owner? || (user.has_role?(:organization_owner, :supervisor) && belongs_to_admin?)
+    user.owner? || (user.has_role?(:organization_owner, :supervisor, :analyst) && belongs_to_admin?)
   end
 
   def new?
@@ -15,7 +15,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def update?
-    show?
+    user.owner? || (user.has_role?(:organization_owner, :supervisor) && belongs_to_admin?)
   end
 
   def edit?
@@ -48,10 +48,10 @@ class UserPolicy < ApplicationPolicy
     def resolve
       if @user.owner?
         scope.all
-      elsif @user.has_role?(:analyst, :counsellor)
+      elsif @user.counsellor?
         scope.none
       else
-        scope.where(id: user.users)
+        scope.where(id: @user.users)
       end
     end
   end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -9,10 +9,14 @@
             <%= link_to 'Edit user', edit_admin_user_path(@user), class: 'btn btn-primary btn-sm' %>
         <% end %>
         <% unless @user.sync_approval_status == 'denied' %>
+          <% if policy(@user).disable_access? %>
             <%= link_to 'Deny access', '#deny-access-modal-' + @user.id , 'data-toggle' => 'modal', class: 'btn btn-danger btn-sm' %>
+          <% end %>
         <% end %>
         <% unless @user.sync_approval_status == 'allowed' %>
+          <% if policy(@user).enable_access? %>
             <%= link_to 'Allow access', admin_user_enable_access_path(@user), method: :put, data: { confirm: I18n.t('admin.enable_access_alert') }, class: 'btn btn-success btn-sm' %>
+          <% end %>
         <% end %>
         <% if policy(@user.audit_logs).index? %>
             <%= link_to 'Audit logs', admin_audit_logs_url(user_name: @user.full_name), class: 'btn btn-secondary btn-sm' %>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,12 +1,12 @@
 <div class="container">
   <div class="row">
-      
+
       <div class="col-sm-5 col-lg-7">
         <% @organizations.each do |organization| %>
             <section id="facility-groups">
               <div class="card">
                 <h2><%= organization.name %></h2>
-                    
+
 
                     <% policy_scope(organization.facility_groups)
                            .flat_map(&:facilities)
@@ -14,17 +14,17 @@
                            .keys
                            .sort
                            .each do |district| %>
-                      
+
                           <%= link_to "<i class='fas fa-angle-right light'></i> #{district}".html_safe, analytics_organization_district_path(organization.id, district), class: "link-row" %>
-                      
+
                     <% end %>
-                  
+
               </div>
             </section>
             <% end %>
          </div>
          <div class="col-sm-7 col-lg-5 mt-3">
             <%= render "shared/user_approvals" %>
-        </div>
+         </div>
   </div>
 </div>

--- a/app/views/shared/_user_approvals.html.erb
+++ b/app/views/shared/_user_approvals.html.erb
@@ -1,35 +1,37 @@
-<% if @users_requesting_approval.any? %>
-  <h2><i class="far fa-bell"></i> Users to review</h2>
-  <p>Contact these users promptly. Check that they are approved to access patient data at their facility.</p>
+<% if @users_requesting_approval.any? && policy(@users_requesting_approval.first).enable_access? %>
+  <% if @users_requesting_approval.any? %>
+    <h2><i class="far fa-bell"></i> Users to review</h2>
+    <p>Contact these users promptly. Check that they are approved to access patient data at their facility.</p>
 
-  <% @users_requesting_approval.each do |user| %>
-    <% if policy(user).enable_access? %>
-        <div class="user-row">
+    <% @users_requesting_approval.each do |user| %>
+      <% if policy(user).enable_access? %>
+          <div class="user-row">
 
 
-              <h5><%= link_to user.full_name, [:admin, user] %></h5>
-              <div class="text-grey mt-1 mb-2">
-                  <% if user.sync_approval_status_reason.present? %>
-                    <span><%= user.sync_approval_status_reason %> at <%= user.registration_facility.present? ? link_to(user.registration_facility.name, admin_facilities_path(user.registration_facility)) : "N/A" %></span>, <%= l user.updated_at.to_date %>
-                  <% end %>
-              </div>
-
-            <div class="row">
-                <div class="col">
-                    <a href="tel:<%= user.phone_number %>" class="btn btn-outline-primary btn-sm btn-phone" style="letter-spacing: 0.1em;"><i class="fas fa-phone" style="font-size: 90%;"></i> <%= user.phone_number %></a>
+                <h5><%= link_to user.full_name, [:admin, user] %></h5>
+                <div class="text-grey mt-1 mb-2">
+                    <% if user.sync_approval_status_reason.present? %>
+                      <span><%= user.sync_approval_status_reason %> at <%= user.registration_facility.present? ? link_to(user.registration_facility.name, admin_facilities_path(user.registration_facility)) : "N/A" %></span>, <%= l user.updated_at.to_date %>
+                    <% end %>
                 </div>
-                <div class="col text-right">
 
-                  <%= link_to "Allow access", admin_user_enable_access_path(user), method: :put, class: "btn btn-sm btn-outline-success", data: { confirm: I18n.t('admin.enable_access_alert') } %>
-                  <%= link_to '<i class="fas fa-times"></i>'.html_safe, '#deny-access-modal-' + user.id, 'data-toggle' => 'modal', class: "btn btn-sm btn-outline-danger" %>
+              <div class="row">
+                  <div class="col">
+                      <a href="tel:<%= user.phone_number %>" class="btn btn-outline-primary btn-sm btn-phone" style="letter-spacing: 0.1em;"><i class="fas fa-phone" style="font-size: 90%;"></i> <%= user.phone_number %></a>
+                  </div>
+                  <div class="col text-right">
 
-                  <%= render partial: "admin/users/deny_access_modal", locals: { user: user } %>
-                </div>
+                    <%= link_to "Allow access", admin_user_enable_access_path(user), method: :put, class: "btn btn-sm btn-outline-success", data: { confirm: I18n.t('admin.enable_access_alert') } %>
+                    <%= link_to '<i class="fas fa-times"></i>'.html_safe, '#deny-access-modal-' + user.id, 'data-toggle' => 'modal', class: "btn btn-sm btn-outline-danger" %>
+
+                    <%= render partial: "admin/users/deny_access_modal", locals: { user: user } %>
+                  </div>
+            </div>
           </div>
-        </div>
+      <% end %>
     <% end %>
+  <% else %>
+      <h2>All users reviewed</h2>
+      <p><i class="fas fa-check"></i> All user approvals are complete. Nice work.</p>
   <% end %>
-<% else %>
-    <h2>All users reviewed</h2>
-    <p><i class="fas fa-check"></i> All user approvals are complete. Nice work.</p>
 <% end %>

--- a/spec/policies/facility_policy_spec.rb
+++ b/spec/policies/facility_policy_spec.rb
@@ -11,18 +11,6 @@ RSpec.describe FacilityPolicy do
   let(:supervisor) { FactoryBot.create(:admin, :supervisor, admin_access_controls: [AdminAccessControl.new(access_controllable: facility_group)]) }
   let(:analyst) { FactoryBot.create(:admin, :analyst) }
 
-  permissions :show? do
-    it "denies organization owners for facilities outside their organizations" do
-      facility = FactoryBot.create(:facility)
-      expect(subject).not_to permit(organization_owner, facility)
-    end
-
-    it "denies supervisors for facilities outside their facility group" do
-      facility = FactoryBot.create(:facility)
-      expect(subject).not_to permit(supervisor, facility)
-    end
-  end
-
   permissions :index?, :show? do
     it "permits owners" do
       expect(subject).to permit(owner, Facility)
@@ -38,8 +26,21 @@ RSpec.describe FacilityPolicy do
       expect(subject).to permit(supervisor, facility)
     end
 
-    it "denies analysts" do
-      expect(subject).not_to permit(analyst, Facility)
+    it "permits analysts for facilities in their facility group" do
+      facility = FactoryBot.create(:facility, facility_group: analyst.facility_groups.first)
+      expect(subject).to permit(analyst, facility)
+    end
+  end
+
+  permissions :show? do
+    it "denies organization owners for facilities outside their organizations" do
+      facility = FactoryBot.create(:facility)
+      expect(subject).not_to permit(organization_owner, facility)
+    end
+
+    it "denies supervisors for facilities outside their facility group" do
+      facility = FactoryBot.create(:facility)
+      expect(subject).not_to permit(supervisor, facility)
     end
   end
 


### PR DESCRIPTION
For facility groups that they oversee, allow analysts to:
- See facilities
- List users in those facilities
- See those specific user pages

Analysts have read-only access, but they should still be able to see these things.