### PR TITLE
Add demo manifest

### DIFF
--- a/public/manifest/demo.json
+++ b/public/manifest/demo.json
@@ -1,0 +1,16 @@
+{
+  "v1": [
+    {
+      "country_code": "IN",
+      "endpoint": "https://api-demo.simple.org/api/",
+      "display_name": "India",
+      "isd_code": "91"
+    },
+    {
+      "country_code": "BD",
+      "endpoint": "https://api-demo.bd.simple.org/api/",
+      "display_name": "Bangladesh",
+      "isd_code": "880"
+    }
+  ]
+}


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/171597578

## Because

We are trying to move away from using the terminology "staging" and towards using "demo".

https://github.com/simpledotorg/deployment/pull/173 changes the `SIMPLE_SERVER_ENV` to `demo`. Before we make that change, we must introduce a `demo.json` manifest file, to ensure the `demo` environment works correctly.

## This addresses

This PR adds a `demo.json` manifest file that is a clone fo the `staging.json` file. 
