### PR TITLE
Fix an edge-case with Progress Tab trophies

### DIFF
--- a/app/presenters/user_analytics_presenter.rb
+++ b/app/presenters/user_analytics_presenter.rb
@@ -197,25 +197,27 @@ class UserAnalyticsPresenter < Struct.new(:current_facility)
   #
   # i.e. increment by TROPHY_MILESTONE_INCR
   def trophy_stats
-    follow_ups =
-      all_time_htn_stats.dig(:grouped_by_gender, :hypertension, :follow_ups).values.sum
+    follow_ups = all_time_htn_stats.dig(:grouped_by_gender, :hypertension, :follow_ups).values.sum
+    trophy_milestone = trophy_milestone(follow_ups)
 
+    {
+      locked_trophy_value:
+        all_trophies[trophy_milestone],
+
+      unlocked_trophy_values:
+        all_trophies[0, trophy_milestone]
+    }
+  end
+
+  def trophy_milestone(follow_ups)
     all_trophies = if follow_ups > TROPHY_MILESTONES.last
                      [*TROPHY_MILESTONES,
-                      *(TROPHY_MILESTONE_INCR..(follow_ups + TROPHY_MILESTONE_INCR)).step(TROPHY_MILESTONE_INCR)]
+                       *(TROPHY_MILESTONE_INCR..(follow_ups + TROPHY_MILESTONE_INCR)).step(TROPHY_MILESTONE_INCR)]
                    else
                      TROPHY_MILESTONES
                    end
 
-    unlocked_trophies_until = all_trophies.index { |v| follow_ups < v }
-
-    {
-      locked_trophy_value:
-        all_trophies[unlocked_trophies_until],
-
-      unlocked_trophy_values:
-        all_trophies[0, unlocked_trophies_until]
-    }
+    all_trophies.index { |v| follow_ups < v }
   end
 
   def monthly_htn_or_dm_stats

--- a/app/presenters/user_analytics_presenter.rb
+++ b/app/presenters/user_analytics_presenter.rb
@@ -197,27 +197,26 @@ class UserAnalyticsPresenter < Struct.new(:current_facility)
   #
   # i.e. increment by TROPHY_MILESTONE_INCR
   def trophy_stats
-    follow_ups = all_time_htn_stats.dig(:grouped_by_gender, :hypertension, :follow_ups).values.sum
-    trophy_milestone = trophy_milestone(follow_ups)
+    follow_up_count = all_time_htn_stats.dig(:grouped_by_gender, :hypertension, :follow_ups).values.sum
+    milestones = trophy_milestones(follow_up_count)
+    locked_milestone_idx = milestones.index { |milestone| follow_up_count < milestone }
 
     {
       locked_trophy_value:
-        all_trophies[trophy_milestone],
+        milestones[locked_milestone_idx],
 
       unlocked_trophy_values:
-        all_trophies[0, trophy_milestone]
+        milestones[0, locked_milestone_idx]
     }
   end
 
-  def trophy_milestone(follow_ups)
-    all_trophies = if follow_ups > TROPHY_MILESTONES.last
-                     [*TROPHY_MILESTONES,
-                       *(TROPHY_MILESTONE_INCR..(follow_ups + TROPHY_MILESTONE_INCR)).step(TROPHY_MILESTONE_INCR)]
-                   else
-                     TROPHY_MILESTONES
-                   end
-
-    all_trophies.index { |v| follow_ups < v }
+  def trophy_milestones(follow_up_count)
+    if follow_up_count >= TROPHY_MILESTONES.last
+      [*TROPHY_MILESTONES,
+        *(TROPHY_MILESTONE_INCR..(follow_up_count + TROPHY_MILESTONE_INCR)).step(TROPHY_MILESTONE_INCR)]
+    else
+      TROPHY_MILESTONES
+    end
   end
 
   def monthly_htn_or_dm_stats

--- a/spec/presenters/user_analytics_presenter_spec.rb
+++ b/spec/presenters/user_analytics_presenter_spec.rb
@@ -727,10 +727,6 @@ RSpec.describe UserAnalyticsPresenter, type: :model do
         expect(data[:trophies]).to eq(expected_output)
       end
 
-      it 'unlocks additional trophies if follow ups cross the baseline' do
-        allow
-      end
-
       it 'has only 1 locked trophy if there are no achievements' do
         data = described_class.new(current_facility).statistics
 
@@ -740,6 +736,50 @@ RSpec.describe UserAnalyticsPresenter, type: :model do
         }
 
         expect(data[:trophies]).to eq(expected_output)
+      end
+
+      context 'unlocks additional trophies' do
+        it 'unlocks a milestone of 10_000 if follow_ups are 5_000' do
+          user_analytics = described_class.new(current_facility)
+
+          all_time_htn_stats = {grouped_by_gender: {hypertension: {follow_ups: {"male" => 5_000}}}}
+          allow(user_analytics).to receive(:all_time_htn_stats).and_return(all_time_htn_stats)
+
+          expected_output = {
+            locked_trophy_value: 10_000,
+            unlocked_trophy_values: [10, 25, 50, 100, 250, 500, 1_000, 2_000, 3_000, 4_000, 5_000]
+          }
+
+          expect(user_analytics.statistics[:trophies]).to eq(expected_output)
+        end
+
+        it 'unlocks a milestone of 10_000 if follow_ups are between 5_000...10_000' do
+          user_analytics = described_class.new(current_facility)
+
+          all_time_htn_stats = {grouped_by_gender: {hypertension: {follow_ups: {"male" => 5_001}}}}
+          allow(user_analytics).to receive(:all_time_htn_stats).and_return(all_time_htn_stats)
+
+          expected_output = {
+            locked_trophy_value: 10_000,
+            unlocked_trophy_values: [10, 25, 50, 100, 250, 500, 1_000, 2_000, 3_000, 4_000, 5_000]
+          }
+
+          expect(user_analytics.statistics[:trophies]).to eq(expected_output)
+        end
+
+        it 'unlocks milestones in increments of 10_000 after reaching 10_000' do
+          user_analytics = described_class.new(current_facility)
+
+          all_time_htn_stats = {grouped_by_gender: {hypertension: {follow_ups: {"male" => 10_000}}}}
+          allow(user_analytics).to receive(:all_time_htn_stats).and_return(all_time_htn_stats)
+
+          expected_output = {
+            locked_trophy_value: 20_000,
+            unlocked_trophy_values: [10, 25, 50, 100, 250, 500, 1_000, 2_000, 3_000, 4_000, 5_000, 10_000]
+          }
+
+          expect(user_analytics.statistics[:trophies]).to eq(expected_output)
+        end
       end
     end
   end

--- a/spec/presenters/user_analytics_presenter_spec.rb
+++ b/spec/presenters/user_analytics_presenter_spec.rb
@@ -727,6 +727,10 @@ RSpec.describe UserAnalyticsPresenter, type: :model do
         expect(data[:trophies]).to eq(expected_output)
       end
 
+      it 'unlocks additional trophies if follow ups cross the baseline' do
+        allow
+      end
+
       it 'has only 1 locked trophy if there are no achievements' do
         data = described_class.new(current_facility).statistics
 


### PR DESCRIPTION
HOTFIX

## Because

When follow ups for a facility reach exactly one of the trophy milestones, like 5000, the trophy milestone computation fails at generating the locked trophy (like, 10_000).

## This addresses

Populate a locked milestone for trophies even if you're exactly on the previous milestone on the dot. Eg.;

```
follow_ups = 5000
locked_trophy = 10_000
unlocked_trohpies = [10, 25, 50, 100, 250, 500, 1_000, 2_000, 3_000, 4_000, 5_000]
```

```
follow_ups = 5001
locked_trophy = 10_000
unlocked_trohpies = [10, 25, 50, 100, 250, 500, 1_000, 2_000, 3_000, 4_000, 5_000]
```

```
follow_ups = 10_000
locked_trophy = 20_000
unlocked_trohpies = [10, 25, 50, 100, 250, 500, 1_000, 2_000, 3_000, 4_000, 5_000, 10_000]
```

```
follow_ups = 10_001
locked_trophy = 20_000
unlocked_trohpies = [10, 25, 50, 100, 250, 500, 1_000, 2_000, 3_000, 4_000, 5_000, 10_000]
```

The check previously was,

```
follow_up_count > TROPHY_MILESTONES.last
```

The only real functional change made:

```
follow_up_count >= TROPHY_MILESTONES.last
```
