### PR TITLE
Use the Facility ID not the object itself for caching

### DIFF
--- a/app/presenters/user_analytics_presenter.rb
+++ b/app/presenters/user_analytics_presenter.rb
@@ -191,6 +191,6 @@ class UserAnalyticsPresenter
   end
 
   def statistics_cache_key
-    "user_analytics/#{@current_facility}/#{@last_refreshed_at}"
+    "user_analytics/#{@current_facility.id}/#{@last_refreshed_at}"
   end
 end


### PR DESCRIPTION
The last PR to fix the progress tab caching is still broken, it should just cache against the ID not the whole object, related: https://github.com/simpledotorg/simple-server/pull/880