### PR TITLE
Do not rescue exceptions from Sidekiq middlewares

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,12 +1,6 @@
 class SetLocalTimezone
   def call(_worker, _job, _queue)
-    begin
-      Time.use_zone(Rails.application.config.country[:time_zone] || 'UTC') do
-        yield
-      end
-    rescue => ex
-      puts ex.message
-    end
+    Time.use_zone(Rails.application.config.country[:time_zone] || 'UTC') { yield }
   end
 end
 

--- a/lib/sidekiq/middleware/server/set_local_timezone.rb
+++ b/lib/sidekiq/middleware/server/set_local_timezone.rb
@@ -1,9 +1,0 @@
-class Sidekiq::Middleware::Server::SetLocalTimezone
-  def call(_worker, _job, _queue)
-    begin
-      Time.use_zone(Rails.application.config.country[:time_zone] || 'UTC') { yield }
-    rescue => ex
-      puts ex.message
-    end
-  end
-end


### PR DESCRIPTION
**Story card:** None

## Because

We were swallowing exceptions in a middleware that set the timezone for all the jobs. We noticed this because jobs weren't really throwing errors up on the Sidekiq dashboard and our dead-set has been empty for a while.

## This addresses

* This removes the rescue block from the middleware and allows the exceptions to propagate.
* It also removes a stale copy of the middleware under `lib/`. The class in the initializer is what is currently functional. The one under `lib/` was never utilized.