### PR TITLE
Revert MyFacilities BP Control footnote

### DIFF
--- a/app/views/my_facilities/blood_pressure_control.html.erb
+++ b/app/views/my_facilities/blood_pressure_control.html.erb
@@ -151,13 +151,12 @@
     <section class="footnotes">
       <ol>
         <li><strong>Overall BP control:</strong>
-        <ul>
-          <li>Percent: <i>(Controlled ÷ Registered)</i> × 100</li>
-          <li>Controlled: Patients registered at this facility whose most recent BP in the past 90 days was under 140/90.</li>
-          <li>Registered: Patients registered at this facility.</li>
-          <li>Patients registered in the last 2 months are excluded from both <i>Controlled</i> and <i>Registered</i>.</li>
-          <li>Note: Follow-up BPs may be recorded at any facility.</li>
-        </ul>
+          <ul>
+            <li>Numerator: Patients registered at this facility whose most recent BP in the past 90 days was under 140/90.</li>
+            <li>Denominator: Patients registered at this facility.</li>
+            <li>Patients registered in the last 2 months are excluded from both the <i>Numerator</i> and <i>Denominator</i>.</li>
+            <li>Note: Follow-up BPs may be recorded at any facility.</li>
+          </ul>
       </ol>
     </section>
     <script>


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/172288095

Reverts the footnote on the MyFacilities BP control page to use `Numerator` and `Denominator` instead of `Controlled` and `Registered`