### PR TITLE
Add readline to development gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development, :test do
   gem 'capistrano-db-tasks', require: false
   gem 'parallel_tests', group: [:development, :test]
   gem 'rails-controller-testing'
+  gem 'rb-readline'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,6 +271,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rb-readline (0.5.5)
     redis (4.1.0)
     redis-actionpack (5.0.2)
       actionpack (>= 4.0, < 6)
@@ -457,6 +458,7 @@ DEPENDENCIES
   rails (~> 5.1.6.2)
   rails-controller-testing
   rails-erd
+  rb-readline
   redis
   redis-rails
   roo (~> 2.8.0)


### PR DESCRIPTION
This prevents the following message:

```
dlopen(/Users/govind/.rbenv/versions/2.5.1/lib/ruby/2.5.0/x86_64-darwin17/readline.bundle, 9): Library not loaded: /usr/local/opt/readline/lib/libreadline.7.dylib (LoadError)
  Referenced from: /Users/govind/.rbenv/versions/2.5.1/lib/ruby/2.5.0/x86_64-darwin17/readline.bundle
  Reason: image not found - /Users/govind/.rbenv/versions/2.5.1/lib/ruby/2.5.0/x86_64-darwin17/readline.bundle``` 