### PR TITLE
Added a nowrap to the bar charts

### DIFF
--- a/app/assets/stylesheets/_dashboard.scss
+++ b/app/assets/stylesheets/_dashboard.scss
@@ -17,6 +17,7 @@ Dashboard UI
     padding: 4px 8px;
     font-size: 110%;
     position: relative;
+    white-space: nowrap;
 }
 
 .split-bars .bar-none { background: $grey-light; color: $grey-dark; border-radius: 3px; }


### PR DESCRIPTION
**Story card:** NONE

## Because

Just adds a `no-wrap` to the cohort bar charts because <1% was wrapping awfully.

## This addresses

Wrapping
