### PR TITLE
Upgrade the move_user_recorded_data script to handle BusinessIdentifier metadata, Blood Sugars and Encounters

### DIFF
--- a/lib/tasks/data_fixes.rake
+++ b/lib/tasks/data_fixes.rake
@@ -1,7 +1,7 @@
 require 'tasks/scripts/move_user_recorded_data_to_registration_facility'
 
 namespace :data_fixes do
-  desc "Move all data recorded by a user from a source facility to a destination facility"
+  desc 'Move all data recorded by a user from a source facility to a destination facility'
   task :move_user_data_from_source_to_destination_facility, [:user_id, :source_facility_id, :destination_facility_id] => :environment do |_t, args|
     user = User.find(args.user_id)
     source_facility = Facility.find(args.source_facility_id)
@@ -11,6 +11,7 @@ namespace :data_fixes do
     bp_count = service.fix_blood_pressure_data
     appointment_count = service.fix_appointment_data
     prescription_drug_count = service.fix_prescription_drug_data
-    puts "[DATA FIXED] #{user.full_name},#{source_facility.name},#{destination_facility.name},#{patient_count},#{bp_count},#{appointment_count},#{prescription_drug_count}"
+    puts "[DATA FIXED] #{user.full_name},#{source_facility.name},#{destination_facility.name},"\
+         "#{patient_count},#{bp_count},#{appointment_count}, #{prescription_drug_count}"
   end
 end

--- a/lib/tasks/scripts/move_user_recorded_data_to_registration_facility.rb
+++ b/lib/tasks/scripts/move_user_recorded_data_to_registration_facility.rb
@@ -9,15 +9,11 @@ class MoveUserRecordedDataToRegistrationFacility
   end
 
   def fix_patient_data
+    patients = Patient.where(registration_user: user, registration_facility: source_facility)
+    fix_pbi_metadata(patients)
     fix_data_for_relation(
-      Patient.where(registration_user: user, registration_facility: source_facility),
+      patients,
       registration_facility: destination_facility)
-  end
-
-  def fix_blood_pressure_data
-    fix_data_for_relation(
-      BloodPressure.where(user: user, facility: source_facility),
-      facility: destination_facility)
   end
 
   def fix_appointment_data
@@ -34,11 +30,56 @@ class MoveUserRecordedDataToRegistrationFacility
     )
   end
 
+  def fix_blood_pressure_data
+    blood_pressures = BloodPressure.where(user: user, facility: source_facility)
+
+    fix_data_for_relation(
+      Encounter.includes(:observations)
+               .where(observations: { observable_id: blood_pressures.pluck(:id) }),
+      facility: destination_facility
+    )
+
+    fix_data_for_relation(
+      blood_pressures,
+      facility: destination_facility
+    )
+  end
+
+  def fix_blood_sugar_data
+    blood_sugars = BloodSugar.where(user: user, facility: source_facility)
+
+    fix_data_for_relation(
+      Encounter.includes(:observations)
+               .where(observations: { observable_id: blood_sugars.pluck(:id) }),
+      facility: destination_facility
+    )
+    fix_data_for_relation(
+      blood_sugars,
+      facility: destination_facility
+    )
+  end
+
   private
 
   def fix_data_for_relation(relation, update_hash)
-    Rails.logger.info "Moving #{relation.count} #{relation.klass.to_s} records, for user: #{user.full_name}, to #{destination_facility.name}"
+    Rails.logger.info "Moving #{relation.count} #{relation.klass.to_s} records, for user: #{user.full_name},"\
+                      "to #{destination_facility.name}"
     updated_records = relation.update(update_hash)
     updated_records.count
+  end
+
+  def fix_pbi_metadata(patients)
+    patient_business_identifiers = patients.map(&:business_identifiers)
+                                           .flatten
+                                           .select { |pbi|
+                                             pbi.metadata == { 'assigning_user_id' => user.id,
+                                                               'assigning_facility_id' => source_facility.id }
+                                           }
+    Rails.logger.info "Fixing metadata for #{patient_business_identifiers.count} PatientBusinessIdentifier records,"\
+                      "for user: #{user.full_name}, changing assigning_facility_id to #{destination_facility.name}"
+    updated_metadata = { "assigning_user_id": user.id, "assigning_facility_id": destination_facility.id }
+    patient_business_identifiers.each do |pbi|
+      pbi.update(metadata: updated_metadata)
+    end
   end
 end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -22,7 +22,13 @@ FactoryBot.define do
     phone_numbers { build_list(:patient_phone_number, 1, patient_id: id) }
     association :registration_facility, factory: :facility
     association :registration_user, factory: :user_created_on_device
-    business_identifiers { build_list(:patient_business_identifier, 1, patient_id: id) }
+    business_identifiers do
+      build_list(:patient_business_identifier,
+                 1,
+                 patient_id: id,
+                 metadata: {assigning_facility_id: registration_facility.id,
+                            assigning_user_id: registration_user.id})
+    end
     reminder_consent { Patient.reminder_consents[:granted] }
 
     trait :denied do


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/n/projects/2184102/stories/171743446

## Because

The existing `move_user_recorded_data_to_registration_facility` is now stale, and doesn't handle `BloodSugars` and `Encounters`. Additionally, the metadata for `PatientBusinessIdentifier` also has a facility field that was missed out previously. 

## This addresses

This PR adds `PatientBusinessIdentifier`. `BloodSugar`, and `Encounter` handling to the `move_user_recorded_data_to_registration_facility` script