### PR TITLE
Spike out adding risk level to patients table

### DIFF
--- a/app/services/set_risk_level.rb
+++ b/app/services/set_risk_level.rb
@@ -1,0 +1,18 @@
+class SetRiskLevel
+  Result = Struct.new(:updates, :no_changes, keyword_init: true)
+
+  def self.call(patients)
+    result = Result.new(updates: 0, no_changes: 0)
+    Array(patients).each do |patient|
+      new_level = patient.risk_priority
+      if patient.risk_level != new_level
+        patient.update(risk_level: new_level)
+        result[:updates] += 1
+      else
+        result[:no_changes] += 1
+      end
+    end
+    result
+  end
+
+end

--- a/db/data/20200504180051_populate_patient_risk_levels.rb
+++ b/db/data/20200504180051_populate_patient_risk_levels.rb
@@ -1,0 +1,16 @@
+class PopulatePatientRiskLevels < ActiveRecord::Migration[5.1]
+  def up
+    totals = SetRiskLevel::Result.new(updates: 0, no_changes: 0)
+    Patient.in_batches do |batch|
+      result = SetRiskLevel.call(batch)
+      totals.updates += result.updates
+      totals.no_changes += result.no_changes
+    end
+    puts "Complete!"
+    puts totals
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200129084509)
+DataMigrate::Data.define(version: 20200504180051)

--- a/db/migrate/20200504174240_add_risk_level_to_patients.rb
+++ b/db/migrate/20200504174240_add_risk_level_to_patients.rb
@@ -1,0 +1,5 @@
+class AddRiskLevelToPatients < ActiveRecord::Migration[5.1]
+  def change
+    add_column :patients, :risk_level, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200430144041) do
+ActiveRecord::Schema.define(version: 20200504174240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -349,6 +349,7 @@ ActiveRecord::Schema.define(version: 20200430144041) do
     t.string "could_not_contact_reason"
     t.datetime "recorded_at"
     t.string "reminder_consent", default: "denied", null: false
+    t.integer "risk_level"
     t.index ["deleted_at"], name: "index_patients_on_deleted_at"
     t.index ["recorded_at"], name: "index_patients_on_recorded_at"
     t.index ["registration_facility_id"], name: "index_patients_on_registration_facility_id"

--- a/spec/services/set_risk_level_spec.rb
+++ b/spec/services/set_risk_level_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe SetRiskLevel do
+  it "sets risk level if nil" do
+    patient = create(:patient)
+    expect(patient.risk_level).to be_nil
+    SetRiskLevel.call(patient)
+    expect(patient.risk_level).to_not be_nil
+  end
+
+  it "does nothing if risk level has not changed" do
+    patient = create(:patient, risk_level: 1)
+    expect(patient.risk_level).to eq(1)
+
+    expect(patient).to receive(:update).never
+
+    SetRiskLevel.call(patient)
+    expect(patient.risk_level).to eq(1)
+  end
+
+  it "has nested result class" do
+    p SetRiskLevel::Result
+  end
+end


### PR DESCRIPTION
*NOTE:* This is just spike quality code at this point. I wanted to see how difficult it would be to get risk_level into the patients table. 

Adds a small service class and a data migration to add risk level to
Patients. The next step will be a daily Sidekiq job to update this risk
level for patients.

I ran this locally with sandbox data, and this totally naive strategy
took about 10 minutes to update all patients:

```
[~/src/simpledotorg/simple-server (spike-adding-risk-level-to-patients)⚡]> time rails data:migrate
== 20200504180051 PopulatePatientRiskLevels: migrating ========================

Complete!
#<struct SetRiskLevel::Result updates=80554, no_changes=0>
== 20200504180051 PopulatePatientRiskLevels: migrated (647.2419s) =============


real	10m50.323s
user	9m16.133s
sys	0m18.664s
```

**Story card:** <pivotal story link>

## Because

Enter the reason for raising this PR...

## This addresses

Enter the details of what all this covers...
