### PR TITLE
Memoize latest BP to reduce query load in exporter

### DIFF
--- a/app/exporters/patients_exporter.rb
+++ b/app/exporters/patients_exporter.rb
@@ -46,6 +46,10 @@ module PatientsExporter
   end
 
   def self.csv_fields(patient)
+    registration_facility = patient.registration_facility
+    latest_bp = patient.latest_blood_pressure
+    latest_bp_facility = latest_bp&.facility
+
     [
       patient.id,
       patient.latest_bp_passport&.shortcode,
@@ -58,18 +62,18 @@ module PatientsExporter
       patient.phone_numbers.last&.number,
       patient.recorded_at.presence && I18n.l(patient.recorded_at),
       patient.recorded_at.presence && quarter_string(patient.recorded_at),
-      patient.registration_facility&.name,
-      patient.registration_facility&.facility_type,
-      patient.registration_facility&.district,
-      patient.registration_facility&.state,
-      patient.latest_blood_pressure&.systolic,
-      patient.latest_blood_pressure&.diastolic,
-      patient.latest_blood_pressure&.recorded_at.presence && I18n.l(patient.latest_blood_pressure&.recorded_at),
-      patient.latest_blood_pressure&.recorded_at.presence && quarter_string(patient.latest_blood_pressure&.recorded_at),
-      patient.latest_blood_pressure&.facility&.name,
-      patient.latest_blood_pressure&.facility&.facility_type,
-      patient.latest_blood_pressure&.facility&.district,
-      patient.latest_blood_pressure&.facility&.state,
+      registration_facility&.name,
+      registration_facility&.facility_type,
+      registration_facility&.district,
+      registration_facility&.state,
+      latest_bp&.systolic,
+      latest_bp&.diastolic,
+      latest_bp&.recorded_at.presence && I18n.l(latest_bp&.recorded_at),
+      latest_bp&.recorded_at.presence && quarter_string(latest_bp&.recorded_at),
+      latest_bp_facility&.name,
+      latest_bp_facility&.facility_type,
+      latest_bp_facility&.district,
+      latest_bp_facility&.state,
       patient.latest_scheduled_appointment&.days_overdue,
       patient.risk_priority_label
     ]


### PR DESCRIPTION
`patient.latest_blood_pressure` is slow, so reduce the number of times we have to call it.