### PR TITLE
Add view_my_facilites permissions to access levels

### DIFF
--- a/app/policies/permissions.rb
+++ b/app/policies/permissions.rb
@@ -121,6 +121,7 @@ module Permissions
         view_health_worker_activity
         download_patient_line_list
         manage_admins
+        view_my_facilities
       ]
     },
     { name: :analyst,
@@ -157,6 +158,7 @@ module Permissions
         view_health_worker_activity
         download_overdue_list
         download_patient_line_list
+        view_my_facilities
       ]
     },
     { name: :custom,


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/n/projects/2184102/stories/172585739

## Because

Supervisors and Owners should have the 'view_my_facilities' permission

## This addresses

Adds the 'view_my_facilities' permission as a default permission for Supervisors and Owners
