### PR TITLE
Drop unused risk labels

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -185,11 +185,4 @@ class Patient < ApplicationRecord
     prescription_drugs.discard_all
     discard
   end
-
-  private
-
-  def low_priority?
-    latest_scheduled_appointment&.overdue_for_over_a_year? &&
-      latest_blood_pressure&.under_control?
-  end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -12,9 +12,7 @@ class Patient < ApplicationRecord
   STATUSES = %w[active dead migrated unresponsive inactive].freeze
   RISK_PRIORITIES = {
     HIGH: 0,
-    REGULAR: 1,
-    LOW: 2,
-    NONE: 3
+    REGULAR: 1
   }.freeze
 
   ANONYMIZED_DATA_FIELDS = %w[id created_at registration_date registration_facility_name user_id age gender]
@@ -114,7 +112,7 @@ class Patient < ApplicationRecord
   end
 
   def risk_priority
-    return RISK_PRIORITIES[:NONE] if latest_scheduled_appointment&.overdue_for_under_a_month?
+    return RISK_PRIORITIES[:REGULAR] if latest_scheduled_appointment&.overdue_for_under_a_month?
 
     if latest_blood_pressure&.critical?
       RISK_PRIORITIES[:HIGH]
@@ -122,12 +120,8 @@ class Patient < ApplicationRecord
       RISK_PRIORITIES[:HIGH]
     elsif latest_blood_sugar&.diabetic?
       RISK_PRIORITIES[:HIGH]
-    elsif latest_blood_pressure&.hypertensive?
-      RISK_PRIORITIES[:REGULAR]
-    elsif low_priority?
-      RISK_PRIORITIES[:LOW]
     else
-      RISK_PRIORITIES[:NONE]
+      RISK_PRIORITIES[:REGULAR]
     end
   end
 

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -124,10 +124,10 @@ describe Patient, type: :model do
     end
 
     describe '#risk_priority' do
-      it 'returns no priority for patients recently overdue' do
+      it 'returns regular priority for patients recently overdue' do
         create(:appointment, scheduled_date: 29.days.ago, status: :scheduled, patient: patient)
 
-        expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:NONE])
+        expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:REGULAR])
       end
 
       it 'returns high priority for patients overdue with critical bp' do
@@ -152,11 +152,11 @@ describe Patient, type: :model do
         expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:REGULAR])
       end
 
-      it 'returns no priority for patients overdue with only medical risk history' do
+      it 'returns regular priority for patients overdue with only medical risk history' do
         create(:medical_history, :prior_risk_history, patient: patient)
         create(:appointment, :overdue, patient: patient)
 
-        expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:NONE])
+        expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:REGULAR])
       end
 
       it 'returns regular priority for patients overdue with hypertension' do
@@ -166,11 +166,11 @@ describe Patient, type: :model do
         expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:REGULAR])
       end
 
-      it 'returns low priority for patients overdue with low risk' do
+      it 'returns regular priority for patients overdue with low risk' do
         create(:blood_pressure, :under_control, patient: patient)
         create(:appointment, scheduled_date: 2.years.ago, status: :scheduled, patient: patient)
 
-        expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:LOW])
+        expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:REGULAR])
       end
 
       it 'returns high priority for patients overdue with high blood sugar' do
@@ -180,11 +180,11 @@ describe Patient, type: :model do
         expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:HIGH])
       end
 
-      it "returns 'none' priority for patients overdue with normal blood sugar" do
+      it "returns regular priority for patients overdue with normal blood sugar" do
         create(:blood_sugar, patient: patient, blood_sugar_type: :random, blood_sugar_value: 150)
         create(:appointment, :overdue, patient: patient)
 
-        expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:NONE])
+        expect(patient.risk_priority).to eq(Patient::RISK_PRIORITIES[:REGULAR])
       end
     end
 


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/172471666

## Because

The app has four risk categories: `HIGH`, `REGULAR`, `LOW`, and `NONE`, out of which `LOW` and `NONE` are no longer used

## This addresses

Removes the `LOW` and `NONE` risk categories in the Patient model risk calculations. It does not alter the risk calculation for the overdue list, since that is calculated independently and does not have `LOW` and `NONE` risk categories.
