### PR TITLE
Allow owners to download whatsapp graphics as well

### DIFF
--- a/app/policies/organization_district_policy.rb
+++ b/app/policies/organization_district_policy.rb
@@ -13,6 +13,6 @@ class OrganizationDistrictPolicy < ApplicationPolicy
   end
 
   def whatsapp_graphics?
-    user.has_role?(:organization_owner, :supervisor) && user.organizations.include?(record.organization)
+    user.owner? || (user.has_role?(:organization_owner, :supervisor) && user.organizations.include?(record.organization))
   end
 end


### PR DESCRIPTION
This bug was recently introduced when adding call details to the dashboard. 