### PR TITLE
Add trailing slash to all manifest URLs

### DIFF
--- a/public/manifest/development.json
+++ b/public/manifest/development.json
@@ -1,13 +1,13 @@
 [
   {
     "country_code": "IN",
-    "endpoint": "http://localhost:3000",
+    "endpoint": "http://localhost:3000/",
     "display_name": "India",
     "isd_code": "91"
   },
   {
     "country_code": "BD",
-    "endpoint": "http://localhost:3000",
+    "endpoint": "http://localhost:3000/",
     "display_name": "Bangladesh",
     "isd_code": "880"
   }

--- a/public/manifest/production.json
+++ b/public/manifest/production.json
@@ -1,13 +1,13 @@
 [
   {
     "country_code": "IN",
-    "endpoint": "https://api.simple.org",
+    "endpoint": "https://api.simple.org/",
     "display_name": "India",
     "isd_code": "91"
   },
   {
     "country_code": "BD",
-    "endpoint": "https://api.bd.simple.org",
+    "endpoint": "https://api.bd.simple.org/",
     "display_name": "Bangladesh",
     "isd_code": "880"
   }

--- a/public/manifest/qa.json
+++ b/public/manifest/qa.json
@@ -1,13 +1,13 @@
 [
   {
     "country_code": "IN",
-    "endpoint": "https://api-qa.simple.org",
+    "endpoint": "https://api-qa.simple.org/",
     "display_name": "India",
     "isd_code": "91"
   },
   {
     "country_code": "BD",
-    "endpoint": "https://api-qa.simple.org",
+    "endpoint": "https://api-qa.simple.org/",
     "display_name": "Bangladesh",
     "isd_code": "880"
   }

--- a/public/manifest/sandbox.json
+++ b/public/manifest/sandbox.json
@@ -1,13 +1,13 @@
 [
   {
     "country_code": "IN",
-    "endpoint": "https://api-sandbox.simple.org",
+    "endpoint": "https://api-sandbox.simple.org/",
     "display_name": "India",
     "isd_code": "91"
   },
   {
     "country_code": "BD",
-    "endpoint": "https://api-sandbox.simple.org",
+    "endpoint": "https://api-sandbox.simple.org/",
     "display_name": "Bangladesh",
     "isd_code": "880"
   }

--- a/public/manifest/staging.json
+++ b/public/manifest/staging.json
@@ -1,13 +1,13 @@
 [
   {
     "country_code": "IN",
-    "endpoint": "https://api-demo.simple.org",
+    "endpoint": "https://api-demo.simple.org/",
     "display_name": "India",
     "isd_code": "91"
   },
   {
     "country_code": "BD",
-    "endpoint": "https://api-demo.bd.simple.org",
+    "endpoint": "https://api-demo.bd.simple.org/",
     "display_name": "Bangladesh",
     "isd_code": "880"
   }


### PR DESCRIPTION
Some limitation with the URL parsing on the mobile client