### PR TITLE
Use recorded_at for graphs in the Progress tab

### DIFF
--- a/app/controllers/api/current/analytics/user_analytics_controller.rb
+++ b/app/controllers/api/current/analytics/user_analytics_controller.rb
@@ -34,7 +34,7 @@ class Api::Current::Analytics::UserAnalyticsController < Api::Current::Analytics
   end
 
   def first_patient_at_facility
-    current_facility.registered_patients.order(:device_created_at).first
+    current_facility.registered_patients.order(:recorded_at).first
   end
 
   def total_patients_count
@@ -43,15 +43,15 @@ class Api::Current::Analytics::UserAnalyticsController < Api::Current::Analytics
 
   def unique_patients_recorded_per_month
     BloodPressure.where(facility: current_facility)
-      .group_by_month(:device_created_at, last: MONTHS_TO_REPORT, reverse: true)
+      .group_by_month(:recorded_at, last: MONTHS_TO_REPORT, reverse: true)
       .count('distinct patient_id')
-      .select { |k, v| k >= first_patient_at_facility.device_created_at.at_beginning_of_month }
+      .select { |k, v| k >= first_patient_at_facility.recorded_at.at_beginning_of_month }
   end
 
   def patients_enrolled_per_month
     Patient.where(registration_facility_id: current_facility.id)
-      .group_by_month(:device_created_at, reverse: true, last: MONTHS_TO_REPORT)
+      .group_by_month(:recorded_at, reverse: true, last: MONTHS_TO_REPORT)
       .count
-      .select { |k, v| k >= first_patient_at_facility.device_created_at.at_beginning_of_month }
+      .select { |k, v| k >= first_patient_at_facility.recorded_at.at_beginning_of_month }
   end
 end


### PR DESCRIPTION
**Bug:** https://www.pivotaltracker.com/story/show/167938948

In the Progress tab of the app, we want to show nurses when the patients were _actually_ seen and BP measured, not when they did data entry in the app.