### PR TITLE
Use `recorded_at` to order a patient's latest BPs

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -19,7 +19,7 @@ class Patient < ApplicationRecord
   has_many :phone_numbers, class_name: 'PatientPhoneNumber'
   has_many :business_identifiers, class_name: 'PatientBusinessIdentifier'
   has_many :blood_pressures, inverse_of: :patient
-  has_many :latest_blood_pressures, -> { order(device_created_at: :desc) }, class_name: 'BloodPressure'
+  has_many :latest_blood_pressures, -> { order(recorded_at: :desc) }, class_name: 'BloodPressure'
   has_many :prescription_drugs
   has_many :facilities, -> { distinct }, through: :blood_pressures
   has_many :users, -> { distinct }, through: :blood_pressures


### PR DESCRIPTION
**Bug:** https://www.pivotaltracker.com/story/show/167752845

`Patient#latest_blood_pressures` currently orders by `device_created_at`, which produces very odd BP order if backdated BPs are entered. It should use `recorded_at` to more accurately reflect the intent of "latest BPs".

Note that this impacts the `Appointment` model in a few places. I'm not sure what the impact is exactly; needs more review.