### PR TITLE
Only show registered patients for the facility in cohort reports

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -46,7 +46,7 @@ class Facility < ApplicationRecord
   friendly_id :name, use: :slugged
 
   def cohort_analytics
-    query = CohortAnalyticsQuery.new(self.patients)
+    query = CohortAnalyticsQuery.new(self.registered_patients)
     results = {}
 
     (0..2).each do |quarters_back|


### PR DESCRIPTION
**Bug:** https://www.pivotaltracker.com/story/show/167753190

The cohort reports should only include registered patients for the facility, not every patient ever seen there.