### PR TITLE
Hide Whatsapp support from BD help screen

### DIFF
--- a/app/assets/stylesheets/help.scss
+++ b/app/assets/stylesheets/help.scss
@@ -11,6 +11,13 @@
     color: #0075EB;
     font-size: 16px;
     letter-spacing: 0.2em;
+
+    &.support {
+      display: none;
+      &.IN {
+        display: block;
+      }
+    }
 }
 
 h6 {
@@ -93,4 +100,11 @@ caption {
 span.code {
     color: #000;
     font-weight: 500;
+}
+
+.card.support {
+  display: none;
+  &.IN {
+    display: block;
+  }
 }

--- a/app/views/api/current/help/show.html.erb
+++ b/app/views/api/current/help/show.html.erb
@@ -13,6 +13,7 @@
 
 </head>
 <%= t('api.help.body_html',
+      country: Rails.application.config.country[:abbreviation],
       help_screen_youtube_video_url: ENV['HELP_SCREEN_YOUTUBE_VIDEO_URL'],
       thumb_demo_svg: inline_svg('thumb_demo.svg'),
       help_screen_youtube_passport_url: ENV['HELP_SCREEN_YOUTUBE_PASSPORT_URL'],

--- a/config/locales/api/help/bn_BD.html
+++ b/config/locales/api/help/bn_BD.html
@@ -4,7 +4,7 @@
     <a href="#watch" style="border-top: none;">ভিডিও</a>
     <a href="#howto">নির্দেশিকাসমূহ</a>
     <a href="#bp">কীভাবে বিপি পরিমাপ করবেন</a>
-    <a href="#support">সহায়্তা চান</a>
+    <a href="#support" class="support %{country}">সহায়্তা চান</a>
 </div>
 
 <div id="watch"></div>
@@ -88,7 +88,7 @@
     <div id="support"></div>
 </div>
 
-<div class="card">
+<div class="card support %{country}">
     <div style="width: 100px; height: 100px; margin: -8px -8px 16px 16px; float: right;">
         %{icon_whatsapp_icon_svg}
     </div>

--- a/config/locales/api/help/bn_IN.html
+++ b/config/locales/api/help/bn_IN.html
@@ -4,7 +4,7 @@
     <a href="#watch" style="border-top: none;">ভিডিও</a>
     <a href="#howto">নির্দেশিকাসমূহ</a>
     <a href="#bp">কীভাবে বিপি পরিমাপ করবেন</a>
-    <a href="#support">সহায়্তা চান</a>
+    <a href="#support" class="support %{country}">সহায়্তা চান</a>
 </div>
 
 <div id="watch"></div>
@@ -88,7 +88,7 @@
     <div id="support"></div>
 </div>
 
-<div class="card">
+<div class="card support %{country}">
     <div style="width: 100px; height: 100px; margin: -8px -8px 16px 16px; float: right;">
         %{icon_whatsapp_icon_svg}
     </div>

--- a/config/locales/api/help/en.html
+++ b/config/locales/api/help/en.html
@@ -4,7 +4,7 @@
     <a href="#watch" style="border-top: none;">VIDEOS</a>
     <a href="#howto">INSTRUCTIONS</a>
     <a href="#bp">HOW TO MEASURE BPs</a>
-    <a href="#support">ASK FOR HELP</a>
+    <a href="#support" class="support %{country}">ASK FOR HELP</a>
 </div>
 
 <div id="watch"></div>
@@ -95,7 +95,7 @@
     <div id="support"></div>
 </div>
 
-<div class="card">
+<div class="card support %{country}">
     <div style="width: 100px; height: 100px; margin: -8px -8px 16px 16px; float: right;">
         %{icon_whatsapp_icon_svg}
     </div>

--- a/config/locales/api/help/hi_IN.html
+++ b/config/locales/api/help/hi_IN.html
@@ -4,7 +4,7 @@
     <a href="#watch" style="border-top: none;">वीडियो</a>
     <a href="#howto">निर्देश</a>
     <a href="#bp">बी पी कैसे नापें</a>
-    <a href="#support">मदद पाने के लिए पूछें</a>
+    <a href="#support" class="support %{country}">मदद पाने के लिए पूछें</a>
 </div>
 
 <div id="watch"></div>
@@ -89,7 +89,7 @@
     <div id="support"></div>
 </div>
 
-<div class="card">
+<div class="card support %{country}">
     <div style="width: 100px; height: 100px; margin: -8px -8px 16px 16px; float: right;">
         %{icon_whatsapp_icon_svg}
     </div>

--- a/config/locales/api/help/ta_IN.html
+++ b/config/locales/api/help/ta_IN.html
@@ -4,7 +4,7 @@
     <a href="#watch" style="border-top: none;">வீடியோக்கள்</a>
     <a href="#howto">வழிமுறைகள்</a>
     <a href="#bp">பிபிகளை எவ்வாறு அளவிடுவது</a>
-    <a href="#support">உதவி கேட்கவும்</a>
+    <a href="#support" class="support %{country}">உதவி கேட்கவும்</a>
 </div>
 
 <div id="watch"></div>
@@ -88,7 +88,7 @@
     <div id="support"></div>
 </div>
 
-<div class="card">
+<div class="card support %{country}">
     <div style="width: 100px; height: 100px; margin: -8px -8px 16px 16px; float: right;">
         %{icon_whatsapp_icon_svg}
     </div>

--- a/config/locales/api/help/te_IN.html
+++ b/config/locales/api/help/te_IN.html
@@ -4,7 +4,7 @@
     <a href="#watch" style="border-top: none;">వీడియోలు</a>
     <a href="#howto">సూచనలు</a>
     <a href="#bp">బిపిలను ఎలా అంచనా వేయాలి</a>
-    <a href="#support">సహాయం కోసం అడగండి</a>
+    <a href="#support" class="support %{country}">సహాయం కోసం అడగండి</a>
 </div>
 
 <div id="watch"></div>
@@ -88,7 +88,7 @@
     <div id="support"></div>
 </div>
 
-<div class="card">
+<div class="card support %{country}">
     <div style="width: 100px; height: 100px; margin: -8px -8px 16px 16px; float: right;">
         %{icon_whatsapp_icon_svg}
     </div>


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/171181270

This PR hides the support section from the help screen for BD (ie, any non-India) country by tagging relevant elements with a country class and hiding through CSS.

This approach is a lot cleaner than the attempt made in #795 . I think the long-term approach is to make these translation files ERB-like templates so we can introduce the necessary logic to hide/show things directly into the template itself. Today, the impact of such a solution on Transifex is unclear, so we're going with a surgical CSS approach instead.