### PR TITLE
Add Flipper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "factory_bot_rails", "~> 4.8", require: false
 gem "faker", require: false
 gem "flipper"
 gem "flipper-active_record"
+gem "flipper-ui"
 gem "friendly_id", "~> 5.2.4"
 gem "groupdate"
 gem "http"

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "dotenv-rails"
 gem "factory_bot_rails", "~> 4.8", require: false
 gem "faker", require: false
 gem "flipper"
+gem "flipper-active_record"
 gem "friendly_id", "~> 5.2.4"
 gem "groupdate"
 gem "http"

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "discard", "~> 1.0"
 gem "dotenv-rails"
 gem "factory_bot_rails", "~> 4.8", require: false
 gem "faker", require: false
+gem "flipper"
 gem "friendly_id", "~> 5.2.4"
 gem "groupdate"
 gem "http"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,9 @@ GEM
       ffi (>= 1.0.0)
       rake
     flipper (0.17.2)
+    flipper-active_record (0.17.2)
+      activerecord (>= 4.2, < 7)
+      flipper (~> 0.17.2)
     formatador (0.2.5)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
@@ -538,6 +541,7 @@ DEPENDENCIES
   faker
   fakeredis
   flipper
+  flipper-active_record
   friendly_id (~> 5.2.4)
   generator_spec
   groupdate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,11 @@ GEM
     flipper-active_record (0.17.2)
       activerecord (>= 4.2, < 7)
       flipper (~> 0.17.2)
+    flipper-ui (0.17.2)
+      erubi (>= 1.0.0, < 2.0.0)
+      flipper (~> 0.17.2)
+      rack (>= 1.4, < 3)
+      rack-protection (>= 1.5.3, < 2.1.0)
     formatador (0.2.5)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
@@ -542,6 +547,7 @@ DEPENDENCIES
   fakeredis
   flipper
   flipper-active_record
+  flipper-ui
   friendly_id (~> 5.2.4)
   generator_spec
   groupdate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    flipper (0.17.2)
     formatador (0.2.5)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
@@ -536,6 +537,7 @@ DEPENDENCIES
   factory_bot_rails (~> 4.8)
   faker
   fakeredis
+  flipper
   friendly_id (~> 5.2.4)
   generator_spec
   groupdate

--- a/app/policies/dashboard_policy.rb
+++ b/app/policies/dashboard_policy.rb
@@ -45,4 +45,12 @@ class DashboardPolicy < Struct.new(:user, :dashboard)
   def view_my_facilities?
     user.has_permission?(:view_my_facilities)
   end
+
+  def view_sidekiq_ui?
+    user.has_permission?(:view_sidekiq_ui)
+  end
+
+  def view_flipper_ui?
+    user.has_permission?(:view_flipper_ui)
+  end
 end

--- a/app/policies/permissions.rb
+++ b/app/policies/permissions.rb
@@ -83,7 +83,13 @@ module Permissions
       description: 'View My Facilities Dashboard',
       resource_priority: %i[global],
       required_permissions: []
-    }
+    },
+    view_flipper_ui: {
+      slug: :view_flipper_ui,
+      description: 'View Flipper UI',
+      resource_priority: %i[global],
+      required_permissions: []
+    },
   }.freeze
 
   ACCESS_LEVELS = [

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -105,6 +105,12 @@
                   <% if policy([:dashboard]).manage_users? %>
                     <%= link_to "Users", admin_users_path, class: "dropdown-item #{active_controller?("users")}" %>
                   <% end %>
+                  <% if policy([:dashboard]).view_sidekiq_ui? %>
+                    <%= link_to "Sidekiq", "/sidekiq", class: "dropdown-item #{active_controller?("users")}" %>
+                  <% end %>
+                  <% if policy([:dashboard]).view_flipper_ui? %>
+                    <%= link_to "Flipper", "/flipper", class: "dropdown-item #{active_controller?("users")}" %>
+                  <% end %>
                 </div>
               </li>
               <% end %>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,7 @@
+Flipper.configure do |config|
+  config.default do
+    adapter = Flipper::Adapters::ActiveRecord.new
+
+    Flipper.new(adapter)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -197,4 +197,8 @@ Rails.application.routes.draw do
     require "sidekiq/web"
     mount Sidekiq::Web => "/sidekiq"
   end
+
+  authenticate :email_authentication, ->(a) { a.user.has_permission?(:view_flipper_ui) } do
+    mount Flipper::UI.app(Flipper) => '/flipper'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,6 +199,6 @@ Rails.application.routes.draw do
   end
 
   authenticate :email_authentication, ->(a) { a.user.has_permission?(:view_flipper_ui) } do
-    mount Flipper::UI.app(Flipper) => '/flipper'
+    mount Flipper::UI.app(Flipper) => "/flipper"
   end
 end

--- a/db/migrate/20200605103543_create_flipper_tables.rb
+++ b/db/migrate/20200605103543_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_28_113844) do
+ActiveRecord::Schema.define(version: 2020_06_05_103543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -242,6 +242,22 @@ ActiveRecord::Schema.define(version: 2020_05_28_113844) do
     t.index ["organization_id"], name: "index_facility_groups_on_organization_id"
     t.index ["protocol_id"], name: "index_facility_groups_on_protocol_id"
     t.index ["slug"], name: "index_facility_groups_on_slug", unique: true
+  end
+
+  create_table "flipper_features", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
+  end
+
+  create_table "flipper_gates", force: :cascade do |t|
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "medical_histories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/policies/dashboard_policy_spec.rb
+++ b/spec/policies/dashboard_policy_spec.rb
@@ -96,4 +96,34 @@ RSpec.describe DashboardPolicy do
     allowed_permissions.each { |slug| include_examples 'grant permission', slug }
     other_permissions.each { |slug| include_examples 'deny permission', slug }
   end
+
+  permissions :view_my_facilities? do
+    allowed_permissions = %i[
+      view_my_facilities
+    ]
+    other_permissions = Permissions::ALL_PERMISSIONS.keys - allowed_permissions
+
+    allowed_permissions.each { |slug| include_examples 'grant permission', slug }
+    other_permissions.each { |slug| include_examples 'deny permission', slug }
+  end
+
+  permissions :view_sidekiq_ui? do
+    allowed_permissions = %i[
+      view_sidekiq_ui
+    ]
+    other_permissions = Permissions::ALL_PERMISSIONS.keys - allowed_permissions
+
+    allowed_permissions.each { |slug| include_examples 'grant permission', slug }
+    other_permissions.each { |slug| include_examples 'deny permission', slug }
+  end
+
+  permissions :view_flipper_ui? do
+    allowed_permissions = %i[
+      view_flipper_ui
+    ]
+    other_permissions = Permissions::ALL_PERMISSIONS.keys - allowed_permissions
+
+    allowed_permissions.each { |slug| include_examples 'grant permission', slug }
+    other_permissions.each { |slug| include_examples 'deny permission', slug }
+  end
 end


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/173192671

## Because

We want to be able to manage toggling of features in a more convenient and granular fashion.

## This addresses

This PR adds the Flipper gem and associated tooling to start managing feature flags.

### Key Decisions

* **Adapter:** I've chosen to use the ActiveRecord adapter, which creates and manages a couple of `flipper_` database tables.
* **UI:** I've mounted the Flipper UI at `/flipper` behind a new `view_flipper_ui` permission. Like Sidekiq, I have not added this to the superadmin role, and plan to provision this permission manually to users via console.
* **Permissions:** I've chosen not to run our `add_permission_to_role` script because all of these system permissions will be taken care of when we add that `superadmin: true` flag to users that short-circuits our permissions.
* **Navigation:** I've added Sidekiq and Flipper items to the "Manage" section of the dashboard navigation.

### Screenshots

#### Features Dashboard
<img width="1141" alt="Screenshot 2020-06-05 at 4 32 02 PM" src="https://user-images.githubusercontent.com/4241399/83870350-bc31fd80-a74b-11ea-83af-db2fb879b172.png">

#### Feature Editor
<img width="1140" alt="Screenshot 2020-06-05 at 4 31 55 PM" src="https://user-images.githubusercontent.com/4241399/83870341-b89e7680-a74b-11ea-8daa-31da0d11fff4.png">

#### New Navigation Items
<img width="976" alt="Screenshot 2020-06-05 at 4 45 15 PM" src="https://user-images.githubusercontent.com/4241399/83870475-f7343100-a74b-11ea-8e10-51027b314f5b.png">
