### PR TITLE
One-off script to remove view_adherence_follow_up_list permissions

### DIFF
--- a/lib/tasks/one-off/delete_adherence_permissions.rake
+++ b/lib/tasks/one-off/delete_adherence_permissions.rake
@@ -1,0 +1,6 @@
+namespace :permissions do
+  desc "Delete view_adherence_follow_up_list permissions"
+  task delete_view_adherence_follow_up_list: :environment do
+    UserPermission.where(permission_slug: "view_adherence_follow_up_list").destroy_all
+  end
+end


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/173195726

## Because

We're removing this permission in #1048 and don't want anything to break because this "invalid" permission exists.

## This addresses

This deletes any `UserPermission` record where the `permission_slug == 'view_adherence_follow_up_list'`.

**This should be run before merging/deploying #1048.**
