### PR TITLE
Fix issues with caching on the [OLD] dashboards 

### DIFF
--- a/app/controllers/analytics/districts_controller.rb
+++ b/app/controllers/analytics/districts_controller.rb
@@ -60,17 +60,19 @@ class Analytics::DistrictsController < AnalyticsController
   end
 
   def set_cohort_analytics(period, prev_periods)
-    @cohort_analytics = set_analytics_cache(
-      analytics_cache_key_cohort(period),
-      @organization_district.cohort_analytics(period, prev_periods))
+    @cohort_analytics =
+      set_analytics_cache(analytics_cache_key_cohort(period)) do
+        @organization_district.cohort_analytics(period, prev_periods)
+      end
   end
 
   def set_dashboard_analytics(period, prev_periods)
-    @dashboard_analytics = set_analytics_cache(
-      analytics_cache_key_dashboard(period),
-      @organization_district.dashboard_analytics(period: period,
-                                                 prev_periods: prev_periods,
-                                                 include_current_period: @show_current_period))
+    @dashboard_analytics =
+      set_analytics_cache(analytics_cache_key_dashboard(period)) do
+        @organization_district.dashboard_analytics(period: period,
+                                                   prev_periods: prev_periods,
+                                                   include_current_period: @show_current_period)
+      end
   end
 
   def analytics_cache_key

--- a/app/controllers/analytics/facilities_controller.rb
+++ b/app/controllers/analytics/facilities_controller.rb
@@ -61,17 +61,19 @@ class Analytics::FacilitiesController < AnalyticsController
   end
 
   def set_cohort_analytics(period, prev_periods)
-    @cohort_analytics = set_analytics_cache(
-      analytics_cache_key_cohort(period),
-      @facility.cohort_analytics(period, prev_periods))
+    @cohort_analytics =
+      set_analytics_cache(analytics_cache_key_cohort(period)) do
+        @facility.cohort_analytics(period, prev_periods)
+      end
   end
 
   def set_dashboard_analytics(period, prev_periods)
-    @dashboard_analytics = set_analytics_cache(
-      analytics_cache_key_dashboard(period),
-      @facility.dashboard_analytics(period: period,
-                                    prev_periods: prev_periods,
-                                    include_current_period: @show_current_period))
+    @dashboard_analytics =
+      set_analytics_cache(analytics_cache_key_dashboard(period)) do
+        @facility.dashboard_analytics(period: period,
+                                      prev_periods: prev_periods,
+                                      include_current_period: @show_current_period)
+      end
   end
 
   def analytics_cache_key

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -40,8 +40,8 @@ class AnalyticsController < AdminController
     @year = params[:year].to_i if params[:year].present?
   end
 
-  def set_analytics_cache(key, data)
-    Rails.cache.fetch(key, expires_in: ENV.fetch('ANALYTICS_DASHBOARD_CACHE_TTL')) { data }
+  def set_analytics_cache(key)
+    Rails.cache.fetch(key, expires_in: ENV.fetch('ANALYTICS_DASHBOARD_CACHE_TTL')) { yield }
   end
 
   def analytics_cache_key_cohort(period)

--- a/spec/controllers/analytics/districts_controller_spec.rb
+++ b/spec/controllers/analytics/districts_controller_spec.rb
@@ -104,6 +104,16 @@ RSpec.describe Analytics::DistrictsController, type: :controller do
         expect(Rails.cache.exist?(analytics_dashboard_cache_key)).to be true
         expect(Rails.cache.fetch(analytics_dashboard_cache_key)).to eq expected_cache_value[:dashboard]
       end
+
+      it 'never ends up querying the database when cached' do
+        get :show, params: { organization_id: organization.id, id: district_name, period: :quarter }
+
+        expect_any_instance_of(OrganizationDistrict).to_not receive(:cohort_analytics)
+        expect_any_instance_of(OrganizationDistrict).to_not receive(:dashboard_analytics)
+
+        # this get should always have cached values
+        get :show, params: { organization_id: organization.id, id: district_name, period: :quarter }
+      end
     end
   end
 

--- a/spec/controllers/analytics/facilities_controller_spec.rb
+++ b/spec/controllers/analytics/facilities_controller_spec.rb
@@ -121,6 +121,16 @@ RSpec.describe Analytics::FacilitiesController, type: :controller do
         expect(Rails.cache.exist?(analytics_dashboard_cache_key)).to be true
         expect(Rails.cache.fetch(analytics_dashboard_cache_key)).to eq expected_cache_value[:dashboard]
       end
+
+      it 'never ends up querying the database when cached' do
+        get :show, params: { id: facility.id }
+
+        expect_any_instance_of(Facility).to_not receive(:cohort_analytics)
+        expect_any_instance_of(Facility).to_not receive(:dashboard_analytics)
+
+        # this get should always have cached values
+        get :show, params: { id: facility.id }
+      end
     end
 
     context 'Recent bps' do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171490643

It seems like we were calling the dashboard queries before caching, at all times, eagerly, defeating the purpose of caching in the first place. 

The cache itself is set and retrieved correctly, but the query is still made needlessly.

**Fix**

The query data is now yielded lazily as per a cache hit or miss.

This was discovered due to the huge amount of data created on SBX.