### PR TITLE
Make date handling and timezones consistent across the app

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -56,6 +56,6 @@ class AdminsController < AdminController
     { full_name: params.require(:full_name),
       role: params.require(:role),
       organization_id: params[:organization_id],
-      device_updated_at: Time.now }
+      device_updated_at: Time.current }
   end
 end

--- a/app/controllers/api/current/analytics/user_analytics_controller.rb
+++ b/app/controllers/api/current/analytics/user_analytics_controller.rb
@@ -30,7 +30,7 @@ class Api::Current::Analytics::UserAnalyticsController < Api::Current::Analytics
   end
 
   def first_of_current_month
-    Date.today.at_beginning_of_month
+    Date.current.at_beginning_of_month
   end
 
   def first_patient_at_facility

--- a/app/controllers/api/current/sync_controller.rb
+++ b/app/controllers/api/current/sync_controller.rb
@@ -20,7 +20,7 @@ class Api::Current::SyncController < APIController
   end
 
   def __sync_to_user__(response_key)
-    AuditLog.create_logs_async(current_user, records_to_sync, 'fetch', Time.now) unless disable_audit_logs?
+    AuditLog.create_logs_async(current_user, records_to_sync, 'fetch', Time.current) unless disable_audit_logs?
     render(
       json: {
         response_key => records_to_sync.map { |record| transform_to_response(record) },

--- a/app/controllers/api/current/twilio_sms_delivery_controller.rb
+++ b/app/controllers/api/current/twilio_sms_delivery_controller.rb
@@ -11,7 +11,7 @@ class Api::Current::TwilioSmsDeliveryController < ApplicationController
 
   def update_params
     details = { result: delivery_status }
-    details.merge!(delivered_on: DateTime.now) if delivery_status == TwilioSmsDeliveryDetail.results[:delivered]
+    details.merge!(delivered_on: DateTime.current) if delivery_status == TwilioSmsDeliveryDetail.results[:delivered]
 
     details
   end

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -19,7 +19,7 @@ class AppointmentsController < AdminController
       format.html { @appointments = paginate(@appointments) }
       format.csv do
         facility_name = selected_facilities.size > 1 ? "all" : selected_facilities.first.name.parameterize
-        send_data @appointments.to_csv, filename: "overdue-patients_#{facility_name}_#{Date.today}.csv"
+        send_data @appointments.to_csv, filename: "overdue-patients_#{facility_name}_#{Date.current}.csv"
       end
     end
   end

--- a/app/controllers/concerns/api/v1/sync_controller_overrides.rb
+++ b/app/controllers/concerns/api/v1/sync_controller_overrides.rb
@@ -4,7 +4,7 @@ module Api::V1::SyncControllerOverrides
   included do
     def __sync_to_user__(response_key)
       records_to_sync = find_records_to_sync(processed_since, limit)
-      AuditLog.create_logs_async(current_user, records_to_sync, 'fetch', Time.now) unless disable_audit_logs?
+      AuditLog.create_logs_async(current_user, records_to_sync, 'fetch', Time.current) unless disable_audit_logs?
       render(
         json: {
           response_key => records_to_sync.map { |record| transform_to_response(record) },

--- a/app/controllers/concerns/graphics_download.rb
+++ b/app/controllers/concerns/graphics_download.rb
@@ -14,7 +14,7 @@ module GraphicsDownload
             quarter_string(quarter_start(@year, @quarter)).split.join('_'),
             organization_name,
             name,
-            Date.today)
+            Date.current)
 
           render_as_png('/shared/graphics/image_template', filename)
         end

--- a/app/controllers/email_authentications/invitations_controller.rb
+++ b/app/controllers/email_authentications/invitations_controller.rb
@@ -40,8 +40,8 @@ class EmailAuthentications::InvitationsController < Devise::InvitationsControlle
     { full_name: params.require(:full_name),
       role: params.require(:role),
       organization_id: params.require(:organization_id),
-      device_created_at: Time.now,
-      device_updated_at: Time.now,
+      device_created_at: Time.current,
+      device_updated_at: Time.current,
       sync_approval_status: :denied }
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,7 +22,7 @@ module ApplicationHelper
   end
 
   def rounded_time_ago_in_words(date)
-    if date == Date.today
+    if date == Date.current
       "Today"
     elsif date == Date.yesterday
       "Yesterday"

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -7,7 +7,7 @@ module DashboardHelper
     value.nil? || value.zero?
   end
 
-  def dates_for_periods(period, previous_periods, from_date: Time.now)
+  def dates_for_periods(period, previous_periods, from_date: Time.current)
     period_range = (0..(previous_periods - 1)).to_a.reverse
 
     if period == :month

--- a/app/helpers/quarter_helper.rb
+++ b/app/helpers/quarter_helper.rb
@@ -4,7 +4,7 @@ module QuarterHelper
   end
 
   def current_quarter
-    quarter(Date.today)
+    quarter(Date.current)
   end
 
   def previous_quarter_and_year
@@ -27,7 +27,7 @@ module QuarterHelper
   end
 
   def current_year
-    Date.today.year
+    Date.current.year
   end
 
   def quarter_datetime(year, quarter)

--- a/app/jobs/automatic_phone_number_whitelisting_worker.rb
+++ b/app/jobs/automatic_phone_number_whitelisting_worker.rb
@@ -14,7 +14,7 @@ class AutomaticPhoneNumberWhitelistingWorker
     ExotelAPIService.new(sid, token)
       .whitelist_phone_numbers(virtual_number, numbers)
 
-    time = Time.now
+    time = Time.current
     patient_phone_numbers.each { |patient_phone_number| patient_phone_number.update_whitelist_requested_at(time) }
   end
 end

--- a/app/mailers/patient_list_download_mailer.rb
+++ b/app/mailers/patient_list_download_mailer.rb
@@ -7,7 +7,7 @@ class PatientListDownloadMailer < ApplicationMailer
 
     subject = I18n.t('patient_list_email.subject', model_type: @model_type, model_name: @model_name)
 
-    file_name = "patient-list_#{model_type}_#{@model_name.strip}_#{I18n.l(Date.today)}.csv"
+    file_name = "patient-list_#{model_type}_#{@model_name.strip}_#{I18n.l(Date.current)}.csv"
     attachments[file_name] = {
       mime_type: "text/csv",
       content: patients_csv

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -41,16 +41,16 @@ class Appointment < ApplicationRecord
 
   def self.overdue
     where(status: 'scheduled')
-      .where('scheduled_date <= ?', Date.today)
-      .where('remind_on IS NULL OR remind_on <= ?', Date.today)
+      .where('scheduled_date <= ?', Date.current)
+      .where('remind_on IS NULL OR remind_on <= ?', Date.current)
   end
 
   def self.overdue_by(number_of_days)
-    overdue.where('scheduled_date <= ?', Date.today - number_of_days.days)
+    overdue.where('scheduled_date <= ?', Date.current - number_of_days.days)
   end
 
   def days_overdue
-    (Date.today - scheduled_date).to_i
+    (Date.current - scheduled_date).to_i
   end
 
   def scheduled?
@@ -58,7 +58,7 @@ class Appointment < ApplicationRecord
   end
 
   def overdue?
-    scheduled? && scheduled_date <= Date.today
+    scheduled? && scheduled_date <= Date.current
   end
 
   def overdue_for_over_a_year?

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -21,7 +21,7 @@ class AuditLog < ApplicationRecord
         auditable_type: record.class.to_s,
         auditable_id: record.id,
         action: MERGE_STATUS_TO_ACTION[record.merge_status],
-        time: Time.now }
+        time: Time.current }
     )
   end
 
@@ -32,7 +32,7 @@ class AuditLog < ApplicationRecord
         auditable_type: record.class.to_s,
         auditable_id: record.id,
         action: 'fetch',
-        time: Time.now }
+        time: Time.current }
     )
   end
 
@@ -43,7 +43,7 @@ class AuditLog < ApplicationRecord
         auditable_type: 'User',
         auditable_id: user.id,
         action: 'login',
-        time: Time.now }
+        time: Time.current }
     )
   end
 

--- a/app/models/blood_pressure.rb
+++ b/app/models/blood_pressure.rb
@@ -38,7 +38,7 @@ class BloodPressure < ApplicationRecord
   end
 
   def recorded_days_ago
-    (Date.today - device_created_at.to_date).to_i
+    (Date.current - device_created_at.to_date).to_i
   end
 
   def to_s

--- a/app/models/communication.rb
+++ b/app/models/communication.rb
@@ -43,8 +43,8 @@ class Communication < ApplicationRecord
                             detailable: sms_delivery_details,
                             appointment: appointment,
                             user: user,
-                            device_created_at: DateTime.now,
-                            device_updated_at: DateTime.now)
+                            device_created_at: DateTime.current,
+                            device_updated_at: DateTime.current)
     end
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -57,7 +57,7 @@ class Patient < ApplicationRecord
   validates_associated :phone_numbers, if: :phone_numbers
 
   def past_date_of_birth
-    if date_of_birth.present? && date_of_birth > Date.today
+    if date_of_birth.present? && date_of_birth > Date.current
       errors.add(:date_of_birth, "can't be in the future")
     end
   end
@@ -125,11 +125,11 @@ class Patient < ApplicationRecord
 
   def current_age
     if date_of_birth.present?
-      Date.today.year - date_of_birth.year
+      Date.current.year - date_of_birth.year
     elsif age.present?
       return 0 if age == 0
 
-      years_since_update = Date.today.year - age_updated_at.year
+      years_since_update = Date.current.year - age_updated_at.year
       age + years_since_update
     end
   end

--- a/app/models/patient_phone_number.rb
+++ b/app/models/patient_phone_number.rb
@@ -26,7 +26,7 @@ class PatientPhoneNumber < ApplicationRecord
         (exotel_phone_number_details.whitelist_status is null) OR
         (exotel_phone_number_details.whitelist_status = 'neutral') OR
         (exotel_phone_number_details.whitelist_status = 'requested' AND exotel_phone_number_details.whitelist_requested_at <= '#{EXOTEL_RE_REQUEST_WHITELIST_MONTHS.ago}') OR
-        (exotel_phone_number_details.whitelist_status = 'whitelist' AND exotel_phone_number_details.whitelist_status_valid_until <= '#{Time.now}'))
+        (exotel_phone_number_details.whitelist_status = 'whitelist' AND exotel_phone_number_details.whitelist_status_valid_until <= '#{Time.current}'))
       )
   end
 

--- a/app/models/phone_number_authentication.rb
+++ b/app/models/phone_number_authentication.rb
@@ -26,14 +26,14 @@ class PhoneNumberAuthentication < ApplicationRecord
   end
 
   def mark_as_logged_in
-    now = Time.now
+    now = Time.current
     self.otp_valid_until = now
     self.logged_in_at = now
     save
   end
 
   def otp_valid?
-    otp_valid_until >= Time.now
+    otp_valid_until >= Time.current
   end
 
   def set_access_token
@@ -52,7 +52,7 @@ class PhoneNumberAuthentication < ApplicationRecord
     6.times do
       otp += digits.sample.to_s
     end
-    otp_valid_until = Time.now + ENV['USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES'].to_i.minutes
+    otp_valid_until = Time.current + ENV['USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES'].to_i.minutes
 
     { otp: otp, otp_valid_until: otp_valid_until }
   end

--- a/app/queries/cohort_analytics_query.rb
+++ b/app/queries/cohort_analytics_query.rb
@@ -5,7 +5,7 @@ class CohortAnalyticsQuery
     @patients = patients
   end
 
-  def patient_counts_by_period(period, prev_periods, from_date: Date.current)
+  def patient_counts_by_period(period, prev_periods, from_date: Time.current)
     results = {}
 
     (0..(prev_periods)).each do |periods_back|

--- a/app/queries/cohort_analytics_query.rb
+++ b/app/queries/cohort_analytics_query.rb
@@ -5,7 +5,7 @@ class CohortAnalyticsQuery
     @patients = patients
   end
 
-  def patient_counts_by_period(period, prev_periods, from_date: Date.today)
+  def patient_counts_by_period(period, prev_periods, from_date: Date.current)
     results = {}
 
     (0..(prev_periods)).each do |periods_back|

--- a/app/services/exotel_api_service.rb
+++ b/app/services/exotel_api_service.rb
@@ -47,7 +47,7 @@ class ExotelAPIService
 
   def parse_exotel_whitelist_expiry(expiry_time)
     return if expiry_time.blank? || expiry_time < 0
-    Time.now + expiry_time.seconds
+    Time.current + expiry_time.seconds
   end
 
   private

--- a/app/validators/api/current/patient_payload_validator.rb
+++ b/app/validators/api/current/patient_payload_validator.rb
@@ -32,7 +32,7 @@ class Api::Current::PatientPayloadValidator < Api::Current::PayloadValidator
   end
 
   def past_date_of_birth
-    if date_of_birth.present? && date_of_birth.to_s.to_time > Date.today
+    if date_of_birth.present? && date_of_birth.to_s.to_time > Date.current
       errors.add(:date_of_birth, "can't be in the future")
     end
   end

--- a/app/views/api/current/analytics/user_analytics/show.html.erb
+++ b/app/views/api/current/analytics/user_analytics/show.html.erb
@@ -41,7 +41,7 @@
   </div>
 
   <footer>
-    <small class="text-muted">Updated at <%= l(Time.now) %></small>
+    <small class="text-muted">Updated at <%= l(Time.current) %></small>
   </footer>
 <% end %>
 </body>

--- a/app/views/api/v2/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v2/analytics/user_analytics/show.html.erb
@@ -41,7 +41,7 @@
   </div>
 
   <footer>
-    <small class="text-muted">Updated at <%= l(Time.now) %></small>
+    <small class="text-muted">Updated at <%= l(Time.current) %></small>
   </footer>
 <% end %>
 </body>

--- a/app/views/shared/graphics/_graphics_download_links.html.erb
+++ b/app/views/shared/graphics/_graphics_download_links.html.erb
@@ -3,7 +3,7 @@
   <p>
     <%= link_to graphics_path.call(options.merge( quarter: previous_quarter, year: previous_quarter_year, format: "png")), class: "download" do %>
       <i class='fas fa-camera mr-2'></i>
-      <%= "#{quarter_string(Date.today.prev_quarter)} snapshot (PNG)" %>
+      <%= "#{quarter_string(Date.current.prev_quarter)} snapshot (PNG)" %>
     <% end %>
 
      and

--- a/bin/deploy.rb
+++ b/bin/deploy.rb
@@ -186,7 +186,7 @@ This is generated from the diff between #{last_deployed_sha}..HEAD
   end
 
   def current_date
-    Time.now.strftime("%Y-%m-%d")
+    Time.current.strftime("%Y-%m-%d")
   end
 
   def deploy

--- a/config/initializers/bot_user.rb
+++ b/config/initializers/bot_user.rb
@@ -6,7 +6,7 @@ module BotUser
   def find_or_create_bot_user(id, name)
     bot_user = find_bot_user(id)
     return bot_user if bot_user.present?
-    current_time = Time.now
+    current_time = Time.current
     User.find_or_initialize_by(
         id: id,
         full_name: name,

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,10 +6,10 @@ env :PATH, ENV['PATH']
 DEFAULT_CRON_TIME_ZONE = 'Asia/Kolkata'
 
 def local(time)
-  TZInfo::Timezone.get(DEFAULT_CRON_TIME_ZONE).local_to_utc(Time.parse(time))
+  ActiveSupport::TimeZone[DEFAULT_CRON_TIME_ZONE].parse(time).utc
 end
 
-every :day, at: local('11:00 pm').utc, roles: [:cron] do
+every :day, at: local('11:00 pm'), roles: [:cron] do
   rake 'appointment_notification:three_days_after_missed_visit'
 end
 

--- a/lib/tasks/cohort_reports.rake
+++ b/lib/tasks/cohort_reports.rake
@@ -10,6 +10,8 @@ namespace :cohort_reports do
     quarter = args[:quarter].to_i
     organization_name = args[:organization_name]
 
+    Time.zone = 'Asia/Kolkata'
+
     report_start = quarter_start(year, quarter)
     report_end   = report_start.end_of_quarter
     cohort_start = (report_start - 3.months).beginning_of_quarter

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -4,7 +4,7 @@ require 'faker'
 require 'timecop'
 
 namespace :generate do
-  def time_entropy(time = Time.now)
+  def time_entropy(time = Time.current)
     entropy_factor = (1 << 12)
     sleep 0.01; time + SecureRandom.rand * (entropy_factor)
   end

--- a/spec/api/current/logins_spec.rb
+++ b/spec/api/current/logins_spec.rb
@@ -21,7 +21,7 @@ describe 'Login Current API', swagger_doc: 'current/swagger.json' do
 
       response '401', 'user is not logged in with expired otp' do
         let(:db_user) do
-          Timecop.freeze(Date.today - 30) { FactoryBot.create(:user, password: '1234') }
+          Timecop.freeze(Date.current - 30) { FactoryBot.create(:user, password: '1234') }
         end
         let(:user) do
           { user: { phone_number: db_user.phone_number,

--- a/spec/api/v2/logins_spec.rb
+++ b/spec/api/v2/logins_spec.rb
@@ -21,7 +21,7 @@ describe 'Login V2 API', swagger_doc: 'v2/swagger.json' do
 
       response '401', 'user is not logged in with expired otp' do
         let(:db_user) do
-          Timecop.freeze(Date.today - 30) { FactoryBot.create(:user, password: '1234') }
+          Timecop.freeze(Date.current - 30) { FactoryBot.create(:user, password: '1234') }
         end
         let(:user) do
           { user: { phone_number: db_user.phone_number,

--- a/spec/controllers/api/current/logins_controller_spec.rb
+++ b/spec/controllers/api/current/logins_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Api::Current::LoginsController, type: :controller do
 
     describe 'request with valid phone number, password and otp, but otp is expired' do
       let(:db_user) do
-        Timecop.freeze(Date.today - 3) { FactoryBot.create(:user, password: password) }
+        Timecop.freeze(Date.current - 3) { FactoryBot.create(:user, password: password) }
       end
       let(:request_params) do
         { user:

--- a/spec/controllers/api/current/logins_controller_spec.rb
+++ b/spec/controllers/api/current/logins_controller_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Api::Current::LoginsController, type: :controller do
                                       auditable_type: 'User',
                                       auditable_id: db_user.id,
                                       action: 'login',
-                                      time: Time.now }.to_json)
+                                      time: Time.current }.to_json)
 
           post :login_user, params: request_params
         end

--- a/spec/controllers/api/current/patients_controller_spec.rb
+++ b/spec/controllers/api/current/patients_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Api::Current::PatientsController, type: :controller do
       end
 
       it 'sets the recorded_at sent in the params' do
-        time = Time.now
+        time = Time.current
         patient = FactoryBot.build(:patient, recorded_at: time)
         patient_payload = build_patient_payload(patient)
         post(:sync_from_user, params: { patients: [patient_payload] }, as: :json)
@@ -157,7 +157,7 @@ RSpec.describe Api::Current::PatientsController, type: :controller do
 
       it 'with only updated phone numbers' do
         patients_payload = updated_patients_payload.map { |patient| patient.except('address') }
-        sync_time = Time.now
+        sync_time = Time.current
         post :sync_from_user, params: { patients: patients_payload }, as: :json
 
         expect(PatientPhoneNumber.updated_on_server_since(sync_time).count).to eq 3
@@ -171,7 +171,7 @@ RSpec.describe Api::Current::PatientsController, type: :controller do
 
       describe 'with all attributes and associations updated' do
         let!(:patients_payload) { updated_patients_payload }
-        let!(:sync_time) { Time.now }
+        let!(:sync_time) { Time.current }
 
         before do
           post :sync_from_user, params: { patients: patients_payload }, as: :json

--- a/spec/controllers/api/v2/logins_controller_spec.rb
+++ b/spec/controllers/api/v2/logins_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Api::V2::LoginsController, type: :controller do
 
     describe 'request with valid phone number, password and otp, but otp is expired' do
       let(:db_user) do
-        Timecop.freeze(Date.today - 3) { FactoryBot.create(:user, password: password) }
+        Timecop.freeze(Date.current - 3) { FactoryBot.create(:user, password: password) }
       end
       let(:request_params) do
         { user:

--- a/spec/controllers/api/v2/logins_controller_spec.rb
+++ b/spec/controllers/api/v2/logins_controller_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Api::V2::LoginsController, type: :controller do
                                       auditable_type: 'User',
                                       auditable_id: db_user.id,
                                       action: 'login',
-                                      time: Time.now }.to_json)
+                                      time: Time.current }.to_json)
 
           post :login_user, params: request_params
         end

--- a/spec/controllers/api/v2/patients_controller_spec.rb
+++ b/spec/controllers/api/v2/patients_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Api::V2::PatientsController, type: :controller do
 
       it 'with only updated phone numbers' do
         patients_payload = updated_patients_payload.map { |patient| patient.except('address') }
-        sync_time = Time.now
+        sync_time = Time.current
         post :sync_from_user, params: { patients: patients_payload }, as: :json
 
         expect(PatientPhoneNumber.updated_on_server_since(sync_time).count).to eq 3
@@ -152,7 +152,7 @@ RSpec.describe Api::V2::PatientsController, type: :controller do
 
       it 'with all attributes and associations updated' do
         patients_payload = updated_patients_payload
-        sync_time = Time.now
+        sync_time = Time.current
         post :sync_from_user, params: { patients: patients_payload }, as: :json
 
         patients_payload.each do |updated_patient|

--- a/spec/controllers/appointments_controller_spec.rb
+++ b/spec/controllers/appointments_controller_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe AppointmentsController, type: :controller do
     end
 
     it 'remind_to_call_later updates remind_on' do
-      new_remind_date = Date.today + 7.days
+      new_remind_date = Date.current + 7.days
 
       put :update, params: {
         id: overdue_appointment.id,
@@ -124,7 +124,7 @@ RSpec.describe AppointmentsController, type: :controller do
     end
 
     it 'agreed_to_visit updates agreed_to_visit and remind_on' do
-      new_remind_date = Date.today + 30.days
+      new_remind_date = Date.current + 30.days
 
       put :update, params: {
         id: overdue_appointment.id,

--- a/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
+++ b/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
@@ -52,7 +52,7 @@ RSpec.shared_examples 'a sync controller that authenticates user requests' do
 
 
     it 'sets user logged_in_at on successful authentication' do
-      now = Time.now
+      now = Time.current
       Timecop.freeze(now) do
         get :sync_to_user, params: empty_payload
 
@@ -423,7 +423,7 @@ RSpec.shared_examples 'a sync controller that audits the data access' do
                                     auditable_type: auditable_type,
                                     auditable_id: record[:id],
                                     action: 'create',
-                                    time: Time.now }.to_json)
+                                    time: Time.current }.to_json)
 
         post :sync_from_user, params: payload, as: :json
       end
@@ -439,7 +439,7 @@ RSpec.shared_examples 'a sync controller that audits the data access' do
                                     auditable_type: auditable_type,
                                     auditable_id: record[:id],
                                     action: 'update',
-                                    time: Time.now }.to_json)
+                                    time: Time.current }.to_json)
 
         post :sync_from_user, params: payload, as: :json
       end
@@ -456,7 +456,7 @@ RSpec.shared_examples 'a sync controller that audits the data access' do
                                     auditable_type: auditable_type,
                                     auditable_id: record[:id],
                                     action: 'touch',
-                                    time: Time.now }.to_json)
+                                    time: Time.current }.to_json)
 
         post :sync_from_user, params: payload, as: :json
       end
@@ -474,7 +474,7 @@ RSpec.shared_examples 'a sync controller that audits the data access' do
                                         auditable_type: auditable_type,
                                         auditable_id: record[:id],
                                         action: 'fetch',
-                                        time: Time.now }.to_json)
+                                        time: Time.current }.to_json)
           end
           get :sync_to_user, params: {
             processed_since: 20.minutes.ago,

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     state { Faker::Address.state }
     country { Faker::Address.country }
     pin { Faker::Address.zip }
-    device_created_at { Time.now }
-    device_updated_at { Time.now }
+    device_created_at { Time.current }
+    device_updated_at { Time.current }
 
     trait(:no_street_address) do
       street_address { nil }

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -6,8 +6,8 @@ FactoryBot.define do
     scheduled_date { 30.days.from_now }
     status :scheduled
     cancel_reason nil
-    device_created_at { Time.now }
-    device_updated_at { Time.now }
+    device_created_at { Time.current }
+    device_updated_at { Time.current }
     agreed_to_visit nil
     remind_on nil
     appointment_type { Appointment.appointment_types.keys.sample }

--- a/spec/factories/blood_pressures.rb
+++ b/spec/factories/blood_pressures.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
     id { SecureRandom.uuid }
     systolic { rand(80..240) }
     diastolic { rand(60..140) }
-    device_created_at { Time.now }
-    device_updated_at { Time.now }
+    device_created_at { Time.current }
+    device_updated_at { Time.current }
     recorded_at { device_created_at }
     association :facility, strategy: :build
     association :patient, strategy: :build

--- a/spec/factories/call_logs.rb
+++ b/spec/factories/call_logs.rb
@@ -3,11 +3,11 @@ FactoryBot.define do
     id { Faker::Number.unique.number }
     session_id { SecureRandom.uuid }
     result { CallLog.results.keys.sample }
-    created_at { Time.now }
-    updated_at { Time.now }
+    created_at { Time.current }
+    updated_at { Time.current }
     duration { 60 }
     start_time { 1.minute.ago }
-    end_time { Time.now }
+    end_time { Time.current }
     callee_phone_number { Faker::PhoneNumber }
     caller_phone_number { Faker::PhoneNumber }
   end

--- a/spec/factories/communications.rb
+++ b/spec/factories/communications.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
     appointment
     user
     communication_type { :manual_call }
-    device_created_at { Time.now }
-    device_updated_at { Time.now }
+    device_created_at { Time.current }
+    device_updated_at { Time.current }
 
     trait(:missed_visit_sms_reminder) { communication_type { :missed_visit_sms_reminder } }
   end

--- a/spec/factories/medical_histories.rb
+++ b/spec/factories/medical_histories.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
     receiving_treatment_for_hypertension { MedicalHistory::MEDICAL_HISTORY_ANSWERS[:no] }
     diabetes { MedicalHistory::MEDICAL_HISTORY_ANSWERS[:no] }
     diagnosed_with_hypertension { MedicalHistory::MEDICAL_HISTORY_ANSWERS[:no] }
-    device_created_at { Time.now }
-    device_updated_at { Time.now }
+    device_created_at { Time.current }
+    device_updated_at { Time.current }
     user
 
     trait :unknown do

--- a/spec/factories/patient_business_identifiers.rb
+++ b/spec/factories/patient_business_identifiers.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
     id { SecureRandom.uuid }
     identifier { SecureRandom.uuid }
     identifier_type { 'simple_bp_passport' }
-    device_created_at { Time.now }
-    device_updated_at { Time.now }
+    device_created_at { Time.current }
+    device_updated_at { Time.current }
     metadata_version { 'org.simple.bppassport.meta.v1' }
     metadata do
       { assigning_user_id: SecureRandom.uuid,

--- a/spec/factories/patient_phone_numbers.rb
+++ b/spec/factories/patient_phone_numbers.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
     number { Faker::PhoneNumber.phone_number }
     phone_type { 'mobile' }
     active { [true, false].sample }
-    device_created_at { Time.now }
-    device_updated_at { Time.now }
+    device_created_at { Time.current }
+    device_updated_at { Time.current }
     dnd_status { true }
     patient
   end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     gender { Patient::GENDERS.sample }
     full_name { common_names[gender].sample + " " + common_names[gender].sample }
     status { Patient::STATUSES[0] }
-    date_of_birth { Date.today if has_date_of_birth? }
+    date_of_birth { Date.current if has_date_of_birth? }
     age { rand(18..100) unless has_date_of_birth? }
     age_updated_at { Time.now - rand(10).days if age.present? }
     device_created_at { Time.now }

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -14,9 +14,9 @@ FactoryBot.define do
     status { Patient::STATUSES[0] }
     date_of_birth { Date.current if has_date_of_birth? }
     age { rand(18..100) unless has_date_of_birth? }
-    age_updated_at { Time.now - rand(10).days if age.present? }
-    device_created_at { Time.now }
-    device_updated_at { Time.now }
+    age_updated_at { Time.current - rand(10).days if age.present? }
+    device_created_at { Time.current }
+    device_updated_at { Time.current }
     recorded_at { device_created_at }
     association :address, strategy: :build
     phone_numbers { build_list(:patient_phone_number, 1, patient_id: id) }

--- a/spec/factories/prescription_drugs.rb
+++ b/spec/factories/prescription_drugs.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     is_protocol_drug { [true, false].sample }
     is_deleted { [true, false].sample }
     rxnorm_code { Faker::Code.npi }
-    device_created_at { Time.now }
-    device_updated_at { Time.now }
+    device_created_at { Time.current }
+    device_updated_at { Time.current }
     association :facility, strategy: :build
     association :patient, strategy: :build
     user

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
 
     full_name { Faker::Name.name }
     organization
-    device_created_at { Time.now }
-    device_updated_at { Time.now }
+    device_created_at { Time.current }
+    device_updated_at { Time.current }
 
     sync_allowed
 
@@ -59,8 +59,8 @@ FactoryBot.define do
     end
 
     full_name { Faker::Name.name }
-    device_created_at { Time.now }
-    device_updated_at { Time.now }
+    device_created_at { Time.current }
+    device_updated_at { Time.current }
     sync_approval_status { User.sync_approval_statuses[:denied] }
     email_authentications { build_list(:email_authentication, 1, email: email, password: password) }
     user_permissions { [] }
@@ -127,7 +127,7 @@ def register_user_request_params(arguments = {})
     phone_number: Faker::PhoneNumber.phone_number,
     password_digest: BCrypt::Password.create("1234"),
     registration_facility_id: SecureRandom.uuid,
-    created_at: Time.now.iso8601,
-    updated_at: Time.now.iso8601
+    created_at: Time.current.iso8601,
+    updated_at: Time.current.iso8601
   }.merge(arguments)
 end

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.feature "User admin", type: :feature do
   let!(:owner) { create(:admin, :owner) }
   let!(:user) { create(:user) }
-  let!(:bp_1) { create(:blood_pressure, user: user, systolic: 145, diastolic: 95, recorded_at: Time.parse("2019-03-15 8:00am +05:30")) }
-  let!(:bp_2) { create(:blood_pressure, user: user, systolic: 115, diastolic: 75, recorded_at: Time.parse("2019-03-15 2:15pm +05:30")) }
+  let!(:bp_1) { create(:blood_pressure, user: user, systolic: 145, diastolic: 95, recorded_at: Time.zone.parse("2019-03-15 8:00am +05:30")) }
+  let!(:bp_2) { create(:blood_pressure, user: user, systolic: 115, diastolic: 75, recorded_at: Time.zone.parse("2019-03-15 2:15pm +05:30")) }
 
   before do
     sign_in(owner.email_authentication)

--- a/spec/features/analytics/facilities_spec.rb
+++ b/spec/features/analytics/facilities_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.feature "Facility analytics", type: :feature do
   let!(:owner) { create(:admin, :owner) }
   let!(:facility) { create(:facility) }
-  let!(:bp_1) { create(:blood_pressure, facility: facility, systolic: 145, diastolic: 95, recorded_at: Time.parse("2019-03-15 8:00am +05:30")) }
-  let!(:bp_2) { create(:blood_pressure, facility: facility, systolic: 115, diastolic: 75, recorded_at: Time.parse("2019-03-15 2:15pm +05:30")) }
+  let!(:bp_1) { create(:blood_pressure, facility: facility, systolic: 145, diastolic: 95, recorded_at: Time.zone.parse("2019-03-15 8:00am +05:30")) }
+  let!(:bp_2) { create(:blood_pressure, facility: facility, systolic: 115, diastolic: 75, recorded_at: Time.zone.parse("2019-03-15 2:15pm +05:30")) }
 
   before do
     sign_in(owner.email_authentication)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe ApplicationHelper, type: :helper do
   context '#rounded_time_ago_in_words' do
     it 'should return Today if date is less than 24 hours' do
-      date = Date.today
+      date = Date.current
       expect(helper.rounded_time_ago_in_words(date)).to eq("Today")
     end
 
@@ -55,7 +55,7 @@ describe ApplicationHelper, type: :helper do
         appointment1 = FactoryBot.create(:appointment, :overdue, patient_id: patient.id)
         appointment1.status = 'visited'
         appointment1.agreed_to_visit = false
-        appointment1.remind_on = Date.today
+        appointment1.remind_on = Date.current
         appointment1.save
 
         appointment2 = FactoryBot.create(:appointment, :overdue, patient_id: patient.id)

--- a/spec/jobs/automatic_phone_number_whitelisting_worker_spec.rb
+++ b/spec/jobs/automatic_phone_number_whitelisting_worker_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe AutomaticPhoneNumberWhitelistingWorker, type: :job do
         AutomaticPhoneNumberWhitelistingWorker.perform_async(phones_numbers_need_whitelisting.map(&:id), virtual_number, account_sid, token)
         AutomaticPhoneNumberWhitelistingWorker.drain
         phones_numbers_need_whitelisting.each do |phone_number|
-          expect(phone_number.exotel_phone_number_detail.whitelist_requested_at.to_i).to eq(Time.now.to_i)
+          expect(phone_number.exotel_phone_number_detail.whitelist_requested_at.to_i).to eq(Time.current.to_i)
         end
       end
     end

--- a/spec/jobs/create_audit_logs_worker_spec.rb
+++ b/spec/jobs/create_audit_logs_worker_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CreateAuditLogsWorker, type: :job do
                                               record_class: record_class,
                                               record_ids: record_ids,
                                               action: action,
-                                              time: Time.now }.to_json)
+                                              time: Time.current }.to_json)
       }.to change(Sidekiq::Queues['audit_log_queue'], :size).by(1)
       CreateAuditLogsWorker.clear
     end
@@ -31,14 +31,14 @@ RSpec.describe CreateAuditLogsWorker, type: :job do
                                         auditable_type: 'Patient',
                                         auditable_id: record.id,
                                         action: 'fetch',
-                                        time: Time.now }.to_json)
+                                        time: Time.current }.to_json)
           end
         end
         CreateAuditLogsWorker.perform_async({ user_id: user.id,
                                               record_class: record_class,
                                               record_ids: record_ids,
                                               action: action,
-                                              time: Time.now }.to_json)
+                                              time: Time.current }.to_json)
 
 
         CreateAuditLogsWorker.drain

--- a/spec/jobs/exotel_call_details_job_spec.rb
+++ b/spec/jobs/exotel_call_details_job_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe ExotelCallDetailsJob, type: :job do
                                                            'duration' => stubbed_call_duration,
                                                            'callee_phone_number' => callee_phone_number,
                                                            'caller_phone_number' => user_phone_number,
-                                                           'start_time' => DateTime.parse(stubbed_call_start_time),
-                                                           'end_time' => DateTime.parse(stubbed_call_end_time) })
+                                                           'start_time' => Time.zone.parse(stubbed_call_start_time),
+                                                           'end_time' => Time.zone.parse(stubbed_call_end_time) })
   end
 
   it 'should not populate a call log if exotel api is unable to return call details' do

--- a/spec/jobs/update_phone_number_details_worker_spec.rb
+++ b/spec/jobs/update_phone_number_details_worker_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe UpdatePhoneNumberDetailsWorker, type: :job do
   describe '#perform' do
     it 'updates the patient phone number details with the values return from exotel apis' do
       UpdatePhoneNumberDetailsWorker.perform_async(patient_phone_number.id, account_sid, token)
-      time = Time.now
+      time = Time.current
       Timecop.freeze(time) do
         UpdatePhoneNumberDetailsWorker.drain
       end

--- a/spec/models/audit_log_spec.rb
+++ b/spec/models/audit_log_spec.rb
@@ -15,7 +15,7 @@ describe AuditLog, type: :model do
                                     auditable_type: record.class.to_s,
                                     auditable_id: record.id,
                                     action: 'create',
-                                    time: Time.now }.to_json)
+                                    time: Time.current }.to_json)
 
         AuditLog.merge_log(user, record)
       end
@@ -30,7 +30,7 @@ describe AuditLog, type: :model do
                                     auditable_type: record.class.to_s,
                                     auditable_id: record.id,
                                     action: 'fetch',
-                                    time: Time.now }.to_json)
+                                    time: Time.current }.to_json)
 
         AuditLog.fetch_log(user, record)
       end
@@ -45,7 +45,7 @@ describe AuditLog, type: :model do
                                     auditable_type: 'User',
                                     auditable_id: user.id,
                                     action: 'login',
-                                    time: Time.now }.to_json)
+                                    time: Time.current }.to_json)
 
         AuditLog.login_log(user)
       end
@@ -59,7 +59,7 @@ describe AuditLog, type: :model do
 
     it 'schedules a job to create audit logs in the background' do
       expect {
-        AuditLog.create_logs_async(user, records, action, Time.now)
+        AuditLog.create_logs_async(user, records, action, Time.current)
       }.to change(CreateAuditLogsWorker.jobs, :size).by(1)
       CreateAuditLogsWorker.clear
     end
@@ -74,11 +74,11 @@ describe AuditLog, type: :model do
                                         auditable_type: 'Patient',
                                         auditable_id: record.id,
                                         action: 'fetch',
-                                        time: Time.now}.to_json)
+                                        time: Time.current}.to_json)
           end
         end
 
-        AuditLog.create_logs_async(user, records, action, Time.now)
+        AuditLog.create_logs_async(user, records, action, Time.current)
         CreateAuditLogsWorker.drain
       end
     end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -124,7 +124,7 @@ describe Patient, type: :model do
       it "returns age based on date of birth year if present" do
         patient.date_of_birth = Date.parse("1980-01-01")
 
-        expect(patient.current_age).to eq(Date.today.year - 1980)
+        expect(patient.current_age).to eq(Date.current.year - 1980)
       end
 
       it "returns age based on age_updated_at if date of birth is not present" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe User, type: :model do
           password_digest: password_digest,
           registration_facility_id: registration_facility.id,
           organization_id: registration_facility.organization.id,
-          device_created_at: Time.now.iso8601,
-          device_updated_at: Time.now.iso8601
+          device_created_at: Time.current.iso8601,
+          device_updated_at: Time.current.iso8601
         }
       end
 

--- a/spec/payloads/api/current/patient_payload_validator_spec.rb
+++ b/spec/payloads/api/current/patient_payload_validator_spec.rb
@@ -12,7 +12,7 @@ describe Api::Current::PatientPayloadValidator, type: :model do
       expect(new_patient_payload('address' => nil,
                                  'phone_numbers' => nil,
                                  'age' => nil,
-                                 'date_of_birth' => Date.today)).to be_valid
+                                 'date_of_birth' => Date.current)).to be_valid
 
       expect(new_patient_payload('address' => nil,
                                  'phone_numbers' => nil,

--- a/spec/payloads/api/current/patient_payload_validator_spec.rb
+++ b/spec/payloads/api/current/patient_payload_validator_spec.rb
@@ -17,7 +17,7 @@ describe Api::Current::PatientPayloadValidator, type: :model do
       expect(new_patient_payload('address' => nil,
                                  'phone_numbers' => nil,
                                  'age' => rand(18..100),
-                                 'age_updated_at' => Time.now,
+                                 'age_updated_at' => Time.current,
                                  'date_of_birth' => nil).valid?).to be true
 
       expect(new_patient_payload('address' => nil,

--- a/spec/payloads/api/v2/patient_payload_validator_spec.rb
+++ b/spec/payloads/api/v2/patient_payload_validator_spec.rb
@@ -12,7 +12,7 @@ describe Api::V2::PatientPayloadValidator, type: :model do
       expect(new_patient_payload('address' => nil,
                                  'phone_numbers' => nil,
                                  'age' => nil,
-                                 'date_of_birth' => Date.today)).to be_valid
+                                 'date_of_birth' => Date.current)).to be_valid
 
       expect(new_patient_payload('address' => nil,
                                  'phone_numbers' => nil,

--- a/spec/payloads/api/v2/patient_payload_validator_spec.rb
+++ b/spec/payloads/api/v2/patient_payload_validator_spec.rb
@@ -17,7 +17,7 @@ describe Api::V2::PatientPayloadValidator, type: :model do
       expect(new_patient_payload('address' => nil,
                                  'phone_numbers' => nil,
                                  'age' => rand(18..100),
-                                 'age_updated_at' => Time.now,
+                                 'age_updated_at' => Time.current,
                                  'date_of_birth' => nil).valid?).to be true
 
       expect(new_patient_payload('address' => nil,

--- a/spec/queries/cohort_analytics_query_spec.rb
+++ b/spec/queries/cohort_analytics_query_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe CohortAnalyticsQuery do
   let!(:facility) { create(:facility) }
   let(:analytics) { CohortAnalyticsQuery.new(facility.registered_patients) }
 
-  let(:jan)   { Date.new(2019, 1, 1) }
-  let(:feb)   { Date.new(2019, 2, 1) }
-  let(:march) { Date.new(2019, 3, 1) }
-  let(:april) { Date.new(2019, 4, 1) }
-  let(:may)   { Date.new(2019, 5, 1) }
-  let(:june)  { Date.new(2019, 6, 1) }
+  let(:jan)   { DateTime.new(2019, 1, 1) }
+  let(:feb)   { DateTime.new(2019, 2, 1) }
+  let(:march) { DateTime.new(2019, 3, 1) }
+  let(:april) { DateTime.new(2019, 4, 1) }
+  let(:may)   { DateTime.new(2019, 5, 1) }
+  let(:june)  { DateTime.new(2019, 6, 1) }
 
   describe "#patient_counts_by_period" do
     before do
@@ -48,8 +48,8 @@ RSpec.describe CohortAnalyticsQuery do
       # Q2 report: registered in Q1, visited in Q2
       # Q1 report: registered in Q4, visited in Q1
 
-      let(:oct_prev) { Date.new(2018, 10, 1) }
-      let(:dec_prev) { Date.new(2018, 12, 1) }
+      let(:oct_prev) { DateTime.new(2018, 10, 1) }
+      let(:dec_prev) { DateTime.new(2018, 12, 1) }
 
       it "correctly calculates the dates of quarterly cohort reports" do
         travel_to(june) do

--- a/spec/queries/district_analytics_query_spec.rb
+++ b/spec/queries/district_analytics_query_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DistrictAnalyticsQuery do
   let!(:district_name) { "Bathinda" }
   let!(:facility) { create(:facility, facility_group: facility_group, district: district_name) }
   let!(:analytics) { DistrictAnalyticsQuery.new(district_name, facility, :month, 5) }
-  let!(:current_month) { Date.today.beginning_of_month }
+  let!(:current_month) { Date.current.beginning_of_month }
 
   let(:four_months_back) { current_month - 4.months }
   let(:three_months_back) { current_month - 3.months }

--- a/spec/queries/facility_analytics_query_spec.rb
+++ b/spec/queries/facility_analytics_query_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe FacilityAnalyticsQuery do
   let!(:users) { create_list(:user, 2) }
   let!(:facility) { create(:facility) }
   let!(:analytics) { FacilityAnalyticsQuery.new(facility, :month, 6) }
-  let!(:current_month) { Date.today.beginning_of_month }
+  let!(:current_month) { Date.current.beginning_of_month }
 
   let(:five_months_back) { current_month - 5.months }
   let(:four_months_back) { current_month - 4.months }

--- a/spec/requests/shared_examples/api/current/shared_spec_for_sync_requests.rb
+++ b/spec/requests/shared_examples/api/current/shared_spec_for_sync_requests.rb
@@ -91,8 +91,8 @@ RSpec.shared_examples 'current API sync requests' do
   context 'resync_token in request headers is present' do
     let(:resync_token) { "1" }
     let(:headers_with_resync_token) { headers.merge('HTTP_X_RESYNC_TOKEN' => resync_token) }
-    let(:process_token_without_resync) { make_process_token(current_facility_processed_since: Time.now,
-                                                            other_facilities_processed_since: Time.now) }
+    let(:process_token_without_resync) { make_process_token(current_facility_processed_since: Time.current,
+                                                            other_facilities_processed_since: Time.current) }
 
     before do
       post sync_route, params: many_valid_records.to_json, headers: headers
@@ -108,8 +108,8 @@ RSpec.shared_examples 'current API sync requests' do
 
     it 'syncs all records from beginning if resync_token in headers is different from the one in process_token' do
       get sync_route,
-          params: { process_token: make_process_token(current_facility_processed_since: Time.now,
-                                                      other_facilities_processed_since: Time.now,
+          params: { process_token: make_process_token(current_facility_processed_since: Time.current,
+                                                      other_facilities_processed_since: Time.current,
                                                       resync_token: '2') },
           headers: headers_with_resync_token
       response_body = JSON(response.body)

--- a/spec/requests/shared_examples/api/v2/shared_spec_for_sync_requests.rb
+++ b/spec/requests/shared_examples/api/v2/shared_spec_for_sync_requests.rb
@@ -91,8 +91,8 @@ RSpec.shared_examples 'v2 API sync requests' do
   context 'resync_token in request headers is present' do
     let(:resync_token) { "1" }
     let(:headers_with_resync_token) { headers.merge('HTTP_X_RESYNC_TOKEN' => resync_token) }
-    let(:process_token_without_resync) { make_process_token(current_facility_processed_since: Time.now,
-                                                            other_facilities_processed_since: Time.now) }
+    let(:process_token_without_resync) { make_process_token(current_facility_processed_since: Time.current,
+                                                            other_facilities_processed_since: Time.current) }
 
     before do
       post sync_route, params: many_valid_records.to_json, headers: headers

--- a/spec/services/exotel_api_service_spec.rb
+++ b/spec/services/exotel_api_service_spec.rb
@@ -122,7 +122,7 @@ describe ExotelAPIService, type: :model do
     end
 
     it 'return the time at which the expiry will happen if expiry time is greater than 0' do
-      Timecop.freeze(Time.now) do
+      Timecop.freeze(Time.current) do
         expected_time = 1.hour.from_now
         expect(service.parse_exotel_whitelist_expiry(3600)).to eq(expected_time)
       end
@@ -173,7 +173,7 @@ describe ExotelAPIService, type: :model do
           .to eq(dnd_status: true,
                  phone_type: :mobile,
                  whitelist_status: :whitelist,
-                 whitelist_status_valid_until: Time.now + 3600.seconds)
+                 whitelist_status_valid_until: Time.current + 3600.seconds)
       end
     end
   end


### PR DESCRIPTION
Updating our entire app to be consistent in how we reference and parse dates and times. In general, I'm following the advice from this post:

https://thoughtbot.com/blog/its-about-time-zones

In practice, we want the app to consistently do the following:
- Use the app's configured `Time.zone` instead of relying on system time
- Use timestamps instead of raw `Date` objects when querying the database (Postgres does not behave like you expect when querying with only dates)

I've made the following updates:
- Replace `Date.today` with `Date.current`
- Replace `Time.now` with `Time.current`
- Parse times using `Time.zone.parse`
- Run all reports in India time
- Pass all queries to Postgres as timestamps in UTC