### PR TITLE
Skip BP display in BP log (facilities dashboard) if its patient record is not present in the backend

### DIFF
--- a/app/views/shared/_recent_bp_log.html.erb
+++ b/app/views/shared/_recent_bp_log.html.erb
@@ -26,6 +26,7 @@
         </thead>
         <% last_date = nil %>
         <% blood_pressures.each do |bp| %>
+          <% next if bp.patient.blank? %>
           <% if print_date = (bp.recorded_at.to_date != last_date) %>
             <% last_date = bp.recorded_at.to_date %>
           <% end %>


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/167893720