### PR TITLE
Locale strings for the new progress tabs

### DIFF
--- a/config/locales/api/bn_BD.yml
+++ b/config/locales/api/bn_BD.yml
@@ -19,6 +19,22 @@ bn-BD:
     patients_enrolled: "কতজন নতুন রোগী %{facility_name} এ নথিভুক্ত রয়েছেন?"
     all_time_patients: "সব সময়: %{count} জন রোগী"
     updated_at: "%{time} এ আপডেট করা হয়েছে"
+  user_analytics:
+    hypertension:
+    diabetes:
+    genders:
+    all_time:
+    follow_up_patients:
+    registered_patients:
+    hypertension_control:
+    hypertension_control_desc:
+    notes:
+    footer_note_1:
+    footer_note_2:
+    thank_you:
+    thank_you_note:
+    updated:
+    ratio_string:
   dashboard:
     graphics:
       graphics_title_html: "<b>%{previous_quarter_string}</b> এর সময় নিবন্ধন করা %{patients_in_previous_quarter} জন রোগীর <b>%{current_quarter_string}</b> এ কী হয়েছিল?"

--- a/config/locales/api/bn_IN.yml
+++ b/config/locales/api/bn_IN.yml
@@ -19,6 +19,22 @@ bn-IN:
     patients_enrolled: "কতজন নতুন রোগী %{facility_name} এ নথিভুক্ত রয়েছেন?"
     all_time_patients: "সব সময়: %{count} জন রোগী"
     updated_at: "%{time} এ আপডেট করা হয়েছে"
+  user_analytics:
+    hypertension:
+    diabetes:
+    genders:
+    all_time:
+    follow_up_patients:
+    registered_patients:
+    hypertension_control:
+    hypertension_control_desc:
+    notes:
+    footer_note_1:
+    footer_note_2:
+    thank_you:
+    thank_you_note:
+    updated:
+    ratio_string:
   dashboard:
     graphics:
       graphics_title_html: "<b>%{previous_quarter_string}</b> এর সময় নিবন্ধন করা %{patients_in_previous_quarter} জন রোগীর <b>%{current_quarter_string}</b> এ কী হয়েছিল?"

--- a/config/locales/api/en.yml
+++ b/config/locales/api/en.yml
@@ -29,7 +29,7 @@ en:
     hypertension_control: 'Hypertension control'
     hypertension_control_desc: 'How many patients with hypertension had BP below 140/90 at their last follow-up visit in the month?'
     notes: 'Notes'
-    footer_note_1: "Data is for all activity at %{facility_name}. If data appears out of date, tap the \"Sync pending\" link on the home screen."
+    footer_note_1: 'Data is for all activity at %{facility_name}. If data appears out of date, tap the "Sync pending" link on the home screen.'
     footer_note_2: 'A follow-up patient is only counted for one visit each month. If a patient follows up multiple times in a month, he or she is only counted once.'
     thank_you: 'Thank You'
     thank_you_note: 'Thank you for all of your hard work treating patients with hypertension. Your work saves lives from heart attacks and strokes.'

--- a/config/locales/api/en.yml
+++ b/config/locales/api/en.yml
@@ -19,6 +19,22 @@ en:
     patients_enrolled: "How many new patients are enrolled at %{facility_name}?"
     all_time_patients: "All time: %{count} patients"
     updated_at: "Updated at %{time}"
+  user_analytics:
+    hypertension: 'Hypertension'
+    diabetes: 'Diabetes'
+    genders: ['all', male', 'female', 'transgender']
+    all_time: 'All-time'
+    follow_up_patients: 'Follow-up hypertension patients'
+    registered_patients: 'Registered Patients'
+    hypertension_control: 'Hypertension control'
+    hypertension_control_desc: 'How many patients with hypertension had BP below 140/90 at their last follow-up visit in the month?'
+    notes: 'Notes'
+    footer_note_1: "Data is for all activity at %{facility_name}. If data appears out of date, tap the \"Sync pending\" link on the home screen."
+    footer_note_2: 'A follow-up patient is only counted for one visit each month. If a patient follows up multiple times in a month, he or she is only counted once.'
+    thank_you: 'Thank You'
+    thank_you_note: 'Thank you for all of your hard work treating patients with hypertension. Your work saves lives from heart attacks and strokes.'
+    updated: 'Updated: %{time}'
+    ratio_string: '%{value_1} of %{value_2}'
   dashboard:
     graphics:
       graphics_title_html: "What happened in <b>%{current_quarter_string}</b> to the %{patients_in_previous_quarter} patients registered during <b>%{previous_quarter_string}</b>?"

--- a/config/locales/api/hi_IN.yml
+++ b/config/locales/api/hi_IN.yml
@@ -15,3 +15,19 @@ hi-IN:
     patients_enrolled: "%{facility_name} में कितने मरीज़ रजिस्टर हुए?"
     all_time_patients: "सभी समय: %{count} मरीज़"
     updated_at: "Updated at %{time}"
+  user_analytics:
+    hypertension:
+    diabetes:
+    genders:
+    all_time:
+    follow_up_patients:
+    registered_patients:
+    hypertension_control:
+    hypertension_control_desc:
+    notes:
+    footer_note_1:
+    footer_note_2:
+    thank_you:
+    thank_you_note:
+    updated:
+    ratio_string:

--- a/config/locales/api/ta_IN.yml
+++ b/config/locales/api/ta_IN.yml
@@ -15,3 +15,19 @@ ta-IN:
     patients_enrolled: "%{facility_name} இல்எத்தனைநோயாளிகள்பதிவுசெய்துள்ளனர்?"
     all_time_patients: "எல்லாநேரமும்: %{count} நோயாளிகள்"
     updated_at: "Updated at %{time}"
+  user_analytics:
+    hypertension:
+    diabetes:
+    genders:
+    all_time:
+    follow_up_patients:
+    registered_patients:
+    hypertension_control:
+    hypertension_control_desc:
+    notes:
+    footer_note_1:
+    footer_note_2:
+    thank_you:
+    thank_you_note:
+    updated:
+    ratio_string:

--- a/config/locales/api/te_IN.yml
+++ b/config/locales/api/te_IN.yml
@@ -15,3 +15,19 @@ te-IN:
     patients_enrolled: "%{facility_name} లోఎంతమందిరోగులునమోదుచేసుకున్నారు?"
     all_time_patients: "మొత్తంసమయం: %{count} మందిరోగులు"
     updated_at: "Updated at %{time}"
+  user_analytics:
+    hypertension:
+    diabetes:
+    genders:
+    all_time:
+    follow_up_patients:
+    registered_patients:
+    hypertension_control:
+    hypertension_control_desc:
+    notes:
+    footer_note_1:
+    footer_note_2:
+    thank_you:
+    thank_you_note:
+    updated:
+    ratio_string:


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/171672661

## Because

The [new progress tab](https://github.com/simpledotorg/simple-server/pull/843) have a lot of strings that need to be localized.

## This addresses

* Left out all locales other an `en` as blank to be populated through Transifex later. 
* The new progress tab locales also sit under a different namespace: `user_analytics` so as to not affect the current progress tab in any way even if this PR gets deployed to Production.