### PR TITLE
Add back link text for overdue download

### DIFF
--- a/app/views/layouts/overdue.html.erb
+++ b/app/views/layouts/overdue.html.erb
@@ -82,8 +82,9 @@
       <section class="mt-5">
         <% if current_facility %>
           <% if @patient_summaries.present? && policy([:overdue_list, @patient_summaries.first]).download? %>
+            <h4>Download</h4>
             <%= link_to(@index_params.merge(format: "csv"), class: "", data: { confirm: I18n.t('admin.phi_download_alert') }) do %>
-              <h4>Download</h4>
+              Download Results
             <% end %>
           <% end %>
         <% else %>

--- a/app/views/layouts/overdue.html.erb
+++ b/app/views/layouts/overdue.html.erb
@@ -82,8 +82,8 @@
       <section class="mt-5">
         <% if current_facility %>
           <% if @patient_summaries.present? && policy([:overdue_list, @patient_summaries.first]).download? %>
-            <h4>Download</h4>
             <%= link_to(@index_params.merge(format: "csv"), class: "", data: { confirm: I18n.t('admin.phi_download_alert') }) do %>
+              <h4>Download</h4>
             <% end %>
           <% end %>
         <% else %>


### PR DESCRIPTION
**Story card:** n/a quick bug fix

<img width="855" alt="image" src="https://user-images.githubusercontent.com/69/84049958-b2d6aa00-a972-11ea-83c4-d0da9f9eca42.png">


## Because

Fixing the download for overdue listing

## This addresses

Making sure we have a link text
