### PR TITLE
Add spring; cuts about ~3 seconds off every local test run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,8 @@ group :development do
   gem 'guard-rspec', require: false
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'rails-erd'
+  gem "spring"
+  gem "spring-commands-rspec"
   gem 'web-console', '>= 3.3.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,6 +428,9 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
+    spring (2.1.0)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -548,6 +551,8 @@ DEPENDENCIES
   sidekiq
   sidekiq-throttled
   simplecov
+  spring
+  spring-commands-rspec
   timecop (~> 0.9.0)
   twilio-ruby (~> 5.10, >= 5.10.3)
   tzinfo-data

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/rspec
+++ b/bin/rspec
@@ -4,6 +4,5 @@ begin
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+# This file loads Spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+unless defined?(Spring)
+  require 'rubygems'
+  require 'bundler'
+
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
+    require 'spring/binstub'
+  end
+end


### PR DESCRIPTION
Before **5.3 seconds for a single spec run**

```
[~/src/simpledotorg/simple-server (add-spring)]> time bin/rspec spec/models/phone_number_authentication_spec.rb
Running via Spring preloader in process 98807
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
[rspec-sidekiq] WARNING! Sidekiq will *NOT* process jobs in this environment. See https://github.com/philostler/rspec-sidekiq/wiki/FAQ-&-Troubleshooting
.........

Finished in 1.08 seconds (files took 0.51137 seconds to load)
9 examples, 0 failures

real	0m5.307s
user	0m0.149s
sys	0m0.058s
```

After **2.1 seconds for the same spec run**

```
[~/src/simpledotorg/simple-server (add-spring)]> time bin/rspec spec/models/phone_number_authentication_spec.rb
Running via Spring preloader in process 98747
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
[rspec-sidekiq] WARNING! Sidekiq will *NOT* process jobs in this environment. See https://github.com/philostler/rspec-sidekiq/wiki/FAQ-&-Troubleshooting
.........

Finished in 1.06 seconds (files took 0.55638 seconds to load)
9 examples, 0 failures

real	0m2.137s
user	0m0.148s
sys	0m0.055s
```

**Story card:** n/a - dev speed improvement

## Because

We want faster tests locally

## This addresses

adding spring
