### PR TITLE
Hotfix for build: make spec more specific

### DIFF
--- a/spec/controllers/email_authentications/invitations_controller_spec.rb
+++ b/spec/controllers/email_authentications/invitations_controller_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe EmailAuthentications::InvitationsController, type: :controller do
       end
 
       it 'responds with bad request if email is invalid' do
-        post :create, params: params.merge(email: 'invalid email')
+        post :create, params: params.merge(email: 'invalid email', password: generate(:strong_password))
 
         expect(response).to be_bad_request
         expect(JSON(response.body)).to eq('errors' => ['Email is invalid'])


### PR DESCRIPTION
Merge in a password to params for this spec, as it is only testing the email
validation.

I'm not sure how this got merged in #938 as a green build, but want to get it fixed up in master to get builds going again.
