### PR TITLE
Return 403 for users not allowed to sync

### DIFF
--- a/app/controllers/api/current/facilities_controller.rb
+++ b/app/controllers/api/current/facilities_controller.rb
@@ -1,4 +1,6 @@
 class Api::Current::FacilitiesController < Api::Current::SyncController
+  skip_before_action :current_user_present?, only: [:sync_to_user]
+  skip_before_action :validate_sync_approval_status_allowed, only: [:sync_to_user]
   skip_before_action :authenticate, only: [:sync_to_user]
   skip_before_action :validate_facility, only: [:sync_to_user]
   skip_before_action :validate_current_facility_belongs_to_users_facility_group, only: [:sync_to_user]

--- a/app/controllers/api/current/help_controller.rb
+++ b/app/controllers/api/current/help_controller.rb
@@ -1,6 +1,8 @@
 class Api::Current::HelpController < APIController
   layout false
 
+  skip_before_action :current_user_present?, only: [:show]
+  skip_before_action :validate_sync_approval_status_allowed, only: [:show]
   skip_before_action :authenticate, only: [:show]
   skip_before_action :validate_facility, only: [:show]
   skip_before_action :validate_current_facility_belongs_to_users_facility_group, only: [:show]

--- a/app/controllers/api/current/logins_controller.rb
+++ b/app/controllers/api/current/logins_controller.rb
@@ -1,4 +1,6 @@
 class Api::Current::LoginsController < APIController
+  skip_before_action :current_user_present?, only: [:login_user]
+  skip_before_action :validate_sync_approval_status_allowed, only: [:login_user]
   skip_before_action :authenticate, only: [:login_user]
   skip_before_action :validate_facility, only: [:login_user]
   skip_before_action :validate_current_facility_belongs_to_users_facility_group, only: [:login_user]

--- a/app/controllers/api/current/protocols_controller.rb
+++ b/app/controllers/api/current/protocols_controller.rb
@@ -1,4 +1,6 @@
 class Api::Current::ProtocolsController < Api::Current::SyncController
+  skip_before_action :current_user_present?, only: [:sync_to_user]
+  skip_before_action :validate_sync_approval_status_allowed, only: [:sync_to_user]
   skip_before_action :authenticate, only: [:sync_to_user]
   skip_before_action :validate_facility, only: [:sync_to_user]
   skip_before_action :validate_current_facility_belongs_to_users_facility_group, only: [:sync_to_user]

--- a/app/controllers/api/current/users_controller.rb
+++ b/app/controllers/api/current/users_controller.rb
@@ -1,4 +1,6 @@
 class Api::Current::UsersController < APIController
+  skip_before_action :current_user_present?, only: [:register, :find, :request_otp]
+  skip_before_action :validate_sync_approval_status_allowed, only: [:register, :find, :request_otp]
   skip_before_action :authenticate, only: [:register, :find, :request_otp]
   skip_before_action :validate_facility, only: [:register, :find, :request_otp]
   skip_before_action :validate_current_facility_belongs_to_users_facility_group, only: [:register, :find, :request_otp]

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,5 +1,9 @@
 class APIController < ApplicationController
-  before_action :authenticate, :validate_facility, :validate_current_facility_belongs_to_users_facility_group
+  before_action :current_user_present?,
+                :validate_sync_approval_status_allowed,
+                :authenticate,
+                :validate_facility,
+                :validate_current_facility_belongs_to_users_facility_group
 
   TIME_WITHOUT_TIMEZONE_FORMAT = '%FT%T.%3NZ'.freeze
 
@@ -12,6 +16,8 @@ class APIController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound do
     head :not_found
   end
+
+  private
 
   def current_user
     @current_user ||= User.find_by(id: request.headers['HTTP_X_USER_ID'])
@@ -33,13 +39,17 @@ class APIController < ApplicationController
     return head :unauthorized unless current_user.present? && current_facility_group.facilities.where(id: current_facility.id).present?
   end
 
-  def authenticate
-    return head :unauthorized unless authenticated?
-    current_user.mark_as_logged_in if current_user.has_never_logged_in?
+  def current_user_present?
+    return head :unauthorized unless current_user.present?
   end
 
-  def authenticated?
-    current_user.present? && current_user.access_token_valid? && access_token_authorized?
+  def validate_sync_approval_status_allowed
+    head :forbidden unless current_user.sync_approval_status_allowed?
+  end
+
+  def authenticate
+    return head :unauthorized unless access_token_authorized?
+    current_user.mark_as_logged_in if current_user.has_never_logged_in?
   end
 
   def access_token_authorized?

--- a/spec/api/current/analytics_spec.rb
+++ b/spec/api/current/analytics_spec.rb
@@ -27,6 +27,8 @@ describe 'Analytics Current API', swagger_doc: 'current/swagger.json' do
 
         run_test!
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 
@@ -56,6 +58,8 @@ describe 'Analytics Current API', swagger_doc: 'current/swagger.json' do
 
         run_test!
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 end

--- a/spec/api/current/appointments_spec.rb
+++ b/spec/api/current/appointments_spec.rb
@@ -32,6 +32,8 @@ describe 'Appointment Current API', swagger_doc: 'current/swagger.json' do
         let(:appointments) { { appointments: (1..3).map { build_invalid_appointment_payload } } }
         run_test!
       end
+
+      include_examples 'returns 403 for post requests for forbidden users', :appointments
     end
 
     get 'Syncs appointment data from server to device.' do
@@ -68,6 +70,8 @@ describe 'Appointment Current API', swagger_doc: 'current/swagger.json' do
           assert_response_matches_metadata(example.metadata)
         end
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 end

--- a/spec/api/current/blood_pressures_spec.rb
+++ b/spec/api/current/blood_pressures_spec.rb
@@ -33,6 +33,8 @@ describe 'BloodPressures Current API', swagger_doc: 'current/swagger.json' do
         let(:blood_pressures) { { blood_pressures: (1..3).map { build_invalid_blood_pressure_payload } } }
         run_test!
       end
+
+      include_examples 'returns 403 for post requests for forbidden users', :blood_pressures
     end
 
     get 'Syncs blood pressure data from server to device.' do
@@ -62,6 +64,8 @@ describe 'BloodPressures Current API', swagger_doc: 'current/swagger.json' do
         let(:limit) { 10 }
         run_test!
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 end

--- a/spec/api/current/medical_histories_spec.rb
+++ b/spec/api/current/medical_histories_spec.rb
@@ -33,6 +33,8 @@ describe 'Medical History Current API', swagger_doc: 'current/swagger.json' do
         let(:medical_histories) { { medical_histories: (1..3).map { build_invalid_medical_history_payload_current } } }
         run_test!
       end
+
+      include_examples 'returns 403 for post requests for forbidden users', :medical_histories
     end
 
     get 'Syncs medical_history data from server to device.' do
@@ -69,6 +71,8 @@ describe 'Medical History Current API', swagger_doc: 'current/swagger.json' do
           assert_response_matches_metadata(example.metadata)
         end
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 end

--- a/spec/api/current/patients_spec.rb
+++ b/spec/api/current/patients_spec.rb
@@ -32,6 +32,8 @@ describe 'Patients Current API', swagger_doc: 'current/swagger.json' do
         let(:patients) { { patients: (1..3).map { build_invalid_patient_payload } } }
         run_test!
       end
+
+      include_examples 'returns 403 for post requests for forbidden users', :patients
     end
 
     get 'Syncs patient, address and phone number data from server to device.' do
@@ -61,6 +63,8 @@ describe 'Patients Current API', swagger_doc: 'current/swagger.json' do
         let(:limit) { 10 }
         run_test!
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 end

--- a/spec/api/current/prescription_drugs_spec.rb
+++ b/spec/api/current/prescription_drugs_spec.rb
@@ -32,6 +32,8 @@ describe 'PrescriptionDrugs Current API', swagger_doc: 'current/swagger.json' do
         let(:prescription_drugs) { { prescription_drugs: (1..3).map { build_invalid_prescription_drug_payload } } }
         run_test!
       end
+
+      include_examples 'returns 403 for post requests for forbidden users', :prescription_drugs
     end
 
     get 'Syncs prescription drugs data from server to device.' do
@@ -61,6 +63,8 @@ describe 'PrescriptionDrugs Current API', swagger_doc: 'current/swagger.json' do
         let(:limit) { 10 }
         run_test!
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 end

--- a/spec/api/current/protocols_spec.rb
+++ b/spec/api/current/protocols_spec.rb
@@ -23,7 +23,7 @@ describe 'Protocols Current API', swagger_doc: 'current/swagger.json' do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
 
         schema Api::Current::Schema.protocol_sync_to_user_response
-        let(:process_token) { Base64.encode64({other_facilities_processed_since: 10.minutes.ago}.to_json) }
+        let(:process_token) { Base64.encode64({ other_facilities_processed_since: 10.minutes.ago }.to_json) }
         let(:limit) { 10 }
 
         before do |example|

--- a/spec/api/shared_examples/shared_spec_for_forbidden_users.rb
+++ b/spec/api/shared_examples/shared_spec_for_forbidden_users.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'returns 403 for post requests for forbidden users' do |request_key|
+  response '403', 'user is not allowed to sync' do
+    let(:request_user) do
+      user = create(:user)
+      user.update(sync_approval_status: :denied)
+      user
+    end
+    let(:request_facility) { create(:facility, facility_group: request_user.facility.facility_group) }
+    let(:HTTP_X_USER_ID) { request_user.id }
+    let(:HTTP_X_FACILITY_ID) { request_facility.id }
+    let(:Authorization) { "Bearer #{request_user.access_token}" }
+
+    let(request_key.to_sym) { { request_key => [] } }
+    run_test!
+  end
+end
+
+RSpec.shared_examples 'returns 403 for get requests for forbidden users' do
+  response '403', 'user is not allowed to sync' do
+    let(:request_user) do
+      user = create(:user)
+      user.update(sync_approval_status: :denied)
+      user
+    end
+
+    let(:request_facility) { create(:facility, facility_group: request_user.facility.facility_group) }
+    let(:HTTP_X_USER_ID) { request_user.id }
+    let(:HTTP_X_FACILITY_ID) { request_facility.id }
+    let(:Authorization) { "Bearer #{request_user.access_token}" }
+
+    let(:process_token) { Base64.encode64({other_facilities_processed_since: 10.minutes.ago}.to_json) }
+    let(:limit) { 10 }
+    run_test!
+  end
+end

--- a/spec/api/v2/analytics_spec.rb
+++ b/spec/api/v2/analytics_spec.rb
@@ -27,6 +27,8 @@ describe 'Analytics V2 API', swagger_doc: 'v2/swagger.json' do
 
         run_test!
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 
@@ -56,6 +58,8 @@ describe 'Analytics V2 API', swagger_doc: 'v2/swagger.json' do
 
         run_test!
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 end

--- a/spec/api/v2/appointments_spec.rb
+++ b/spec/api/v2/appointments_spec.rb
@@ -32,6 +32,8 @@ describe 'Appointment V2 API', swagger_doc: 'v2/swagger.json' do
         let(:appointments) { { appointments: (1..3).map { build_invalid_appointment_payload } } }
         run_test!
       end
+
+      include_examples 'returns 403 for post requests for forbidden users', :appointments
     end
 
     get 'Syncs appointment data from server to device.' do
@@ -68,6 +70,8 @@ describe 'Appointment V2 API', swagger_doc: 'v2/swagger.json' do
           assert_response_matches_metadata(example.metadata)
         end
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 end

--- a/spec/api/v2/blood_pressures_spec.rb
+++ b/spec/api/v2/blood_pressures_spec.rb
@@ -33,6 +33,8 @@ describe 'BloodPressures V2 API', swagger_doc: 'v2/swagger.json' do
         let(:blood_pressures) { { blood_pressures: (1..3).map { build_invalid_blood_pressure_payload } } }
         run_test!
       end
+
+      include_examples 'returns 403 for post requests for forbidden users', :blood_pressures
     end
 
     get 'Syncs blood pressure data from server to device.' do
@@ -62,6 +64,8 @@ describe 'BloodPressures V2 API', swagger_doc: 'v2/swagger.json' do
         let(:limit) { 10 }
         run_test!
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 end

--- a/spec/api/v2/communications_spec.rb
+++ b/spec/api/v2/communications_spec.rb
@@ -33,6 +33,8 @@ describe 'Communication V2 API', swagger_doc: 'v2/swagger.json' do
         let(:communications) { { communications: (1..3).map { build_invalid_communication_payload } } }
         run_test!
       end
+
+      include_examples 'returns 403 for post requests for forbidden users', :communications
     end
 
     get 'Syncs communication data from server to device.' do
@@ -68,6 +70,8 @@ describe 'Communication V2 API', swagger_doc: 'v2/swagger.json' do
           assert_response_matches_metadata(example.metadata)
         end
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 end

--- a/spec/api/v2/medical_histories_spec.rb
+++ b/spec/api/v2/medical_histories_spec.rb
@@ -33,6 +33,8 @@ describe 'Medical History V2 API', swagger_doc: 'v2/swagger.json' do
         let(:medical_histories) { { medical_histories: (1..3).map { build_invalid_medical_history_payload_v2 } } }
         run_test!
       end
+
+      include_examples 'returns 403 for post requests for forbidden users', :medical_histories
     end
 
     get 'Syncs medical_history data from server to device.' do
@@ -69,6 +71,8 @@ describe 'Medical History V2 API', swagger_doc: 'v2/swagger.json' do
           assert_response_matches_metadata(example.metadata)
         end
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 end

--- a/spec/api/v2/patients_spec.rb
+++ b/spec/api/v2/patients_spec.rb
@@ -32,6 +32,8 @@ describe 'Patients V2 API', swagger_doc: 'v2/swagger.json' do
         let(:patients) { { patients: (1..3).map { build_invalid_patient_payload } } }
         run_test!
       end
+
+      include_examples 'returns 403 for post requests for forbidden users', :patients
     end
 
     get 'Syncs patient, address and phone number data from server to device.' do
@@ -61,6 +63,8 @@ describe 'Patients V2 API', swagger_doc: 'v2/swagger.json' do
         let(:limit) { 10 }
         run_test!
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 end

--- a/spec/api/v2/prescription_drugs_spec.rb
+++ b/spec/api/v2/prescription_drugs_spec.rb
@@ -32,6 +32,8 @@ describe 'PrescriptionDrugs V2 API', swagger_doc: 'v2/swagger.json' do
         let(:prescription_drugs) { { prescription_drugs: (1..3).map { build_invalid_prescription_drug_payload } } }
         run_test!
       end
+
+      include_examples 'returns 403 for post requests for forbidden users', :prescription_drugs
     end
 
     get 'Syncs prescription drugs data from server to device.' do
@@ -61,6 +63,8 @@ describe 'PrescriptionDrugs V2 API', swagger_doc: 'v2/swagger.json' do
         let(:limit) { 10 }
         run_test!
       end
+
+      include_examples 'returns 403 for get requests for forbidden users'
     end
   end
 end

--- a/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
+++ b/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
@@ -36,6 +36,21 @@ RSpec.shared_examples 'a sync controller that authenticates user requests' do
       expect(response.status).not_to eq(401)
     end
 
+    it 'returns 403 for user which has been denied access' do
+      request_user.update(sync_approval_status: :denied)
+      get :sync_to_user, params: empty_payload
+
+      expect(response.status).to eq(403)
+    end
+
+    it 'returns 403 for users which have sync approval status set to requested' do
+      request_user.update(sync_approval_status: :requested)
+      get :sync_to_user, params: empty_payload
+
+      expect(response.status).to eq(403)
+    end
+
+
     it 'sets user logged_in_at on successful authentication' do
       now = Time.now
       Timecop.freeze(now) do

--- a/swagger/current/swagger.json
+++ b/swagger/current/swagger.json
@@ -58,6 +58,9 @@
         "responses": {
           "200": {
             "description": "JSON received"
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }
@@ -93,6 +96,9 @@
         "responses": {
           "200": {
             "description": "HTML received"
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }
@@ -140,6 +146,9 @@
         "responses": {
           "200": {
             "description": "some, or no errors were found"
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       },
@@ -198,6 +207,9 @@
                 "process_token"
               ]
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }
@@ -253,6 +265,9 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       },
@@ -311,6 +326,9 @@
                 "process_token"
               ]
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }
@@ -513,6 +531,9 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       },
@@ -571,6 +592,9 @@
                 "process_token"
               ]
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }
@@ -626,6 +650,9 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       },
@@ -684,6 +711,9 @@
                 "process_token"
               ]
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }
@@ -739,6 +769,9 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       },
@@ -797,6 +830,9 @@
                 "process_token"
               ]
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -58,6 +58,9 @@
         "responses": {
           "200": {
             "description": "JSON received"
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }
@@ -93,6 +96,9 @@
         "responses": {
           "200": {
             "description": "HTML received"
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }
@@ -140,6 +146,9 @@
         "responses": {
           "200": {
             "description": "some, or no errors were found"
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       },
@@ -198,6 +207,9 @@
                 "process_token"
               ]
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }
@@ -253,6 +265,9 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       },
@@ -311,6 +326,9 @@
                 "process_token"
               ]
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }
@@ -366,6 +384,9 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       },
@@ -424,6 +445,9 @@
                 "process_token"
               ]
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }
@@ -626,6 +650,9 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       },
@@ -684,6 +711,9 @@
                 "process_token"
               ]
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }
@@ -739,6 +769,9 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       },
@@ -797,6 +830,9 @@
                 "process_token"
               ]
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }
@@ -852,6 +888,9 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       },
@@ -910,6 +949,9 @@
                 "process_token"
               ]
             }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
           }
         }
       }


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/167668258

The Android app uses response code `401` to automatically log the user out. Returning `403` to prevent this.