### PR TITLE
Fix data migration for updating creation_facility in Appointments

### DIFF
--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -93,7 +93,7 @@ namespace :data_migration do
 
   desc 'Backfill creation_facility for all existing Appointments'
   task backfill_creation_facility_in_appointments: :environment do
-    Appointment.in_batches.update_all('creation_facility_id = facility_id')
+    Appointment.where(creation_facility_id: nil).in_batches.update_all('creation_facility_id = facility_id')
   end
 
   desc 'Make all occurrences of the SMS Reminder Bot User nil'


### PR DESCRIPTION
Since the patient transfer feature has gone out, we cannot and should not update all appointments and make their `creation_facility_id` the same as `facility_id`, so we pick only the ones where `creation_facility_id` is not set.