### PR TITLE
Use cohort report permission to authorize

### DIFF
--- a/app/controllers/dashboard/districts_controller.rb
+++ b/app/controllers/dashboard/districts_controller.rb
@@ -6,13 +6,14 @@ class Dashboard::DistrictsController < AdminController
   EXAMPLE_DATA_FILE = "db/data/example_dashboard_data.json"
 
   def index
-    authorize([:manage, Organization])
-    @organizations = policy_scope([:manage, :facility, Organization])
+    authorize(:dashboard, :show?)
+
+    @organizations = policy_scope([:cohort_report, Organization]).order(:name)
   end
 
   def show
     @district = FacilityGroup.find_by(slug: district_params[:id])
-    authorize([:manage, @district])
+    authorize(:dashboard, :show?)
 
     @selected_date = if district_params[:selected_date]
       Time.parse(district_params[:selected_date])

--- a/app/views/dashboard/districts/index.html.erb
+++ b/app/views/dashboard/districts/index.html.erb
@@ -5,7 +5,7 @@
       <section>
         <div class="card">
           <h2><%= organization.name %></h2>
-          <% organization.facility_groups.order(:name).each do |district| %>
+          <% policy_scope([:cohort_report, organization.facility_groups]).order(:name).each do |district| %>
             <%= link_to(dashboard_district_path(district.slug), class: "link-row") do %>
               <i class='fas fa-angle-right light'></i>
               <%= district.name %>


### PR DESCRIPTION
**Story card:** TBD

## Because

The new district dashboards use the `manage organization` permission to authorize. CVHOs and most users don't have this permission.

## This addresses

Use the cohort_report permission to authorize/scope for the new district dashboards. This brings it in line with the existing analytics dashboard permissions, so all users who can currently access the old dashboard will also be able to access the new ones.