### PR TITLE
Explicitly order patient relations in the Patient Line List exporter

### DIFF
--- a/app/exporters/patients_exporter.rb
+++ b/app/exporters/patients_exporter.rb
@@ -71,8 +71,10 @@ module PatientsExporter
 
   def self.csv_fields(patient)
     registration_facility = patient.registration_facility
-    latest_bp = patient.latest_blood_pressure
+    latest_bp = patient.latest_blood_pressures.order(recorded_at: :desc).first
     latest_bp_facility = latest_bp&.facility
+    latest_appointment = patient.latest_scheduled_appointments.order(scheduled_date: :desc).first
+    latest_bp_passport = patient.latest_bp_passports.order(device_created_at: :desc).first
 
     [
       patient.recorded_at.presence && I18n.l(patient.recorded_at),
@@ -96,11 +98,11 @@ module PatientsExporter
       latest_bp_facility&.facility_type,
       latest_bp_facility&.district,
       latest_bp_facility&.state,
-      patient.latest_scheduled_appointment&.facility&.name,
-      patient.latest_scheduled_appointment&.scheduled_date&.to_s(:rfc822),
-      patient.latest_scheduled_appointment&.days_overdue,
+      latest_appointment&.facility&.name,
+      latest_appointment&.scheduled_date&.to_s(:rfc822),
+      latest_appointment&.days_overdue,
       ('High' if patient.high_risk?),
-      patient.latest_bp_passport&.shortcode,
+      latest_bp_passport&.shortcode,
       patient.id,
       *medications_for(patient)
     ]


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/172240654

## Because

The downloadable Patient Line List can have incorrect data for Latest BP, Latest Appointment, and Latest BP Passport. This happens because ordering is not preserved when processing data using ActiveRecord's [Batch](https://api.rubyonrails.org/v5.1/classes/ActiveRecord/Batches.html) processing tools.  

## This addresses

Explicitly orders the relations on Patient which need the latest data