### PR TITLE
Add bootsnap to speed up startup time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 
 gem 'activerecord-import'
 gem 'bcrypt', '~> 3.1', '>= 3.1.11'
+gem 'bootsnap', require: false
 gem 'bootstrap', '~> 4.3.1'
 gem 'bootstrap_form', '>= 4.1.0'
 gem 'connection_pool'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,8 @@ GEM
       execjs (~> 2.0)
     bcrypt (3.1.13)
     bindex (0.5.0)
+    bootsnap (1.4.6)
+      msgpack (~> 1.0)
     bootstrap (4.3.1)
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
@@ -230,6 +232,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.13.0)
+    msgpack (1.3.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     nenv (0.3.0)
@@ -474,6 +477,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-import
   bcrypt (~> 3.1, >= 3.1.11)
+  bootsnap
   bootstrap (~> 4.3.1)
   bootstrap_form (>= 4.1.0)
   byebug

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup'


### PR DESCRIPTION
This shaves a second off an individual test run, which is pretty nice
locally.

This is already in the Rails 5.2 upgrade (#915) but I'd like to ship it
independently first because its a big win locally. That upgrade PR will take more testing, so probably won't land till next week.

I also just want to make sure this doesn't impact anything on sandbox / heroku servers, just to be safe.

**Story card:** n/a

## Because

We want faster load times

## This addresses

load time
