### PR TITLE
Use dynamic attributes for factory-bot; fixes deprecation

### DIFF
--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -5,18 +5,18 @@ FactoryBot.define do
     association :creation_facility, factory: :facility
     association :patient, strategy: :build
     scheduled_date { 30.days.from_now }
-    status :scheduled
-    cancel_reason nil
+    status { :scheduled }
+    cancel_reason { nil }
     device_created_at { Time.current }
     device_updated_at { Time.current }
-    agreed_to_visit nil
-    remind_on nil
+    agreed_to_visit { nil }
+    remind_on { nil }
     appointment_type { Appointment.appointment_types.keys.sample }
     user
 
     trait :overdue do
       scheduled_date { rand(30..90).days.ago }
-      status :scheduled
+      status { :scheduled }
     end
   end
 end

--- a/spec/factories/blood_pressures.rb
+++ b/spec/factories/blood_pressures.rb
@@ -12,18 +12,18 @@ FactoryBot.define do
     association :patient, strategy: :create
 
     trait :critical do
-      systolic 181
-      diastolic 111
+      systolic { 181 }
+      diastolic { 111 }
     end
 
     trait :hypertensive do
-      systolic 140
-      diastolic 90
+      systolic { 140 }
+      diastolic { 90 }
     end
 
     trait :under_control do
-      systolic 80
-      diastolic 60
+      systolic { 80 }
+      diastolic { 60 }
     end
   end
 end

--- a/spec/factories/encounters.rb
+++ b/spec/factories/encounters.rb
@@ -21,11 +21,11 @@ FactoryBot.define do
       encountered_on { observable.recorded_at.to_date }
     end
 
-    encountered_on '2019-09-11'
+    encountered_on { '2019-09-11' }
 
-    timezone_offset 0
-    metadata nil
-    notes ''
+    timezone_offset { 0 }
+    metadata { nil }
+    notes { '' }
 
     device_created_at { Time.now }
     device_updated_at { Time.now }

--- a/spec/factories/facilities.rb
+++ b/spec/factories/facilities.rb
@@ -4,16 +4,16 @@ FactoryBot.define do
     sequence(:name) { |n| "Facility #{n}" }
     sequence(:street_address) { |n| "#{n} Gandhi Road" }
     sequence(:village_or_colony) { |n| "Colony #{n}" }
-    district 'Bathinda'
-    state 'Punjab'
-    country 'India'
-    pin '123456'
-    zone 'Block ABC'
-    facility_type 'PHC'
+    district { 'Bathinda' }
+    state { 'Punjab' }
+    country { 'India' }
+    pin { '123456' }
+    zone { 'Block ABC' }
+    facility_type { 'PHC' }
     facility_size { Facility.facility_sizes[:small] }
     facility_group { create(:facility_group) }
     enable_diabetes_management { true }
-    monthly_estimated_opd_load 300
+    monthly_estimated_opd_load { 300 }
 
     sequence :slug do |n|
       "#{name.to_s.parameterize.underscore}_#{n}"

--- a/spec/factories/twilio_sms_delivery_details.rb
+++ b/spec/factories/twilio_sms_delivery_details.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     session_id { SecureRandom.uuid }
     result { 'sent' }
     callee_phone_number { Faker::PhoneNumber.phone_number }
-    delivered_on nil
+    delivered_on { nil }
     association :communication
 
     trait(:sent) { result { 'sent' } }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -66,10 +66,10 @@ FactoryBot.define do
     user_permissions { [] }
     organization
 
-    role :owner
+    role { :owner }
 
     trait(:owner) do
-      role :owner
+      role { :owner }
 
       after :create do |user, _options|
         access_level = Permissions::ACCESS_LEVELS.find { |access_level| access_level[:name] == user.role.to_sym }
@@ -80,7 +80,7 @@ FactoryBot.define do
     end
 
     trait(:supervisor) do
-      role :supervisor
+      role { :supervisor }
       after :create do |user, options|
         access_level = Permissions::ACCESS_LEVELS.find { |access_level| access_level[:name] == user.role.to_sym }
         access_level[:default_permissions].each do |slug|
@@ -90,7 +90,7 @@ FactoryBot.define do
     end
 
     trait(:analyst) do
-      role :analyst
+      role { :analyst }
       after :create do |user, options|
         access_level = Permissions::ACCESS_LEVELS.find { |access_level| access_level[:name] == user.role.to_sym }
         access_level[:default_permissions].each do |slug|
@@ -100,7 +100,7 @@ FactoryBot.define do
     end
 
     trait(:counsellor) do
-      role :counsellor
+      role { :counsellor }
       after :create do |user, options|
         access_level = Permissions::ACCESS_LEVELS.find { |access_level| access_level[:name] == user.role.to_sym }
         access_level[:default_permissions].each do |slug|
@@ -110,7 +110,7 @@ FactoryBot.define do
     end
 
     trait(:organization_owner) do
-      role :organization_owner
+      role { :organization_owner }
       after :create do |user, options|
         access_level = Permissions::ACCESS_LEVELS.find { |access_level| access_level[:name] == user.role.to_sym }
         access_level[:default_permissions].each do |slug|


### PR DESCRIPTION
This addresses a deprecation in factory bot that full on breaks in Rails
5.2.You can see the details on the deprecation here:


https://thoughtbot.com/blog/deprecating-static-attributes-in-factory_bot-4-11

This is a cherry pick from the [Rails 5.2 upgrade](https://github.com/simpledotorg/simple-server/pull/915)

**Story card:** n/a

## Because

we want to be on the latest stable versions of software

## This addresses

a factory bot problem breaking Rails 5.2
