### PR TITLE
Patient list formatting

### DIFF
--- a/app/exporters/patients_exporter.rb
+++ b/app/exporters/patients_exporter.rb
@@ -17,21 +17,17 @@ module PatientsExporter
     end
   end
 
-  private
-
   def self.csv_headers
     [
-      "Simple Patient ID",
-      "BP Passport ID",
+      "Registration Date",
+      "Registration Quarter",
       "Patient Name",
-      "Patient Gender",
       "Patient Age",
+      "Patient Gender",
+      "Patient Phone Number",
       "Patient Village/Colony",
       "Patient District",
       "Patient State",
-      "Patient Phone Number",
-      "Registration Date",
-      "Registration Quarter",
       "Registration Facility Name",
       "Registration Facility Type",
       "Registration Facility District",
@@ -45,7 +41,9 @@ module PatientsExporter
       "Latest BP Facility District",
       "Latest BP Facility State",
       "Days Overdue",
-      "Risk Level"
+      "Risk Level",
+      "BP Passport ID",
+      "Simple Patient ID"
     ]
   end
 
@@ -55,17 +53,15 @@ module PatientsExporter
     latest_bp_facility = latest_bp&.facility
 
     [
-      patient.id,
-      patient.latest_bp_passport&.shortcode,
+      patient.recorded_at.presence && I18n.l(patient.recorded_at),
+      patient.recorded_at.presence && quarter_string(patient.recorded_at),
       patient.full_name,
-      patient.gender.capitalize,
       patient.current_age,
+      patient.gender.capitalize,
+      patient.phone_numbers.last&.number,
       patient.address.village_or_colony,
       patient.address.district,
       patient.address.state,
-      patient.phone_numbers.last&.number,
-      patient.recorded_at.presence && I18n.l(patient.recorded_at),
-      patient.recorded_at.presence && quarter_string(patient.recorded_at),
       registration_facility&.name,
       registration_facility&.facility_type,
       registration_facility&.district,
@@ -79,7 +75,9 @@ module PatientsExporter
       latest_bp_facility&.district,
       latest_bp_facility&.state,
       patient.latest_scheduled_appointment&.days_overdue,
-      patient.risk_priority_label
+      patient.risk_priority_label,
+      patient.latest_bp_passport&.shortcode,
+      patient.id
     ]
   end
 end

--- a/app/jobs/patient_list_download_job.rb
+++ b/app/jobs/patient_list_download_job.rb
@@ -14,7 +14,12 @@ class PatientListDownloadJob < ApplicationJob
       model_name = model.name
     end
 
-    patients_csv = PatientsExporter.csv(model.registered_patients)
+    patients_csv = PatientsExporter.csv(
+      model
+        .registered_patients
+        .joins(:registration_facility)
+        .order("facilities.state, facilities.district, facilities.name, patients.recorded_at ASC")
+    )
 
     PatientListDownloadMailer.patient_list(recipient_email, model_type, model_name, patients_csv).deliver_later
   end

--- a/spec/exporters/patients_exporter_spec.rb
+++ b/spec/exporters/patients_exporter_spec.rb
@@ -10,17 +10,15 @@ RSpec.describe PatientsExporter do
 
   let(:headers) do
     [
-      "Simple Patient ID",
-      "BP Passport ID",
+      "Registration Date",
+      "Registration Quarter",
       "Patient Name",
-      "Patient Gender",
       "Patient Age",
+      "Patient Gender",
+      "Patient Phone Number",
       "Patient Village/Colony",
       "Patient District",
       "Patient State",
-      "Patient Phone Number",
-      "Registration Date",
-      "Registration Quarter",
       "Registration Facility Name",
       "Registration Facility Type",
       "Registration Facility District",
@@ -34,23 +32,23 @@ RSpec.describe PatientsExporter do
       "Latest BP Facility District",
       "Latest BP Facility State",
       "Days Overdue",
-      "Risk Level"
+      "Risk Level",
+      "BP Passport ID",
+      "Simple Patient ID"
     ]
   end
 
   let(:fields) do
     [
-      patient.id,
-      patient.latest_bp_passport&.shortcode,
+      I18n.l(patient.recorded_at),
+      quarter_string(patient.recorded_at),
       patient.full_name,
-      patient.gender.capitalize,
       patient.current_age,
+      patient.gender.capitalize,
+      patient.phone_numbers.last&.number,
       patient.address.village_or_colony,
       patient.address.district,
       patient.address.state,
-      patient.phone_numbers.last&.number,
-      I18n.l(patient.recorded_at),
-      quarter_string(patient.recorded_at),
       facility.name,
       facility.facility_type,
       facility.district,
@@ -64,7 +62,9 @@ RSpec.describe PatientsExporter do
       blood_pressure.facility.district,
       blood_pressure.facility.state,
       appointment.days_overdue,
-      patient.risk_priority_label
+      patient.risk_priority_label,
+      patient.latest_bp_passport&.shortcode,
+      patient.id
     ]
   end
 


### PR DESCRIPTION
**Story:** https://www.pivotaltracker.com/story/show/169809203

Improve the patient line list so it can be more easily used for register reconciliation.

Basic improvements:
- Ordered by date of registration
- Fields: Date of registration, name, age, gender, phone, address (in that order)