### PR TITLE
Observables for Observations should be optional for dealing with discarded observables

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1,5 +1,5 @@
 class Observation < ApplicationRecord
   belongs_to :encounter
   belongs_to :user
-  belongs_to :observable, polymorphic: true
+  belongs_to :observable, polymorphic: true, optional: true
 end

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe Observation, type: :model do
   describe 'Associations' do
     it { should belong_to(:encounter) }
     it { should belong_to(:user) }
-    it { should belong_to(:observable) }
+    it { should belong_to(:observable).optional }
   end
 end


### PR DESCRIPTION
This is to resolve the bug where soft-deleted BPs where failing to sync and throwing a 422.

* [Story](https://www.pivotaltracker.com/story/show/170864811)
* [Slack](https://simpledotorg.slack.com/archives/GQ73JT9NY/p1579696848023700)
* [Sentry](https://sentry.io/organizations/resolve-to-save-lives/issues/1457040891/?project=1217715&query=is%3Aunresolved&statsPeriod=14d)