### PR TITLE
Update QA box IP for cap

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,1 +1,1 @@
-server "ec2-13-233-19-238.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web app db sidekiq cron)
+server "ec2-35-154-20-1.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web app db sidekiq cron)


### PR DESCRIPTION
QA box could not handle the load for testing v4 API. It died and we had to spin up a new one. Changed the type from `micro` to `small` as well.