### PR TITLE
Progress tab timestamp

### DIFF
--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -1,3 +1,7 @@
+.text-muted {
+  color: #ADB2B8;
+}
+
 .bar-chart {
   clear: both;
   //overflow: scroll;

--- a/app/views/api/current/analytics/user_analytics/show.html.erb
+++ b/app/views/api/current/analytics/user_analytics/show.html.erb
@@ -40,7 +40,9 @@
     </div>
   </div>
 
-  <footer></footer>
+  <footer>
+    <small class="text-muted">Updated at <%= l(Time.now) %></small>
+  </footer>
 <% end %>
 </body>
 </html>

--- a/app/views/api/v2/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v2/analytics/user_analytics/show.html.erb
@@ -40,7 +40,9 @@
     </div>
   </div>
 
-  <footer></footer>
+  <footer>
+    <small class="text-muted">Updated at <%= Time.now %></small>
+  </footer>
 <% end %>
 </body>
 </html>

--- a/app/views/api/v2/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v2/analytics/user_analytics/show.html.erb
@@ -41,7 +41,7 @@
   </div>
 
   <footer>
-    <small class="text-muted">Updated at <%= Time.now %></small>
+    <small class="text-muted">Updated at <%= l(Time.now) %></small>
   </footer>
 <% end %>
 </body>


### PR DESCRIPTION
Adds a "last updated at" timestamp so users know when the progress tab view is stale

<img width="451" alt="image" src="https://user-images.githubusercontent.com/612212/64926481-02b18780-d7cc-11e9-9088-bb48fe033e71.png">
