### PR TITLE
Resources Page - Asset fix

### DIFF
--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -122,12 +122,12 @@
                 <h2>Presentations</h2>
 
                 <a href="https://docs.google.com/presentation/d/1y4tEmm6ZaIphf48s8NNr6LjQt7pV8m_2AAubovGGVO8/edit" style="display: block" class="mt-3">
-                    <img src="<%= asset_path('presentation-users.jpg') %>" style="width: 100%; margin-bottom: 0.5em;">
+                    <%= image_tag 'presentation-users.jpg', style: 'width: 100%; margin-bottom: 0.5em;' %>
                     Presentation for training users (Google Docs)
                 </a>
 
                 <a href="https://docs.google.com/presentation/d/1sna087oQH6NbMk28pwmvvLvvAV4xyB0hHBACLP4iU1E/edit#slide=id.g7402fb462f_0_836" style="display: block" class="mt-3">
-                    <img src="<%= asset_path('presentation-trainers.jpg') %>" style="width: 100%; margin-bottom: 0.5em;">
+                    <%= image_tag 'presentation-trainers.jpg', style: 'width: 100%; margin-bottom: 0.5em;' %>
                     Training trainers (Google Docs)
                 </a>
 
@@ -159,12 +159,12 @@
                 <h2>Print-outs</h2>
 
                 <div class="doc">
-                    <img src="<%= image_path('user-handbook.jpg') %>" style="width: 200px;">
+                    <%= image_tag 'user-handbook.jpg', style: 'width: 200px;' %>
                     <h5>App Users Guidebook</h5>
                     <a href="https://drive.google.com/file/d/1MM2dEpUBgE3EyZS9CrzuxgjHqIQa3eb1/view" class="doc-download">Download PDF</a>
                 </div>
                 <div class="doc">
-                    <img src="<%= image_path('bp-poster.jpg') %>" style="width: 200px;">
+                    <%= image_tag 'bp-poster.jpg', style: 'width: 200px' %>
                     <h5>How to take a blood pressure poster</h5>
 
                     <a href="" class="doc-download">Download PDF</a>

--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -159,12 +159,12 @@
                 <h2>Print-outs</h2>
 
                 <div class="doc">
-                    <img src="/assets/user-handbook.jpg" style="width: 200px;">
+                    <img src="<%= image_path('user-handbook.jpg') %>" style="width: 200px;">
                     <h5>App Users Guidebook</h5>
                     <a href="https://drive.google.com/file/d/1MM2dEpUBgE3EyZS9CrzuxgjHqIQa3eb1/view" class="doc-download">Download PDF</a>
                 </div>
                 <div class="doc">
-                    <img src="/assets/bp-poster.jpg" style="width: 200px;">
+                    <img src="<%= image_path('bp-poster.jpg') %>" style="width: 200px;">
                     <h5>How to take a blood pressure poster</h5>
 
                     <a href="" class="doc-download">Download PDF</a>

--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -122,12 +122,12 @@
                 <h2>Presentations</h2>
 
                 <a href="https://docs.google.com/presentation/d/1y4tEmm6ZaIphf48s8NNr6LjQt7pV8m_2AAubovGGVO8/edit" style="display: block" class="mt-3">
-                    <img src="/assets/presentation-users.jpg" style="width: 100%; margin-bottom: 0.5em;">
+                    <img src="<%= asset_path('presentation-users.jpg') %>" style="width: 100%; margin-bottom: 0.5em;">
                     Presentation for training users (Google Docs)
                 </a>
 
                 <a href="https://docs.google.com/presentation/d/1sna087oQH6NbMk28pwmvvLvvAV4xyB0hHBACLP4iU1E/edit#slide=id.g7402fb462f_0_836" style="display: block" class="mt-3">
-                    <img src="/assets/presentation-trainers.jpg" style="width: 100%; margin-bottom: 0.5em;">
+                    <img src="<%= asset_path('presentation-trainers.jpg') %>" style="width: 100%; margin-bottom: 0.5em;">
                     Training trainers (Google Docs)
                 </a>
 


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/171019431

This PR fixes broken assets on the `/resources` page by using the appropriate asset helpers.

### Before

<img width="471" alt="Screenshot 2020-01-31 at 6 01 27 PM" src="https://user-images.githubusercontent.com/4241399/73539597-c23d6800-4453-11ea-9129-6accf1bcec9d.png">

<img width="484" alt="Screenshot 2020-01-31 at 5 59 34 PM" src="https://user-images.githubusercontent.com/4241399/73539484-7d193600-4453-11ea-9f6f-30feb3b40cb3.png">

### After

<img width="471" alt="Screenshot 2020-01-31 at 6 01 35 PM" src="https://user-images.githubusercontent.com/4241399/73539606-c8cbdf80-4453-11ea-968e-d4be2d4e6f47.png">

<img width="485" alt="Screenshot 2020-01-31 at 5 59 41 PM" src="https://user-images.githubusercontent.com/4241399/73539493-80acbd00-4453-11ea-931f-07362f085272.png">
