### PR TITLE
Fix duplicate gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,10 +53,7 @@ gem 'lodash-rails'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'factory_bot_rails', require: true
   gem 'shoulda-matchers', '~> 3.1'
-  gem 'faker', require: true
-  gem 'timecop', '~> 0.9.0', require: true
   gem 'capistrano', '~> 3.10'
   gem 'capistrano-rails'
   gem 'capistrano-rbenv'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,9 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 require 'capybara/rails'
 require 'pundit/rspec'
+require 'factory_bot_rails'
+require 'faker'
+require 'timecop'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 Dir[Rails.root.join('spec/pages/application_page.rb')].each { |f| require f }


### PR DESCRIPTION
Bundler doesn't allow you to easily add conditions around auto-require, so let's disable auto-require for these gems and require the manually where necessary.

- FactoryBot
- Faker
- Timecop