### PR TITLE
Set default timezone from config for all sidekiq jobs as a middleware

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,8 +4,7 @@ module SidekiqConfig
   Sidekiq::Extensions.enable_delay!
 
   def self.connection_pool
-    ConnectionPool.new(size: Config.get_int('SIDEKIQ_REDIS_POOL_SIZE',
-                                            DEFAULT_REDIS_POOL_SIZE)) do
+    ConnectionPool.new(size: Config.get_int('SIDEKIQ_REDIS_POOL_SIZE', DEFAULT_REDIS_POOL_SIZE)) do
       Redis.new(host: ENV['SIDEKIQ_REDIS_HOST'])
     end
   end
@@ -16,6 +15,7 @@ Sidekiq.configure_client do |config|
 end
 
 Sidekiq.configure_server do |config|
+  config.server_middleware { |chain| chain.add(Sidekiq::Middleware::Server::SetLocalTimezone) }
   config.redis = SidekiqConfig.connection_pool
 end
 

--- a/lib/sidekiq/middleware/server/set_local_timezone.rb
+++ b/lib/sidekiq/middleware/server/set_local_timezone.rb
@@ -1,0 +1,9 @@
+class Sidekiq::Middleware::Server::SetLocalTimezone
+  def call(_worker, _job, _queue)
+    begin
+      Time.use_zone(ENV['DEFAULT_TIME_ZONE'] || 'UTC') { yield }
+    rescue => ex
+      puts ex.message
+    end
+  end
+end


### PR DESCRIPTION
This is largely due to an issue where the downloadable patient line-list had `recorded_at` showing up in UTC. For India, the list should now pick up `Asia/Kolkata` as the default timezone.