### PR TITLE
Remove whitelist_phone_numbers cap role from Bangladesh servers

### DIFF
--- a/config/deploy/bangladesh/production.rb
+++ b/config/deploy/bangladesh/production.rb
@@ -1,3 +1,3 @@
-server "ec2-13-234-38-169.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web app db cron whitelist_phone_numbers)
+server "ec2-13-234-38-169.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web app db cron)
 server "ec2-13-127-239-96.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web app db)
 server "ec2-52-66-210-7.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(sidekiq)


### PR DESCRIPTION
Bangladesh has secure calling disabled, so the phone numbers don't need to be whitelisted for anything.