### PR TITLE
Add zone to facility_params permit list

### DIFF
--- a/app/controllers/admin/facilities_controller.rb
+++ b/app/controllers/admin/facilities_controller.rb
@@ -81,7 +81,8 @@ class Admin::FacilitiesController < AdminController
       :facility_size,
       :latitude,
       :longitude,
-      :enable_diabetes_management
+      :enable_diabetes_management,
+      :zone
     )
   end
 


### PR DESCRIPTION
The `Facility` create/update controller does not have `:zone` in the list of permitted params, this adds it in.