### PR TITLE
Change died status column in patient line list

### DIFF
--- a/app/exporters/patients_exporter.rb
+++ b/app/exporters/patients_exporter.rb
@@ -39,6 +39,7 @@ module PatientsExporter
     [
       'Registration Date',
       'Registration Quarter',
+      'Patient died?',
       'Patient Name',
       'Patient Age',
       'Patient Gender',
@@ -62,7 +63,6 @@ module PatientsExporter
       'Follow-up Date',
       'Days Overdue',
       'Risk Level',
-      'Dead?',
       'BP Passport ID',
       'Simple Patient ID',
       'Medication 1',
@@ -88,6 +88,7 @@ module PatientsExporter
     [
       patient.recorded_at.presence && I18n.l(patient.recorded_at),
       patient.recorded_at.presence && quarter_string(patient.recorded_at),
+      ('Died' if patient.status == 'dead'),
       patient.full_name,
       patient.current_age,
       patient.gender.capitalize,
@@ -111,7 +112,6 @@ module PatientsExporter
       latest_appointment&.scheduled_date&.to_s(:rfc822),
       latest_appointment&.days_overdue,
       ('High' if patient.high_risk?),
-      ('Died' if patient.status == 'dead'),
       latest_bp_passport&.shortcode,
       patient.id,
       *medications_for(patient)

--- a/spec/exporters/patients_exporter_spec.rb
+++ b/spec/exporters/patients_exporter_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe PatientsExporter do
     [
       'Registration Date',
       'Registration Quarter',
+      'Patient died?',
       'Patient Name',
       'Patient Age',
       'Patient Gender',
@@ -45,7 +46,6 @@ RSpec.describe PatientsExporter do
       'Follow-up Date',
       'Days Overdue',
       'Risk Level',
-      'Dead?',
       'BP Passport ID',
       'Simple Patient ID',
       'Medication 1',
@@ -65,6 +65,7 @@ RSpec.describe PatientsExporter do
     [
       I18n.l(patient.recorded_at),
       quarter_string(patient.recorded_at),
+      'Died',
       patient.full_name,
       patient.current_age,
       patient.gender.capitalize,
@@ -88,7 +89,6 @@ RSpec.describe PatientsExporter do
       appointment.scheduled_date.to_s(:rfc822),
       appointment.days_overdue,
       'High',
-      'Died',
       patient.latest_bp_passport&.shortcode,
       patient.id,
       prescription_drug_1.name,


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/172817001/comments/214411642

## Because

Some [changes](https://www.pivotaltracker.com/story/show/172817001/comments/214411642) were requested in #973.

## This addresses

- Changes name of the `Died?` column to "Patient died?"
- puts it before "Patient name"