### PR TITLE
Add the “web” cap role for all standalone sidekiq boxes

### DIFF
--- a/config/deploy/bangladesh/demo.rb
+++ b/config/deploy/bangladesh/demo.rb
@@ -1,2 +1,2 @@
 server "ec2-13-127-62-208.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web app db cron)
-server "ec2-3-6-91-15.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(sidekiq)
+server "ec2-3-6-91-15.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web sidekiq)

--- a/config/deploy/bangladesh/production.rb
+++ b/config/deploy/bangladesh/production.rb
@@ -1,3 +1,3 @@
 server "ec2-13-234-38-169.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web app db cron)
 server "ec2-13-127-239-96.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web app db)
-server "ec2-52-66-210-7.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(sidekiq)
+server "ec2-52-66-210-7.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web sidekiq)

--- a/config/deploy/india/production.rb
+++ b/config/deploy/india/production.rb
@@ -4,4 +4,4 @@ server "ec2-13-126-205-193.ap-south-1.compute.amazonaws.com", user: "deploy", ro
 server "ec2-13-232-216-64.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web app db)
 server "ec2-15-206-127-129.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web app db)
 
-server "ec2-13-126-110-54.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(sidekiq)
+server "ec2-13-126-110-54.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web sidekiq)

--- a/config/deploy/security.rb
+++ b/config/deploy/security.rb
@@ -1,3 +1,3 @@
 server "ec2-13-127-26-45.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web app db cron whitelist_phone_numbers)
 server "ec2-13-234-115-73.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web app db)
-server "ec2-13-234-17-30.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(sidekiq)
+server "ec2-13-234-17-30.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web sidekiq)


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/171832155
## Because

This is due to a bug addressed [here](https://simpledotorg.slack.com/archives/CFHKJ5WJY/p1584088859022800). Standalone sidekiq boxes don't have the `web` capistrano role and hence don't run the `assets:precompile` step. This causes the mailers to just break because the new e-mails wouldn't have the the appropriate assets available off of the sidekiq box (from where async emails are sent).

## This addresses

Adds a `web` role to all envs with standalone sidekiq boxes.
