### PR TITLE
Fix patient_business_identifier spec

### DIFF
--- a/app/models/patient_business_identifier.rb
+++ b/app/models/patient_business_identifier.rb
@@ -10,12 +10,25 @@ class PatientBusinessIdentifier < ApplicationRecord
     ethiopia_medical_record: 'ethiopia_medical_record'
   }
 
-  validates :identifier, presence: true, unless: -> { identifier_type == 'bangladesh_national_id' }
-  validates :identifier, presence: true, allow_blank: true, if: -> { identifier_type == 'bangladesh_national_id' }
+  validate :identifier_present
   validates :identifier_type, presence: true
 
   validates :device_created_at, presence: true
   validates :device_updated_at, presence: true
+
+  # We want to allow blank values (but not nil) for Bangladesh because of legacy reasons,
+  # and prevent blank _and_ nil for all other identifier types.
+  def identifier_present
+    if identifier_type == "bangladesh_national_id"
+      if identifier.nil?
+        errors.add(:identifier, "can't be blank")
+      end
+    else
+      if identifier.blank?
+        errors.add(:identifier, "can't be blank")
+      end
+    end
+  end
 
   def shortcode
     if simple_bp_passport?

--- a/spec/models/patient_business_identifier_spec.rb
+++ b/spec/models/patient_business_identifier_spec.rb
@@ -11,9 +11,16 @@ RSpec.describe PatientBusinessIdentifier, type: :model do
     it { should validate_presence_of(:identifier_type) }
 
     context 'for bangladesh national IDs' do
-      subject { described_class.new(identifier_type: 'bangladesh_national_id') }
+      it "cannot be nil" do
+        identifier = build(:patient_business_identifier, identifier: nil, identifier_type: "bangladesh_national_id")
+        expect(identifier).to_not be_valid
+        expect(identifier.errors[:identifier]).to eq(["can't be blank"])
+      end
 
-      it { should validate_presence_of(:identifier).allow_nil }
+      it "can be blank" do
+        identifier = build(:patient_business_identifier, identifier: "", identifier_type: "bangladesh_national_id")
+        expect(identifier).to be_valid
+      end
     end
 
     it_behaves_like 'a record that validates device timestamps'


### PR DESCRIPTION
Having two validations of the same field and type probably doesn't do
what we want it too, especially in Rails 5.2 and newer. I don't know if
they have any sort of 'merge' behavior.

I unrolled to a custom validator, and also unrolled the specs a bit for
clarity.

**Story card:** n/a

Cherry picked from Rails 5.2 upgrade - #915 .
