### PR TITLE
Multiply monthly_estimated_opd_load by 3 for quarterly view

### DIFF
--- a/app/helpers/my_facilities_helper.rb
+++ b/app/helpers/my_facilities_helper.rb
@@ -7,4 +7,15 @@ module MyFacilitiesHelper
     return '—' if denominator.nil? || denominator.zero? || numerator.nil?
     percentage_string((numerator * 100.0) / denominator)
   end
+
+  def opd_load(facility, selected_period)
+    return if facility.monthly_estimated_opd_load.nil?
+
+    case selected_period
+    when :quarter
+      facility.monthly_estimated_opd_load * 3
+    when :month
+      facility.monthly_estimated_opd_load
+    end
+  end
 end

--- a/app/views/my_facilities/registrations.html.erb
+++ b/app/views/my_facilities/registrations.html.erb
@@ -87,7 +87,7 @@
             <% @display_periods.reverse.each do |period| %>
               <% unless @selected_period == :day %>
                 <td class="type-percent" data-sort-column-key="<%= period.join %>">
-                  <em><%= percentage(@registrations[[facility.id, period.first.to_s, period.second.to_s]], facility.monthly_estimated_opd_load) %></em>
+                  <em><%= percentage(@registrations[[facility.id, period.first.to_s, period.second.to_s]], opd_load(facility, @selected_period)) %></em>
                 </td>
               <% end %>
               <td class="type-number" <% if @selected_period == :day %>data-sort-column-key="<%= period.join %>"<% end %>>

--- a/spec/helpers/my_facilities_helper_spec.rb
+++ b/spec/helpers/my_facilities_helper_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe MyFacilitiesHelper, type: :helper do
+  describe '#opd_load' do
+    let!(:facility) { create(:facility, monthly_estimated_opd_load: 100) }
+
+    it 'returns nil if the selected period is not :month or :quarter' do
+      expect(opd_load(facility, :day)).to be_nil
+    end
+
+    it 'returns the monthly_estimated_opd_load if the selected_period is :month' do
+      expect(opd_load(facility, :month)).to eq 100
+    end
+
+    it 'returns the 3 * monthly_estimated_opd_load if the selected_period is :quarter' do
+      expect(opd_load(facility, :quarter)).to eq 300
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/172413621

## Because

The MyFacilities New Registrations page uses a facility's `monthly_estimated_opd_load` to calculate the `% of OPD` columns, for both quarterly and monthly views

## This addresses

This PR multiplies `monthly_estimated_opd_load` by 3 for the quarterly view
