### PR TITLE
Add a new sidekiq box for the sandbox env

### DIFF
--- a/config/deploy/sandbox.rb
+++ b/config/deploy/sandbox.rb
@@ -1,1 +1,2 @@
-server "ec2-13-235-33-14.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web app db sidekiq cron whitelist_phone_numbers seed)
+server "ec2-13-235-33-14.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web app db cron whitelist_phone_numbers seed)
+server "ec2-15-206-123-187.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w(web sidekiq)


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/171810658

## Because

The sandbox env runs sidekiq on the same box as the webserver. This can potentially hide problems in other environments where sidekiq on a separate box, and doesn't have access to the same environment as the webserver box. 

## This addresses

This PR along with the related [deployment PR](https://github.com/simpledotorg/deployment/pull/182) adds a separate sidekiq box for the sandbox environment so we can catch problems of this type in the sandbox environment.
