### PR TITLE
Overdue list download bug

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,21 +4,21 @@ module ApplicationHelper
 
   def bootstrap_class_for_flash(flash_type)
     case flash_type
-      when 'success'
-        'alert-success'
-      when 'error'
-        'alert-danger'
-      when 'alert'
-        'alert-warning'
-      when 'notice'
-        'alert-primary'
-      else
-        flash_type.to_s
+    when 'success'
+      'alert-success'
+    when 'error'
+      'alert-danger'
+    when 'alert'
+      'alert-warning'
+    when 'notice'
+      'alert-primary'
+    else
+      flash_type.to_s
     end
   end
 
   def display_date(date)
-    date.strftime(STANDARD_DATE_DISPLAY_FORMAT)
+    date&.strftime(STANDARD_DATE_DISPLAY_FORMAT)
   end
 
   def rounded_time_ago_in_words(date)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -9,6 +9,22 @@ describe ApplicationHelper, type: :helper do
     specify { expect(helper.bootstrap_class_for_flash('something-else')).to eq('something-else') }
   end
 
+  describe '#display_date' do
+    let(:date) { Date.new(2020, 1, 15) }
+
+    it 'returns a standard formatted date' do
+      expect(helper.display_date(date)).to eq('15-JAN-2020')
+    end
+
+    context 'when date is nil' do
+      let(:date) { nil }
+
+      xit 'returns nil' do
+
+      end
+    end
+  end
+
   describe '#rounded_time_ago_in_words' do
     it 'should return Today if date is less than 24 hours' do
       date = Date.current

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -19,8 +19,8 @@ describe ApplicationHelper, type: :helper do
     context 'when date is nil' do
       let(:date) { nil }
 
-      xit 'returns nil' do
-
+      it 'returns nil' do
+        expect(helper.display_date(date)).to eq(nil)
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,7 +1,15 @@
 require 'rails_helper'
 
 describe ApplicationHelper, type: :helper do
-  context '#rounded_time_ago_in_words' do
+  describe '#bootstrap_class_for_flash' do
+    specify { expect(helper.bootstrap_class_for_flash('success')).to eq('alert-success') }
+    specify { expect(helper.bootstrap_class_for_flash('error')).to eq('alert-danger') }
+    specify { expect(helper.bootstrap_class_for_flash('alert')).to eq('alert-warning') }
+    specify { expect(helper.bootstrap_class_for_flash('notice')).to eq('alert-primary') }
+    specify { expect(helper.bootstrap_class_for_flash('something-else')).to eq('something-else') }
+  end
+
+  describe '#rounded_time_ago_in_words' do
     it 'should return Today if date is less than 24 hours' do
       date = Date.current
       expect(helper.rounded_time_ago_in_words(date)).to eq('Today')


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/172427262

## Because

The overdue list download fails if a patient doesn't have a latest BP

## This addresses

This PR gracefully handles the case when `ApplicationHelper#display_date` is passed a nil date, but returning nil.
