### PR TITLE
Run rails server directly, and on port 3000

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: bundle exec puma
+web: bundle exec rails server -p 3000
 worker: bundle exec sidekiq
 clock: bundle exec whenever && sleep infinity


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/171510556

This PR does the following
* Run `rails server` instead of `puma` in `Procfile.dev` to get our server logs back
* Run the server on port 3000 for consistentcy