### PR TITLE
Fix missing exclusion in MyFacilities BloodPressureControlQuery

### DIFF
--- a/app/queries/my_facilities/blood_pressure_control_query.rb
+++ b/app/queries/my_facilities/blood_pressure_control_query.rb
@@ -53,14 +53,13 @@ class MyFacilities::BloodPressureControlQuery
 
   def overall_patients
     @overall_patients ||= Patient
-                      .where('recorded_at < ?', Time.current.beginning_of_day - REGISTRATION_BUFFER)
-                      .where(registration_facility: facilities)
+                          .where('recorded_at < ?', Time.current.beginning_of_day - REGISTRATION_BUFFER)
+                          .where(registration_facility: facilities)
   end
 
   def overall_controlled_bps
     @overall_controlled_bps ||=
       LatestBloodPressuresPerPatient
-      .where(registration_facility: facilities)
       .where(patient: overall_patients)
       .where('bp_recorded_at > ?', Time.current.beginning_of_day - 90.days)
       .under_control

--- a/app/queries/my_facilities/blood_pressure_control_query.rb
+++ b/app/queries/my_facilities/blood_pressure_control_query.rb
@@ -61,6 +61,7 @@ class MyFacilities::BloodPressureControlQuery
     @overall_controlled_bps ||=
       LatestBloodPressuresPerPatient
       .where(registration_facility: facilities)
+      .where('patient_recorded_at < ?', Time.current.beginning_of_day - REGISTRATION_BUFFER)
       .where('bp_recorded_at > ?', Time.current.beginning_of_day - 90.days)
       .under_control
   end

--- a/app/queries/my_facilities/blood_pressure_control_query.rb
+++ b/app/queries/my_facilities/blood_pressure_control_query.rb
@@ -61,7 +61,7 @@ class MyFacilities::BloodPressureControlQuery
     @overall_controlled_bps ||=
       LatestBloodPressuresPerPatient
       .where(registration_facility: facilities)
-      .where('patient_recorded_at < ?', Time.current.beginning_of_day - REGISTRATION_BUFFER)
+      .where(patient: overall_patients)
       .where('bp_recorded_at > ?', Time.current.beginning_of_day - 90.days)
       .under_control
   end

--- a/spec/queries/my_facilities/blood_pressure_control_query_spec.rb
+++ b/spec/queries/my_facilities/blood_pressure_control_query_spec.rb
@@ -292,6 +292,20 @@ RSpec.describe MyFacilities::BloodPressureControlQuery do
                facility: facility,
                user: user)
       end
+
+      let!(:old_patient) do
+        create(:patient, registration_facility: facility, registration_user: user, recorded_at: 6.months.ago)
+      end
+
+      let!(:old_bp) do
+        create(:blood_pressure,
+               :under_control,
+               facility: facility,
+               patient: old_patient,
+               recorded_at: old_patient.recorded_at,
+               user: user)
+      end
+
       before do
         ActiveRecord::Base.transaction do
           ActiveRecord::Base.connection.execute("SET LOCAL TIME ZONE '#{Rails.application.config.country[:time_zone]}'")
@@ -301,11 +315,11 @@ RSpec.describe MyFacilities::BloodPressureControlQuery do
       end
 
       describe '#overall_patients' do
-        specify { expect(described_class.new.overall_patients.count).to eq(4) }
+        specify { expect(described_class.new.overall_patients.count).to eq(5) }
       end
 
       describe '#overall_controlled_bps' do
-        specify { expect(described_class.new.overall_controlled_bps.count).to eq(2) }
+        specify { expect(described_class.new.overall_controlled_bps.count).to eq(1) }
       end
     end
   end


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/172306738

## Because

An exclusion for recently registered patients is missing from the numerator for the BloodPressureControlQuery

## This addresses

Re-adds the exclusion for recent patients
