### PR TITLE
Rename otp_valid_until to otp_expires_at for consistency (Redo of #924)

### DIFF
--- a/app/models/passport_authentication.rb
+++ b/app/models/passport_authentication.rb
@@ -7,11 +7,11 @@ class PassportAuthentication < ActiveRecord::Base
 
   validates :access_token, presence: true
   validates :otp, presence: true
-  validates :otp_valid_until, presence: true
+  validates :otp_expires_at, presence: true
   validates :patient_business_identifier, presence: true
 
   def otp_valid?
-    otp_valid_until >= Time.current
+    otp_expires_at >= Time.current
   end
 
   def generate_access_token
@@ -26,22 +26,22 @@ class PassportAuthentication < ActiveRecord::Base
     new_otp = build_otp
 
     self.otp ||= new_otp[:otp]
-    self.otp_valid_until ||= new_otp[:otp_valid_until]
+    self.otp_expires_at ||= new_otp[:otp_expires_at]
 
-    { otp: otp, otp_valid_until: otp_valid_until }
+    { otp: otp, otp_expires_at: otp_expires_at }
   end
 
   def reset_otp
     new_otp = build_otp
 
     self.otp = new_otp[:otp]
-    self.otp_valid_until = new_otp[:otp_valid_until]
+    self.otp_expires_at = new_otp[:otp_expires_at]
 
-    { otp: otp, otp_valid_until: otp_valid_until }
+    { otp: otp, otp_expires_at: otp_expires_at }
   end
 
   def expire_otp
-    self.otp_valid_until = Time.at(0)
+    self.otp_expires_at = Time.at(0)
   end
 
   def validate_otp(otp)
@@ -64,8 +64,8 @@ class PassportAuthentication < ActiveRecord::Base
       SecureRandom.random_number.to_s[2..7]
     end
 
-    new_otp_valid_until = Time.current + ENV['USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES'].to_i.minutes
+    new_otp_expires_at = Time.current + ENV['USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES'].to_i.minutes
 
-    { otp: new_otp, otp_valid_until: new_otp_valid_until }
+    { otp: new_otp, otp_expires_at: new_otp_expires_at }
   end
 end

--- a/app/models/phone_number_authentication.rb
+++ b/app/models/phone_number_authentication.rb
@@ -27,13 +27,13 @@ class PhoneNumberAuthentication < ApplicationRecord
 
   def mark_as_logged_in
     now = Time.current
-    self.otp_valid_until = now
+    self.otp_expires_at = now
     self.logged_in_at = now
     save
   end
 
   def otp_valid?
-    otp_valid_until >= Time.current
+    otp_expires_at >= Time.current
   end
 
   def set_access_token
@@ -43,11 +43,11 @@ class PhoneNumberAuthentication < ApplicationRecord
   def set_otp
     generated_otp = self.class.generate_otp
     self.otp = generated_otp[:otp]
-    self.otp_valid_until = generated_otp[:otp_valid_until]
+    self.otp_expires_at = generated_otp[:otp_expires_at]
   end
 
   def invalidate_otp
-    self.otp_valid_until = Time.at(0)
+    self.otp_expires_at = Time.at(0)
   end
 
   def self.generate_otp
@@ -56,9 +56,9 @@ class PhoneNumberAuthentication < ApplicationRecord
     6.times do
       otp += digits.sample.to_s
     end
-    otp_valid_until = Time.current + ENV['USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES'].to_i.minutes
+    otp_expires_at = Time.current + ENV['USER_OTP_VALID_UNTIL_DELTA_IN_MINUTES'].to_i.minutes
 
-    { otp: otp, otp_valid_until: otp_valid_until }
+    { otp: otp, otp_expires_at: otp_expires_at }
   end
 
   def self.generate_access_token

--- a/app/transformers/api/v3/user_transformer.rb
+++ b/app/transformers/api/v3/user_transformer.rb
@@ -5,7 +5,7 @@ class Api::V3::UserTransformer
         .merge('registration_facility_id' => user.registration_facility.id,
                'phone_number' => user.phone_number,
                'password_digest' => user.phone_number_authentication.password_digest)
-        .except('otp', 'otp_valid_until', 'access_token', 'logged_in_at', 'role', 'organization_id')
+        .except('otp', 'otp_expires_at', 'access_token', 'logged_in_at', 'role', 'organization_id')
     end
   end
 end

--- a/app/transformers/api/v4/user_transformer.rb
+++ b/app/transformers/api/v4/user_transformer.rb
@@ -5,7 +5,7 @@ class Api::V4::UserTransformer
         .merge('registration_facility_id' => user.registration_facility.id,
                'phone_number' => user.phone_number,
                'password_digest' => user.phone_number_authentication.password_digest)
-        .except('otp', 'otp_valid_until', 'access_token', 'logged_in_at', 'role', 'organization_id')
+        .except('otp', 'otp_expires_at', 'access_token', 'logged_in_at', 'role', 'organization_id')
     end
 
     def to_find_response(user)

--- a/db/migrate/20200504204839_rename_otp_valid_until_to_otp_expires_at.rb
+++ b/db/migrate/20200504204839_rename_otp_valid_until_to_otp_expires_at.rb
@@ -1,0 +1,6 @@
+class RenameOtpValidUntilToOtpExpiresAt < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :passport_authentications, :otp_valid_until, :otp_expires_at
+    rename_column :phone_number_authentications, :otp_valid_until, :otp_expires_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200501174342) do
+ActiveRecord::Schema.define(version: 20200504204839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200430144041) do
+ActiveRecord::Schema.define(version: 20200501174342) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -291,7 +291,7 @@ ActiveRecord::Schema.define(version: 20200430144041) do
   create_table "passport_authentications", force: :cascade do |t|
     t.string "access_token", null: false
     t.string "otp", null: false
-    t.datetime "otp_valid_until", null: false
+    t.datetime "otp_expires_at", null: false
     t.uuid "patient_business_identifier_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -360,7 +360,7 @@ ActiveRecord::Schema.define(version: 20200430144041) do
     t.string "phone_number", null: false
     t.string "password_digest", null: false
     t.string "otp", null: false
-    t.datetime "otp_valid_until", null: false
+    t.datetime "otp_expires_at", null: false
     t.datetime "logged_in_at"
     t.string "access_token", null: false
     t.uuid "registration_facility_id"

--- a/spec/factories/passport_authentications.rb
+++ b/spec/factories/passport_authentications.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :passport_authentication do
     otp { rand(100_000..999_999).to_s }
-    otp_valid_until { 3.minutes.from_now }
+    otp_expires_at { 3.minutes.from_now }
     access_token { SecureRandom.hex(32) }
 
     patient_business_identifier do

--- a/spec/factories/phone_number_authentications.rb
+++ b/spec/factories/phone_number_authentications.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     password { rand(1000..9999).to_s }
     password_confirmation { password }
     otp { rand(100_000..999_999).to_s }
-    otp_valid_until { 3.minutes.from_now }
+    otp_expires_at { 3.minutes.from_now }
     access_token { SecureRandom.hex(32) }
 
     facility

--- a/spec/models/passport_authentication_spec.rb
+++ b/spec/models/passport_authentication_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe PassportAuthentication, type: :model do
   describe 'Validations' do
     it { is_expected.to validate_presence_of(:access_token) }
     it { is_expected.to validate_presence_of(:otp) }
-    it { is_expected.to validate_presence_of(:otp_valid_until) }
+    it { is_expected.to validate_presence_of(:otp_expires_at) }
     it { is_expected.to validate_presence_of(:patient_business_identifier) }
   end
 
@@ -60,13 +60,13 @@ RSpec.describe PassportAuthentication, type: :model do
     describe '#generate_otp' do
       it 'sets a six digit OTP' do
         auth.otp = nil
-        auth.otp_valid_until = nil
+        auth.otp_expires_at = nil
 
         travel_to now do
           auth.generate_otp
 
           expect(auth.otp).to match(/[0-9]{6}/)
-          expect(auth.otp_valid_until).to eq(5.minutes.from_now)
+          expect(auth.otp_expires_at).to eq(5.minutes.from_now)
         end
       end
 
@@ -80,13 +80,13 @@ RSpec.describe PassportAuthentication, type: :model do
     describe '#reset_otp' do
       it 'sets a six digit OTP' do
         auth.otp = nil
-        auth.otp_valid_until = nil
+        auth.otp_expires_at = nil
 
         travel_to now do
           auth.reset_otp
 
           expect(auth.otp).to match(/[0-9]{6}/)
-          expect(auth.otp_valid_until).to eq(5.minutes.from_now)
+          expect(auth.otp_expires_at).to eq(5.minutes.from_now)
         end
       end
 
@@ -108,14 +108,14 @@ RSpec.describe PassportAuthentication, type: :model do
     describe '#otp_valid?' do
       context 'when OTP has not expired' do
         it 'returns true' do
-          auth.otp_valid_until = 5.minutes.from_now
+          auth.otp_expires_at = 5.minutes.from_now
           expect(auth).to be_otp_valid
         end
       end
 
       context 'when OTP has expired' do
         it 'returns false' do
-          auth.otp_valid_until = 5.minutes.ago
+          auth.otp_expires_at = 5.minutes.ago
           expect(auth).not_to be_otp_valid
         end
       end
@@ -144,7 +144,7 @@ RSpec.describe PassportAuthentication, type: :model do
       context 'when OTP is expired' do
         let(:otp) { auth.otp }
 
-        before { auth.otp_valid_until = 5.minutes.ago }
+        before { auth.otp_expires_at = 5.minutes.ago }
 
         it 'returns false' do
           expect(auth.validate_otp(otp)).to eq(false)

--- a/spec/models/phone_number_authentication_spec.rb
+++ b/spec/models/phone_number_authentication_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe PhoneNumberAuthentication, type: :model do
   end
 
   describe 'invalidate_otp' do
-    subject(:authentication) { described_class.new(otp: '123456', otp_valid_until: Time.now) }
+    subject(:authentication) { described_class.new(otp: '123456', otp_expires_at: Time.now) }
 
     it 'clears the otp fields' do
       authentication.invalidate_otp
-      expect(authentication.otp_valid_until.to_i).to eq(0)
+      expect(authentication.otp_expires_at.to_i).to eq(0)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe User, type: :model do
 
       it 'assigns an otp and access token to the phone number authentication' do
         expect(phone_number_authentication.otp).to be_present
-        expect(phone_number_authentication.otp_valid_until).to be_present
+        expect(phone_number_authentication.otp_expires_at).to be_present
         expect(phone_number_authentication.access_token).to be_present
       end
 

--- a/spec/transformers/api/v3/user_transformer_spec.rb
+++ b/spec/transformers/api/v3/user_transformer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V3::UserTransformer do
         .and_return(
           'user' => 'attributes',
           'otp' => '123456',
-          'otp_valid_until' => Time.now,
+          'otp_expires_at' => Time.now,
           'access_token' => 'supersecretaccesstoken',
           'logged_in_at' => Time.now,
           'role' => 'admin',
@@ -35,7 +35,7 @@ RSpec.describe Api::V3::UserTransformer do
     it 'excludes sensitive params' do
       expect(response).not_to include(
         'otp',
-        'otp_valid_until',
+        'otp_expires_at',
         'access_token',
         'logged_in_at',
         'role',

--- a/spec/transformers/api/v4/user_transformer_spec.rb
+++ b/spec/transformers/api/v4/user_transformer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V4::UserTransformer do
       user
         .attributes
         .merge('otp' => '123456',
-               'otp_valid_until' => Time.current,
+               'otp_expires_at' => Time.current,
                'access_token' => 'access token string',
                'logged_in_at' => Time.current)
     end
@@ -41,7 +41,7 @@ RSpec.describe Api::V4::UserTransformer do
 
     it 'excludes sensitive params' do
       expect(response).not_to include('otp',
-                                      'otp_valid_until',
+                                      'otp_expires_at',
                                       'access_token',
                                       'logged_in_at',
                                       'role',
@@ -59,7 +59,7 @@ RSpec.describe Api::V4::UserTransformer do
         'field' => 'values',
         'password_digest' => 'supersecretdigest',
         'otp' => '123456',
-        'otp_valid_until' => Time.current,
+        'otp_expires_at' => Time.current,
         'access_token' => 'access token string',
         'logged_in_at' => Time.current
       }
@@ -87,7 +87,7 @@ RSpec.describe Api::V4::UserTransformer do
     it 'excludes sensitive params' do
       expect(response).not_to include('password_digest',
                                       'otp',
-                                      'otp_valid_until',
+                                      'otp_expires_at',
                                       'access_token',
                                       'logged_in_at',
                                       'role',

--- a/spec/utils.rb
+++ b/spec/utils.rb
@@ -1,6 +1,6 @@
 class Hash
   def with_int_timestamps
-    ts_keys = %w[recorded_at created_at updated_at device_created_at device_updated_at age_updated_at otp_valid_until deleted_at]
+    ts_keys = %w[recorded_at created_at updated_at device_created_at device_updated_at age_updated_at otp_expires_at deleted_at]
     each_pair do |key, value|
       if ts_keys.include?(key) && value.present?
         self[key] = value.to_time.to_i


### PR DESCRIPTION
## Because

I'm cleaning up some authentication behavior and this field was confusing. This is a redo of #924 where I accidentally edited old migrations and merged some bad typos.

## This addresses

This renames `otp_valid_until` to `otp_expires_at` to be consistent with other DateTime fields (and match Rails convention). It also better indicates that this field is for expiration, not validity.