### PR TITLE
Hard lock Capistrano to 3.11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'wkhtmltoimage-binary'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'capistrano', '~> 3.10'
+  gem 'capistrano', '3.11.0'
   gem 'capistrano-db-tasks', require: false
   gem 'capistrano-multiconfig', require: true
   gem 'capistrano-passenger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       activemodel (>= 5.2)
     builder (3.2.4)
     byebug (11.1.3)
-    capistrano (3.14.0)
+    capistrano (3.11.0)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -490,7 +490,7 @@ DEPENDENCIES
   bootstrap (~> 4.3.1)
   bootstrap_form (>= 4.1.0)
   byebug
-  capistrano (~> 3.10)
+  capistrano (= 3.11.0)
   capistrano-db-tasks
   capistrano-multiconfig
   capistrano-passenger


### PR DESCRIPTION
This is what our Capfile specifies, and I don't want to upgrade this
along w/ our Rails version (/cc #915). So reverting back to 3.11.0 to
get deploys happy again.

**Story card:** n/a quick deploy fix
