### PR TITLE
Use rspec hooks to clean up the UserAnalytics locale spec

### DIFF
--- a/spec/presenters/user_analytics_presenter_spec.rb
+++ b/spec/presenters/user_analytics_presenter_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe UserAnalyticsPresenter, type: :model do
         end
 
         I18n.available_locales.each do |locale|
-          it "has the formatted_today_string in #{locale}" do
+          it "is in #{locale}" do
             I18n.locale = locale
             data = described_class.new(current_facility).statistics
 

--- a/spec/presenters/user_analytics_presenter_spec.rb
+++ b/spec/presenters/user_analytics_presenter_spec.rb
@@ -256,20 +256,23 @@ RSpec.describe UserAnalyticsPresenter, type: :model do
         end
       end
 
-      it 'has the formatted_today_string (in the correct locale)' do
-        current_locale = I18n.locale
-
-        I18n.available_locales.each do |locale|
-          I18n.locale = locale
-
-          data = described_class.new(current_facility).statistics
-
-          expect(data.dig(:metadata, :today_string))
-            .to eq(I18n.t(:today_str))
+      context 'formatted_today_string' do
+        before do
+          @current_locale = I18n.locale
         end
 
-        # reset locale
-        I18n.locale = current_locale
+        after do
+          I18n.locale = @current_locale
+        end
+
+        I18n.available_locales.each do |locale|
+          it "has the formatted_today_string in #{locale}" do
+            I18n.locale = locale
+            data = described_class.new(current_facility).statistics
+
+            expect(data.dig(:metadata, :today_string)).to eq(I18n.t(:today_str, locale: locale))
+          end
+        end
       end
 
       it 'has the formatted_next_date' do


### PR DESCRIPTION
**Story card:** N/A

## Because

One of the tests in the `UserAnalyticsPresenter` tests for a string that's localized. 

However, the generation of that string is wrapped in a cache block and the spec tests for that string in multiple locales. 

This breaks the spec because the first version of the string in the first locale gets cached and breaks for subsequent locales since we call the test method multiple times within the same `it` block.

## This addresses

Tease out the locale specs in separate `it` blocks (since we already clear cache between `it` blocks) and handle clean-up using rspec hooks.

![Screenshot 2020-05-08 at 1 24 10 PM](https://user-images.githubusercontent.com/50663/81384426-47a97600-912f-11ea-9a6a-6792728d8b62.png)