### PR TITLE
Fix overview query spec

### DIFF
--- a/spec/queries/my_facilities/blood_pressure_control_query_spec.rb
+++ b/spec/queries/my_facilities/blood_pressure_control_query_spec.rb
@@ -99,7 +99,6 @@ RSpec.describe MyFacilities::BloodPressureControlQuery do
 
       before do
         ActiveRecord::Base.transaction do
-          ActiveRecord::Base.connection.execute("SET LOCAL TIME ZONE '#{Rails.application.config.country[:time_zone]}'")
           LatestBloodPressuresPerPatientPerMonth.refresh
           LatestBloodPressuresPerPatientPerQuarter.refresh
         end
@@ -239,10 +238,7 @@ RSpec.describe MyFacilities::BloodPressureControlQuery do
       end
 
       before do
-        ActiveRecord::Base.transaction do
-          ActiveRecord::Base.connection.execute("SET LOCAL TIME ZONE '#{Rails.application.config.country[:time_zone]}'")
-          LatestBloodPressuresPerPatientPerMonth.refresh
-        end
+        LatestBloodPressuresPerPatientPerMonth.refresh
       end
 
       context 'considers only htn diagnosed patients' do
@@ -371,7 +367,6 @@ RSpec.describe MyFacilities::BloodPressureControlQuery do
 
       before do
         ActiveRecord::Base.transaction do
-          ActiveRecord::Base.connection.execute("SET LOCAL TIME ZONE '#{Rails.application.config.country[:time_zone]}'")
           LatestBloodPressuresPerPatientPerMonth.refresh
           LatestBloodPressuresPerPatient.refresh
         end

--- a/spec/queries/my_facilities/overview_query_spec.rb
+++ b/spec/queries/my_facilities/overview_query_spec.rb
@@ -47,10 +47,7 @@ RSpec.describe MyFacilities::OverviewQuery do
     end
 
     before do
-      ActiveRecord::Base.transaction do
-        ActiveRecord::Base.connection.execute("SET LOCAL TIME ZONE '#{Rails.application.config.country[:time_zone]}'")
-        BloodPressuresPerFacilityPerDay.refresh
-      end
+      BloodPressuresPerFacilityPerDay.refresh
     end
 
     it 'returns only inactive facilities' do
@@ -76,10 +73,7 @@ RSpec.describe MyFacilities::OverviewQuery do
     end
 
     before do
-      ActiveRecord::Base.transaction do
-        ActiveRecord::Base.connection.execute("SET LOCAL TIME ZONE '#{Rails.application.config.country[:time_zone]}'")
-        BloodPressuresPerFacilityPerDay.refresh
-      end
+      BloodPressuresPerFacilityPerDay.refresh
     end
 
     context 'considers only htn diagnosed patients' do

--- a/spec/queries/my_facilities/overview_query_spec.rb
+++ b/spec/queries/my_facilities/overview_query_spec.rb
@@ -77,10 +77,7 @@ RSpec.describe MyFacilities::OverviewQuery do
     end
 
     context 'considers only htn diagnosed patients' do
-      specify do
-        pending "intermittently failing"
-        expect(described_class.new(facilities: facility).total_bps_in_last_n_days(n: 2)[facility.id]).to eq(1)
-      end
+      specify { expect(described_class.new(facilities: facility).total_bps_in_last_n_days(n: 2)[facility.id]).to eq(1) }
     end
   end
 end

--- a/spec/queries/my_facilities/registrations_query_spec.rb
+++ b/spec/queries/my_facilities/registrations_query_spec.rb
@@ -30,10 +30,7 @@ RSpec.describe MyFacilities::RegistrationsQuery do
         let!(:non_htn_patient) { create(:patient, :without_hypertension, recorded_at: included_timestamps.first) }
 
         before do
-          ActiveRecord::Base.transaction do
-            ActiveRecord::Base.connection.execute("SET LOCAL TIME ZONE '#{Rails.application.config.country[:time_zone]}'")
-            PatientRegistrationsPerDayPerFacility.refresh
-          end
+          PatientRegistrationsPerDayPerFacility.refresh
         end
 
         context 'considers only htn diagnosed patients' do
@@ -54,10 +51,7 @@ RSpec.describe MyFacilities::RegistrationsQuery do
         let!(:non_htn_patient) { create(:patient, :without_hypertension, recorded_at: included_timestamps.first) }
 
         before do
-          ActiveRecord::Base.transaction do
-            ActiveRecord::Base.connection.execute("SET LOCAL TIME ZONE '#{Rails.application.config.country[:time_zone]}'")
-            PatientRegistrationsPerDayPerFacility.refresh
-          end
+          PatientRegistrationsPerDayPerFacility.refresh
         end
 
         context 'considers only htn diagnosed patients' do
@@ -76,10 +70,7 @@ RSpec.describe MyFacilities::RegistrationsQuery do
         let!(:non_htn_patient) { create(:patient, :without_hypertension, recorded_at: included_timestamps.first) }
 
         before do
-          ActiveRecord::Base.transaction do
-            ActiveRecord::Base.connection.execute("SET LOCAL TIME ZONE '#{Rails.application.config.country[:time_zone]}'")
-            PatientRegistrationsPerDayPerFacility.refresh
-          end
+          PatientRegistrationsPerDayPerFacility.refresh
         end
 
         context 'considers only htn diagnosed patients' do


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/172909765

## Because

A flaky spec was added in #940 which uncovered an underlying issue in the way we use time zones in the my facilities query specs.

## This addresses

Ideally we should be running all our specs in UTC. Currently the My facilities query specs do a view refresh in `Asia/Kolkata` and run expectations in UTC, which is incorrect. This was causing a `daily` view spec for example to fail from midnight to 5:30 AM IST. This removes the time zoning around view refreshes so everything runs in UTC.

This fixes the flaky test marked pending in #982.
