### PR TITLE
Fixed broken ascending icon

### DIFF
--- a/app/assets/stylesheets/_dashboard.scss
+++ b/app/assets/stylesheets/_dashboard.scss
@@ -150,5 +150,6 @@ th[aria-sort=descending]:not(.no-sort):after {
 }
 
 th[aria-sort=ascending]:not(.no-sort):after {
-	border-width: 0 4px 4px;
+  border-bottom: 4px solid;
+  border-width: 0 4px 4px;
 }


### PR DESCRIPTION
Need to override `border-bottom` defined in the tablesort library's CSS:

https://github.com/tristen/tablesort/blob/gh-pages/tablesort.css#L21