### PR TITLE
Fix WhatsApp Twilio delivery status

### DIFF
--- a/app/controllers/api/v3/twilio_sms_delivery_controller.rb
+++ b/app/controllers/api/v3/twilio_sms_delivery_controller.rb
@@ -21,7 +21,7 @@ class Api::V3::TwilioSmsDeliveryController < ApplicationController
   end
 
   def delivery_status
-    params["SmsStatus"] || params["MessageStatus"] || TwilioSmsDeliveryDetail.results[:unknown]
+    params["MessageStatus"] || params["SmsStatus"] || TwilioSmsDeliveryDetail.results[:unknown]
   end
 
   def validate_request

--- a/app/controllers/api/v3/twilio_sms_delivery_controller.rb
+++ b/app/controllers/api/v3/twilio_sms_delivery_controller.rb
@@ -3,7 +3,7 @@ class Api::V3::TwilioSmsDeliveryController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def create
-    TwilioSmsDeliveryDetail.where(session_id: params["SmsSid"]).first.update(update_params)
+    TwilioSmsDeliveryDetail.where(session_id: message_session_id).first.update(update_params)
     head :ok
   end
 
@@ -14,6 +14,10 @@ class Api::V3::TwilioSmsDeliveryController < ApplicationController
     details[:delivered_on] = DateTime.current if delivery_status == TwilioSmsDeliveryDetail.results[:delivered]
 
     details
+  end
+
+  def message_session_id
+    params["MessageSid"] || params["SmsSid"]
   end
 
   def delivery_status

--- a/spec/controllers/api/v3/twilio_sms_delivery_controller_spec.rb
+++ b/spec/controllers/api/v3/twilio_sms_delivery_controller_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe Api::V3::TwilioSmsDeliveryController, type: :controller do
           create(:twilio_sms_delivery_detail,
             session_id: session_id,
             result: "queued")
-          params = base_callback_params.merge("SmsSid" => session_id,
-                                              "SmsStatus" => "sent")
+          params = base_callback_params.except("MessageSid", "MessageStatus")
+                                       .merge("SmsSid" => session_id, "SmsStatus" => "sent")
 
           set_twilio_signature_header(callback_url, params)
           post :create, params: params

--- a/spec/controllers/api/v3/twilio_sms_delivery_controller_spec.rb
+++ b/spec/controllers/api/v3/twilio_sms_delivery_controller_spec.rb
@@ -8,12 +8,14 @@ end
 RSpec.describe Api::V3::TwilioSmsDeliveryController, type: :controller do
   describe "#create" do
     let!(:callback_url) { api_v3_twilio_sms_delivery_url(host: request.host) }
+
+    let(:base_session_id) { SecureRandom.uuid }
     let!(:base_callback_params) do
-      {"SmsSid" => SecureRandom.uuid,
+      {"SmsSid" => base_session_id,
        "SmsStatus" => "delivered",
+       "MessageSid" => base_session_id,
        "MessageStatus" => "delivered",
        "To" => Faker::PhoneNumber.phone_number,
-       "MessageSid" => SecureRandom.uuid,
        "AccountSid" => SecureRandom.uuid,
        "From" => "+15005550006",
        "ApiVersion" => "2010-04-01"}
@@ -25,7 +27,7 @@ RSpec.describe Api::V3::TwilioSmsDeliveryController, type: :controller do
         create(:twilio_sms_delivery_detail,
           session_id: session_id,
           result: "queued")
-        params = base_callback_params.merge("SmsSid" => session_id)
+        params = base_callback_params.merge("MessageSid" => session_id)
         set_twilio_signature_header(callback_url, params)
         post :create, params: params
 
@@ -33,7 +35,7 @@ RSpec.describe Api::V3::TwilioSmsDeliveryController, type: :controller do
       end
 
       context "TwilioSmsDeliveryDetail" do
-        it "updates the result" do
+        it "updates the result for SmsSid and SmsStatus" do
           session_id = SecureRandom.uuid
           create(:twilio_sms_delivery_detail,
             session_id: session_id,
@@ -48,13 +50,28 @@ RSpec.describe Api::V3::TwilioSmsDeliveryController, type: :controller do
           expect(twilio_sms_delivery_detail.result).to eq("sent")
         end
 
+        it "updates the result for MessageSid and MessageStatus" do
+          session_id = SecureRandom.uuid
+          create(:twilio_sms_delivery_detail,
+            session_id: session_id,
+            result: "queued")
+          params = base_callback_params.merge("MessageSid" => session_id,
+                                              "MessageStatus" => "sent")
+
+          set_twilio_signature_header(callback_url, params)
+          post :create, params: params
+
+          twilio_sms_delivery_detail = TwilioSmsDeliveryDetail.find_by_session_id(session_id)
+          expect(twilio_sms_delivery_detail.result).to eq("sent")
+        end
+
         it "updates the result and delivered_on" do
           session_id = SecureRandom.uuid
           create(:twilio_sms_delivery_detail,
             session_id: session_id,
             result: "sent")
-          params = base_callback_params.merge("SmsSid" => session_id,
-                                              "SmsStatus" => "delivered")
+          params = base_callback_params.merge("MessageSid" => session_id,
+                                              "MessageStatus" => "delivered")
 
           set_twilio_signature_header(callback_url, params)
           post :create, params: params
@@ -69,8 +86,8 @@ RSpec.describe Api::V3::TwilioSmsDeliveryController, type: :controller do
           create(:twilio_sms_delivery_detail,
             session_id: session_id,
             result: "queued")
-          params = base_callback_params.merge("SmsSid" => session_id,
-                                              "SmsStatus" => "sent")
+          params = base_callback_params.merge("MessageSid" => session_id,
+                                              "MessageStatus" => "sent")
 
           set_twilio_signature_header(callback_url, params)
           post :create, params: params


### PR DESCRIPTION
**Story card:** none

## Because

We need to capture Twilio session IDs to handle delivery status notifications, and WhatsApp uses `MessageSid` instead of `SmsSid`.

## This addresses

This hotfix allows us to accept both values.
