### PR TITLE
Fixed the path to the favicon so it is correct on production. Yay!

### DIFF
--- a/app/helpers/simple_server_env_helper.rb
+++ b/app/helpers/simple_server_env_helper.rb
@@ -25,6 +25,7 @@ module SimpleServerEnvHelper
 
     image_name = CUSTOMIZED_ENVS.include?(env) ? "simple_logo_#{env}_favicon.png" : "simple_logo_favicon.png"
 
+    image_path(image_name)
   end
 
   def alt_for_environment

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
 
-    <link rel="icon" type="image/png" href="/assets/<%= favicon_for_environment %>">
+    <link rel="icon" type="image/png" href="<%= image_path(favicon_for_environment) %>">
 
     <!-- Roboto font -->
     <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:400,700|Roboto:400,700" rel="stylesheet">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
 
-    <link rel="icon" type="image/png" href="<%= image_path(favicon_for_environment) %>">
+    <link rel="icon" type="image/png" href="<%= favicon_for_environment %>">
 
     <!-- Roboto font -->
     <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:400,700|Roboto:400,700" rel="stylesheet">
@@ -50,13 +50,13 @@
         <div class="collapse navbar-collapse" id="navbars-menu">
           <% if email_authentication_signed_in? %>
             <ul class="navbar-nav mr-auto">
-                
+
               <% if policy(:dashboard).view_my_facilities? && FeatureToggle.enabled?("MY_FACILITIES")%>
                 <li class="nav-item">
                   <%= link_to "My Facilities", my_facilities_path, class: "nav-link #{active_controller?("my_facilities")}" %>
                 </li>
               <% end %>
-                
+
               <% if policy(:dashboard).show? %>
                 <li class="nav-item">
                   <%= link_to "Dashboard", root_path, class: "nav-link #{active_controller?("organizations", "facility_groups")}" %>
@@ -68,13 +68,13 @@
                   <%= link_to "Overdue patients", appointments_path, class: "nav-link #{active_controller?("appointments")}" %>
                 </li>
               <% end %>
-                
+
               <% if policy(:dashboard).adherence_follow_up? %>
                 <li class="nav-item">
                   <%= link_to "Adherence patients", patients_path, class: "nav-link #{active_controller?("patients")}" %>
                 </li>
               <% end %>
-            
+
               <li class="nav-item">
                 <%= link_to "Resources", resources_path, class: "nav-link #{active_controller?("resources")}" %>
               </li>

--- a/spec/helpers/simple_server_env_helper_spec.rb
+++ b/spec/helpers/simple_server_env_helper_spec.rb
@@ -99,22 +99,26 @@ RSpec.describe SimpleServerEnvHelper do
   end
 
   describe 'favicon_for_environment' do
+    before { allow(self).to receive(:image_path).with(expected_favicon).and_return('fingerprinted_favicon') }
+
     context 'when in the default environment' do
+      let(:expected_favicon) { 'simple_logo_favicon.png' }
+
       it 'should return the default logo' do
         ENV[simple_server_env] = 'default'
-        favicon_for_default_environment = 'simple_logo_favicon.png'
 
-        expect(favicon_for_environment).to eq favicon_for_default_environment
+        expect(favicon_for_environment).to eq 'fingerprinted_favicon'
       end
     end
 
     SimpleServerEnvHelper::CUSTOMIZED_ENVS.each do |environment|
       context "when in the #{environment} environment" do
+        let(:expected_favicon) { "simple_logo_#{environment}_favicon.png" }
+
         it "should return the #{environment} favicon" do
           ENV[simple_server_env] = environment
-          favicon_for_environment = "simple_logo_#{environment}_favicon.png"
 
-          expect(favicon_for_environment).to eq favicon_for_environment
+          expect(favicon_for_environment).to eq 'fingerprinted_favicon'
         end
       end
     end


### PR DESCRIPTION
This PR replaces #815 , since #815 was not based off of master

Favicon `link` tags were not using Rails asset helpers to reference the favicon assets. and hence favicon assets were broken. This PR fixes this so favicons work in production-like environments again. Screenshot of the PR on QA environment below:

<img width="214" alt="Screenshot 2020-02-24 at 2 52 12 PM" src="https://user-images.githubusercontent.com/4241399/75140617-43b3ad80-5715-11ea-9ae6-fd881b0e594c.png">
