### PR TITLE
Fix various tz + date issues in specs

### DIFF
--- a/app/controllers/api/v3/analytics_controller.rb
+++ b/app/controllers/api/v3/analytics_controller.rb
@@ -7,6 +7,7 @@ class Api::V3::AnalyticsController < APIController
     time_zone = Rails.application.config.country[:time_zone] || DEFAULT_ANALYTICS_TIME_ZONE
 
     Groupdate.time_zone = time_zone
+
     Time.use_zone(time_zone) do
       yield
     end

--- a/app/models/blood_pressure.rb
+++ b/app/models/blood_pressure.rb
@@ -84,7 +84,7 @@ class BloodPressure < ApplicationRecord
   # time-period-boundary issues.
   #
   def self.date_to_period_sql(period)
-    tz = Rails.application.config.country[:time_zone]
+    tz = Time.zone.name
     "(DATE_TRUNC('#{period}', (blood_pressures.recorded_at::timestamptz) AT TIME ZONE '#{tz}')) AT TIME ZONE '#{tz}'"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,6 @@ require "action_mailer/railtie"
 require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
-# require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/spec/controllers/api/v3/analytics/user_analytics_controller_spec.rb
+++ b/spec/controllers/api/v3/analytics/user_analytics_controller_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe Api::V3::Analytics::UserAnalyticsController, type: :controller do
           expect(response.body).to match(/Tap "Sync" on the home screen for new data/)
         end
 
-
         it 'has the registrations card' do
           get :show, format: :html
 
@@ -63,7 +62,7 @@ RSpec.describe Api::V3::Analytics::UserAnalyticsController, type: :controller do
 
         context 'achievements' do
           it 'has the section visible' do
-            let(:request_date) { Date.new(2018, 4, 8) }
+            request_date = Date.new(2018, 4, 8)
 
             #
             # create BPs (follow-ups)
@@ -83,10 +82,10 @@ RSpec.describe Api::V3::Analytics::UserAnalyticsController, type: :controller do
                                             user: request_user))
                 end
               end
-
-              get :show, format: :html
-              expect(response.body).to match(/Achievements/)
             end
+
+            get :show, format: :html
+            expect(response.body).to match(/Achievements/)
           end
 
           it 'is not visible if there are insufficient follow_ups' do

--- a/spec/controllers/api/v3/analytics/user_analytics_controller_spec.rb
+++ b/spec/controllers/api/v3/analytics/user_analytics_controller_spec.rb
@@ -63,24 +63,24 @@ RSpec.describe Api::V3::Analytics::UserAnalyticsController, type: :controller do
 
         context 'achievements' do
           it 'has the section visible' do
-            Timecop.freeze("10:00 AM UTC") do
-              #
-              # create BPs (follow-ups)
-              #
-              patients = create_list(:patient, 3, registration_facility: request_facility)
-              patients.each do |patient|
-                [patient.recorded_at + 1.month,
-                patient.recorded_at + 2.months,
-                patient.recorded_at + 3.months,
-                patient.recorded_at + 4.months].each do |date|
-                  travel_to(date) do
-                    create(:encounter,
-                          :with_observables,
-                          observable: create(:blood_pressure,
-                                              patient: patient,
-                                              facility: request_facility,
-                                              user: request_user))
-                  end
+            let(:request_date) { Date.new(2018, 4, 8) }
+
+            #
+            # create BPs (follow-ups)
+            #
+            patients = create_list(:patient, 3, registration_facility: request_facility, recorded_at: request_date)
+            patients.each do |patient|
+              [patient.recorded_at + 1.month,
+               patient.recorded_at + 2.months,
+               patient.recorded_at + 3.months,
+               patient.recorded_at + 4.months].each do |date|
+                travel_to(date) do
+                  create(:encounter,
+                         :with_observables,
+                         observable: create(:blood_pressure,
+                                            patient: patient,
+                                            facility: request_facility,
+                                            user: request_user))
                 end
               end
 

--- a/spec/helpers/period_helper_helper_spec.rb
+++ b/spec/helpers/period_helper_helper_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe PeriodHelper, type: :helper do
     let(:current_date) { Date.current }
 
     it 'generates a sorted list of dates given a quarter and time range' do
-      expect(period_list_as_dates(:quarter, 3)).to eq([current_date.beginning_of_month,
-                                                       current_date.beginning_of_month - 3.months,
-                                                       current_date.beginning_of_month - 6.months])
+      expect(period_list_as_dates(:quarter, 3)).to eq([current_date.beginning_of_quarter,
+                                                       current_date.beginning_of_quarter - 3.months,
+                                                       current_date.beginning_of_quarter - 6.months])
     end
 
     it 'generates a sorted list of dates given a month and time range' do

--- a/spec/presenters/user_analytics_presenter_spec.rb
+++ b/spec/presenters/user_analytics_presenter_spec.rb
@@ -328,26 +328,26 @@ RSpec.describe UserAnalyticsPresenter, type: :model do
       expect(data[:trophies]).to eq(expected_output)
     end
   end
-end
 
-describe '#display_percentage' do
-  it 'displays 0% if denominator is zero' do
-    expect(described_class.new(current_facility).display_percentage(2, 0)).to eq("0%")
-  end
+  describe '#display_percentage' do
+    it 'displays 0% if denominator is zero' do
+      expect(described_class.new(current_facility).display_percentage(2, 0)).to eq("0%")
+    end
 
-  it 'displays 0% if denominator is nil' do
-    expect(described_class.new(current_facility).display_percentage(2, nil)).to eq("0%")
-  end
+    it 'displays 0% if denominator is nil' do
+      expect(described_class.new(current_facility).display_percentage(2, nil)).to eq("0%")
+    end
 
-  it 'displays 0% if numerator is zero' do
-    expect(described_class.new(current_facility).display_percentage(0, 3)).to eq("0%")
-  end
+    it 'displays 0% if numerator is zero' do
+      expect(described_class.new(current_facility).display_percentage(0, 3)).to eq("0%")
+    end
 
-  it 'displays 0% if numerator is nil' do
-    expect(described_class.new(current_facility).display_percentage(nil, 2)).to eq("0%")
-  end
+    it 'displays 0% if numerator is nil' do
+      expect(described_class.new(current_facility).display_percentage(nil, 2)).to eq("0%")
+    end
 
-  it 'displays the percentage rounded up' do
-    expect(described_class.new(current_facility).display_percentage(22, 7)).to eq("314%")
+    it 'displays the percentage rounded up' do
+      expect(described_class.new(current_facility).display_percentage(22, 7)).to eq("314%")
+    end
   end
 end


### PR DESCRIPTION
**Story card:** N/A

## Because

Our build was broken.

  There's some small but fundamental issues with our specs and time-zones.

**Don't be alarmed:** These issues are restricted to specs and don't leak into production code. The following points should validate that.

1. Our Rails app and our specs (unless explicitly forced) are in UTC.
2. Most (hopefully all) of our [controllers](https://github.com/simpledotorg/simple-server/blob/master/app/controllers/analytics_controller.rb#L8) run in a specified timezone linked to a particular country.
3. This means, that we can safely use `Date.current` or `Time.current` everywhere.
4. In some places, however, like [custom SQL queries](https://github.com/simpledotorg/simple-server/blob/master/app/models/blood_pressure.rb#L86), we need a timezone to be manually specified since rails can't attach one itself.
  5. In [Controller specs](https://github.com/simpledotorg/simple-server/blob/master/spec/controllers/api/v3/analytics/user_analytics_controller_spec.rb#L64) where we setup data and assert on that data against a controller action which is now run in in the configured timezone. You see time-boundary issues. Because the test data is in UTC but the returned data was in, say, `'Asia/Kolkata'`

**Potential solutions:**

1. We run our entire rails app in the country-specific tz (just app tz, not `ActiveRecord`). Instead of just the controller paths.
  2. We run just our specs in a the country-specific tz.
  3. We explicitly set tz in much lower, test-level data setups. This can quickly become not at all obvious and is easy to miss and will only surface when it is run on boundaries
4. We stop using country-configured tz in our app anywhere other than the perimeters of the app (around_action, rake tasks etc.)
5. We setup our data in such a way where these time boundary issues are smothered, and devs don't need to care since we know that the overarching time-zone handling is "safe".

## This addresses

* This PR basically takes the 4. & 5. option, since it's the least invasive. However, we should talk about some Do-s and Dont-s of tzs pertaining to **our** app in particular:

  * We still end up using not-`Date.current` sometimes, there's no way to enforce this currently.
  * If we run our raills app in UTC, we should do 4: stop using country-configured tz in the middle layers like model, service etc.
  * Be aware that certain controllers have middlewares that transform the tz, but we create seed data in these specs that are not in that timezone. Hence, in interesting queries, that specifically rely on month boundaries, you'll see failures.

