### PR TITLE
Patient app API authentication

### DIFF
--- a/app/controllers/api/v4/patient_controller.rb
+++ b/app/controllers/api/v4/patient_controller.rb
@@ -53,8 +53,10 @@ class Api::V4::PatientController < PatientAPIController
 
   def access_token_response(authentication)
     {
-      access_token: authentication.access_token,
-      patient_id: authentication.patient.id
+      patient: {
+        access_token: authentication.access_token,
+        patient_id: authentication.patient.id
+      }
     }
   end
 end

--- a/app/controllers/api/v4/patient_controller.rb
+++ b/app/controllers/api/v4/patient_controller.rb
@@ -20,6 +20,11 @@ class Api::V4::PatientController < APIController
       patient_business_identifier: passport
     )
 
+    unless authentication.otp_valid?
+      authentication.reset_otp
+      authentication.save!
+    end
+
     unless FeatureToggle.enabled?('FIXED_OTP_ON_REQUEST_FOR_QA')
       SendPatientOtpSmsJob.set(wait: otp_delay_seconds).perform_later(authentication)
     end

--- a/app/controllers/api/v4/patient_controller.rb
+++ b/app/controllers/api/v4/patient_controller.rb
@@ -1,10 +1,4 @@
-class Api::V4::PatientController < APIController
-  skip_before_action :current_user_present?
-  skip_before_action :validate_sync_approval_status_allowed
-  skip_before_action :authenticate
-  skip_before_action :validate_facility
-  skip_before_action :validate_current_facility_belongs_to_users_facility_group
-
+class Api::V4::PatientController < PatientAPIController
   def activate
     passport = PatientBusinessIdentifier.find_by(
       identifier: passport_id,

--- a/app/controllers/api/v4/patient_controller.rb
+++ b/app/controllers/api/v4/patient_controller.rb
@@ -42,7 +42,7 @@ class Api::V4::PatientController < APIController
 
     authentication = PassportAuthentication.find_by!(patient_business_identifier: passport)
 
-    if authentication.otp == request_otp && authentication.otp_valid?
+    if authentication.validate_otp(request_otp)
       render json: access_token_response(authentication), status: :ok
     else
       return head :unauthorized

--- a/app/controllers/api/v4/patient_controller.rb
+++ b/app/controllers/api/v4/patient_controller.rb
@@ -54,8 +54,8 @@ class Api::V4::PatientController < PatientAPIController
   def access_token_response(authentication)
     {
       patient: {
-        access_token: authentication.access_token,
-        patient_id: authentication.patient.id
+        id: authentication.patient.id,
+        access_token: authentication.access_token
       }
     }
   end

--- a/app/controllers/api/v4/patient_controller.rb
+++ b/app/controllers/api/v4/patient_controller.rb
@@ -9,7 +9,7 @@ class Api::V4::PatientController < APIController
 
   def request_otp
     passport = PatientBusinessIdentifier.find_by(
-      identifier: request_passport_id,
+      identifier: passport_id,
       identifier_type: "simple_bp_passport"
     )
     patient  = passport&.patient
@@ -34,7 +34,7 @@ class Api::V4::PatientController < APIController
 
   def activate
     passport = PatientBusinessIdentifier.find_by(
-      identifier: request_passport_id,
+      identifier: passport_id,
       identifier_type: "simple_bp_passport"
     )
     patient  = passport&.patient
@@ -42,7 +42,7 @@ class Api::V4::PatientController < APIController
 
     authentication = PassportAuthentication.find_by!(patient_business_identifier: passport)
 
-    if authentication.validate_otp(request_otp)
+    if authentication.validate_otp(otp)
       render json: access_token_response(authentication), status: :ok
     else
       return head :unauthorized
@@ -51,11 +51,11 @@ class Api::V4::PatientController < APIController
 
   private
 
-  def request_passport_id
+  def passport_id
     params.require(:passport_id)
   end
 
-  def request_otp
+  def otp
     params.require(:otp)
   end
 

--- a/app/controllers/api/v4/patient_controller.rb
+++ b/app/controllers/api/v4/patient_controller.rb
@@ -5,7 +5,7 @@ class Api::V4::PatientController < APIController
   skip_before_action :validate_facility
   skip_before_action :validate_current_facility_belongs_to_users_facility_group
 
-  def request_otp
+  def activate
     passport = PatientBusinessIdentifier.find_by(
       identifier: passport_id,
       identifier_type: "simple_bp_passport"
@@ -30,7 +30,7 @@ class Api::V4::PatientController < APIController
     head :ok
   end
 
-  def activate
+  def login
     passport = PatientBusinessIdentifier.find_by(
       identifier: passport_id,
       identifier_type: "simple_bp_passport"

--- a/app/controllers/api/v4/patient_controller.rb
+++ b/app/controllers/api/v4/patient_controller.rb
@@ -5,8 +5,6 @@ class Api::V4::PatientController < APIController
   skip_before_action :validate_facility
   skip_before_action :validate_current_facility_belongs_to_users_facility_group
 
-  DEFAULT_USER_OTP_DELAY_IN_SECONDS = 5
-
   def request_otp
     passport = PatientBusinessIdentifier.find_by(
       identifier: passport_id,
@@ -26,7 +24,7 @@ class Api::V4::PatientController < APIController
     end
 
     unless FeatureToggle.enabled?('FIXED_OTP_ON_REQUEST_FOR_QA')
-      SendPatientOtpSmsJob.set(wait: otp_delay_seconds).perform_later(authentication)
+      SendPatientOtpSmsJob.perform_later(authentication)
     end
 
     head :ok
@@ -64,9 +62,5 @@ class Api::V4::PatientController < APIController
       access_token: authentication.access_token,
       patient_id: authentication.patient.id
     }
-  end
-
-  def otp_delay_seconds
-    (ENV['USER_OTP_SMS_DELAY_IN_SECONDS'] || DEFAULT_USER_OTP_DELAY_IN_SECONDS).to_i.seconds
   end
 end

--- a/app/controllers/api/v4/patient_controller.rb
+++ b/app/controllers/api/v4/patient_controller.rb
@@ -7,7 +7,7 @@ class Api::V4::PatientController < APIController
 
   DEFAULT_USER_OTP_DELAY_IN_SECONDS = 5
 
-  def activate
+  def request_otp
     passport = PatientBusinessIdentifier.find_by(
       identifier: request_passport_id,
       identifier_type: "simple_bp_passport"
@@ -32,7 +32,7 @@ class Api::V4::PatientController < APIController
     head :ok
   end
 
-  def authenticate
+  def activate
     passport = PatientBusinessIdentifier.find_by(
       identifier: request_passport_id,
       identifier_type: "simple_bp_passport"

--- a/app/controllers/api/v4/patient_controller.rb
+++ b/app/controllers/api/v4/patient_controller.rb
@@ -1,0 +1,58 @@
+class Api::V4::PatientController < APIController
+  skip_before_action :current_user_present?
+  skip_before_action :validate_sync_approval_status_allowed
+  skip_before_action :authenticate
+  skip_before_action :validate_facility
+  skip_before_action :validate_current_facility_belongs_to_users_facility_group
+
+  DEFAULT_USER_OTP_DELAY_IN_SECONDS = 5
+
+  def activate
+    passport = PatientBusinessIdentifier.find_by(
+      identifier: request_passport_id,
+      identifier_type: "simple_bp_passport"
+    )
+    patient  = passport&.patient
+    return head :not_found unless patient.present?
+
+    authentication = PassportAuthentication.find_or_create_by!(
+      patient: patient,
+      patient_business_identifier: passport
+    )
+
+    # TODO: Send OTP
+
+    head :ok
+  end
+
+  def authenticate
+    passport = PatientBusinessIdentifier.find_by(
+      identifier: request_passport_id,
+      identifier_type: "simple_bp_passport"
+    )
+    patient  = passport&.patient
+    return head :not_found unless patient.present?
+
+    authentication = PassportAuthentication.find_by!(patient_business_identifier: passport)
+
+    if authentication.otp == request_otp && authentication.otp_valid?
+      render json: access_token_response(authentication), status: :ok
+    else
+      return head :unauthorized
+    end
+  end
+
+  private
+
+  def request_passport_id
+    params.require(:passport_id)
+  end
+
+  def request_otp
+    params.require(:otp)
+  end
+
+  def access_token_response(authentication)
+    { access_token: authentication.access_token }
+  end
+end

--- a/app/controllers/api/v4/patient_controller.rb
+++ b/app/controllers/api/v4/patient_controller.rb
@@ -38,7 +38,7 @@ class Api::V4::PatientController < APIController
       identifier_type: "simple_bp_passport"
     )
     patient  = passport&.patient
-    return head :not_found unless patient.present?
+    return head :unauthorized unless patient.present?
 
     authentication = PassportAuthentication.find_by!(patient_business_identifier: passport)
 
@@ -60,7 +60,10 @@ class Api::V4::PatientController < APIController
   end
 
   def access_token_response(authentication)
-    { access_token: authentication.access_token }
+    {
+      access_token: authentication.access_token,
+      patient_id: authentication.patient.id
+    }
   end
 
   def otp_delay_seconds

--- a/app/controllers/api/v4/patient_controller.rb
+++ b/app/controllers/api/v4/patient_controller.rb
@@ -13,7 +13,7 @@ class Api::V4::PatientController < APIController
       identifier_type: "simple_bp_passport"
     )
     patient  = passport&.patient
-    return head :not_found unless patient.present?
+    return head :not_found unless patient.present? && patient.latest_mobile_number.present?
 
     authentication = PassportAuthentication.find_or_create_by!(
       patient: patient,

--- a/app/controllers/patient_api_controller.rb
+++ b/app/controllers/patient_api_controller.rb
@@ -1,0 +1,11 @@
+class PatientAPIController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  rescue_from ActionController::ParameterMissing do
+    head :bad_request
+  end
+
+  rescue_from ActiveRecord::RecordNotFound do
+    head :not_found
+  end
+end

--- a/app/jobs/send_patient_otp_sms_job.rb
+++ b/app/jobs/send_patient_otp_sms_job.rb
@@ -9,6 +9,6 @@ class SendPatientOtpSmsJob < ApplicationJob
 
     SmsNotificationService
       .new(phone_number, ENV['TWILIO_PHONE_NUMBER'])
-      .send_request_otp_sms(patient_authentication.otp)
+      .send_patient_request_otp_sms(patient_authentication.otp)
   end
 end

--- a/app/jobs/send_patient_otp_sms_job.rb
+++ b/app/jobs/send_patient_otp_sms_job.rb
@@ -1,0 +1,14 @@
+class SendPatientOtpSmsJob < ApplicationJob
+  queue_as :default
+  self.queue_adapter = :sidekiq
+
+  def perform(patient_authentication)
+    phone_number = patient_authentication.patient&.latest_mobile_number
+
+    return unless phone_number.present?
+
+    SmsNotificationService
+      .new(phone_number, ENV['TWILIO_PHONE_NUMBER'])
+      .send_request_otp_sms(patient_authentication.otp)
+  end
+end

--- a/app/models/passport_authentication.rb
+++ b/app/models/passport_authentication.rb
@@ -23,18 +23,6 @@ class PassportAuthentication < ActiveRecord::Base
     self.access_token = SecureRandom.hex(32)
   end
 
-  def build_otp
-    new_otp = if FeatureToggle.enabled?('FIXED_OTP_ON_REQUEST_FOR_QA')
-      "000000"
-    else
-      SecureRandom.random_number.to_s[2..7]
-    end
-
-    new_otp_valid_until = Time.current + ENV['USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES'].to_i.minutes
-
-    { otp: new_otp, otp_valid_until: new_otp_valid_until }
-  end
-
   def generate_otp
     new_otp = build_otp
 
@@ -66,5 +54,19 @@ class PassportAuthentication < ActiveRecord::Base
     else
       false
     end
+  end
+
+  private
+
+  def build_otp
+    new_otp = if FeatureToggle.enabled?('FIXED_OTP_ON_REQUEST_FOR_QA')
+      "000000"
+    else
+      SecureRandom.random_number.to_s[2..7]
+    end
+
+    new_otp_valid_until = Time.current + ENV['USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES'].to_i.minutes
+
+    { otp: new_otp, otp_valid_until: new_otp_valid_until }
   end
 end

--- a/app/models/passport_authentication.rb
+++ b/app/models/passport_authentication.rb
@@ -1,0 +1,36 @@
+class PassportAuthentication < ApplicationRecord
+  after_initialize :generate_access_token, if: :new_record?
+  after_initialize :generate_otp, if: :new_record?
+
+  belongs_to :patient
+  belongs_to :patient_business_identifier
+
+  validates :access_token, presence: true
+  validates :otp, presence: true
+  validates :otp_valid_until, presence: true
+  validates :patient, presence: true
+  validates :patient_business_identifier, presence: true
+
+  def otp_valid?
+    otp_valid_until >= Time.current
+  end
+
+  def generate_access_token
+    self.access_token ||= SecureRandom.hex(32)
+  end
+
+  def generate_otp
+    new_otp = if FeatureToggle.enabled?('FIXED_OTP_ON_REQUEST_FOR_QA')
+      "000000"
+    else
+      SecureRandom.random_number.to_s[2..7]
+    end
+
+    new_otp_valid_until = Time.current + ENV['USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES'].to_i.minutes
+
+    self.otp ||= new_otp
+    self.otp_valid_until ||= new_otp_valid_until
+
+    { otp: otp, otp_valid_until: otp_valid_until }
+  end
+end

--- a/app/models/passport_authentication.rb
+++ b/app/models/passport_authentication.rb
@@ -1,4 +1,4 @@
-class PassportAuthentication < ApplicationRecord
+class PassportAuthentication < ActiveRecord::Base
   after_initialize :generate_access_token, if: :new_record?
   after_initialize :generate_otp, if: :new_record?
 

--- a/app/schema/api/v4/models.rb
+++ b/app/schema/api/v4/models.rb
@@ -50,6 +50,16 @@ class Api::V4::Models
       }
     end
 
+    def login_patient
+      {
+        type: :object,
+        properties: {
+          access_token: { '$ref' => '#/definitions/non_empty_string' },
+          patient_id: { '$ref' => '#/definitions/uuid' }
+        }
+      }
+    end
+
     def user
       { type: :object,
         properties: {
@@ -99,6 +109,7 @@ class Api::V4::Models
         bcrypt_password: bcrypt_password,
         blood_sugar: blood_sugar,
         blood_sugars: array_of('blood_sugar'),
+        login_patient: login_patient,
         user: user,
         find_user: find_user,
         activate_user: activate_user

--- a/app/schema/api/v4/models.rb
+++ b/app/schema/api/v4/models.rb
@@ -54,8 +54,8 @@ class Api::V4::Models
       {
         type: :object,
         properties: {
-          access_token: { '$ref' => '#/definitions/non_empty_string' },
-          patient_id: { '$ref' => '#/definitions/uuid' }
+          id: { '$ref' => '#/definitions/uuid' },
+          access_token: { '$ref' => '#/definitions/non_empty_string' }
         }
       }
     end

--- a/app/schema/api/v4/schema.rb
+++ b/app/schema/api/v4/schema.rb
@@ -56,23 +56,31 @@ class Api::V4::Schema
     end
 
     def patient_activate_request
-      { type: :object,
+      {
+        type: :object,
         properties: {
-          passport_id: { '$ref' => '#/definitions/uuid' } } }
+          passport_id: { '$ref' => '#/definitions/uuid' }
+        }
+      }
     end
 
     def patient_login_request
-      { type: :object,
+      {
+        type: :object,
         properties: {
           passport_id: { '$ref' => '#/definitions/uuid' },
-          otp: { '$ref' => '#/definitions/non_empty_string' }, } }
+          otp: { '$ref' => '#/definitions/non_empty_string' }
+        }
+      }
     end
 
     def patient_login_response
-      { type: :object,
+      {
+        type: :object,
         properties: {
-          access_token: { '$ref' => '#/definitions/non_empty_string' },
-          patient_id: { '$ref' => '#/definitions/uuid' } } }
+          patient: { '$ref' => '#/definitions/login_patient' }
+        }
+      }
     end
 
     def user_find_request

--- a/app/schema/api/v4/schema.rb
+++ b/app/schema/api/v4/schema.rb
@@ -55,6 +55,12 @@ class Api::V4::Schema
       sync_to_user_response(:blood_sugars)
     end
 
+    def patient_activate_request
+      { type: :object,
+        properties: {
+          passport_id: { '$ref' => '#/definitions/uuid' } } }
+    end
+
     def user_find_request
       { type: :object,
         properties: { phone_number: { '$ref' => '#/definitions/non_empty_string'} },

--- a/app/schema/api/v4/schema.rb
+++ b/app/schema/api/v4/schema.rb
@@ -55,23 +55,24 @@ class Api::V4::Schema
       sync_to_user_response(:blood_sugars)
     end
 
-    def patient_activate_request
+    def patient_request_otp_request
       { type: :object,
         properties: {
           passport_id: { '$ref' => '#/definitions/uuid' } } }
     end
 
-    def patient_authenticate_request
+    def patient_activate_request
       { type: :object,
         properties: {
           passport_id: { '$ref' => '#/definitions/uuid' },
           otp: { '$ref' => '#/definitions/non_empty_string' }, } }
     end
 
-    def patient_authenticate_response
+    def patient_activate_response
       { type: :object,
         properties: {
-          access_token: { '$ref' => '#/definitions/non_empty_string' } } }
+          access_token: { '$ref' => '#/definitions/non_empty_string' },
+          patient_id: { '$ref' => '#/definitions/uuid' } } }
     end
 
     def user_find_request

--- a/app/schema/api/v4/schema.rb
+++ b/app/schema/api/v4/schema.rb
@@ -55,20 +55,20 @@ class Api::V4::Schema
       sync_to_user_response(:blood_sugars)
     end
 
-    def patient_request_otp_request
+    def patient_activate_request
       { type: :object,
         properties: {
           passport_id: { '$ref' => '#/definitions/uuid' } } }
     end
 
-    def patient_activate_request
+    def patient_login_request
       { type: :object,
         properties: {
           passport_id: { '$ref' => '#/definitions/uuid' },
           otp: { '$ref' => '#/definitions/non_empty_string' }, } }
     end
 
-    def patient_activate_response
+    def patient_login_response
       { type: :object,
         properties: {
           access_token: { '$ref' => '#/definitions/non_empty_string' },

--- a/app/schema/api/v4/schema.rb
+++ b/app/schema/api/v4/schema.rb
@@ -61,6 +61,19 @@ class Api::V4::Schema
           passport_id: { '$ref' => '#/definitions/uuid' } } }
     end
 
+    def patient_authenticate_request
+      { type: :object,
+        properties: {
+          passport_id: { '$ref' => '#/definitions/uuid' },
+          otp: { '$ref' => '#/definitions/non_empty_string' }, } }
+    end
+
+    def patient_authenticate_response
+      { type: :object,
+        properties: {
+          access_token: { '$ref' => '#/definitions/non_empty_string' } } }
+    end
+
     def user_find_request
       { type: :object,
         properties: { phone_number: { '$ref' => '#/definitions/non_empty_string'} },

--- a/app/services/sms_notification_service.rb
+++ b/app/services/sms_notification_service.rb
@@ -22,6 +22,10 @@ class SmsNotificationService
     send_sms(body, callback_url)
   end
 
+  def send_patient_request_otp_sms(otp)
+    send_sms(I18n.t('sms.patient_request_otp', otp: otp))
+  end
+
   private
 
   attr_reader :sender_phone_number, :recipient_number, :client

--- a/bin/docs
+++ b/bin/docs
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-bundle exec rake rswag:specs:swaggerize

--- a/bin/docs
+++ b/bin/docs
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+bundle exec rake rswag:specs:swaggerize

--- a/config/locales/api/en.yml
+++ b/config/locales/api/en.yml
@@ -15,6 +15,7 @@ en:
     request_otp: '<#> %{otp} is your Simple verification code\n%{app_signature}'
     appointment_reminders:
       missed_visit_sms_reminder: 'Our staff at %{facility_name} are thinking of you and your heart health. Our health team is always here if you have any follow-up questions or concerns.'
+    patient_request_otp: '%{otp} is your BP Passport verification code'
   analytics:
     followup_patients: "How many follow-up patients visited %{facility_name}?"
     patients_enrolled: "How many new patients are enrolled at %{facility_name}?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,8 +137,8 @@ Rails.application.routes.draw do
       end
 
       resource :patient, only: [:show] do
-        post 'request_otp', to: 'patient#request_otp'
         post 'activate', to: 'patient#activate'
+        post 'login', to: 'patient#login'
       end
 
       scope :users do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,8 +137,8 @@ Rails.application.routes.draw do
       end
 
       resource :patient, only: [:show] do
+        post 'request_otp', to: 'patient#request_otp'
         post 'activate', to: 'patient#activate'
-        post 'authenticate', to: 'patient#authenticate'
       end
 
       scope :users do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,6 +136,11 @@ Rails.application.routes.draw do
         post 'sync', to: 'blood_sugars#sync_from_user'
       end
 
+      resource :patient, only: [:show] do
+        post 'activate', to: 'patient#activate'
+        post 'authenticate', to: 'patient#authenticate'
+      end
+
       scope :users do
         post 'find', to: 'users#find'
         post 'activate', to: 'users#activate'

--- a/db/migrate/20200410201924_create_passport_authentications.rb
+++ b/db/migrate/20200410201924_create_passport_authentications.rb
@@ -1,0 +1,13 @@
+class CreatePassportAuthentications < ActiveRecord::Migration[5.1]
+  def change
+    create_table :passport_authentications do |t|
+      t.string :access_token, null: false
+      t.string :otp, null: false
+      t.datetime :otp_valid_until, null: false
+      t.uuid :patient_id, null: false
+      t.uuid :patient_business_identifier_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -479,31 +479,6 @@ ActiveRecord::Schema.define(version: 20200410201924) do
   add_foreign_key "patients", "addresses"
   add_foreign_key "protocol_drugs", "protocols"
 
-  create_view "blood_pressures_per_facility_per_days", materialized: true, sql_definition: <<-SQL
-      WITH latest_bp_per_patient_per_day AS (
-           SELECT DISTINCT ON (blood_pressures.facility_id, blood_pressures.patient_id, (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text) blood_pressures.id AS bp_id,
-              blood_pressures.facility_id,
-              (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS day,
-              (date_part('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS month,
-              (date_part('quarter'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS quarter,
-              (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS year
-             FROM blood_pressures
-            WHERE (blood_pressures.deleted_at IS NULL)
-            ORDER BY blood_pressures.facility_id, blood_pressures.patient_id, (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, blood_pressures.recorded_at DESC, blood_pressures.id
-          )
-   SELECT count(latest_bp_per_patient_per_day.bp_id) AS bp_count,
-      facilities.id AS facility_id,
-      timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, facilities.deleted_at)) AS deleted_at,
-      latest_bp_per_patient_per_day.day,
-      latest_bp_per_patient_per_day.month,
-      latest_bp_per_patient_per_day.quarter,
-      latest_bp_per_patient_per_day.year
-     FROM (latest_bp_per_patient_per_day
-       JOIN facilities ON ((facilities.id = latest_bp_per_patient_per_day.facility_id)))
-    GROUP BY latest_bp_per_patient_per_day.day, latest_bp_per_patient_per_day.month, latest_bp_per_patient_per_day.quarter, latest_bp_per_patient_per_day.year, facilities.deleted_at, facilities.id;
-  SQL
-  add_index "blood_pressures_per_facility_per_days", ["facility_id", "day", "year"], name: "index_blood_pressures_per_facility_per_days", unique: true
-
   create_view "bp_drugs_views", sql_definition: <<-SQL
       SELECT bp.id AS bp_id,
       bp.systolic,
@@ -606,138 +581,6 @@ ActiveRecord::Schema.define(version: 20200410201924) do
      FROM (appointments ap
        JOIN facilities f ON ((ap.facility_id = f.id)));
   SQL
-  create_view "latest_blood_pressures_per_patient_per_days", materialized: true, sql_definition: <<-SQL
-      WITH latest_bp_per_patient_per_month AS (
-           SELECT DISTINCT ON (blood_pressures.patient_id, (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, (date_part('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text) blood_pressures.id AS bp_id,
-              blood_pressures.patient_id,
-              patients.registration_facility_id,
-              blood_pressures.facility_id AS bp_facility_id,
-              timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at)) AS bp_recorded_at,
-              timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, patients.recorded_at)) AS patient_recorded_at,
-              blood_pressures.systolic,
-              blood_pressures.diastolic,
-              timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.deleted_at)) AS deleted_at,
-              (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS day,
-              (date_part('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS month,
-              (date_part('quarter'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS quarter,
-              (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS year
-             FROM (blood_pressures
-               JOIN patients ON ((patients.id = blood_pressures.patient_id)))
-            WHERE (blood_pressures.deleted_at IS NULL)
-            ORDER BY blood_pressures.patient_id, (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, (date_part('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, blood_pressures.recorded_at DESC, blood_pressures.id
-          )
-   SELECT latest_bp_per_patient_per_month.bp_id,
-      latest_bp_per_patient_per_month.patient_id,
-      latest_bp_per_patient_per_month.registration_facility_id,
-      latest_bp_per_patient_per_month.bp_facility_id,
-      latest_bp_per_patient_per_month.bp_recorded_at,
-      latest_bp_per_patient_per_month.patient_recorded_at,
-      latest_bp_per_patient_per_month.systolic,
-      latest_bp_per_patient_per_month.diastolic,
-      latest_bp_per_patient_per_month.deleted_at,
-      latest_bp_per_patient_per_month.day,
-      latest_bp_per_patient_per_month.month,
-      latest_bp_per_patient_per_month.quarter,
-      latest_bp_per_patient_per_month.year,
-      lag(latest_bp_per_patient_per_month.bp_facility_id, 1) OVER (PARTITION BY latest_bp_per_patient_per_month.patient_id ORDER BY latest_bp_per_patient_per_month.bp_recorded_at, latest_bp_per_patient_per_month.bp_id) AS responsible_facility_id,
-      lag(latest_bp_per_patient_per_month.bp_id, 1) OVER (PARTITION BY latest_bp_per_patient_per_month.patient_id ORDER BY latest_bp_per_patient_per_month.bp_recorded_at, latest_bp_per_patient_per_month.bp_id) AS previous_bp_id
-     FROM latest_bp_per_patient_per_month;
-  SQL
-  add_index "latest_blood_pressures_per_patient_per_days", ["bp_id"], name: "index_latest_blood_pressures_per_patient_per_days", unique: true
-
-  create_view "latest_blood_pressures_per_patient_per_months", materialized: true, sql_definition: <<-SQL
-      WITH latest_bp_per_patient_per_month AS (
-           SELECT DISTINCT ON (blood_pressures.patient_id, (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, (date_part('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text) blood_pressures.id AS bp_id,
-              blood_pressures.patient_id,
-              patients.registration_facility_id,
-              blood_pressures.facility_id AS bp_facility_id,
-              timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at)) AS bp_recorded_at,
-              timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, patients.recorded_at)) AS patient_recorded_at,
-              blood_pressures.systolic,
-              blood_pressures.diastolic,
-              timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.deleted_at)) AS deleted_at,
-              (date_part('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS month,
-              (date_part('quarter'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS quarter,
-              (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS year
-             FROM (blood_pressures
-               JOIN patients ON ((patients.id = blood_pressures.patient_id)))
-            WHERE (blood_pressures.deleted_at IS NULL)
-            ORDER BY blood_pressures.patient_id, (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, (date_part('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, blood_pressures.recorded_at DESC, blood_pressures.id
-          )
-   SELECT latest_bp_per_patient_per_month.bp_id,
-      latest_bp_per_patient_per_month.patient_id,
-      latest_bp_per_patient_per_month.registration_facility_id,
-      latest_bp_per_patient_per_month.bp_facility_id,
-      latest_bp_per_patient_per_month.bp_recorded_at,
-      latest_bp_per_patient_per_month.patient_recorded_at,
-      latest_bp_per_patient_per_month.systolic,
-      latest_bp_per_patient_per_month.diastolic,
-      latest_bp_per_patient_per_month.deleted_at,
-      latest_bp_per_patient_per_month.month,
-      latest_bp_per_patient_per_month.quarter,
-      latest_bp_per_patient_per_month.year,
-      lag(latest_bp_per_patient_per_month.bp_facility_id, 1) OVER (PARTITION BY latest_bp_per_patient_per_month.patient_id ORDER BY latest_bp_per_patient_per_month.bp_recorded_at, latest_bp_per_patient_per_month.bp_id) AS responsible_facility_id,
-      lag(latest_bp_per_patient_per_month.bp_id, 1) OVER (PARTITION BY latest_bp_per_patient_per_month.patient_id ORDER BY latest_bp_per_patient_per_month.bp_recorded_at, latest_bp_per_patient_per_month.bp_id) AS previous_bp_id
-     FROM latest_bp_per_patient_per_month;
-  SQL
-  add_index "latest_blood_pressures_per_patient_per_months", ["bp_id"], name: "index_latest_blood_pressures_per_patient_per_months", unique: true
-
-  create_view "latest_blood_pressures_per_patient_per_quarters", materialized: true, sql_definition: <<-SQL
-      WITH latest_bp_per_patient_per_quarter AS (
-           SELECT DISTINCT ON (latest_blood_pressures_per_patient_per_months.patient_id, latest_blood_pressures_per_patient_per_months.year, latest_blood_pressures_per_patient_per_months.quarter) latest_blood_pressures_per_patient_per_months.bp_id,
-              latest_blood_pressures_per_patient_per_months.patient_id,
-              latest_blood_pressures_per_patient_per_months.registration_facility_id,
-              latest_blood_pressures_per_patient_per_months.bp_facility_id,
-              latest_blood_pressures_per_patient_per_months.bp_recorded_at,
-              latest_blood_pressures_per_patient_per_months.patient_recorded_at,
-              latest_blood_pressures_per_patient_per_months.systolic,
-              latest_blood_pressures_per_patient_per_months.diastolic,
-              latest_blood_pressures_per_patient_per_months.deleted_at,
-              latest_blood_pressures_per_patient_per_months.month,
-              latest_blood_pressures_per_patient_per_months.quarter,
-              latest_blood_pressures_per_patient_per_months.year,
-              latest_blood_pressures_per_patient_per_months.responsible_facility_id,
-              latest_blood_pressures_per_patient_per_months.previous_bp_id
-             FROM latest_blood_pressures_per_patient_per_months
-            ORDER BY latest_blood_pressures_per_patient_per_months.patient_id, latest_blood_pressures_per_patient_per_months.year, latest_blood_pressures_per_patient_per_months.quarter, latest_blood_pressures_per_patient_per_months.bp_recorded_at DESC, latest_blood_pressures_per_patient_per_months.bp_id
-          )
-   SELECT latest_bp_per_patient_per_quarter.bp_id,
-      latest_bp_per_patient_per_quarter.patient_id,
-      latest_bp_per_patient_per_quarter.registration_facility_id,
-      latest_bp_per_patient_per_quarter.bp_facility_id,
-      latest_bp_per_patient_per_quarter.bp_recorded_at,
-      latest_bp_per_patient_per_quarter.patient_recorded_at,
-      latest_bp_per_patient_per_quarter.systolic,
-      latest_bp_per_patient_per_quarter.diastolic,
-      latest_bp_per_patient_per_quarter.deleted_at,
-      latest_bp_per_patient_per_quarter.month,
-      latest_bp_per_patient_per_quarter.quarter,
-      latest_bp_per_patient_per_quarter.year,
-      lag(latest_bp_per_patient_per_quarter.bp_facility_id, 1) OVER (PARTITION BY latest_bp_per_patient_per_quarter.patient_id ORDER BY latest_bp_per_patient_per_quarter.bp_recorded_at, latest_bp_per_patient_per_quarter.bp_id) AS responsible_facility_id
-     FROM latest_bp_per_patient_per_quarter;
-  SQL
-  add_index "latest_blood_pressures_per_patient_per_quarters", ["bp_id"], name: "index_latest_blood_pressures_per_patient_per_quarters", unique: true
-
-  create_view "latest_blood_pressures_per_patients", materialized: true, sql_definition: <<-SQL
-      SELECT DISTINCT ON (latest_blood_pressures_per_patient_per_months.patient_id) latest_blood_pressures_per_patient_per_months.bp_id,
-      latest_blood_pressures_per_patient_per_months.patient_id,
-      latest_blood_pressures_per_patient_per_months.registration_facility_id,
-      latest_blood_pressures_per_patient_per_months.bp_facility_id,
-      latest_blood_pressures_per_patient_per_months.bp_recorded_at,
-      latest_blood_pressures_per_patient_per_months.patient_recorded_at,
-      latest_blood_pressures_per_patient_per_months.systolic,
-      latest_blood_pressures_per_patient_per_months.diastolic,
-      latest_blood_pressures_per_patient_per_months.deleted_at,
-      latest_blood_pressures_per_patient_per_months.month,
-      latest_blood_pressures_per_patient_per_months.quarter,
-      latest_blood_pressures_per_patient_per_months.year,
-      latest_blood_pressures_per_patient_per_months.responsible_facility_id,
-      latest_blood_pressures_per_patient_per_months.previous_bp_id
-     FROM latest_blood_pressures_per_patient_per_months
-    ORDER BY latest_blood_pressures_per_patient_per_months.patient_id, latest_blood_pressures_per_patient_per_months.bp_recorded_at DESC, latest_blood_pressures_per_patient_per_months.bp_id;
-  SQL
-  add_index "latest_blood_pressures_per_patients", ["bp_id"], name: "index_latest_blood_pressures_per_patients", unique: true
-
   create_view "overdue_views", sql_definition: <<-SQL
       SELECT ap.id AS appointment_id,
       ap.facility_id,
@@ -811,6 +654,33 @@ ActiveRecord::Schema.define(version: 20200410201924) do
        JOIN users u ON ((u.id = bp.user_id)))
        LEFT JOIN patient_phone_numbers pn ON ((pn.patient_id = p.id)));
   SQL
+  create_view "patients_blood_pressures_facilities", sql_definition: <<-SQL
+      SELECT patients.id AS p_id,
+      patients.age AS p_age,
+      patients.gender AS p_gender,
+      blood_pressures.id,
+      blood_pressures.systolic,
+      blood_pressures.diastolic,
+      blood_pressures.patient_id,
+      blood_pressures.created_at,
+      blood_pressures.updated_at,
+      blood_pressures.device_created_at,
+      blood_pressures.device_updated_at,
+      blood_pressures.facility_id,
+      blood_pressures.user_id,
+      blood_pressures.deleted_at,
+      facilities.name,
+      facilities.district,
+      facilities.state,
+      facilities.facility_type,
+      users.full_name,
+      users.sync_approval_status
+     FROM patients,
+      blood_pressures,
+      facilities,
+      users
+    WHERE ((blood_pressures.patient_id = patients.id) AND (blood_pressures.facility_id = facilities.id) AND (blood_pressures.user_id = users.id));
+  SQL
   create_view "patient_registrations_per_day_per_facilities", materialized: true, sql_definition: <<-SQL
       SELECT count(patients.id) AS registration_count,
       patients.registration_facility_id AS facility_id,
@@ -826,6 +696,163 @@ ActiveRecord::Schema.define(version: 20200410201924) do
   SQL
   add_index "patient_registrations_per_day_per_facilities", ["facility_id", "day", "year"], name: "index_patient_registrations_per_day_per_facilities", unique: true
 
+  create_view "latest_blood_pressures_per_patient_per_months", materialized: true, sql_definition: <<-SQL
+      WITH latest_bp_per_patient_per_month AS (
+           SELECT DISTINCT ON (blood_pressures.patient_id, (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, (date_part('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text) blood_pressures.id AS bp_id,
+              blood_pressures.patient_id,
+              patients.registration_facility_id,
+              blood_pressures.facility_id AS bp_facility_id,
+              timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at)) AS bp_recorded_at,
+              timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, patients.recorded_at)) AS patient_recorded_at,
+              blood_pressures.systolic,
+              blood_pressures.diastolic,
+              timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.deleted_at)) AS deleted_at,
+              (date_part('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS month,
+              (date_part('quarter'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS quarter,
+              (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS year
+             FROM (blood_pressures
+               JOIN patients ON ((patients.id = blood_pressures.patient_id)))
+            WHERE (blood_pressures.deleted_at IS NULL)
+            ORDER BY blood_pressures.patient_id, (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, (date_part('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, blood_pressures.recorded_at DESC, blood_pressures.id
+          )
+   SELECT latest_bp_per_patient_per_month.bp_id,
+      latest_bp_per_patient_per_month.patient_id,
+      latest_bp_per_patient_per_month.registration_facility_id,
+      latest_bp_per_patient_per_month.bp_facility_id,
+      latest_bp_per_patient_per_month.bp_recorded_at,
+      latest_bp_per_patient_per_month.patient_recorded_at,
+      latest_bp_per_patient_per_month.systolic,
+      latest_bp_per_patient_per_month.diastolic,
+      latest_bp_per_patient_per_month.deleted_at,
+      latest_bp_per_patient_per_month.month,
+      latest_bp_per_patient_per_month.quarter,
+      latest_bp_per_patient_per_month.year,
+      lag(latest_bp_per_patient_per_month.bp_facility_id, 1) OVER (PARTITION BY latest_bp_per_patient_per_month.patient_id ORDER BY latest_bp_per_patient_per_month.bp_recorded_at, latest_bp_per_patient_per_month.bp_id) AS responsible_facility_id,
+      lag(latest_bp_per_patient_per_month.bp_id, 1) OVER (PARTITION BY latest_bp_per_patient_per_month.patient_id ORDER BY latest_bp_per_patient_per_month.bp_recorded_at, latest_bp_per_patient_per_month.bp_id) AS previous_bp_id
+     FROM latest_bp_per_patient_per_month;
+  SQL
+  add_index "latest_blood_pressures_per_patient_per_months", ["bp_id"], name: "index_latest_blood_pressures_per_patient_per_months", unique: true
+
+  create_view "latest_blood_pressures_per_patients", materialized: true, sql_definition: <<-SQL
+      SELECT DISTINCT ON (latest_blood_pressures_per_patient_per_months.patient_id) latest_blood_pressures_per_patient_per_months.bp_id,
+      latest_blood_pressures_per_patient_per_months.patient_id,
+      latest_blood_pressures_per_patient_per_months.registration_facility_id,
+      latest_blood_pressures_per_patient_per_months.bp_facility_id,
+      latest_blood_pressures_per_patient_per_months.bp_recorded_at,
+      latest_blood_pressures_per_patient_per_months.patient_recorded_at,
+      latest_blood_pressures_per_patient_per_months.systolic,
+      latest_blood_pressures_per_patient_per_months.diastolic,
+      latest_blood_pressures_per_patient_per_months.deleted_at,
+      latest_blood_pressures_per_patient_per_months.month,
+      latest_blood_pressures_per_patient_per_months.quarter,
+      latest_blood_pressures_per_patient_per_months.year,
+      latest_blood_pressures_per_patient_per_months.responsible_facility_id,
+      latest_blood_pressures_per_patient_per_months.previous_bp_id
+     FROM latest_blood_pressures_per_patient_per_months
+    ORDER BY latest_blood_pressures_per_patient_per_months.patient_id, latest_blood_pressures_per_patient_per_months.bp_recorded_at DESC, latest_blood_pressures_per_patient_per_months.bp_id;
+  SQL
+  add_index "latest_blood_pressures_per_patients", ["bp_id"], name: "index_latest_blood_pressures_per_patients", unique: true
+
+  create_view "latest_blood_pressures_per_patient_per_quarters", materialized: true, sql_definition: <<-SQL
+      WITH latest_bp_per_patient_per_quarter AS (
+           SELECT DISTINCT ON (latest_blood_pressures_per_patient_per_months.patient_id, latest_blood_pressures_per_patient_per_months.year, latest_blood_pressures_per_patient_per_months.quarter) latest_blood_pressures_per_patient_per_months.bp_id,
+              latest_blood_pressures_per_patient_per_months.patient_id,
+              latest_blood_pressures_per_patient_per_months.registration_facility_id,
+              latest_blood_pressures_per_patient_per_months.bp_facility_id,
+              latest_blood_pressures_per_patient_per_months.bp_recorded_at,
+              latest_blood_pressures_per_patient_per_months.patient_recorded_at,
+              latest_blood_pressures_per_patient_per_months.systolic,
+              latest_blood_pressures_per_patient_per_months.diastolic,
+              latest_blood_pressures_per_patient_per_months.deleted_at,
+              latest_blood_pressures_per_patient_per_months.month,
+              latest_blood_pressures_per_patient_per_months.quarter,
+              latest_blood_pressures_per_patient_per_months.year,
+              latest_blood_pressures_per_patient_per_months.responsible_facility_id,
+              latest_blood_pressures_per_patient_per_months.previous_bp_id
+             FROM latest_blood_pressures_per_patient_per_months
+            ORDER BY latest_blood_pressures_per_patient_per_months.patient_id, latest_blood_pressures_per_patient_per_months.year, latest_blood_pressures_per_patient_per_months.quarter, latest_blood_pressures_per_patient_per_months.bp_recorded_at DESC, latest_blood_pressures_per_patient_per_months.bp_id
+          )
+   SELECT latest_bp_per_patient_per_quarter.bp_id,
+      latest_bp_per_patient_per_quarter.patient_id,
+      latest_bp_per_patient_per_quarter.registration_facility_id,
+      latest_bp_per_patient_per_quarter.bp_facility_id,
+      latest_bp_per_patient_per_quarter.bp_recorded_at,
+      latest_bp_per_patient_per_quarter.patient_recorded_at,
+      latest_bp_per_patient_per_quarter.systolic,
+      latest_bp_per_patient_per_quarter.diastolic,
+      latest_bp_per_patient_per_quarter.deleted_at,
+      latest_bp_per_patient_per_quarter.month,
+      latest_bp_per_patient_per_quarter.quarter,
+      latest_bp_per_patient_per_quarter.year,
+      lag(latest_bp_per_patient_per_quarter.bp_facility_id, 1) OVER (PARTITION BY latest_bp_per_patient_per_quarter.patient_id ORDER BY latest_bp_per_patient_per_quarter.bp_recorded_at, latest_bp_per_patient_per_quarter.bp_id) AS responsible_facility_id
+     FROM latest_bp_per_patient_per_quarter;
+  SQL
+  add_index "latest_blood_pressures_per_patient_per_quarters", ["bp_id"], name: "index_latest_blood_pressures_per_patient_per_quarters", unique: true
+
+  create_view "blood_pressures_per_facility_per_days", materialized: true, sql_definition: <<-SQL
+      WITH latest_bp_per_patient_per_day AS (
+           SELECT DISTINCT ON (blood_pressures.facility_id, blood_pressures.patient_id, (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text) blood_pressures.id AS bp_id,
+              blood_pressures.facility_id,
+              (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS day,
+              (date_part('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS month,
+              (date_part('quarter'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS quarter,
+              (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS year
+             FROM blood_pressures
+            WHERE (blood_pressures.deleted_at IS NULL)
+            ORDER BY blood_pressures.facility_id, blood_pressures.patient_id, (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, blood_pressures.recorded_at DESC, blood_pressures.id
+          )
+   SELECT count(latest_bp_per_patient_per_day.bp_id) AS bp_count,
+      facilities.id AS facility_id,
+      timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, facilities.deleted_at)) AS deleted_at,
+      latest_bp_per_patient_per_day.day,
+      latest_bp_per_patient_per_day.month,
+      latest_bp_per_patient_per_day.quarter,
+      latest_bp_per_patient_per_day.year
+     FROM (latest_bp_per_patient_per_day
+       JOIN facilities ON ((facilities.id = latest_bp_per_patient_per_day.facility_id)))
+    GROUP BY latest_bp_per_patient_per_day.day, latest_bp_per_patient_per_day.month, latest_bp_per_patient_per_day.quarter, latest_bp_per_patient_per_day.year, facilities.deleted_at, facilities.id;
+  SQL
+  add_index "blood_pressures_per_facility_per_days", ["facility_id", "day", "year"], name: "index_blood_pressures_per_facility_per_days", unique: true
+
+  create_view "latest_blood_pressures_per_patient_per_days", materialized: true, sql_definition: <<-SQL
+      WITH latest_bp_per_patient_per_day AS (
+           SELECT DISTINCT ON (blood_pressures.patient_id, (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text) blood_pressures.id AS bp_id,
+              blood_pressures.patient_id,
+              patients.registration_facility_id,
+              blood_pressures.facility_id AS bp_facility_id,
+              timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at)) AS bp_recorded_at,
+              timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, patients.recorded_at)) AS patient_recorded_at,
+              blood_pressures.systolic,
+              blood_pressures.diastolic,
+              timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.deleted_at)) AS deleted_at,
+              (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS day,
+              (date_part('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS month,
+              (date_part('quarter'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS quarter,
+              (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text AS year
+             FROM (blood_pressures
+               JOIN patients ON ((patients.id = blood_pressures.patient_id)))
+            WHERE (blood_pressures.deleted_at IS NULL)
+            ORDER BY blood_pressures.patient_id, (date_part('year'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('utc'::text, blood_pressures.recorded_at))))::text, blood_pressures.recorded_at DESC, blood_pressures.id
+          )
+   SELECT latest_bp_per_patient_per_day.bp_id,
+      latest_bp_per_patient_per_day.patient_id,
+      latest_bp_per_patient_per_day.registration_facility_id,
+      latest_bp_per_patient_per_day.bp_facility_id,
+      latest_bp_per_patient_per_day.bp_recorded_at,
+      latest_bp_per_patient_per_day.patient_recorded_at,
+      latest_bp_per_patient_per_day.systolic,
+      latest_bp_per_patient_per_day.diastolic,
+      latest_bp_per_patient_per_day.deleted_at,
+      latest_bp_per_patient_per_day.day,
+      latest_bp_per_patient_per_day.month,
+      latest_bp_per_patient_per_day.quarter,
+      latest_bp_per_patient_per_day.year,
+      lag(latest_bp_per_patient_per_day.bp_facility_id, 1) OVER (PARTITION BY latest_bp_per_patient_per_day.patient_id ORDER BY latest_bp_per_patient_per_day.bp_recorded_at, latest_bp_per_patient_per_day.bp_id) AS responsible_facility_id,
+      lag(latest_bp_per_patient_per_day.bp_id, 1) OVER (PARTITION BY latest_bp_per_patient_per_day.patient_id ORDER BY latest_bp_per_patient_per_day.bp_recorded_at, latest_bp_per_patient_per_day.bp_id) AS previous_bp_id
+     FROM latest_bp_per_patient_per_day;
+  SQL
+  add_index "latest_blood_pressures_per_patient_per_days", ["bp_id"], name: "index_latest_blood_pressures_per_patient_per_days", unique: true
+
   create_view "patient_summaries", sql_definition: <<-SQL
       SELECT p.recorded_at,
       concat(date_part('year'::text, p.recorded_at), ' Q', date_part('quarter'::text, p.recorded_at)) AS registration_quarter,
@@ -837,37 +864,50 @@ ActiveRecord::Schema.define(version: 20200410201924) do
       p.gender,
       latest_phone_number.number AS latest_phone_number,
       addresses.village_or_colony,
+      addresses.street_address,
       addresses.district,
       addresses.state,
       reg_facility.name AS registration_facility_name,
       reg_facility.facility_type AS registration_facility_type,
       reg_facility.district AS registration_district,
       reg_facility.state AS registration_state,
-      latest_bp.systolic AS latest_bp_systolic,
-      latest_bp.diastolic AS latest_bp_diastolic,
-      latest_bp.recorded_at AS latest_bp_recorded_at,
-      concat(date_part('year'::text, latest_bp.recorded_at), ' Q', date_part('quarter'::text, latest_bp.recorded_at)) AS latest_bp_quarter,
-      latest_bp_facility.name AS latest_bp_facility_name,
-      latest_bp_facility.facility_type AS latest_bp_facility_type,
-      latest_bp_facility.district AS latest_bp_district,
-      latest_bp_facility.state AS latest_bp_state,
+      latest_blood_pressure.systolic AS latest_blood_pressure_systolic,
+      latest_blood_pressure.diastolic AS latest_blood_pressure_diastolic,
+      latest_blood_pressure.recorded_at AS latest_blood_pressure_recorded_at,
+      concat(date_part('year'::text, latest_blood_pressure.recorded_at), ' Q', date_part('quarter'::text, latest_blood_pressure.recorded_at)) AS latest_blood_pressure_quarter,
+      latest_blood_pressure_facility.name AS latest_blood_pressure_facility_name,
+      latest_blood_pressure_facility.facility_type AS latest_blood_pressure_facility_type,
+      latest_blood_pressure_facility.district AS latest_blood_pressure_district,
+      latest_blood_pressure_facility.state AS latest_blood_pressure_state,
+      latest_blood_sugar.blood_sugar_type AS latest_blood_sugar_type,
+      latest_blood_sugar.blood_sugar_value AS latest_blood_sugar_value,
+      latest_blood_sugar.recorded_at AS latest_blood_sugar_recorded_at,
+      concat(date_part('year'::text, latest_blood_sugar.recorded_at), ' Q', date_part('quarter'::text, latest_blood_sugar.recorded_at)) AS latest_blood_sugar_quarter,
+      latest_blood_sugar_facility.name AS latest_blood_sugar_facility_name,
+      latest_blood_sugar_facility.facility_type AS latest_blood_sugar_facility_type,
+      latest_blood_sugar_facility.district AS latest_blood_sugar_district,
+      latest_blood_sugar_facility.state AS latest_blood_sugar_state,
       GREATEST((0)::double precision, date_part('day'::text, (now() - (next_appointment.scheduled_date)::timestamp with time zone))) AS days_overdue,
+      next_appointment.id AS next_appointment_id,
       next_appointment.scheduled_date AS next_appointment_scheduled_date,
+      next_appointment.status AS next_appointment_status,
+      next_appointment.remind_on AS next_appointment_remind_on,
+      next_appointment_facility.id AS next_appointment_facility_id,
       next_appointment_facility.name AS next_appointment_facility_name,
       next_appointment_facility.facility_type AS next_appointment_facility_type,
       next_appointment_facility.district AS next_appointment_district,
       next_appointment_facility.state AS next_appointment_state,
           CASE
-              WHEN ((latest_bp.systolic >= 180) OR (latest_bp.diastolic >= 110)) THEN 0
-              WHEN ((mh.prior_heart_attack = 'yes'::text) OR (mh.prior_stroke = 'yes'::text) OR (mh.diabetes = 'yes'::text) OR (mh.chronic_kidney_disease = 'yes'::text)) THEN 1
-              WHEN (((latest_bp.systolic >= 160) AND (latest_bp.systolic <= 179)) OR ((latest_bp.diastolic >= 100) AND (latest_bp.diastolic <= 109))) THEN 2
-              WHEN (((latest_bp.systolic >= 140) AND (latest_bp.systolic <= 159)) OR ((latest_bp.diastolic >= 90) AND (latest_bp.diastolic <= 99))) THEN 3
-              WHEN ((latest_bp.systolic < 140) AND (latest_bp.diastolic < 90)) THEN 4
-              ELSE 5
+              WHEN (next_appointment.scheduled_date IS NULL) THEN 0
+              WHEN (next_appointment.scheduled_date > date_trunc('day'::text, (now() - '30 days'::interval))) THEN 0
+              WHEN ((latest_blood_pressure.systolic >= 180) OR (latest_blood_pressure.diastolic >= 110)) THEN 1
+              WHEN (((mh.prior_heart_attack = 'yes'::text) OR (mh.prior_stroke = 'yes'::text)) AND ((latest_blood_pressure.systolic >= 140) OR (latest_blood_pressure.diastolic >= 90))) THEN 1
+              WHEN ((((latest_blood_sugar.blood_sugar_type)::text = 'random'::text) AND (latest_blood_sugar.blood_sugar_value >= (300)::numeric)) OR (((latest_blood_sugar.blood_sugar_type)::text = 'post_prandial'::text) AND (latest_blood_sugar.blood_sugar_value >= (300)::numeric)) OR (((latest_blood_sugar.blood_sugar_type)::text = 'fasting'::text) AND (latest_blood_sugar.blood_sugar_value >= (200)::numeric)) OR (((latest_blood_sugar.blood_sugar_type)::text = 'hba1c'::text) AND (latest_blood_sugar.blood_sugar_value >= 9.0))) THEN 1
+              ELSE 0
           END AS risk_level,
       latest_bp_passport.identifier AS latest_bp_passport,
       p.id
-     FROM (((((((((patients p
+     FROM (((((((((((patients p
        LEFT JOIN addresses ON ((addresses.id = p.address_id)))
        LEFT JOIN facilities reg_facility ON ((reg_facility.id = p.registration_facility_id)))
        LEFT JOIN medical_histories mh ON ((mh.patient_id = p.id)))
@@ -897,8 +937,23 @@ ActiveRecord::Schema.define(version: 20200410201924) do
               blood_pressures.deleted_at,
               blood_pressures.recorded_at
              FROM blood_pressures
-            ORDER BY blood_pressures.patient_id, blood_pressures.recorded_at DESC) latest_bp ON ((latest_bp.patient_id = p.id)))
-       LEFT JOIN facilities latest_bp_facility ON ((latest_bp_facility.id = latest_bp.facility_id)))
+            ORDER BY blood_pressures.patient_id, blood_pressures.recorded_at DESC) latest_blood_pressure ON ((latest_blood_pressure.patient_id = p.id)))
+       LEFT JOIN facilities latest_blood_pressure_facility ON ((latest_blood_pressure_facility.id = latest_blood_pressure.facility_id)))
+       LEFT JOIN ( SELECT DISTINCT ON (blood_sugars.patient_id) blood_sugars.id,
+              blood_sugars.blood_sugar_type,
+              blood_sugars.blood_sugar_value,
+              blood_sugars.patient_id,
+              blood_sugars.user_id,
+              blood_sugars.facility_id,
+              blood_sugars.device_created_at,
+              blood_sugars.device_updated_at,
+              blood_sugars.deleted_at,
+              blood_sugars.recorded_at,
+              blood_sugars.created_at,
+              blood_sugars.updated_at
+             FROM blood_sugars
+            ORDER BY blood_sugars.patient_id, blood_sugars.recorded_at DESC) latest_blood_sugar ON ((latest_blood_sugar.patient_id = p.id)))
+       LEFT JOIN facilities latest_blood_sugar_facility ON ((latest_blood_sugar_facility.id = latest_blood_sugar.facility_id)))
        LEFT JOIN ( SELECT DISTINCT ON (patient_business_identifiers.patient_id) patient_business_identifiers.id,
               patient_business_identifiers.identifier,
               patient_business_identifiers.identifier_type,
@@ -932,32 +987,5 @@ ActiveRecord::Schema.define(version: 20200410201924) do
              FROM appointments
             ORDER BY appointments.patient_id, appointments.scheduled_date DESC) next_appointment ON ((next_appointment.patient_id = p.id)))
        LEFT JOIN facilities next_appointment_facility ON ((next_appointment_facility.id = next_appointment.facility_id)));
-  SQL
-  create_view "patients_blood_pressures_facilities", sql_definition: <<-SQL
-      SELECT patients.id AS p_id,
-      patients.age AS p_age,
-      patients.gender AS p_gender,
-      blood_pressures.id,
-      blood_pressures.systolic,
-      blood_pressures.diastolic,
-      blood_pressures.patient_id,
-      blood_pressures.created_at,
-      blood_pressures.updated_at,
-      blood_pressures.device_created_at,
-      blood_pressures.device_updated_at,
-      blood_pressures.facility_id,
-      blood_pressures.user_id,
-      blood_pressures.deleted_at,
-      facilities.name,
-      facilities.district,
-      facilities.state,
-      facilities.facility_type,
-      users.full_name,
-      users.sync_approval_status
-     FROM patients,
-      blood_pressures,
-      facilities,
-      users
-    WHERE ((blood_pressures.patient_id = patients.id) AND (blood_pressures.facility_id = facilities.id) AND (blood_pressures.user_id = users.id));
   SQL
 end

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -1,0 +1,3 @@
+desc 'Regenerate documentation'
+task :docs => %w[rswag:specs:swaggerize] do
+end

--- a/spec/api/v4/patient_spec.rb
+++ b/spec/api/v4/patient_spec.rb
@@ -4,7 +4,7 @@ describe 'Patient v4 API', swagger_doc: 'v4/swagger.json' do
   path '/patient/activate' do
     post 'Trigger an OTP to be sent to a patient' do
       tags 'Patient'
-      parameter name: :passport_id, in: :body, schema: Api::V4::Schema.patient_activate_request, description: 'Patient\'s BP Passport UUID'
+      parameter name: :request_body, in: :body, schema: Api::V4::Schema.patient_activate_request, description: 'Patient\'s BP Passport UUID'
 
       before :each do
         sms_notification_service = double(SmsNotificationService.new(nil, nil))
@@ -12,15 +12,39 @@ describe 'Patient v4 API', swagger_doc: 'v4/swagger.json' do
         allow(sms_notification_service).to receive(:send_request_otp_sms).and_return(true)
       end
 
-      response '200', 'patient is found and an OTP is sent to their phone' do
+      response '200', 'Patient is found and an OTP is sent to their phone' do
         let(:bp_passport) { create(:patient_business_identifier, identifier_type: 'simple_bp_passport') }
-        let(:passport_id) { { passport_id: bp_passport.identifier } }
+        let(:request_body) { { passport_id: bp_passport.identifier } }
 
         run_test!
       end
 
-      response '404', 'incorrect passport id' do
-        let(:passport_id) { { passport_id: 'itsafake-uuid-0000-0000-000000000000' } }
+      response '404', 'Incorrect passport id' do
+        let(:request_body) { { passport_id: 'itsafake-uuid-0000-0000-000000000000' } }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/patient/authenticate' do
+    post 'Authenticate a patient with BP Passport UUID and OTP' do
+      tags 'Patient'
+      parameter name: :request_body, in: :body, schema: Api::V4::Schema.patient_authenticate_request, description: 'Patient\'s BP Passport UUID and OTP'
+
+      response '200', 'Correct OTP is submitted and access token is returned' do
+        let(:bp_passport) { create(:patient_business_identifier, identifier_type: 'simple_bp_passport') }
+        let(:passport_authentication) { create(:passport_authentication, patient_business_identifier: bp_passport, patient: bp_passport.patient) }
+        let(:request_body) { { passport_id: bp_passport.identifier, otp: passport_authentication.otp } }
+
+        schema Api::V4::Schema.patient_authenticate_response
+        run_test!
+      end
+
+      response '401', 'Incorrect BP Passport UUID or OTP' do
+        let(:bp_passport) { create(:patient_business_identifier, identifier_type: 'simple_bp_passport') }
+        let!(:passport_authentication) { create(:passport_authentication, patient_business_identifier: bp_passport, patient: bp_passport.patient) }
+        let(:request_body) { { passport_id: bp_passport.identifier, otp: 'wrong' } }
 
         run_test!
       end

--- a/spec/api/v4/patient_spec.rb
+++ b/spec/api/v4/patient_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 describe 'Patient v4 API', swagger_doc: 'v4/swagger.json' do
-  path '/patient/activate' do
-    post 'Trigger an OTP to be sent to a patient' do
+  path '/patient/request_otp' do
+    post 'Request an OTP to be sent to a patient' do
       tags 'Patient'
-      parameter name: :request_body, in: :body, schema: Api::V4::Schema.patient_activate_request, description: 'Patient\'s BP Passport UUID'
+      parameter name: :request_body, in: :body, schema: Api::V4::Schema.patient_request_otp_request, description: 'Patient\'s BP Passport UUID'
 
       before :each do
         sms_notification_service = double(SmsNotificationService.new(nil, nil))
@@ -27,17 +27,17 @@ describe 'Patient v4 API', swagger_doc: 'v4/swagger.json' do
     end
   end
 
-  path '/patient/authenticate' do
-    post 'Authenticate a patient with BP Passport UUID and OTP' do
+  path '/patient/activate' do
+    post 'Activate a patient with BP Passport UUID and OTP' do
       tags 'Patient'
-      parameter name: :request_body, in: :body, schema: Api::V4::Schema.patient_authenticate_request, description: 'Patient\'s BP Passport UUID and OTP'
+      parameter name: :request_body, in: :body, schema: Api::V4::Schema.patient_activate_request, description: 'Patient\'s BP Passport UUID and OTP'
 
       response '200', 'Correct OTP is submitted and access token is returned' do
         let(:bp_passport) { create(:patient_business_identifier, identifier_type: 'simple_bp_passport') }
         let(:passport_authentication) { create(:passport_authentication, patient_business_identifier: bp_passport, patient: bp_passport.patient) }
         let(:request_body) { { passport_id: bp_passport.identifier, otp: passport_authentication.otp } }
 
-        schema Api::V4::Schema.patient_authenticate_response
+        schema Api::V4::Schema.patient_activate_response
         run_test!
       end
 

--- a/spec/api/v4/patient_spec.rb
+++ b/spec/api/v4/patient_spec.rb
@@ -1,0 +1,29 @@
+require 'swagger_helper'
+
+describe 'Patient v4 API', swagger_doc: 'v4/swagger.json' do
+  path '/patient/activate' do
+    post 'Trigger an OTP to be sent to a patient' do
+      tags 'Patient'
+      parameter name: :passport_id, in: :body, schema: Api::V4::Schema.patient_activate_request, description: 'Patient\'s BP Passport UUID'
+
+      before :each do
+        sms_notification_service = double(SmsNotificationService.new(nil, nil))
+        allow(SmsNotificationService).to receive(:new).and_return(sms_notification_service)
+        allow(sms_notification_service).to receive(:send_request_otp_sms).and_return(true)
+      end
+
+      response '200', 'patient is found and an OTP is sent to their phone' do
+        let(:bp_passport) { create(:patient_business_identifier, identifier_type: 'simple_bp_passport') }
+        let(:passport_id) { { passport_id: bp_passport.identifier } }
+
+        run_test!
+      end
+
+      response '404', 'incorrect passport id' do
+        let(:passport_id) { { passport_id: 'itsafake-uuid-0000-0000-000000000000' } }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/api/v4/patient_spec.rb
+++ b/spec/api/v4/patient_spec.rb
@@ -1,15 +1,15 @@
 require 'swagger_helper'
 
 describe 'Patient v4 API', swagger_doc: 'v4/swagger.json' do
-  path '/patient/request_otp' do
+  path '/patient/activate' do
     post 'Request an OTP to be sent to a patient' do
       tags 'Patient'
-      parameter name: :request_body, in: :body, schema: Api::V4::Schema.patient_request_otp_request, description: 'Patient\'s BP Passport UUID'
+      parameter name: :request_body, in: :body, schema: Api::V4::Schema.patient_activate_request, description: 'Patient\'s BP Passport UUID'
 
       before :each do
         sms_notification_service = double(SmsNotificationService.new(nil, nil))
         allow(SmsNotificationService).to receive(:new).and_return(sms_notification_service)
-        allow(sms_notification_service).to receive(:send_patient_request_otp_sms).and_return(true)
+        allow(sms_notification_service).to receive(:send_patient_activate_sms).and_return(true)
       end
 
       response '200', 'Patient is found and an OTP is sent to their phone' do
@@ -27,17 +27,17 @@ describe 'Patient v4 API', swagger_doc: 'v4/swagger.json' do
     end
   end
 
-  path '/patient/activate' do
-    post 'Activate a patient with BP Passport UUID and OTP' do
+  path '/patient/login' do
+    post 'Log in a patient with BP Passport UUID and OTP' do
       tags 'Patient'
-      parameter name: :request_body, in: :body, schema: Api::V4::Schema.patient_activate_request, description: 'Patient\'s BP Passport UUID and OTP'
+      parameter name: :request_body, in: :body, schema: Api::V4::Schema.patient_login_request, description: 'Patient\'s BP Passport UUID and OTP'
 
       response '200', 'Correct OTP is submitted and API credentials are returned' do
         let(:bp_passport) { create(:patient_business_identifier, identifier_type: 'simple_bp_passport') }
         let(:passport_authentication) { create(:passport_authentication, patient_business_identifier: bp_passport, patient: bp_passport.patient) }
         let(:request_body) { { passport_id: bp_passport.identifier, otp: passport_authentication.otp } }
 
-        schema Api::V4::Schema.patient_activate_response
+        schema Api::V4::Schema.patient_login_response
         run_test!
       end
 

--- a/spec/api/v4/patient_spec.rb
+++ b/spec/api/v4/patient_spec.rb
@@ -9,7 +9,7 @@ describe 'Patient v4 API', swagger_doc: 'v4/swagger.json' do
       before :each do
         sms_notification_service = double(SmsNotificationService.new(nil, nil))
         allow(SmsNotificationService).to receive(:new).and_return(sms_notification_service)
-        allow(sms_notification_service).to receive(:send_request_otp_sms).and_return(true)
+        allow(sms_notification_service).to receive(:send_patient_request_otp_sms).and_return(true)
       end
 
       response '200', 'Patient is found and an OTP is sent to their phone' do

--- a/spec/api/v4/patient_spec.rb
+++ b/spec/api/v4/patient_spec.rb
@@ -32,7 +32,7 @@ describe 'Patient v4 API', swagger_doc: 'v4/swagger.json' do
       tags 'Patient'
       parameter name: :request_body, in: :body, schema: Api::V4::Schema.patient_activate_request, description: 'Patient\'s BP Passport UUID and OTP'
 
-      response '200', 'Correct OTP is submitted and access token is returned' do
+      response '200', 'Correct OTP is submitted and API credentials are returned' do
         let(:bp_passport) { create(:patient_business_identifier, identifier_type: 'simple_bp_passport') }
         let(:passport_authentication) { create(:passport_authentication, patient_business_identifier: bp_passport, patient: bp_passport.patient) }
         let(:request_body) { { passport_id: bp_passport.identifier, otp: passport_authentication.otp } }

--- a/spec/controllers/api/v4/patient_controller_spec.rb
+++ b/spec/controllers/api/v4/patient_controller_spec.rb
@@ -48,8 +48,10 @@ RSpec.describe Api::V4::PatientController, type: :controller do
 
       response_data = JSON.parse(response.body)
       expect(response_data).to match(
-        "access_token" => passport_authentication.reload.access_token,
-        "patient_id" => patient.id
+        "patient" => {
+          "access_token" => passport_authentication.reload.access_token,
+          "patient_id" => patient.id
+        }
       )
     end
 

--- a/spec/controllers/api/v4/patient_controller_spec.rb
+++ b/spec/controllers/api/v4/patient_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V4::PatientController, type: :controller do
-  describe '#request_otp' do
+  describe '#activate' do
     let!(:bp_passport) { create(:patient_business_identifier, identifier_type: 'simple_bp_passport') }
     let(:patient) { bp_passport.patient }
     let!(:passport_authentication) { create(:passport_authentication, patient: patient, patient_business_identifier: bp_passport) }
@@ -11,18 +11,18 @@ RSpec.describe Api::V4::PatientController, type: :controller do
     end
 
     it 'returns a successful response' do
-      post :request_otp, params: { passport_id: bp_passport.identifier }
+      post :activate, params: { passport_id: bp_passport.identifier }
       expect(response.status).to eq(200)
     end
 
     it 'send an OTP SMS' do
       expect(SendPatientOtpSmsJob).to receive(:perform_later).with(passport_authentication)
-      post :request_otp, params: { passport_id: bp_passport.identifier }
+      post :activate, params: { passport_id: bp_passport.identifier }
     end
 
     context 'when BP passport ID does not exist' do
       it 'returns a 404 response' do
-        post :request_otp, params: { passport_id: 'some-identifier' }
+        post :activate, params: { passport_id: 'some-identifier' }
         expect(response.status).to eq(404)
       end
     end
@@ -31,19 +31,19 @@ RSpec.describe Api::V4::PatientController, type: :controller do
       it 'returns a 404 response' do
         patient.phone_numbers.destroy_all
 
-        post :request_otp, params: { passport_id: bp_passport.identifier }
+        post :activate, params: { passport_id: bp_passport.identifier }
         expect(response.status).to eq(404)
       end
     end
   end
 
-  describe '#activate' do
+  describe '#login' do
     let!(:bp_passport) { create(:patient_business_identifier, identifier_type: 'simple_bp_passport') }
     let(:patient) { bp_passport.patient }
     let!(:passport_authentication) { create(:passport_authentication, patient: patient, patient_business_identifier: bp_passport) }
 
     it 'returns a successful response' do
-      post :activate, params: { passport_id: bp_passport.identifier, otp: passport_authentication.otp }
+      post :login, params: { passport_id: bp_passport.identifier, otp: passport_authentication.otp }
       expect(response.status).to eq(200)
 
       response_data = JSON.parse(response.body)
@@ -55,14 +55,14 @@ RSpec.describe Api::V4::PatientController, type: :controller do
 
     context 'when otp is wrong' do
       it 'returns an unauthorized response' do
-        post :activate, params: { passport_id: bp_passport.identifier, otp: 'wrong-otp' }
+        post :login, params: { passport_id: bp_passport.identifier, otp: 'wrong-otp' }
         expect(response.status).to eq(401)
       end
     end
 
     context 'when BP passport ID is wrong' do
       it 'returns an unauthorized response' do
-        post :activate, params: { passport_id: 'wrong-identifier', otp: passport_authentication.otp }
+        post :login, params: { passport_id: 'wrong-identifier', otp: passport_authentication.otp }
         expect(response.status).to eq(401)
       end
     end
@@ -71,15 +71,15 @@ RSpec.describe Api::V4::PatientController, type: :controller do
       before { passport_authentication.tap(&:expire_otp).save! }
 
       it 'returns an unauthorized response' do
-        post :activate, params: { passport_id: bp_passport.identifier, otp: passport_authentication.otp }
+        post :login, params: { passport_id: bp_passport.identifier, otp: passport_authentication.otp }
         expect(response.status).to eq(401)
       end
     end
 
     context 'when an OTP is re-used' do
       it 'returns an unauthorized response' do
-        post :activate, params: { passport_id: bp_passport.identifier, otp: passport_authentication.otp }
-        post :activate, params: { passport_id: bp_passport.identifier, otp: passport_authentication.otp }
+        post :login, params: { passport_id: bp_passport.identifier, otp: passport_authentication.otp }
+        post :login, params: { passport_id: bp_passport.identifier, otp: passport_authentication.otp }
 
         expect(response.status).to eq(401)
       end

--- a/spec/controllers/api/v4/patient_controller_spec.rb
+++ b/spec/controllers/api/v4/patient_controller_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Api::V4::PatientController, type: :controller do
     let!(:passport_authentication) { create(:passport_authentication, patient: patient, patient_business_identifier: bp_passport) }
 
     before do
-      allow(SendPatientOtpSmsJob).to receive(:set).and_return(SendPatientOtpSmsJob)
       allow(SendPatientOtpSmsJob).to receive(:perform_later)
     end
 

--- a/spec/controllers/api/v4/patient_controller_spec.rb
+++ b/spec/controllers/api/v4/patient_controller_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe Api::V4::PatientController, type: :controller do
       response_data = JSON.parse(response.body)
       expect(response_data).to match(
         "patient" => {
-          "access_token" => passport_authentication.reload.access_token,
-          "patient_id" => patient.id
+          "id" => patient.id,
+          "access_token" => passport_authentication.reload.access_token
         }
       )
     end

--- a/spec/controllers/api/v4/patient_controller_spec.rb
+++ b/spec/controllers/api/v4/patient_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe Api::V4::PatientController, type: :controller do
+  describe '#request_otp' do
+    let!(:bp_passport) { create(:patient_business_identifier, identifier_type: 'simple_bp_passport') }
+    let(:patient) { bp_passport.patient }
+    let!(:passport_authentication) { create(:passport_authentication, patient: patient, patient_business_identifier: bp_passport) }
+
+    before do
+      allow(SendPatientOtpSmsJob).to receive(:set).and_return(SendPatientOtpSmsJob)
+      allow(SendPatientOtpSmsJob).to receive(:perform_later)
+    end
+
+    it 'returns a successful response' do
+      post :request_otp, params: { passport_id: bp_passport.identifier }
+      expect(response.status).to eq(200)
+    end
+
+    it 'send an OTP SMS' do
+      expect(SendPatientOtpSmsJob).to receive(:perform_later).with(passport_authentication)
+      post :request_otp, params: { passport_id: bp_passport.identifier }
+    end
+
+    context 'when BP passport ID does not exist' do
+      it 'returns a 404 response' do
+        post :request_otp, params: { passport_id: 'some-identifier' }
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'when patient does not have any mobile numbers' do
+      it 'returns a 404 response' do
+        patient.phone_numbers.destroy_all
+
+        post :request_otp, params: { passport_id: bp_passport.identifier }
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+end

--- a/spec/factories/passport_authentications.rb
+++ b/spec/factories/passport_authentications.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :passport_authentication do
+    otp { rand(100_000..999_999).to_s }
+    otp_valid_until { 3.minutes.from_now }
+    access_token { SecureRandom.hex(32) }
+
+    patient
+    patient_business_identifier do
+      create(:patient_business_identifier, patient: patient, identifier_type: 'simple_bp_passport')
+    end
+  end
+end

--- a/spec/factories/patient_business_identifiers.rb
+++ b/spec/factories/patient_business_identifiers.rb
@@ -11,6 +11,8 @@ FactoryBot.define do
         assigning_facility_id: SecureRandom.uuid }
     end
 
+    patient
+
     trait(:without_metadata) do
       metadata_version { nil }
       metadata { nil }

--- a/spec/jobs/send_patient_otp_sms_job_spec.rb
+++ b/spec/jobs/send_patient_otp_sms_job_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe SendPatientOtpSmsJob, type: :job do
+  Sidekiq::Testing.fake!
+
+  let!(:passport_authentication) { create(:passport_authentication) }
+  let!(:sms_notification_service) { double(SmsNotificationService.new(nil, nil)) }
+
+  it 'calls off to the SMSNotificationService to deliver the otp SMS' do
+    expect(SmsNotificationService)
+      .to receive(:new)
+            .with(passport_authentication.patient.latest_mobile_number, ENV['TWILIO_PHONE_NUMBER'])
+            .and_return(sms_notification_service)
+
+    expect(sms_notification_service)
+      .to receive(:send_request_otp_sms)
+            .with(passport_authentication.otp)
+            .and_return(true)
+
+    described_class.perform_later(passport_authentication)
+
+    Sidekiq::Worker.drain_all
+  end
+end

--- a/spec/jobs/send_patient_otp_sms_job_spec.rb
+++ b/spec/jobs/send_patient_otp_sms_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SendPatientOtpSmsJob, type: :job do
             .and_return(sms_notification_service)
 
     expect(sms_notification_service)
-      .to receive(:send_request_otp_sms)
+      .to receive(:send_patient_request_otp_sms)
             .with(passport_authentication.otp)
             .and_return(true)
 

--- a/spec/models/passport_authentication_spec.rb
+++ b/spec/models/passport_authentication_spec.rb
@@ -16,43 +16,43 @@ RSpec.describe PassportAuthentication, type: :model do
     it { should validate_presence_of(:patient_business_identifier) }
   end
 
-  describe "Access Token" do
-    describe "#generate_access_token" do
-      it "sets a 32-digit hex token" do
+  describe 'Access Token' do
+    describe '#generate_access_token' do
+      it 'sets a 32-digit hex token' do
         auth.access_token = nil
         auth.generate_access_token
         expect(auth.access_token).to match(/[a-z0-9]{32}/)
       end
 
-      it "does not generate if already set" do
-        auth.access_token = "test token"
+      it 'does not generate if already set' do
+        auth.access_token = 'test token'
         auth.generate_access_token
-        expect(auth.access_token).to eq("test token")
+        expect(auth.access_token).to eq('test token')
       end
     end
 
-    describe "#reset_access_token" do
-      it "sets a 32-digit hex token" do
+    describe '#reset_access_token' do
+      it 'sets a 32-digit hex token' do
         auth.access_token = nil
         auth.reset_access_token
         expect(auth.access_token).to match(/[a-z0-9]{32}/)
       end
 
-      it "generates a new access token if already set" do
-        auth.access_token = "test token"
+      it 'generates a new access token if already set' do
+        auth.access_token = 'test token'
         auth.reset_access_token
-        expect(auth.access_token).not_to eq("test token")
+        expect(auth.access_token).not_to eq('test token')
       end
     end
   end
 
-  describe "OTP" do
+  describe 'OTP' do
     include ActiveSupport::Testing::TimeHelpers
     let(:now) { Time.current }
     before { ENV['USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES'] = '5' }
 
-    describe "#generate_otp" do
-      it "sets a six digit OTP" do
+    describe '#generate_otp' do
+      it 'sets a six digit OTP' do
         auth.otp = nil
         auth.otp_valid_until = nil
 
@@ -64,15 +64,15 @@ RSpec.describe PassportAuthentication, type: :model do
         end
       end
 
-      it "does not generate OTP if already set" do
-        auth.otp = "111111"
+      it 'does not generate OTP if already set' do
+        auth.otp = '111111'
         auth.generate_otp
-        expect(auth.otp).to eq("111111")
+        expect(auth.otp).to eq('111111')
       end
     end
 
-    describe "#reset_otp" do
-      it "sets a six digit OTP" do
+    describe '#reset_otp' do
+      it 'sets a six digit OTP' do
         auth.otp = nil
         auth.otp_valid_until = nil
 
@@ -84,10 +84,73 @@ RSpec.describe PassportAuthentication, type: :model do
         end
       end
 
-      it "does not generate OTP if already set" do
-        auth.otp = "111111"
+      it 'does not generate OTP if already set' do
+        auth.otp = '111111'
         auth.reset_otp
-        expect(auth.otp).not_to eq("111111")
+        expect(auth.otp).not_to eq('111111')
+      end
+    end
+
+    describe '#expire_otp' do
+      it 'expires the OTP' do
+        expect(auth).to be_otp_valid
+        auth.expire_otp
+        expect(auth).not_to be_otp_valid
+      end
+    end
+
+    describe '#otp_valid?' do
+      context 'when OTP has not expired' do
+        it 'returns true' do
+          auth.otp_valid_until = 5.minutes.from_now
+          expect(auth).to be_otp_valid
+        end
+      end
+
+      context 'when OTP has expired' do
+        it 'returns false' do
+          auth.otp_valid_until = 5.minutes.ago
+          expect(auth).not_to be_otp_valid
+        end
+      end
+    end
+
+    describe '#validate_otp' do
+      before { allow(auth).to receive(:save!).and_return(true) }
+
+      context 'when OTP is valid and correct' do
+        let(:otp) { auth.otp }
+
+        it 'returns true' do
+          expect(auth.validate_otp(otp)).to eq(true)
+        end
+
+        it 'expires the otp' do
+          auth.validate_otp(otp)
+          expect(auth).not_to be_otp_valid
+        end
+
+        it 'generates a new access token' do
+          expect { auth.validate_otp(otp) }.to change { auth.access_token }
+        end
+      end
+
+      context 'when OTP is expired' do
+        let(:otp) { auth.otp }
+
+        before { auth.otp_valid_until = 5.minutes.ago }
+
+        it 'returns false' do
+          expect(auth.validate_otp(otp)).to eq(false)
+        end
+      end
+
+      context 'when OTP is incorrect' do
+        let(:otp) { '111111' }
+
+        it 'returns false' do
+          expect(auth.validate_otp(otp)).to eq(false)
+        end
       end
     end
   end

--- a/spec/models/passport_authentication_spec.rb
+++ b/spec/models/passport_authentication_spec.rb
@@ -16,26 +16,78 @@ RSpec.describe PassportAuthentication, type: :model do
     it { should validate_presence_of(:patient_business_identifier) }
   end
 
-  describe "Authentication" do
+  describe "Access Token" do
     describe "#generate_access_token" do
-      it "returns a 32-digit hex token" do
-        expect(auth.generate_access_token).to match(/[a-z0-9]{32}/)
+      it "sets a 32-digit hex token" do
+        auth.access_token = nil
+        auth.generate_access_token
+        expect(auth.access_token).to match(/[a-z0-9]{32}/)
       end
 
       it "does not generate if already set" do
         auth.access_token = "test token"
-        expect(auth.generate_access_token).to eq("test token")
+        auth.generate_access_token
+        expect(auth.access_token).to eq("test token")
       end
     end
 
+    describe "#reset_access_token" do
+      it "sets a 32-digit hex token" do
+        auth.access_token = nil
+        auth.reset_access_token
+        expect(auth.access_token).to match(/[a-z0-9]{32}/)
+      end
+
+      it "generates a new access token if already set" do
+        auth.access_token = "test token"
+        auth.reset_access_token
+        expect(auth.access_token).not_to eq("test token")
+      end
+    end
+  end
+
+  describe "OTP" do
+    include ActiveSupport::Testing::TimeHelpers
+    let(:now) { Time.current }
+    before { ENV['USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES'] = '5' }
+
     describe "#generate_otp" do
-      it "returns a six digit OTP" do
-        expect(auth.generate_otp[:otp]).to match(/[0-9]{6}/)
+      it "sets a six digit OTP" do
+        auth.otp = nil
+        auth.otp_valid_until = nil
+
+        travel_to now do
+          auth.generate_otp
+
+          expect(auth.otp).to match(/[0-9]{6}/)
+          expect(auth.otp_valid_until).to eq(5.minutes.from_now)
+        end
       end
 
       it "does not generate OTP if already set" do
         auth.otp = "111111"
-        expect(auth.generate_otp[:otp]).to eq("111111")
+        auth.generate_otp
+        expect(auth.otp).to eq("111111")
+      end
+    end
+
+    describe "#reset_otp" do
+      it "sets a six digit OTP" do
+        auth.otp = nil
+        auth.otp_valid_until = nil
+
+        travel_to now do
+          auth.reset_otp
+
+          expect(auth.otp).to match(/[0-9]{6}/)
+          expect(auth.otp_valid_until).to eq(5.minutes.from_now)
+        end
+      end
+
+      it "does not generate OTP if already set" do
+        auth.otp = "111111"
+        auth.reset_otp
+        expect(auth.otp).not_to eq("111111")
       end
     end
   end

--- a/spec/models/passport_authentication_spec.rb
+++ b/spec/models/passport_authentication_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe PassportAuthentication, type: :model do
+  subject(:auth) { PassportAuthentication.new }
+
+  describe 'Associations' do
+    it { should belong_to(:patient) }
+    it { should belong_to(:patient_business_identifier) }
+  end
+
+  describe 'Validations' do
+    it { should validate_presence_of(:access_token) }
+    it { should validate_presence_of(:otp) }
+    it { should validate_presence_of(:otp_valid_until) }
+    it { should validate_presence_of(:patient) }
+    it { should validate_presence_of(:patient_business_identifier) }
+  end
+
+  describe "Authentication" do
+    describe "#generate_access_token" do
+      it "returns a 32-digit hex token" do
+        expect(auth.generate_access_token).to match(/[a-z0-9]{32}/)
+      end
+
+      it "does not generate if already set" do
+        auth.access_token = "test token"
+        expect(auth.generate_access_token).to eq("test token")
+      end
+    end
+
+    describe "#generate_otp" do
+      it "returns a six digit OTP" do
+        expect(auth.generate_otp[:otp]).to match(/[0-9]{6}/)
+      end
+
+      it "does not generate OTP if already set" do
+        auth.otp = "111111"
+        expect(auth.generate_otp[:otp]).to eq("111111")
+      end
+    end
+  end
+end

--- a/spec/services/sms_notification_service_spec.rb
+++ b/spec/services/sms_notification_service_spec.rb
@@ -9,12 +9,28 @@ RSpec.describe SmsNotificationService do
            scheduled_date: appointment_scheduled_date)
   end
 
-  context '#send_reminder_sms' do
-    let(:twilio_client) { double('TwilioClientDouble') }
-    let(:sender_phone_number) { ENV['TWILIO_PHONE_NUMBER'] }
-    let(:recipient_phone_number) { '8585858585' }
-    let(:expected_sms_recipient_phone_number) { '+918585858585' }
+  let(:twilio_client) { double('TwilioClientDouble') }
+  let(:sender_phone_number) { ENV['TWILIO_PHONE_NUMBER'] }
+  let(:recipient_phone_number) { '8585858585' }
+  let(:expected_sms_recipient_phone_number) { '+918585858585' }
 
+  subject(:sms) { SmsNotificationService.new(recipient_phone_number, sender_phone_number, twilio_client) }
+
+  describe '#send_patient_request_otp_sms' do
+    it 'does stuff' do
+      expect(twilio_client).to receive_message_chain('messages.create').with(
+        from: '+15005550006',
+        to: expected_sms_recipient_phone_number,
+        status_callback: '',
+        body: /123456/
+      )
+
+      sms.send_patient_request_otp_sms('123456')
+    end
+
+  end
+
+  describe '#send_reminder_sms' do
     context 'follow_up_reminder' do
       it 'should have the SMS body in the default locale' do
         sms = SmsNotificationService.new(recipient_phone_number, sender_phone_number, twilio_client)

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -1854,15 +1854,6 @@
         "full_name": {
           "$ref": "#/definitions/non_empty_string"
         },
-        "phone_number": {
-          "$ref": "#/definitions/non_empty_string"
-        },
-        "password_digest": {
-          "$ref": "#/definitions/bcrypt_password"
-        },
-        "registration_facility_id": {
-          "$ref": "#/definitions/uuid"
-        },
         "sync_approval_status": {
           "type": [
             "string",
@@ -1874,6 +1865,15 @@
             "string",
             "null"
           ]
+        },
+        "phone_number": {
+          "$ref": "#/definitions/non_empty_string"
+        },
+        "password_digest": {
+          "$ref": "#/definitions/bcrypt_password"
+        },
+        "registration_facility_id": {
+          "$ref": "#/definitions/uuid"
         }
       },
       "required": [

--- a/swagger/v3/swagger.json
+++ b/swagger/v3/swagger.json
@@ -1991,15 +1991,6 @@
         "full_name": {
           "$ref": "#/definitions/non_empty_string"
         },
-        "phone_number": {
-          "$ref": "#/definitions/non_empty_string"
-        },
-        "password_digest": {
-          "$ref": "#/definitions/bcrypt_password"
-        },
-        "registration_facility_id": {
-          "$ref": "#/definitions/uuid"
-        },
         "sync_approval_status": {
           "type": [
             "string",
@@ -2011,6 +2002,15 @@
             "string",
             "null"
           ]
+        },
+        "phone_number": {
+          "$ref": "#/definitions/non_empty_string"
+        },
+        "password_digest": {
+          "$ref": "#/definitions/bcrypt_password"
+        },
+        "registration_facility_id": {
+          "$ref": "#/definitions/uuid"
         }
       },
       "required": [

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -503,11 +503,11 @@
     "login_patient": {
       "type": "object",
       "properties": {
+        "id": {
+          "$ref": "#/definitions/uuid"
+        },
         "access_token": {
           "$ref": "#/definitions/non_empty_string"
-        },
-        "patient_id": {
-          "$ref": "#/definitions/uuid"
         }
       }
     },

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -203,7 +203,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Correct OTP is submitted and access token is returned",
+            "description": "Correct OTP is submitted and API credentials are returned",
             "schema": {
               "type": "object",
               "properties": {

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -146,6 +146,37 @@
         }
       }
     },
+    "/patient/activate": {
+      "post": {
+        "summary": "Trigger an OTP to be sent to a patient",
+        "tags": [
+          "Patient"
+        ],
+        "parameters": [
+          {
+            "name": "passport_id",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "passport_id": {
+                  "$ref": "#/definitions/uuid"
+                }
+              }
+            },
+            "description": "Patient's BP Passport UUID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "patient is found and an OTP is sent to their phone"
+          },
+          "404": {
+            "description": "incorrect passport id"
+          }
+        }
+      }
+    },
     "/users/find": {
       "post": {
         "summary": "Find a existing user",

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -154,7 +154,7 @@
         ],
         "parameters": [
           {
-            "name": "passport_id",
+            "name": "request_body",
             "in": "body",
             "schema": {
               "type": "object",
@@ -169,10 +169,52 @@
         ],
         "responses": {
           "200": {
-            "description": "patient is found and an OTP is sent to their phone"
+            "description": "Patient is found and an OTP is sent to their phone"
           },
           "404": {
-            "description": "incorrect passport id"
+            "description": "Incorrect passport id"
+          }
+        }
+      }
+    },
+    "/patient/authenticate": {
+      "post": {
+        "summary": "Authenticate a patient with BP Passport UUID and OTP",
+        "tags": [
+          "Patient"
+        ],
+        "parameters": [
+          {
+            "name": "request_body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "passport_id": {
+                  "$ref": "#/definitions/uuid"
+                },
+                "otp": {
+                  "$ref": "#/definitions/non_empty_string"
+                }
+              }
+            },
+            "description": "Patient's BP Passport UUID and OTP"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Correct OTP is submitted and access token is returned",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "access_token": {
+                  "$ref": "#/definitions/non_empty_string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Incorrect BP Passport UUID or OTP"
           }
         }
       }

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -146,9 +146,9 @@
         }
       }
     },
-    "/patient/activate": {
+    "/patient/request_otp": {
       "post": {
-        "summary": "Trigger an OTP to be sent to a patient",
+        "summary": "Request an OTP to be sent to a patient",
         "tags": [
           "Patient"
         ],
@@ -177,9 +177,9 @@
         }
       }
     },
-    "/patient/authenticate": {
+    "/patient/activate": {
       "post": {
-        "summary": "Authenticate a patient with BP Passport UUID and OTP",
+        "summary": "Activate a patient with BP Passport UUID and OTP",
         "tags": [
           "Patient"
         ],
@@ -209,6 +209,9 @@
               "properties": {
                 "access_token": {
                   "$ref": "#/definitions/non_empty_string"
+                },
+                "patient_id": {
+                  "$ref": "#/definitions/uuid"
                 }
               }
             }

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -146,7 +146,7 @@
         }
       }
     },
-    "/patient/request_otp": {
+    "/patient/activate": {
       "post": {
         "summary": "Request an OTP to be sent to a patient",
         "tags": [
@@ -177,9 +177,9 @@
         }
       }
     },
-    "/patient/activate": {
+    "/patient/login": {
       "post": {
-        "summary": "Activate a patient with BP Passport UUID and OTP",
+        "summary": "Log in a patient with BP Passport UUID and OTP",
         "tags": [
           "Patient"
         ],
@@ -207,11 +207,8 @@
             "schema": {
               "type": "object",
               "properties": {
-                "access_token": {
-                  "$ref": "#/definitions/non_empty_string"
-                },
-                "patient_id": {
-                  "$ref": "#/definitions/uuid"
+                "patient": {
+                  "$ref": "#/definitions/login_patient"
                 }
               }
             }
@@ -501,6 +498,17 @@
       ],
       "items": {
         "$ref": "#/definitions/blood_sugar"
+      }
+    },
+    "login_patient": {
+      "type": "object",
+      "properties": {
+        "access_token": {
+          "$ref": "#/definitions/non_empty_string"
+        },
+        "patient_id": {
+          "$ref": "#/definitions/uuid"
+        }
       }
     },
     "user": {


### PR DESCRIPTION
**Story cards:**
- https://www.pivotaltracker.com/story/show/172298399
- https://www.pivotaltracker.com/story/show/172298486

## Because

We're enabling patients to download their own BP Passport record from Simple, and we need to authenticate and authorize them to do so. This adds patient app APIs as a separate namespace to our current API endpoints.

See the PRD:
https://docs.google.com/document/d/1nrdTxR0nyv8aKnPTo32Lnem9YiddusbfjNgKW7uKxIk/edit#

## This addresses

This adds patient activation (via OTP) and authentication via access token.

## Implementation Details

* A new `PassportAuthentication` model is introduced, referencing a BP passport and a Patient
* Two API endpoints are introduced
  * `POST /api/v4/patient/activate` - Send a BP Passport UUID and trigger an OTP
  * `POST /api/v4/patient/login` - Send a BP Passport UUID and OTP and receive an access token
* A new `PatientAPIController` base controller class is introduced to separate patient app concerns from the Simple app API

## To Do

- [x] Sending the OTP via SMS
- [x] Handling access token expiration - New tokens are issued on every sign-in, like the Simple app, for now. Expiration of each token should likely be a subsequent PR.
- [x] Sending errors if needed - We will establish a contract with the A2 team, but don't need to implement it here.
- [x] Any necessary integration with swagger/schema/docs
- [x] Integration specs to ensure the thing actually works :)
- [x] Wrap responses in a `patient: {}` key
- [x] Stop inheriting from `ApiController`
- [x] Pick a naming convention for the API endpoints. The most consistent option would be `activate` and `login`, instead of `request_otp` and `activate`.