### PR TITLE
Updated failed login error message

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -14,7 +14,7 @@ en:
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys} or password."
       timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "You need to sign in or sign up before continuing."
+      unauthenticated: "Login failed. Please check your email and password."
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -14,7 +14,7 @@ en:
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys} or password."
       timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "Login failed. Please check your email and password."
+      unauthenticated: "You must sign in before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:


### PR DESCRIPTION
The previous message indicated you needed to sign up, which of course we don't allow.