### PR TITLE
Fix failing age spec due to year rollover

### DIFF
--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     status { Patient::STATUSES[0] }
     date_of_birth { Date.current if has_date_of_birth? }
     age { rand(18..100) unless has_date_of_birth? }
-    age_updated_at { Time.current - rand(10).days if age.present? }
+    age_updated_at { Time.current }
     device_created_at { Time.current }
     device_updated_at { Time.current }
     recorded_at { device_created_at }


### PR DESCRIPTION
We're not sure why the -10 days was required on age_updated_at in the patient factory, it was causing a spec to fail due to year rollover.

Example failure: https://semaphoreci.com/resolvetosavelives/simple-server/branches/soft-delete-duplicate-patients/builds/10