### PR TITLE
Default Country Bug - Fix

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,7 +6,7 @@ env :PATH, ENV['PATH']
 DEFAULT_CRON_TIME_ZONE = 'Asia/Kolkata'
 
 def local(time)
-  TZInfo::Timezone.get(Rails.application.config.country[:time_zone] || DEFAULT_CRON_TIME_ZONE)
+  TZInfo::Timezone.get(DEFAULT_CRON_TIME_ZONE)
                   .local_to_utc(Time.parse(time))
 end
 


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/170972119

This PR fixes a problem introduced in #783.

#783 propagated some country-specific configuration including timezones to various parts of the app, including the `whenever` gem's configuration file - `config/schedule.rb`. However, this file is not loaded in the context of the Rails app environment, and hence we cannot pull from the Rails config to set a timezone to execute cronjobs in.

However, this file used to statically set timezone to `Asia/Kolkata` regardless of any environment variables, so this PR fixes the problem by simply reverting back to that simple behavior.