### PR TITLE
Cleaned up formatting of My Facilities

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -768,7 +768,9 @@ th sup {
       background: #F1DBFF;
       color: #BE72E3;
       border-radius: 100px;
-      padding: 2px 10px;
+      padding: 2px;
+      width: 3.5em;
+      display: block;
     }
 
     .row-total td.type-percent em {

--- a/app/helpers/my_facilities_helper.rb
+++ b/app/helpers/my_facilities_helper.rb
@@ -4,7 +4,7 @@ module MyFacilitiesHelper
   end
 
   def percentage(numerator, denominator)
-    return 'NA' if denominator.nil? || denominator.zero? || numerator.nil?
+    return '—' if denominator.nil? || denominator.zero? || numerator.nil?
     percentage_string((numerator * 100.0) / denominator)
   end
 end

--- a/app/views/my_facilities/blood_pressure_control.html.erb
+++ b/app/views/my_facilities/blood_pressure_control.html.erb
@@ -74,28 +74,28 @@
           <col>
           <col class="table-divider">
           <col>
+          <col class="table-divider">
           <col class="mobile">
         </colgroup>
         <thead>
         <tr>
           <th></th>
           <th colspan="6">Cohort of patients registered in <%= registration_period %></th>
-          <th colspan="2">Overall BP control<sup>1</sup></th>
+          <th colspan="3">Overall BP control<sup>1</sup></th>
           <th class="mobile">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</th>
         </tr>
         <tr data-sort-method="thead" class="sorts">
           <th class="row-label sort-label">Facilities</th>
-          <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="controlled" colspan="2" data-sort-default>Visited with controlled
-            <br>BP in <%= visited_in_period %>
+          <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="controlled" colspan="2" data-sort-default>Controlled
+            BP<br>in <%= visited_in_period %>
           </th>
-          <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="uncontrolled" colspan="2">Visited with uncontrolled<br>BP
+          <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="uncontrolled" colspan="2">Uncontrolled BP<br>
             in <%= visited_in_period %>
           </th>
           <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="missed" colspan="2">Missed visit<br>in <%= visited_in_period %>
           </th>
-          <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="overall-percent">Percent</th>
-          <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="overall-controlled">Controlled</th>
-          <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="overall-registered">Registered</th>
+          <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="overall-percent" colspan="2">Controlled BP<br>in last 90 days</th>
+          <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="overall-registered">Registered<br>&gt; 2 months ago</th>
           <th class="mobile"></th>
         </tr>
         </thead>
@@ -152,7 +152,7 @@
       <ol>
         <li><strong>Overall BP control:</strong>
           <ul>
-            <li>Numerator: Patients registered at this facility whose most recent BP in the past 90 days was under 140/90.</li>
+            <li>Numerator: Patients registered at this facility whose most recent BP in the past 90 days was &lt;140/90.</li>
             <li>Denominator: Patients registered at this facility.</li>
             <li>Patients registered in the last 2 months are excluded from both the <i>Numerator</i> and <i>Denominator</i>.</li>
             <li>Note: Follow-up BPs may be recorded at any facility.</li>

--- a/app/views/my_facilities/missed_visits.html.erb
+++ b/app/views/my_facilities/missed_visits.html.erb
@@ -58,13 +58,13 @@
               <th colspan="2"><%= "Reg in #{month_short_name_and_year(local_month_start(year, month))}" %></th>
             <% end %>
           <% end %>
-          <th>Calls made <sup>1</sup></th>
+          <th>Calls&nbsp;made<sup>1</sup></th>
           <th>Total</th>
         </tr>
         <tr data-sort-method="thead" class="sorts">
           <th class="row-label sort-label">Facilities</th>
           <% @display_periods.reverse.each do |(year, period)| %>
-            <th class="row-label sort-label" data-sort-default>Percent</th>
+            <th class="row-label sort-label" data-sort-default>%</th>
             <% case @selected_period %>
               <% when :quarter %>
                 <% visited_in_year, visited_in_quarter = next_year_and_quarter(year, period) %>


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/172402703

## Because

I rewrote table headers to make the My Facilities sections easier to scan to wrap less in narrow layouts.

## This addresses

Headers in tables
NA in percentages becomes an em dash —
All pills for 30% etc are now equal width.
