### PR TITLE
Set Asia/Kolkata as the IST time zone for the api/analytics controller

### DIFF
--- a/app/controllers/api/current/analytics_controller.rb
+++ b/app/controllers/api/current/analytics_controller.rb
@@ -5,7 +5,7 @@ class Api::Current::AnalyticsController < APIController
   private
 
   def set_timezone_to_IST
-    Groupdate.time_zone = "New Delhi"
+    Groupdate.time_zone = "Asia/Kolkata"
   end
 
   def set_timezone_to_UTC


### PR DESCRIPTION
The set_timezone_to_IST method is setting the time zone to "New Delhi" which isn't a valid time zone. Set it to "Asia/Kolkata" instead.