### PR TITLE
Support medication history in line lists

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -188,7 +188,7 @@ class Patient < ApplicationRecord
     super(new_call_result)
   end
 
-  def prescribed_drugs(date: Date.today)
+  def prescribed_drugs(date: Date.current)
     prescription_drugs.prescribed_as_of(date)
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -188,6 +188,10 @@ class Patient < ApplicationRecord
     super(new_call_result)
   end
 
+  def prescribed_drugs(date: Date.current)
+    prescription_drugs.prescribed_as_on(date: date)
+  end
+
   def self.not_contacted
     where(contacted_by_counsellor: false)
       .where(could_not_contact_reason: nil)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -189,7 +189,7 @@ class Patient < ApplicationRecord
   end
 
   def prescribed_drugs(date: Date.today)
-    prescription_drugs.prescribed_as_on(date: date)
+    prescription_drugs.prescribed_as_of(date)
   end
 
   def self.not_contacted

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -188,7 +188,7 @@ class Patient < ApplicationRecord
     super(new_call_result)
   end
 
-  def prescribed_drugs(date: Date.current)
+  def prescribed_drugs(date: Date.today)
     prescription_drugs.prescribed_as_on(date: date)
   end
 

--- a/app/models/prescription_drug.rb
+++ b/app/models/prescription_drug.rb
@@ -13,6 +13,13 @@ class PrescriptionDrug < ApplicationRecord
   validates :is_protocol_drug, inclusion: {in: [true, false]}
   validates :is_deleted, inclusion: {in: [true, false]}
 
+  def self.prescribed_as_on(date: Date.today)
+    where("device_created_at < ?", date.end_of_day)
+      .where(%(prescription_drugs.is_deleted = false OR
+              (prescription_drugs.is_deleted = true AND
+               prescription_drugs.device_updated_at > ?)), date.end_of_day)
+  end
+
   def anonymized_data
     {id: hash_uuid(id),
      patient_id: hash_uuid(patient_id),

--- a/app/models/prescription_drug.rb
+++ b/app/models/prescription_drug.rb
@@ -13,7 +13,7 @@ class PrescriptionDrug < ApplicationRecord
   validates :is_protocol_drug, inclusion: {in: [true, false]}
   validates :is_deleted, inclusion: {in: [true, false]}
 
-  def self.prescribed_as_on(date: Date.today)
+  def self.prescribed_as_of(date)
     where("device_created_at <= ?", date.end_of_day)
       .where(%(prescription_drugs.is_deleted = false OR
               (prescription_drugs.is_deleted = true AND

--- a/app/models/prescription_drug.rb
+++ b/app/models/prescription_drug.rb
@@ -14,7 +14,7 @@ class PrescriptionDrug < ApplicationRecord
   validates :is_deleted, inclusion: {in: [true, false]}
 
   def self.prescribed_as_on(date: Date.today)
-    where("device_created_at < ?", date.end_of_day)
+    where("device_created_at <= ?", date.end_of_day)
       .where(%(prescription_drugs.is_deleted = false OR
               (prescription_drugs.is_deleted = true AND
                prescription_drugs.device_updated_at > ?)), date.end_of_day)

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -414,6 +414,22 @@ describe Patient, type: :model do
         expect(patient.reload.latest_mobile_number).to eq(number_1.number)
       end
     end
+
+    describe "#prescribed_drugs" do
+      let!(:date) { Date.parse "01-01-2020" }
+
+      it "returns the prescribed drugs for a patient as of a date" do
+        dbl = double("patient.prescribed_as_of")
+        allow(patient.prescription_drugs).to receive(:prescribed_as_of).and_return dbl
+
+        expect(patient.prescribed_drugs(date: date)).to be dbl
+      end
+
+      it "defaults to current date when no date is passed" do
+        expect(patient.prescription_drugs).to receive(:prescribed_as_of).with(Date.current)
+        patient.prescribed_drugs
+      end
+    end
   end
 
   context "Virtual params" do

--- a/spec/models/prescription_drug_spec.rb
+++ b/spec/models/prescription_drug_spec.rb
@@ -19,14 +19,16 @@ RSpec.describe PrescriptionDrug, type: :model do
       prescription_drug.update(is_deleted: true, device_updated_at: time)
     end
 
-    let!(:facility) { create(:facility) }
     let!(:patient) { create(:patient) }
-    let!(:user) { create(:user) }
     let!(:initial_visit_time) { Time.parse "01 Jan 2020 14:30" }
     let!(:latest_visit_time) { Time.parse "15 Jan 2020 14:30" }
     let!(:prescription_drugs) do
       Timecop.freeze(initial_visit_time) do
-        create_list(:prescription_drug, 2, is_protocol_drug: true, patient: patient, facility: facility, user: user)
+        create_list(:prescription_drug, 2,
+          is_protocol_drug: true,
+          patient: patient,
+          facility: patient.registration_facility,
+          user: patient.registration_user)
       end
     end
 
@@ -66,13 +68,13 @@ RSpec.describe PrescriptionDrug, type: :model do
         prescription_drug = create(:prescription_drug)
 
         anonymised_data =
-          {id: Hashable.hash_uuid(prescription_drug.id),
-           patient_id: Hashable.hash_uuid(prescription_drug.patient_id),
-           created_at: prescription_drug.created_at,
-           registration_facility_name: prescription_drug.facility.name,
-           user_id: Hashable.hash_uuid(prescription_drug.patient.registration_user.id),
-           medicine_name: prescription_drug.name,
-           dosage: prescription_drug.dosage}
+            {id: Hashable.hash_uuid(prescription_drug.id),
+             patient_id: Hashable.hash_uuid(prescription_drug.patient_id),
+             created_at: prescription_drug.created_at,
+             registration_facility_name: prescription_drug.facility.name,
+             user_id: Hashable.hash_uuid(prescription_drug.patient.registration_user.id),
+             medicine_name: prescription_drug.name,
+             dosage: prescription_drug.dosage}
 
         expect(prescription_drug.anonymized_data).to eq anonymised_data
       end

--- a/spec/models/prescription_drug_spec.rb
+++ b/spec/models/prescription_drug_spec.rb
@@ -68,13 +68,13 @@ RSpec.describe PrescriptionDrug, type: :model do
         prescription_drug = create(:prescription_drug)
 
         anonymised_data =
-            {id: Hashable.hash_uuid(prescription_drug.id),
-             patient_id: Hashable.hash_uuid(prescription_drug.patient_id),
-             created_at: prescription_drug.created_at,
-             registration_facility_name: prescription_drug.facility.name,
-             user_id: Hashable.hash_uuid(prescription_drug.patient.registration_user.id),
-             medicine_name: prescription_drug.name,
-             dosage: prescription_drug.dosage}
+          {id: Hashable.hash_uuid(prescription_drug.id),
+           patient_id: Hashable.hash_uuid(prescription_drug.patient_id),
+           created_at: prescription_drug.created_at,
+           registration_facility_name: prescription_drug.facility.name,
+           user_id: Hashable.hash_uuid(prescription_drug.patient.registration_user.id),
+           medicine_name: prescription_drug.name,
+           dosage: prescription_drug.dosage}
 
         expect(prescription_drug.anonymized_data).to eq anonymised_data
       end

--- a/spec/models/prescription_drug_spec.rb
+++ b/spec/models/prescription_drug_spec.rb
@@ -14,6 +14,52 @@ RSpec.describe PrescriptionDrug, type: :model do
     it_behaves_like "a record that is deletable"
   end
 
+  describe ".prescribed_as_on" do
+    def remove_drug(prescription_drug, time)
+      prescription_drug.update(is_deleted: true, device_updated_at: time)
+    end
+
+    let!(:facility) { create(:facility) }
+    let!(:patient) { create(:patient) }
+    let!(:user) { create(:user) }
+    let!(:initial_visit_time) { Time.parse "01 Jan 2020 14:30" }
+    let!(:latest_visit_date) { Time.parse "15 Jan 2020 14:30" }
+    let!(:prescription_drugs) do
+      Timecop.freeze(initial_visit_time) do
+        create_list(:prescription_drug, 2, is_protocol_drug: true, patient: patient, facility: facility, user: user)
+      end
+    end
+
+    it "returns no prescription drugs for dates before the initial visit" do
+      expect(described_class.prescribed_as_on(date: initial_visit_time.to_date - 1.day)).to be_empty
+    end
+
+    it "returns all prescription drugs for the day of initial visit" do
+      expect(described_class.prescribed_as_on(date: initial_visit_time.to_date)).to match_array prescription_drugs
+    end
+
+    it "returns all prescription drugs for later visit dates" do
+      expect(described_class.prescribed_as_on(date: latest_visit_date)).to match_array prescription_drugs
+    end
+
+    context "when a drug is removed in a visit" do
+      let!(:visit_time) { Time.parse "10 Jan 2020 14:30" }
+      before { remove_drug(prescription_drugs.first, visit_time) }
+
+      it "returns all prescription drugs for dates before the visit" do
+        expect(described_class.prescribed_as_on(date: visit_time.to_date - 1.day)).to match_array prescription_drugs
+      end
+
+      it "does not return the removed prescription drug for the visit date" do
+        expect(described_class.prescribed_as_on(date: visit_time.to_date)).to contain_exactly prescription_drugs.second
+      end
+
+      it "does not return the removed prescription drug on later visit dates" do
+        expect(described_class.prescribed_as_on(date: latest_visit_date)).to contain_exactly prescription_drugs.second
+      end
+    end
+  end
+
   context "anonymised data for prescription drugs" do
     describe "anonymized_data" do
       it "correctly retrieves the anonymised data for the prescription drug" do

--- a/spec/models/prescription_drug_spec.rb
+++ b/spec/models/prescription_drug_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe PrescriptionDrug, type: :model do
     let!(:patient) { create(:patient) }
     let!(:user) { create(:user) }
     let!(:initial_visit_time) { Time.parse "01 Jan 2020 14:30" }
-    let!(:latest_visit_date) { Time.parse "15 Jan 2020 14:30" }
+    let!(:latest_visit_time) { Time.parse "15 Jan 2020 14:30" }
     let!(:prescription_drugs) do
       Timecop.freeze(initial_visit_time) do
         create_list(:prescription_drug, 2, is_protocol_drug: true, patient: patient, facility: facility, user: user)
@@ -39,7 +39,7 @@ RSpec.describe PrescriptionDrug, type: :model do
     end
 
     it "returns all prescription drugs for later visit dates" do
-      expect(described_class.prescribed_as_on(date: latest_visit_date)).to match_array prescription_drugs
+      expect(described_class.prescribed_as_on(date: latest_visit_time.to_date)).to match_array prescription_drugs
     end
 
     context "when a drug is removed in a visit" do
@@ -55,7 +55,7 @@ RSpec.describe PrescriptionDrug, type: :model do
       end
 
       it "does not return the removed prescription drug on later visit dates" do
-        expect(described_class.prescribed_as_on(date: latest_visit_date)).to contain_exactly prescription_drugs.second
+        expect(described_class.prescribed_as_on(date: latest_visit_time.to_date)).to contain_exactly prescription_drugs.second
       end
     end
   end

--- a/spec/models/prescription_drug_spec.rb
+++ b/spec/models/prescription_drug_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe PrescriptionDrug, type: :model do
     it_behaves_like "a record that is deletable"
   end
 
-  describe ".prescribed_as_on" do
+  describe ".prescribed_as_of" do
     def remove_drug(prescription_drug, time)
       prescription_drug.update(is_deleted: true, device_updated_at: time)
     end
@@ -33,15 +33,15 @@ RSpec.describe PrescriptionDrug, type: :model do
     end
 
     it "returns no prescription drugs for dates before the initial visit" do
-      expect(described_class.prescribed_as_on(date: initial_visit_time.to_date - 1.day)).to be_empty
+      expect(described_class.prescribed_as_of(date: initial_visit_time.to_date - 1.day)).to be_empty
     end
 
     it "returns all prescription drugs for the day of initial visit" do
-      expect(described_class.prescribed_as_on(date: initial_visit_time.to_date)).to match_array prescription_drugs
+      expect(described_class.prescribed_as_of(date: initial_visit_time.to_date)).to match_array prescription_drugs
     end
 
     it "returns all prescription drugs for later visit dates" do
-      expect(described_class.prescribed_as_on(date: latest_visit_time.to_date)).to match_array prescription_drugs
+      expect(described_class.prescribed_as_of(date: latest_visit_time.to_date)).to match_array prescription_drugs
     end
 
     context "when a drug is removed in a visit" do
@@ -49,15 +49,15 @@ RSpec.describe PrescriptionDrug, type: :model do
       before { remove_drug(prescription_drugs.first, visit_time) }
 
       it "returns all prescription drugs for dates before the visit" do
-        expect(described_class.prescribed_as_on(date: visit_time.to_date - 1.day)).to match_array prescription_drugs
+        expect(described_class.prescribed_as_of(date: visit_time.to_date - 1.day)).to match_array prescription_drugs
       end
 
       it "does not return the removed prescription drug for the visit date" do
-        expect(described_class.prescribed_as_on(date: visit_time.to_date)).to contain_exactly prescription_drugs.second
+        expect(described_class.prescribed_as_of(date: visit_time.to_date)).to contain_exactly prescription_drugs.second
       end
 
       it "does not return the removed prescription drug on later visit dates" do
-        expect(described_class.prescribed_as_on(date: latest_visit_time.to_date)).to contain_exactly prescription_drugs.second
+        expect(described_class.prescribed_as_of(date: latest_visit_time.to_date)).to contain_exactly prescription_drugs.second
       end
     end
   end

--- a/spec/models/prescription_drug_spec.rb
+++ b/spec/models/prescription_drug_spec.rb
@@ -33,15 +33,15 @@ RSpec.describe PrescriptionDrug, type: :model do
     end
 
     it "returns no prescription drugs for dates before the initial visit" do
-      expect(described_class.prescribed_as_of(date: initial_visit_time.to_date - 1.day)).to be_empty
+      expect(described_class.prescribed_as_of(initial_visit_time.to_date - 1.day)).to be_empty
     end
 
     it "returns all prescription drugs for the day of initial visit" do
-      expect(described_class.prescribed_as_of(date: initial_visit_time.to_date)).to match_array prescription_drugs
+      expect(described_class.prescribed_as_of(initial_visit_time.to_date)).to match_array prescription_drugs
     end
 
     it "returns all prescription drugs for later visit dates" do
-      expect(described_class.prescribed_as_of(date: latest_visit_time.to_date)).to match_array prescription_drugs
+      expect(described_class.prescribed_as_of(latest_visit_time.to_date)).to match_array prescription_drugs
     end
 
     context "when a drug is removed in a visit" do
@@ -49,15 +49,15 @@ RSpec.describe PrescriptionDrug, type: :model do
       before { remove_drug(prescription_drugs.first, visit_time) }
 
       it "returns all prescription drugs for dates before the visit" do
-        expect(described_class.prescribed_as_of(date: visit_time.to_date - 1.day)).to match_array prescription_drugs
+        expect(described_class.prescribed_as_of(visit_time.to_date - 1.day)).to match_array prescription_drugs
       end
 
       it "does not return the removed prescription drug for the visit date" do
-        expect(described_class.prescribed_as_of(date: visit_time.to_date)).to contain_exactly prescription_drugs.second
+        expect(described_class.prescribed_as_of(visit_time.to_date)).to contain_exactly prescription_drugs.second
       end
 
       it "does not return the removed prescription drug on later visit dates" do
-        expect(described_class.prescribed_as_of(date: latest_visit_time.to_date)).to contain_exactly prescription_drugs.second
+        expect(described_class.prescribed_as_of(latest_visit_time.to_date)).to contain_exactly prescription_drugs.second
       end
     end
   end


### PR DESCRIPTION
**Story card:** https://www.pivotaltracker.com/story/show/173464679

## Because

We want to expose medication histories for patients to our users. [PRD: Medication History](https://docs.google.com/document/d/1lJo9jLlPPDjBFJ12tBGgdF-22rCGhNiVkquG7u9hBbo). 

## This addresses

This adds a method to `PrescriptionDrug` that returns the `active` prescription drugs for a patient on a given date. This can be used to construct what the medications looked like for each visit in the line list.
