### PR TITLE
CV history lenience

### DIFF
--- a/app/models/medical_history.rb
+++ b/app/models/medical_history.rb
@@ -22,11 +22,6 @@ class MedicalHistory < ApplicationRecord
     unknown: 'unknown'
   }.freeze
 
-  MEDICAL_HISTORY_DEFINITIVE_ANSWERS = {
-    yes: 'yes',
-    no: 'no'
-  }.freeze
-
   enum prior_heart_attack: MEDICAL_HISTORY_ANSWERS, _prefix: true
   enum prior_stroke: MEDICAL_HISTORY_ANSWERS, _prefix: true
   enum chronic_kidney_disease: MEDICAL_HISTORY_ANSWERS, _prefix: true

--- a/app/schema/api/current/models.rb
+++ b/app/schema/api/current/models.rb
@@ -311,7 +311,7 @@ class Api::Current::Models
           chronic_kidney_disease: { type: :string, enum: MedicalHistory::MEDICAL_HISTORY_ANSWERS.keys },
           receiving_treatment_for_hypertension: { type: :string, enum: MedicalHistory::MEDICAL_HISTORY_ANSWERS.keys },
           diabetes: { type: :string, enum: MedicalHistory::MEDICAL_HISTORY_ANSWERS.keys },
-          hypertension: { type: :string, enum: MedicalHistory::MEDICAL_HISTORY_DEFINITIVE_ANSWERS.keys },
+          hypertension: { type: :string, enum: MedicalHistory::MEDICAL_HISTORY_ANSWERS.keys },
           diagnosed_with_hypertension: { type: :string, enum: MedicalHistory::MEDICAL_HISTORY_ANSWERS.keys },
           deleted_at: { '$ref' => '#/definitions/nullable_timestamp' },
           created_at: { '$ref' => '#/definitions/timestamp' },

--- a/swagger/current/swagger.json
+++ b/swagger/current/swagger.json
@@ -2245,7 +2245,8 @@
           "type": "string",
           "enum": [
             "yes",
-            "no"
+            "no",
+            "unknown"
           ]
         },
         "diagnosed_with_hypertension": {


### PR DESCRIPTION
After [this Slack conversation](https://simpledotorg.slack.com/archives/CLS8YD22H/p1580709471072400), we decided that even though the answers to the new `hypertension` question must be `yes` or `no`, the API should continue to support `unknown` as a valid answer to ease the app update transition, and avoid messy race conditions between updating the app and triggering a resync.

This PR adds `unknown` as a valid option, and removes the `MEDICAL_HISTORY_DEFINITIVE_ANSWERS` constant, as it's no longer needed.