### PR TITLE
Update 'Benchmarks' card styling

### DIFF
--- a/app/assets/stylesheets/partials/_reports.scss
+++ b/app/assets/stylesheets/partials/_reports.scss
@@ -48,16 +48,17 @@
   .d-lg-none { display: none; }
   .d-lg-flex { display: flex; }
   // Flexbox
-  .fd-lg-column { flex-direction: column; }
+  .direction-lg-column { flex-direction: column; }
   .flex-lg-1 { flex: 1; }
   .flex-lg-2 { flex: 2; }
   .flex-lg-3 { flex: 3; }
   .flex-lg-4 { flex: 4; }
   .align-lg-center { align-items: center; }
+  .align-lg-baseline { align-items: baseline; }
   .justify-lg-end { justify-content: flex-end; }
   .justify-lg-center { justify-content: center; }
   .justify-lg-between { justify-content: space-between; }
-  .flex-lg-wrap { flex-wrap: wrap; }
+  .wrap-lg-wrap { flex-wrap: wrap; }
   .order-lg-1 { order: 1; }
   .order-lg-2 { order: 2; }
   .order-lg-3 { order: 3; }
@@ -70,7 +71,11 @@
   .mb-lg-0 { margin-bottom: 0; }
   .pb-lg-0 { padding-bottom: 0; }
   // Typography
+  .fs-lg-small { font-size: 14px; }
+  .fw-lg-bold { font-weight: 700; }
+  .ls-lg-1px { letter-spacing: 1px; }
   .ta-lg-center { text-align: center; }
+  .tt-lg-uppercase { text-transform: uppercase; }
   .c-lg-grey-dark { color: $grey-dark; }
   // Borders
   .br-lg { border-right: 1px solid; }

--- a/app/views/dashboard/districts/show.html.erb
+++ b/app/views/dashboard/districts/show.html.erb
@@ -11,9 +11,9 @@
     </h1>
   </div>
 </div>
-<div class="d-lg-flex flex-lg-wrap">
+<div class="d-lg-flex wrap-lg-wrap">
   <div class="d-lg-flex order-lg-1 w-lg-50 pr-lg-2">
-    <div class="card pb-4 d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0">
+    <div class="card pb-4 d-lg-flex direction-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0">
       <div>
         <div class="mb-2">
           <h3>
@@ -225,46 +225,38 @@
   </div>
   <div class="d-lg-flex order-lg-2 w-lg-50 pl-lg-2">
     <div class="card pb-4 h-lg-full w-lg-full mt-lg-0">
-      <div class="mb-2">
-        <h3>
-          Benchmarks
-        </h3>
+      <div class="mb-3 d-lg-flex align-lg-baseline bb-1px bb-grey-light mb-lg-0 pb-lg-3">
+        <div class="flex-lg-2 align-lg-center justify-lg-center">
+          <h3 class="mb-lg-0 pb-lg-0">
+            Benchmarks
+          </h3>
+        </div>
+        <div class="d-none d-lg-block flex-lg-1 align-lg-center justify-lg-center">
+          <p class="fs-lg-small fw-lg-bold ls-lg-1px tt-lg-uppercase ta-lg-center mb-lg-0 c-lg-grey-dark">
+            Top district
+          </p>
+        </div>
+        <div class="d-none d-lg-block flex-lg-1 align-lg-center justify-lg-center">
+          <p class="fs-lg-small fw-lg-bold ls-lg-1px tt-lg-uppercase ta-lg-center mb-lg-0 c-lg-grey-dark">
+            <%= @district.name %>
+          </p>
+        </div>
+        <div class="d-none d-lg-block flex-lg-1 align-lg-center justify-lg-center">
+        </div>
       </div>
       <div>
-        <div class="d-none d-lg-block d-lg-flex bb-1px bb-grey-light">
-          <div class="pt-lg-4 pb-lg-4 flex-lg-2 align-lg-center justify-lg-center br-lg br-lg-grey-light">
-            <p class="mb-lg-0 c-lg-grey-dark">
-              Benchmark
-            </p>
-          </div>
-          <div class="pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center br-lg br-lg-grey-light">
-            <p class="ta-lg-center mb-lg-0 c-lg-grey-dark">
-              Top district
-            </p>
-          </div>
-          <div class="pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center br-lg br-lg-grey-light">
-            <p class="ta-lg-center mb-lg-0 c-lg-grey-dark">
-              <%= @district.name %>
-            </p>
-          </div>
-          <div class="pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center">
-            <p class="ta-lg-center mb-lg-0 c-lg-grey-dark">
-              Difference
-            </p>
-          </div>
-        </div>
         <div class="mb-3 pb-3 bb-1px bb-grey-light d-lg-flex mb-lg-0 pb-lg-0">
-          <div class="mb-1 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-2 align-lg-center justify-lg-center br-lg br-lg-grey-light">
+          <div class="mb-1 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-2 align-lg-center justify-lg-center">
             <p class="mb-0 ls-145">
               Control of registered patients
             </p>
           </div>
-          <div class="mb-0 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center br-lg br-lg-grey-light">
+          <div class="mb-0 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center">
             <p class="mb-0 ta-lg-center c-grey-dark">
               <span class="fw-bold d-lg-none">Bathinda: </span> Coming Soon...
             </p>
           </div>
-          <div class="mb-0 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center br-lg br-lg-grey-light">
+          <div class="mb-0 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center">
             <p class="mb-0 ta-lg-center c-grey-dark">
               <span class="fw-bold d-lg-none">Top district: </span> Coming Soon...
             </p>
@@ -276,17 +268,17 @@
           </div>
         </div>
         <div class="mb-3 pb-3 bb-1px bb-grey-light d-lg-flex mb-lg-0 pb-lg-0">
-          <div class="mb-1 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-2 align-lg-center justify-lg-center br-lg br-lg-grey-light">
+          <div class="mb-1 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-2 align-lg-center justify-lg-center">
             <p class="mb-0 ls-145">
               Q2 cohort BP control
             </p>
           </div>
-          <div class="mb-0 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center br-lg br-lg-grey-light">
+          <div class="mb-0 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center">
             <p class="mb-0 ta-lg-center c-grey-dark">
               <span class="fw-bold d-lg-none">Bathinda: </span> Coming Soon...
             </p>
           </div>
-          <div class="mb-0 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center br-lg br-lg-grey-light">
+          <div class="mb-0 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center">
             <p class="mb-0 ta-lg-center c-grey-dark">
               <span class="fw-bold d-lg-none">Top district: </span> Coming Soon...
             </p>
@@ -298,17 +290,17 @@
           </div>
         </div>
         <div class="d-lg-flex mb-lg-0 pb-lg-0">
-          <div class="mb-1 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-2 align-lg-center justify-lg-center br-lg br-lg-grey-light">
+          <div class="mb-1 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-2 align-lg-center justify-lg-center">
             <p class="mb-0 ls-145">
               Q2 cohort missed visit
             </p>
           </div>
-          <div class="mb-0 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center br-lg br-lg-grey-light">
+          <div class="mb-0 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center">
             <p class="mb-0 ta-lg-center c-grey-dark">
               <span class="fw-bold d-lg-none">Bathinda: </span> Coming Soon...
             </p>
           </div>
-          <div class="mb-0 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center br-lg br-lg-grey-light">
+          <div class="mb-0 mb-lg-0 pt-lg-4 pb-lg-4 flex-lg-1 align-lg-center justify-lg-center">
             <p class="mb-0 ta-lg-center c-grey-dark">
               <span class="fw-bold d-lg-none">Top district: </span> Coming Soon...
             </p>


### PR DESCRIPTION
## Because

Received a request to match 'Benchmarks' styling designs with [Figma designs](https://www.figma.com/file/9inSvRD4dXcMfXchlyDZVV/Simple-Dashboard?node-id=94%3A509)

## This addresses

**Screenshots**
![image](https://user-images.githubusercontent.com/16785131/85788830-902aec00-b6fb-11ea-913f-1abca333fdd8.png)
![image](https://user-images.githubusercontent.com/16785131/85788872-a33dbc00-b6fb-11ea-801c-81c1acaf17e6.png)

(Made a few minor class naming updates to make them more readable/consistent)
