### PR TITLE
Small fixes to Patient Lookup

### DIFF
--- a/app/policies/overdue_list/patient_policy.rb
+++ b/app/policies/overdue_list/patient_policy.rb
@@ -17,7 +17,7 @@ class OverdueList::PatientPolicy < ApplicationPolicy
       facility_ids = facility_ids_for_permission(:view_overdue_list)
       return scope.all unless facility_ids.present?
 
-      scope.where(facility_id: facility_ids)
+      scope.where(registration_facility_id: facility_ids)
     end
   end
 end

--- a/app/views/patients/lookup.html.erb
+++ b/app/views/patients/lookup.html.erb
@@ -16,7 +16,7 @@
               selected: @facility_id,
               wrapper: false
           },
-          { onchange: "this.form.submit();" }
+          {onchange: "this.form.submit();"}
       %>
     </div>
 
@@ -38,7 +38,10 @@
 
         <span class="text-secondary">Address:</span>
         <address>
-          <%= patient.address.street_address %><br/>
+          <% if patient.address.has_street_address? %>
+            <%= patient.address.street_address %><br/>
+          <% end %>
+
           <%= patient.address.village_or_colony %><br/>
           <%= patient.address.district %><br/>
           <%= patient.address.state %>
@@ -46,7 +49,7 @@
 
         <div>
           <span class="text-secondary">Registered at:</span>
-          <%= patient.registration_facility.name %>
+          <%= patient.registration_facility&.name || "Unknown" %>
         </div>
         <div>
           <span class="text-secondary">District:</span>

--- a/spec/policies/overdue_list/patient_policy_spec.rb
+++ b/spec/policies/overdue_list/patient_policy_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe OverdueList::PatientPolicy do
+  subject { described_class }
+
+  let(:patient) { build(:patient) }
+
+  context "user with permission to view overdue list" do
+    let(:user_with_permission) do
+      create(:admin, user_permissions: [
+        build(:user_permission, permission_slug: :view_overdue_list)
+      ])
+    end
+
+    permissions :lookup? do
+      it "permits the user" do
+        expect(subject).to permit(user_with_permission, Patient)
+      end
+    end
+  end
+end
+
+RSpec.describe OverdueList::PatientPolicy::Scope do
+  let(:subject) { described_class }
+
+  let(:organization) { create(:organization) }
+  let(:facility_group) { create(:facility_group, organization: organization) }
+
+  let(:facility1) { create(:facility, facility_group: facility_group) }
+  let(:facility2) { create(:facility) }
+
+  let!(:patient1) { create(:patient, registration_facility: facility1) }
+  let!(:patient2) { create(:patient, registration_facility: facility2) }
+  let!(:patient3) { create(:patient) }
+
+  context "user with permission to access patient information for all organizations" do
+    let(:user) do
+      create(:admin, user_permissions: [
+        build(:user_permission, permission_slug: :view_overdue_list)
+      ])
+    end
+
+    it "resolves all patients for users who can access appointment information for all organizations" do
+      resolved_records = subject.new(user, Patient).resolve
+      expect(resolved_records).to match_array(Patient.all)
+    end
+  end
+
+  context "user with permission to access patient information for an organization" do
+    let(:user) do
+      create(:admin, user_permissions: [
+        build(:user_permission, permission_slug: :view_overdue_list, resource: organization)
+      ])
+    end
+
+    it "resolves all patients in the organization" do
+      resolved_records = subject.new(user, Patient).resolve
+      expect(resolved_records).to match_array(Patient.where(registration_facility: organization.facilities))
+    end
+  end
+
+  context "user with permission to access patient information for a facility group" do
+    let(:user) do
+      create(:admin, user_permissions: [
+        build(:user_permission, permission_slug: :view_overdue_list, resource: facility_group)
+      ])
+    end
+
+    it "resolves all patients in the facility group" do
+      resolved_records = subject.new(user, Patient).resolve
+      expect(resolved_records).to match_array(Patient.where(registration_facility: facility_group.facilities))
+    end
+  end
+
+  context "other users" do
+    let(:other_user) { create(:user) }
+
+    it "resolves no appointments other users" do
+      resolved_records = subject.new(other_user, Patient).resolve
+      expect(resolved_records).to match_array(Patient.none)
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** N/A

## Because

1. The page breaks because some patients don't have a registration_facility attached (probably card-reader patients). [Ref](https://sentry.io/organizations/resolve-to-save-lives/issues/1731043039/?environment=production&project=1217715&query=is%3Aunresolved)
2. Users who are not admins could not access the page because finer-grained resolution on `PatientPolicy` for overdue permission was broken. [Ref](https://sentry.io/organizations/resolve-to-save-lives/issues/1735134150/?environment=production&project=1217715&query=is%3Aunresolved).

## This addresses

1. Safe navigate.
2. The scope on Patient for facility is called `registration_facility` not `facility`.
