### PR TITLE
Return 404 if the Twilio delivery callback fails to find a session

### DIFF
--- a/app/controllers/api/current/twilio_sms_delivery_controller.rb
+++ b/app/controllers/api/current/twilio_sms_delivery_controller.rb
@@ -3,8 +3,14 @@ class Api::Current::TwilioSmsDeliveryController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def create
-    TwilioSmsDeliveryDetail.where(session_id: params['SmsSid']).first.update(update_params)
-    head :ok
+    existing_session = TwilioSmsDeliveryDetail.where(session_id: params['SmsSid'])
+
+    if existing_session.blank?
+      head :not_found
+    else
+      existing_session.first.update(update_params)
+      head :ok
+    end
   end
 
   private


### PR DESCRIPTION
So that Twilio knows that the delivery status update was unsuccessful.