### PR TITLE
User analytics specs failing - Freeze time to try to fix

### DIFF
--- a/app/presenters/user_analytics_presenter.rb
+++ b/app/presenters/user_analytics_presenter.rb
@@ -105,11 +105,11 @@ class UserAnalyticsPresenter
   def trophy_stats
     follow_ups = all_time_follow_ups_by_gender.values.sum
 
-    all_trophies =
-      follow_ups > TROPHY_MILESTONES.last ?
-        [*TROPHY_MILESTONES,
-         *(TROPHY_MILESTONE_INCR..(follow_ups + TROPHY_MILESTONE_INCR)).step(TROPHY_MILESTONE_INCR)] :
-        TROPHY_MILESTONES
+    all_trophies = if follow_ups > TROPHY_MILESTONES.last
+      [*TROPHY_MILESTONES, *(TROPHY_MILESTONE_INCR..(follow_ups + TROPHY_MILESTONE_INCR)).step(TROPHY_MILESTONE_INCR)]
+    else
+      TROPHY_MILESTONES
+    end
 
     unlocked_trophies_until = all_trophies.index { |v| follow_ups < v }
 

--- a/spec/controllers/api/v2/analytics/user_analytics_controller_spec.rb
+++ b/spec/controllers/api/v2/analytics/user_analytics_controller_spec.rb
@@ -63,28 +63,30 @@ RSpec.describe Api::V2::Analytics::UserAnalyticsController, type: :controller do
 
         context 'achievements' do
           it 'has the section visible' do
-            #
-            # create BPs (follow-ups)
-            #
-            patients = create_list(:patient, 3, registration_facility: request_facility)
-            patients.each do |patient|
-              [patient.recorded_at + 1.month,
-               patient.recorded_at + 2.months,
-               patient.recorded_at + 3.months,
-               patient.recorded_at + 4.months].each do |date|
-                travel_to(date) do
-                  create(:encounter,
-                         :with_observables,
-                         observable: create(:blood_pressure,
-                                            patient: patient,
-                                            facility: request_facility,
-                                            user: request_user))
+            Timecop.freeze("10:00 AM UTC") do
+              #
+              # create BPs (follow-ups)
+              #
+              patients = create_list(:patient, 3, registration_facility: request_facility)
+              patients.each do |patient|
+                [patient.recorded_at + 1.month,
+                patient.recorded_at + 2.months,
+                patient.recorded_at + 3.months,
+                patient.recorded_at + 4.months].each do |date|
+                  travel_to(date) do
+                    create(:encounter,
+                          :with_observables,
+                          observable: create(:blood_pressure,
+                                              patient: patient,
+                                              facility: request_facility,
+                                              user: request_user))
+                  end
                 end
               end
-            end
 
-            get :show, format: :html
-            expect(response.body).to match(/Achievements/)
+              get :show, format: :html
+              expect(response.body).to match(/Achievements/)
+            end
           end
 
           it 'is not visible if there are insufficient follow_ups' do

--- a/spec/controllers/api/v3/analytics/user_analytics_controller_spec.rb
+++ b/spec/controllers/api/v3/analytics/user_analytics_controller_spec.rb
@@ -63,28 +63,30 @@ RSpec.describe Api::V3::Analytics::UserAnalyticsController, type: :controller do
 
         context 'achievements' do
           it 'has the section visible' do
-            #
-            # create BPs (follow-ups)
-            #
-            patients = create_list(:patient, 3, registration_facility: request_facility)
-            patients.each do |patient|
-              [patient.recorded_at + 1.month,
-               patient.recorded_at + 2.months,
-               patient.recorded_at + 3.months,
-               patient.recorded_at + 4.months].each do |date|
-                travel_to(date) do
-                  create(:encounter,
-                         :with_observables,
-                         observable: create(:blood_pressure,
-                                            patient: patient,
-                                            facility: request_facility,
-                                            user: request_user))
+            Timecop.freeze("10:00 AM UTC") do
+              #
+              # create BPs (follow-ups)
+              #
+              patients = create_list(:patient, 3, registration_facility: request_facility)
+              patients.each do |patient|
+                [patient.recorded_at + 1.month,
+                patient.recorded_at + 2.months,
+                patient.recorded_at + 3.months,
+                patient.recorded_at + 4.months].each do |date|
+                  travel_to(date) do
+                    create(:encounter,
+                          :with_observables,
+                          observable: create(:blood_pressure,
+                                              patient: patient,
+                                              facility: request_facility,
+                                              user: request_user))
+                  end
                 end
               end
-            end
 
-            get :show, format: :html
-            expect(response.body).to match(/Achievements/)
+              get :show, format: :html
+              expect(response.body).to match(/Achievements/)
+            end
           end
 
           it 'is not visible if there are insufficient follow_ups' do

--- a/spec/presenters/user_analytics_presenter_spec.rb
+++ b/spec/presenters/user_analytics_presenter_spec.rb
@@ -286,34 +286,40 @@ RSpec.describe UserAnalyticsPresenter, type: :model do
 
     context 'trophies' do
       it 'has both unlocked and the upcoming locked trophy' do
-        #
-        # create BPs (follow-ups)
-        #
-        patients = create_list(:patient, 3, registration_facility: current_facility)
-        patients.each do |patient|
-          [patient.recorded_at + 1.month,
-           patient.recorded_at + 2.months,
-           patient.recorded_at + 3.months,
-           patient.recorded_at + 4.months].each do |date|
-            travel_to(date) do
-              create(:encounter,
-                     :with_observables,
-                     observable: create(:blood_pressure,
-                                        patient: patient,
-                                        facility: current_facility,
-                                        user: current_user))
+        Timecop.freeze("10:00 AM UTC") do
+          #
+          # create BPs (follow-ups)
+          #
+          patients = create_list(:patient, 3, registration_facility: current_facility)
+          patients.each do |patient|
+            [patient.recorded_at + 1.month,
+            patient.recorded_at + 2.months,
+            patient.recorded_at + 3.months,
+            patient.recorded_at + 4.months].each do |date|
+              puts Time.current
+              puts Date.current
+              puts "traveling to #{date}"
+              Timecop.freeze(date) do
+                create(:encounter,
+                      :with_observables,
+                      observable: create(:blood_pressure,
+                                          patient: patient,
+                                          facility: current_facility,
+                                          user: current_user))
+              end
             end
           end
+          puts "its now #{Date.current}"
+
+          data = described_class.new(current_facility).statistics
+
+          expected_output = {
+            locked_trophy_value: 25,
+            unlocked_trophy_values: [10]
+          }
+
+          expect(data[:trophies]).to eq(expected_output)
         end
-
-        data = described_class.new(current_facility).statistics
-
-        expected_output = {
-          locked_trophy_value: 25,
-          unlocked_trophy_values: [10]
-        }
-
-        expect(data[:trophies]).to eq(expected_output)
       end
 
       it 'has only 1 locked trophy if there are no achievements' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,9 @@ WebMock.allow_net_connect!
 RSpec.configure do |config|
   SimpleCov.start
 
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
I'm not entirely sure what is going on here, but it appears since we are
on the last day of the month these specs started failing that are
setting up fixture data on one month intervals.

In the interest of getting CI green, it looks like freezing time to the
morning here fixes things, at least locally.  So lets see if that helps CI.

**Story card:** n/a - fixing the build

## Because

Trying to fix the build

## This addresses

Build is broken on last day of month
