### PR TITLE
Put dashboard v2 behind a Flipper feature flag

### DIFF
--- a/app/controllers/dashboard/districts_controller.rb
+++ b/app/controllers/dashboard/districts_controller.rb
@@ -1,5 +1,6 @@
 class Dashboard::DistrictsController < AdminController
   layout "application"
+  before_action :feature_flag_required
   skip_after_action :verify_policy_scoped
   around_action :set_time_zone
 
@@ -26,6 +27,10 @@ class Dashboard::DistrictsController < AdminController
   end
 
   private
+
+  def feature_flag_required
+    redirect_to root_url unless current_admin.feature_enabled?(:dashboard_v2)
+  end
 
   def district_params
     params.permit(:selected_date, :id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,6 +73,14 @@ class User < ApplicationRecord
     :authenticatable_salt,
     :invited_to_sign_up?, to: :email_authentication, allow_nil: true
 
+  def feature_enabled?(feature)
+    Flipper.enabled?(feature, self)
+  end
+
+  def flipper_id
+    "User;#{id}"
+  end
+
   def phone_number_authentication
     phone_number_authentications.first
   end

--- a/app/policies/manage/admin/user_policy.rb
+++ b/app/policies/manage/admin/user_policy.rb
@@ -40,7 +40,7 @@ class Manage::Admin::UserPolicy < ApplicationPolicy
   end
 
   def allowed_permissions
-    Permissions::ALL_PERMISSIONS.slice(*user_permissions).values
+    Permissions::ALL_PERMISSIONS.values
   end
 
   class Scope < Scope

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,7 +66,13 @@
                 <li class="nav-item">
                   <%= link_to "Dashboard", root_path, class: "nav-link #{active_controller?("organizations", "facility_groups")}" %>
                 </li>
+                <% if current_admin.feature_enabled?(:dashboard_v2) %>
+                <li class="nav-item">
+                  <%= link_to "Dashboard v2", dashboard_districts_path, class: "nav-link #{active_controller?("organizations", "facility_groups")}" %>
+                </li>
+                <% end %>
               <% end %>
+
 
               <% if policy(:dashboard).overdue_list? %>
                 <li class="nav-item">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,7 +68,7 @@
                 </li>
                 <% if current_admin.feature_enabled?(:dashboard_v2) %>
                 <li class="nav-item">
-                  <%= link_to "Dashboard v2", dashboard_districts_path, class: "nav-link #{active_controller?("organizations", "facility_groups")}" %>
+                  <%= link_to "Dashboard v2", dashboard_districts_path, class: "nav-link #{active_controller?("dashboard/districts")}" %>
                 </li>
                 <% end %>
               <% end %>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -8,7 +8,7 @@
                 <h2><%= organization.name %></h2>
 
 
-                    <% policy_scope([:cohort_report, organization.facility_groups])
+                    <% policy_scope([:cohort_report, organization.facility_groups.includes(:facilities)])
                            .flat_map(&:facilities)
                            .group_by(&:district)
                            .keys

--- a/spec/controllers/dashboard/districts_controller_spec.rb
+++ b/spec/controllers/dashboard/districts_controller_spec.rb
@@ -7,25 +7,45 @@ RSpec.describe Dashboard::DistrictsController, type: :controller do
       user.user_permissions.create!(permission_slug: "view_my_facilities")
     end
   end
+  let(:facility_group) {
+    create(:facility_group, organization: organization).tap { |fg| fg.facilities << build(:facility) }
+  }
+
+  context "feature flag" do
+    it "renders for feature flagged users" do
+      Flipper[:dashboard_v2].enable(supervisor)
+      sign_in(supervisor.email_authentication)
+
+      get :show, params: {id: facility_group.slug}
+      expect(response).to be_successful
+    end
+
+    it "redirects for non feature flagged users" do
+      Flipper[:dashboard_v2].disable(supervisor)
+      sign_in(supervisor.email_authentication)
+      get :show, params: {id: facility_group.slug}
+      expect(response).to be_redirect
+    end
+  end
 
   context "show" do
     render_views
 
     before do
-      @facility_group = create(:facility_group, organization: organization)
-      @facility = create(:facility, name: "CHC Barnagar", facility_group: @facility_group)
+      Flipper[:dashboard_v2].enable(supervisor)
     end
 
     it "retrieves data" do
+      facility = facility_group.facilities.first
       jan_2020 = Time.parse("January 1 2020")
-      patient = create(:patient, registration_facility: @facility, recorded_at: jan_2020.advance(months: -1))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility)
+      patient = create(:patient, registration_facility: facility, recorded_at: jan_2020.advance(months: -1))
+      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: facility)
+      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: facility)
       LatestBloodPressuresPerPatient.refresh
       LatestBloodPressuresPerPatientPerMonth.refresh
 
       sign_in(supervisor.email_authentication)
-      get :show, params: {id: @facility.facility_group.slug}
+      get :show, params: {id: facility_group.slug}
       expect(response).to be_successful
       data = assigns(:data)
       expect(data[:controlled_patients].size).to eq(12) # 1 year of data

--- a/spec/policies/manage/admin/user_policy_spec.rb
+++ b/spec/policies/manage/admin/user_policy_spec.rb
@@ -83,16 +83,10 @@ RSpec.describe Manage::Admin::UserPolicy do
       end
     end
 
-    it "includes all the permissions the user can access" do
+    it "includes all the permissions" do
       allowed_permissions = subject.new(user, nil).allowed_permissions
       expect(allowed_permissions.map { |permission| permission[:slug] })
-        .to match_array(user_permission_slugs)
-    end
-
-    it "does not include other permissions" do
-      allowed_permissions = subject.new(user, nil).allowed_permissions
-      expect(allowed_permissions.map { |permission| permission[:slug] })
-        .not_to include(*(Permissions::ALL_PERMISSIONS.keys - user_permission_slugs))
+        .to match_array(Permissions::ALL_PERMISSIONS.keys)
     end
   end
 


### PR DESCRIPTION
**Story card:** Pivotal card: https://www.pivotaltracker.com/story/show/171110822

## Because

We only want the new dashboards to be turned on for a certain set of users. We also want to be turn on the new dashboard for **all** users when the real production ship date comes.

## This addresses

Putting the new v2 dashboards behind a flipper feature flag, and adding some convenience features to make it easier to turn on.  This includes showing all possible permission levels in the user admin edit screen, because other turning on the "flipper UI" has to be done via rails console, which seems less than desirable.

Here is the top nav bar with the "Dashboard v2" in the header, which will only show for users who have `dashboard_v2` turned on.  Non feature flagged users will see the normal nav bar.

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/69/85906549-43671400-b7d4-11ea-9050-55bb924ea736.png">

The feature should look like this for a set of user(s):

<img width="1156" alt="image" src="https://user-images.githubusercontent.com/69/85906540-3d713300-b7d4-11ea-9d40-45f672a01ba9.png">
