### PR TITLE
Add resync_token to facility and protocol process tokens

### DIFF
--- a/app/controllers/api/current/facilities_controller.rb
+++ b/app/controllers/api/current/facilities_controller.rb
@@ -20,7 +20,8 @@ class Api::Current::FacilitiesController < Api::Current::SyncController
   end
 
   def response_process_token
-    { other_facilities_processed_since: processed_until(other_facility_records) || other_facilities_processed_since }
+    { other_facilities_processed_since: processed_until(other_facility_records) || other_facilities_processed_since,
+      resync_token: resync_token }
   end
 
   def records_to_sync

--- a/app/controllers/api/current/protocols_controller.rb
+++ b/app/controllers/api/current/protocols_controller.rb
@@ -24,6 +24,7 @@ class Api::Current::ProtocolsController < Api::Current::SyncController
   end
 
   def response_process_token
-    { other_facilities_processed_since: processed_until(other_facility_records) || other_facilities_processed_since }
+    { other_facilities_processed_since: processed_until(other_facility_records) || other_facilities_processed_since, 
+      resync_token: resync_token }
   end
 end


### PR DESCRIPTION
Missing `resync-token` causes forced resync for facilities and protocols.

In order to add fields to an api without bumping up the api version, we use `resync_token`s. There is a `resync_token` present in both the headers and the process token for each api. If the two `resync_token`s are different, the server forces syncing from the beginning of time. 

In the case of facilities and protocols, the process token is missing a `resync_token`, but the headers have a `resync_token`, forcing them to be synced from beginning of time. This is not a issue with other apis because their process tokens contain a `resync_token` key. This issue wasn't noticed earlier because we had less facilities than the sync batch size. 

This PR adds `resync_token` to the process tokens of facilities and protocols. 