### PR TITLE
Bangladesh medical history cleanup

### DIFF
--- a/lib/tasks/data_fixes.rake
+++ b/lib/tasks/data_fixes.rake
@@ -1,5 +1,6 @@
 require 'tasks/scripts/move_user_recorded_data_to_registration_facility'
 require 'tasks/scripts/correct_bangladesh_medication_dosages'
+require 'tasks/scripts/correct_bangladesh_medical_histories'
 
 namespace :data_fixes do
   desc 'Move all data recorded by a user from a source facility to a destination facility'
@@ -27,5 +28,15 @@ namespace :data_fixes do
   desc 'Correct zero dosage medication in Bangladesh (dryrun)'
   task :correct_bangladesh_medication_dosages_dryrun => :environment do
     CorrectBangladeshMedicationDosages.call(dryrun: true)
+  end
+
+  desc 'Correct medical histories in Bangladesh'
+  task :correct_bangladesh_medical_histories => :environment do
+    CorrectBangladeshMedicalHistories.call
+  end
+
+  desc 'Correct medical histories in Bangladesh (dryrun)'
+  task :correct_bangladesh_medical_histories_dryrun => :environment do
+    CorrectBangladeshMedicalHistories.call(dryrun: true)
   end
 end

--- a/lib/tasks/scripts/correct_bangladesh_medical_histories.rb
+++ b/lib/tasks/scripts/correct_bangladesh_medical_histories.rb
@@ -17,7 +17,7 @@ class CorrectBangladeshMedicalHistories
 
     return if dryrun
 
-    log 'Updating dosages...'
+    log 'Updating medical histories...'
     update_medical_histories
 
     log 'Complete. Goodbye.'

--- a/lib/tasks/scripts/correct_bangladesh_medical_histories.rb
+++ b/lib/tasks/scripts/correct_bangladesh_medical_histories.rb
@@ -13,14 +13,19 @@ class CorrectBangladeshMedicalHistories
   end
 
   def call
+    unless Rails.application.config.country[:abbreviation] == "BD"
+      log "Cannot run this cleanup outside of Bangladesh"
+      return
+    end
+
     print_summary
 
     return if dryrun
 
-    log 'Updating medical histories...'
+    log "Updating medical histories..."
     update_medical_histories
 
-    log 'Complete. Goodbye.'
+    log "Complete. Goodbye."
   end
 
   def print_summary
@@ -28,13 +33,13 @@ class CorrectBangladeshMedicalHistories
   end
 
   def eligible_medical_histories
-    MedicalHistory.where(hypertension: 'unknown')
+    MedicalHistory.where(hypertension: "unknown")
   end
 
   def update_medical_histories
     eligible_medical_histories.update_all(
-      hypertension: 'yes',
-      diagnosed_with_hypertension: 'yes'
+      hypertension: "yes",
+      diagnosed_with_hypertension: "yes"
     )
   end
 

--- a/lib/tasks/scripts/correct_bangladesh_medical_histories.rb
+++ b/lib/tasks/scripts/correct_bangladesh_medical_histories.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class CorrectBangladeshMedicalHistories
+  def self.call(*args)
+    new(*args).call
+  end
+
+  attr_reader :dryrun, :verbose
+
+  def initialize(dryrun: false, verbose: true)
+    @dryrun = dryrun
+    @verbose = verbose
+  end
+
+  def call
+    print_summary
+
+    return if dryrun
+
+    log 'Updating dosages...'
+    update_medical_histories
+
+    log 'Complete. Goodbye.'
+  end
+
+  def print_summary
+    log "Medical histories with 'unknown' hypertension: #{eligible_medical_histories.count} records"
+  end
+
+  def eligible_medical_histories
+    MedicalHistory.where(hypertension: 'unknown')
+  end
+
+  def update_medical_histories
+    eligible_medical_histories.update_all(
+      hypertension: 'yes',
+      diagnosed_with_hypertension: 'yes'
+    )
+  end
+
+  def log(message)
+    puts message if verbose
+  end
+end

--- a/spec/factories/medical_histories.rb
+++ b/spec/factories/medical_histories.rb
@@ -31,6 +31,10 @@ FactoryBot.define do
       hypertension { MedicalHistory::MEDICAL_HISTORY_ANSWERS[:no] }
     end
 
+    trait :hypertension_unknown do
+      hypertension { MedicalHistory::MEDICAL_HISTORY_ANSWERS[:unknown] }
+    end
+
     trait :diabetes_yes do
       diabetes { MedicalHistory::MEDICAL_HISTORY_ANSWERS[:yes] }
     end

--- a/spec/lib/tasks/scripts/correct_bangladesh_medical_histories.rb
+++ b/spec/lib/tasks/scripts/correct_bangladesh_medical_histories.rb
@@ -1,9 +1,12 @@
-require 'rails_helper'
-require 'tasks/scripts/correct_bangladesh_medical_histories'
+require "rails_helper"
+require "tasks/scripts/correct_bangladesh_medical_histories"
 
 RSpec.describe CorrectBangladeshMedicalHistories do
-  describe '#call' do
-    it 'set only unknown hypertensions to yes' do
+  describe "#call" do
+    it "set only unknown hypertensions to yes" do
+      original_country = Rails.application.config.country[:abbreviation]
+      Rails.application.config.country[:abbreviation] = "BD"
+
       yeses = create_list(:medical_history, 2, :hypertension_yes)
       nos = create_list(:medical_history, 3, :hypertension_no)
       unknowns = create_list(:medical_history, 4, :hypertension_unknown)
@@ -23,10 +26,15 @@ RSpec.describe CorrectBangladeshMedicalHistories do
       nos.each do |medical_history|
         expect(medical_history.reload.hypertension).to eq("no")
       end
+
+       Rails.application.config.country[:abbreviation] = original_country
     end
 
-    context 'with dryrun' do
-      it 'does not modify any drugs' do
+    context "outside of Bangladesh" do
+      it "does not modify any drugs" do
+        original_country = Rails.application.config.country[:abbreviation]
+        Rails.application.config.country[:abbreviation] = "IN"
+
         yes = create(:medical_history, :hypertension_yes)
         no = create(:medical_history, :hypertension_no)
         unknown = create(:medical_history, :hypertension_unknown)
@@ -36,6 +44,27 @@ RSpec.describe CorrectBangladeshMedicalHistories do
         expect(yes.hypertension).to eq("yes")
         expect(no.hypertension).to eq("no")
         expect(unknown.hypertension).to eq("unknown")
+
+        Rails.application.config.country[:abbreviation] = original_country
+      end
+    end
+
+    context "with dryrun" do
+      it "does not modify any drugs" do
+        original_country = Rails.application.config.country[:abbreviation]
+        Rails.application.config.country[:abbreviation] = "BD"
+
+        yes = create(:medical_history, :hypertension_yes)
+        no = create(:medical_history, :hypertension_no)
+        unknown = create(:medical_history, :hypertension_unknown)
+
+        CorrectBangladeshMedicalHistories.call(dryrun: true, verbose: false)
+
+        expect(yes.hypertension).to eq("yes")
+        expect(no.hypertension).to eq("no")
+        expect(unknown.hypertension).to eq("unknown")
+
+        Rails.application.config.country[:abbreviation] = original_country
       end
     end
   end

--- a/spec/lib/tasks/scripts/correct_bangladesh_medical_histories.rb
+++ b/spec/lib/tasks/scripts/correct_bangladesh_medical_histories.rb
@@ -39,7 +39,7 @@ RSpec.describe CorrectBangladeshMedicalHistories do
         no = create(:medical_history, :hypertension_no)
         unknown = create(:medical_history, :hypertension_unknown)
 
-        CorrectBangladeshMedicalHistories.call(dryrun: true, verbose: false)
+        CorrectBangladeshMedicalHistories.call(verbose: false)
 
         expect(yes.hypertension).to eq("yes")
         expect(no.hypertension).to eq("no")

--- a/spec/lib/tasks/scripts/correct_bangladesh_medical_histories.rb
+++ b/spec/lib/tasks/scripts/correct_bangladesh_medical_histories.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+require 'tasks/scripts/correct_bangladesh_medical_histories'
+
+RSpec.describe CorrectBangladeshMedicalHistories do
+  describe '#call' do
+    it 'set only unknown hypertensions to yes' do
+      yeses = create_list(:medical_history, 2, :hypertension_yes)
+      nos = create_list(:medical_history, 3, :hypertension_no)
+      unknowns = create_list(:medical_history, 4, :hypertension_unknown)
+
+      CorrectBangladeshMedicalHistories.call(verbose: false)
+
+      unknowns.each do |medical_history|
+        medical_history.reload
+        expect(medical_history.hypertension).to eq("yes")
+        expect(medical_history.diagnosed_with_hypertension).to eq("yes")
+      end
+
+      yeses.each do |medical_history|
+        expect(medical_history.reload.hypertension).to eq("yes")
+      end
+
+      nos.each do |medical_history|
+        expect(medical_history.reload.hypertension).to eq("no")
+      end
+    end
+
+    context 'with dryrun' do
+      it 'does not modify any drugs' do
+        yes = create(:medical_history, :hypertension_yes)
+        no = create(:medical_history, :hypertension_no)
+        unknown = create(:medical_history, :hypertension_unknown)
+
+        CorrectBangladeshMedicalHistories.call(dryrun: true, verbose: false)
+
+        expect(yes.hypertension).to eq("yes")
+        expect(no.hypertension).to eq("no")
+        expect(unknown.hypertension).to eq("unknown")
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/n/projects/2184102/stories/172931517

## Because

Large swathes of imported patients in BD aren't marked "hypertension=true"

## This addresses

A rake task to execute in BD to correct these records, marking them "hypertension=true". It also marks the deprecated "diagnosed_with_hypertension=true" to be consistent with API behavior.
