### PR TITLE
Add timestamps to downloadable repots

### DIFF
--- a/app/exporters/patients_exporter.rb
+++ b/app/exporters/patients_exporter.rb
@@ -7,6 +7,7 @@ module PatientsExporter
 
   def self.csv(patients)
     CSV.generate(headers: true) do |csv|
+      csv << timestamp
       csv << csv_headers
 
       patients.in_batches(of: BATCH_SIZE).each do |batch|
@@ -25,6 +26,13 @@ module PatientsExporter
         end
       end
     end
+  end
+
+  def self.timestamp
+    [
+      'Report generated at:',
+      Time.current
+    ]
   end
 
   def self.csv_headers

--- a/spec/exporters/patients_exporter_spec.rb
+++ b/spec/exporters/patients_exporter_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe PatientsExporter do
   let!(:appointment) { create(:appointment, :overdue, facility: facility, patient: patient) }
   let!(:prescription_drug_1) { create(:prescription_drug, patient: patient) }
   let!(:prescription_drug_2) { create(:prescription_drug, patient: patient) }
+  let(:now) { Time.current }
+
+  let(:timestamp) do
+    [
+      'Report generated at:',
+      now
+    ]
+  end
 
   let(:headers) do
     [
@@ -96,11 +104,15 @@ RSpec.describe PatientsExporter do
     let(:patient_batch) { Patient.where(id: patient.id) }
 
     it 'generates a CSV of patient records' do
-      expect(subject.csv(Patient.all)).to eq(headers.to_csv + fields.to_csv)
+      travel_to now do
+        expect(subject.csv(Patient.all)).to eq(timestamp.to_csv + headers.to_csv + fields.to_csv)
+      end
     end
 
     it 'generates a blank CSV (only headers) if no patients exist' do
-      expect(subject.csv(Patient.none)).to eq(headers.to_csv)
+      travel_to now do
+        expect(subject.csv(Patient.none)).to eq(timestamp.to_csv + headers.to_csv)
+      end
     end
 
     it 'uses fetches patients in batches' do


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/172537522

This PR addresses the following stragglers, adding a "Report generated at:" timestamp to the top of the file:

* Patient line list download

Other downloadable reports already feature this timestamp:

* [District cohort reports](https://github.com/simpledotorg/simple-server/blob/4d04b2435ce7d793d91058701abc7d14bfc93603/app/views/analytics/districts/show.csv.erb#L1-L4)
* [Facility cohort reports](https://github.com/simpledotorg/simple-server/blob/4d04b2435ce7d793d91058701abc7d14bfc93603/app/views/analytics/facilities/show.csv.erb#L1-L4)
* [Overdue list](https://github.com/simpledotorg/simple-server/blob/4d04b2435ce7d793d91058701abc7d14bfc93603/app/views/appointments/index.csv.erb#L1-L4)