### PR TITLE
Clearer Cohort Report Download Links

### DIFF
--- a/app/controllers/analytics/districts_controller.rb
+++ b/app/controllers/analytics/districts_controller.rb
@@ -95,6 +95,9 @@ class Analytics::DistrictsController < AnalyticsController
   end
 
   def download_filename
-    "district-cohort-report_#{@organization_district.district_name}_#{Time.current.to_s(:number)}.csv"
+    period = @period == :quarter ? "quarterly" : "monthly"
+    district = @organization_district.district_name
+    time = Time.current.to_s(:number)
+    "district-#{period}-cohort-report_#{district}_#{time}.csv"
   end
 end

--- a/app/controllers/analytics/facilities_controller.rb
+++ b/app/controllers/analytics/facilities_controller.rb
@@ -88,6 +88,9 @@ class Analytics::FacilitiesController < AnalyticsController
   end
 
   def download_filename
-    "facility-cohort-report_#{@facility.name}_#{Time.current.to_s(:number)}.csv"
+    period = @period == :quarter ? "quarterly" : "monthly"
+    facility = @facility.name
+    time = Time.current.to_s(:number)
+    "facility-#{period}-cohort-report_#{facility}_#{time}.csv"
   end
 end

--- a/app/views/analytics/districts/show.csv.erb
+++ b/app/views/analytics/districts/show.csv.erb
@@ -1,17 +1,18 @@
 <%= [
-  "Report generated at:",
+  'Report generated at:',
   Time.current
 ].to_csv -%>
-<%= ["#{@organization_district.district_name} Cohort Report"].to_csv -%>
+<% period = @period == :quarter ? 'Quarterly' : 'Monthly' %>
+<%= ["#{@organization_district.district_name} #{period} Cohort Report"].to_csv -%>
 <%= ['Facility'].concat(@cohort_analytics.each_with_index.flat_map do |(report_dates, analytics), index|
   [
     'Cohort period',
     'Follow up period',
-    'Patients registered',
+    'Patients in cohort',
     'Patients followed up',
     'Patients controlled',
     'Patients uncontrolled',
-    'Patients defaulted',
+    "Patients didn't attend",
     'Control rate',
     'Uncontrolled rate',
     'Default rate',

--- a/app/views/analytics/districts/show.html.erb
+++ b/app/views/analytics/districts/show.html.erb
@@ -23,9 +23,15 @@
   <h4>Downloads</h4>
 
   <p>
-    <%= link_to(period: params[:period], format: :csv) do %>
-    <i class="far fa-file-excel mr-2"></i>
-    Cohort report
+    <%= link_to(period: :quarter, format: :csv) do %>
+      <i class="far fa-file-excel mr-2"></i>
+      Quarterly cohort report
+    <% end %>
+  </p>
+  <p>
+    <%= link_to(period: :month, format: :csv) do %>
+      <i class="far fa-file-excel mr-2"></i>
+      Monthly cohort report
     <% end %>
   </p>
 

--- a/app/views/analytics/facilities/show.csv.erb
+++ b/app/views/analytics/facilities/show.csv.erb
@@ -1,19 +1,20 @@
 <%= [
-  "Report generated at:",
+  'Report generated at:',
   Time.current
 ].to_csv -%>
-<%= ["#{@facility.name} Cohort Report"].to_csv -%>
+<% period = @period == :quarter ? 'Quarterly' : 'Monthly' %>
+<%= ["#{@facility.name} #{period} Cohort Report"].to_csv -%>
 <%= [
-  "Cohort period",
-  "Follow up period",
-  "Patients registered",
-  "Patients followed up",
-  "Patients controlled",
-  "Patients uncontrolled",
-  "Patients defaulted",
-  "Control rate",
-  "Uncontrolled rate",
-  "Default rate"
+  'Cohort period',
+  'Follow up period',
+  'Patients in cohort',
+  'Patients followed up',
+  'Patients controlled',
+  'Patients uncontrolled',
+  "Patients didn't attend",
+  'Control rate',
+  'Uncontrolled rate',
+  'Default rate'
 ].to_csv -%>
 <% @cohort_analytics.each_with_index do |(report_dates, analytics), index| %>
   <%

--- a/app/views/analytics/facilities/show.html.erb
+++ b/app/views/analytics/facilities/show.html.erb
@@ -34,9 +34,15 @@
   <h4>Downloads</h4>
 
   <p>
-    <%= link_to(period: params[:period], format: :csv) do %>
-    <i class="far fa-file-excel mr-2"></i>
-    Cohort report
+    <%= link_to(period: :quarter, format: :csv) do %>
+      <i class="far fa-file-excel mr-2"></i>
+      Quarterly cohort report
+    <% end %>
+  </p>
+  <p>
+    <%= link_to(period: :month, format: :csv) do %>
+      <i class="far fa-file-excel mr-2"></i>
+      Monthly cohort report
     <% end %>
   </p>
 


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/172668133

## Because

Currently, the cohort report download link is either monthly or quarterly based on the current web view. [This is confusing](https://simpledotorg.slack.com/archives/CFHMC60P5/p1587740374418900).

## This addresses

Adding explicit "Quarterly Cohort Report" and "Monthly Cohort Report" download links, regardless of webview. This addresses the cohort download links on both district and facility pages.

Additionally, it makes a few small tweaks based on @dburka's wisdom:
* Add "Monthly"/"Quarterly" to filename and report title
* `Patients registered` -> `Patients in cohort`
* `Patients defaulted` -> `Patients didn't attend`

## Screenshots

### Before

<img width="314" alt="Screenshot 2020-05-05 at 1 58 08 PM" src="https://user-images.githubusercontent.com/4241399/81047857-e720fb80-8ed8-11ea-8d63-3e2ab3e95b20.png">

### After

<img width="321" alt="Screenshot 2020-05-05 at 1 57 50 PM" src="https://user-images.githubusercontent.com/4241399/81047866-ea1bec00-8ed8-11ea-91c2-f36b28169fd1.png">
