### PR TITLE
Add index on deleted_at for Encounters

### DIFF
--- a/db/migrate/20200515101844_add_index_on_deleted_at_for_encounters.rb
+++ b/db/migrate/20200515101844_add_index_on_deleted_at_for_encounters.rb
@@ -1,0 +1,7 @@
+class AddIndexOnDeletedAtForEncounters < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+  
+  def change
+    add_index :encounters, :deleted_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -178,6 +178,7 @@ ActiveRecord::Schema.define(version: 20200505104339) do
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["deleted_at"], name: "index_encounters_on_deleted_at"
     t.index ["facility_id"], name: "index_encounters_on_facility_id"
     t.index ["patient_id"], name: "index_encounters_on_patient_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200505104339) do
+ActiveRecord::Schema.define(version: 2020_05_15_101844) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
   enable_extension "pgcrypto"
+  enable_extension "plpgsql"
 
   create_table "addresses", id: :uuid, default: nil, force: :cascade do |t|
     t.string "street_address"


### PR DESCRIPTION
**Story card:** N/A

## Because

The follow up queries now use the `Encounter` model. Adding this index makes them a little faster since all queries around any resource ostensibly have `deleted_at = nil` in their clause.

## This addresses

Adds a migration to put an index on `deleted_at` in `encounters`
