### PR TITLE
Quick report fixes

### DIFF
--- a/app/views/dashboard/districts/show.html.erb
+++ b/app/views/dashboard/districts/show.html.erb
@@ -1,3 +1,6 @@
+<div class="alert alert-primary">
+  <span class="fw-bold">Report early access:</span> Thanks for your patience as we improve this page
+</div>
 <div class="dashboard">
   <nav class="breadcrumb">
     <%= link_to 'All reports', dashboard_districts_path %>
@@ -108,7 +111,7 @@
                       data-toggle="tooltip"
                       data-placement="top"
                       data-trigger="hover focus click"
-                      title="<%= number_with_delimiter(registrations[1]) %> total registrations in <%= registrations[0] %>"
+                      title="<%= number_with_delimiter(registrations[1]) %> patients in <%= registrations[0] %>"
                     >
                     </td>
                   </tr>
@@ -308,8 +311,8 @@
             </p>
           </div>
         </div>
-        <div class="mb-3 pb-3 d-lg-flex mb-lg-2 pb-lg-0">
-          <div class="mb-1 mb-lg-0 pt-lg-3 pb-lg-4 flex-lg-2 align-lg-center justify-lg-center">
+        <div class="mb-2 d-lg-flex mb-lg-2 pb-lg-0">
+          <div class="mb-lg-0 pt-lg-3 pb-lg-4 flex-lg-2 align-lg-center justify-lg-center">
             <p class="mb-0 ls-145 c-grey-dark">
               More benchmarks coming soon
             </p>

--- a/app/views/dashboard/districts/show.html.erb
+++ b/app/views/dashboard/districts/show.html.erb
@@ -1,5 +1,5 @@
 <div class="alert alert-primary">
-  <span class="fw-bold">Report early access:</span> Thanks for your patience as we improve this page
+  <span class="fw-bold">Early access:</span> This page is under active development, thanks for your patience as we work on improving it
 </div>
 <div class="dashboard">
   <nav class="breadcrumb">


### PR DESCRIPTION
## Because

Making minor polishes and additions for initial Reports release

## This addresses

* Added alert disclaimer banner, "Report early access: Thanks for your patience as we improve this page"
* Updated 'Cumulative registrations' copy, "1,314 patients in Mar 2020" to match labels used within card
* Removed 'Benchmarks' card bottom spacing for small devices

**Screenshots**

![image](https://user-images.githubusercontent.com/16785131/86263389-2a24e580-bb8f-11ea-9bed-c0a7e3ae7824.png)

![image](https://user-images.githubusercontent.com/16785131/86263326-14afbb80-bb8f-11ea-8290-6d6beb694dc3.png)
