### PR TITLE
bin/deploy.rb -> bin/deploy

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -7,7 +7,7 @@
 # * Be functional on Linux and OS X
 #
 # ---- Run this command to get instructions on how to use this script:
-# ± bin/deploy.rb help
+# ± bin/deploy help
 #
 require 'pathname'
 
@@ -200,7 +200,7 @@ This is generated from the diff between #{last_deployed_sha}..HEAD
   end
 
   def print_usage_and_exit
-    $stderr.puts "Usage: bin/deploy.rb <country> <environment> [tag-to-deploy]"
+    $stderr.puts "Usage: bin/deploy <country> <environment> [tag-to-deploy]"
     $stderr.puts ""
     $stderr.puts "Note: tag-to-deploy is required to deploy to production"
     $stderr.puts "Note: Make sure you are locally on the latest master branch"


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/172525837

## Because

Since this deploy script is an executable, and is application agnostic, there's no need for it to have a `.rb` suffix.

## This addresses

* Rename `bin/deploy.rb -> bin/deploy`
* Update script usage instructions accordingly
