### PR TITLE
Do not show appointments more than 1 year overdue

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -11,6 +11,7 @@ class AppointmentsController < AdminController
                       .joins(patient: { latest_blood_pressures: :facility })
                       .includes(patient: [:address, :phone_numbers, :medical_history, { latest_blood_pressures: :facility }])
                       .overdue
+                      .where("scheduled_date >= ?", 12.months.ago)
                       .distinct
                       .order(scheduled_date: :asc)
 


### PR DESCRIPTION
**Story:** https://www.pivotaltracker.com/story/show/169809192

Patients more than 1 year overdue are unlikely to return, so there's no point in showing them.