### PR TITLE
Fix visit reminder job schedule

### DIFF
--- a/app/jobs/appointment_notification/missed_visit_job.rb
+++ b/app/jobs/appointment_notification/missed_visit_job.rb
@@ -10,6 +10,6 @@ class AppointmentNotification::MissedVisitJob
     AppointmentNotificationService
       .new
       .send_after_missed_visit(schedule_at:
-                                 schedule_now_or_tomorrow(schedule_hour_start, schedule_hour_finish))
+                                 schedule_today_or_tomorrow(schedule_hour_start, schedule_hour_finish))
   end
 end

--- a/app/jobs/concerns/notifiable.rb
+++ b/app/jobs/concerns/notifiable.rb
@@ -1,12 +1,17 @@
 module Notifiable
-  def schedule_now_or_tomorrow(start, finish)
+  def schedule_today_or_tomorrow(start, finish)
     now = DateTime
             .now
             .in_time_zone(ENV.fetch('DEFAULT_TIME_ZONE'))
 
-    now_within_time_window?(now, start, finish) ?
-      now :
+    case
+    when now_within_time_window?(now, start, finish)
+      now
+    when now.hour <= start
+      now.change(hour: start)
+    else
       now.change(hour: start) + 1.day
+    end
   end
 
   def now_within_time_window?(now, start, finish)


### PR DESCRIPTION
Fixes potential issue:

If the `MissedVisit` job is run before the scheduled SMS time (say before 2PM IST) on the **same day** then the job is scheduled for the next day, it should be scheduled for 2PM the same day instead.