### PR TITLE
Report hotfixes: end of month as time boundary; apply org policy scoping:

### DIFF
--- a/app/controllers/dashboard/districts_controller.rb
+++ b/app/controllers/dashboard/districts_controller.rb
@@ -12,7 +12,6 @@ class Dashboard::DistrictsController < AdminController
   end
 
   def show
-    @organizations = policy_scope([:cohort_report, Organization]).order(:name)
     @district = FacilityGroup.find_by(slug: district_params[:id])
     authorize(:dashboard, :show?)
 

--- a/app/controllers/dashboard/districts_controller.rb
+++ b/app/controllers/dashboard/districts_controller.rb
@@ -12,6 +12,7 @@ class Dashboard::DistrictsController < AdminController
   end
 
   def show
+    @organizations = policy_scope([:cohort_report, Organization]).order(:name)
     @district = FacilityGroup.find_by(slug: district_params[:id])
     authorize(:dashboard, :show?)
 
@@ -20,7 +21,9 @@ class Dashboard::DistrictsController < AdminController
     else
       Date.current.advance(months: -1)
     end
-    @data = DistrictReportService.new(facilities: @district.facilities, selected_date: @selected_date).call
+    @data = DistrictReportService.new(facilities: @district.facilities,
+                                      selected_date: @selected_date,
+                                      organizations: @organizations).call
     @controlled_patients = @data[:controlled_patients]
     @registrations = @data[:registrations]
     @quarterly_registrations = @data[:quarterly_registrations]

--- a/app/controllers/dashboard/districts_controller.rb
+++ b/app/controllers/dashboard/districts_controller.rb
@@ -23,7 +23,7 @@ class Dashboard::DistrictsController < AdminController
     end
     @data = DistrictReportService.new(facilities: @district.facilities,
                                       selected_date: @selected_date,
-                                      organizations: @organizations).call
+                                      current_user: current_user).call
     @controlled_patients = @data[:controlled_patients]
     @registrations = @data[:registrations]
     @quarterly_registrations = @data[:quarterly_registrations]

--- a/app/controllers/dashboard/districts_controller.rb
+++ b/app/controllers/dashboard/districts_controller.rb
@@ -23,7 +23,7 @@ class Dashboard::DistrictsController < AdminController
     end
     @data = DistrictReportService.new(facilities: @district.facilities,
                                       selected_date: @selected_date,
-                                      current_user: current_user).call
+                                      current_user: current_admin).call
     @controlled_patients = @data[:controlled_patients]
     @registrations = @data[:registrations]
     @quarterly_registrations = @data[:quarterly_registrations]

--- a/app/helpers/month_helper.rb
+++ b/app/helpers/month_helper.rb
@@ -23,11 +23,15 @@ module MonthHelper
     Date.civil(year.to_i, moy.to_i)
   end
 
-  def last_n_months(n:, inclusive: false)
+  def last_n_months(n:, inclusive: false, end_of_month: false)
     range = inclusive ? (0..(n - 1)) : (1..n)
 
     range.map do |i|
-      Time.current.beginning_of_month - i.months
+      if end_of_month
+        Time.current.end_of_month - i.months
+      else
+        Time.current.beginning_of_month - i.months
+      end
     end
   end
 end

--- a/app/helpers/month_helper.rb
+++ b/app/helpers/month_helper.rb
@@ -28,9 +28,9 @@ module MonthHelper
 
     range.map do |i|
       if end_of_month
-        Time.current.end_of_month - i.months
+        Time.current.end_of_month.advance(months: -i)
       else
-        Time.current.beginning_of_month - i.months
+        Time.current.beginning_of_month.advance(months: -i)
       end
     end
   end

--- a/app/services/district_report_service.rb
+++ b/app/services/district_report_service.rb
@@ -2,8 +2,9 @@ class DistrictReportService
   include SQLHelpers
   MAX_MONTHS_OF_DATA = 24
 
-  def initialize(facilities:, selected_date:, organizations:)
-    @organizations = organizations
+  def initialize(facilities:, selected_date:, current_user:)
+    @current_user = current_user
+    @organizations = Pundit.policy_scope(current_user, [:cohort_report, Organization]).order(:name)
     @facilities = Array(facilities)
     @selected_date = selected_date.end_of_month
     @data = {
@@ -15,7 +16,11 @@ class DistrictReportService
     }.with_indifferent_access
   end
 
-  attr_reader :selected_date, :facilities, :data, :organizations
+  attr_reader :current_user
+  attr_reader :data
+  attr_reader :facilities
+  attr_reader :organizations
+  attr_reader :selected_date
 
   def call
     compile_control_and_registration_data

--- a/app/views/dashboard/districts/show.html.erb
+++ b/app/views/dashboard/districts/show.html.erb
@@ -15,7 +15,7 @@
       </a>
       <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
         <%= form_tag dashboard_district_path(@district), method: :get do %>
-          <% last_n_months(n: 12).each do |time| %>
+          <% last_n_months(n: 12, end_of_month: true).each do |time| %>
             <% selected = (time.year == @selected_date.year && time.month == @selected_date.month) %>
             <button class="dropdown-item query-filter-month <%= 'active' if selected %>"
                     name="selected_date"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,3 +62,8 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :inline
 end
+
+# Set a longer session timeout to make things easier on developers
+Devise.setup do |config|
+  config.timeout_in = 8.hours
+end

--- a/spec/controllers/dashboard/districts_controller_spec.rb
+++ b/spec/controllers/dashboard/districts_controller_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe Dashboard::DistrictsController, type: :controller do
   let(:organization) { FactoryBot.create(:organization) }
-  let(:supervisor) do
-    create(:admin, :organization_owner, organization: organization).tap do |user|
-      user.user_permissions.create!(permission_slug: "view_my_facilities")
-    end
+  let(:cvho) do
+    create(:admin, :supervisor, organization: organization).tap { |user|
+      user.user_permissions << build(:user_permission, permission_slug: :view_cohort_reports, resource: organization)
+    }
   end
 
   context "show" do
@@ -25,7 +25,7 @@ RSpec.describe Dashboard::DistrictsController, type: :controller do
       LatestBloodPressuresPerPatientPerMonth.refresh
 
       Timecop.freeze("June 1 2020") do
-        sign_in(supervisor.email_authentication)
+        sign_in(cvho.email_authentication)
         get :show, params: {id: @facility.facility_group.slug}
       end
       expect(response).to be_successful

--- a/spec/controllers/dashboard/districts_controller_spec.rb
+++ b/spec/controllers/dashboard/districts_controller_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe Dashboard::DistrictsController, type: :controller do
   let(:organization) { FactoryBot.create(:organization) }
   let(:cvho) do
-    create(:admin, :supervisor, organization: organization).tap { |user|
+    create(:admin, :supervisor, organization: organization).tap do |user|
       user.user_permissions << build(:user_permission, permission_slug: :view_cohort_reports, resource: organization)
-    }
+    end
   end
 
   context "show" do

--- a/spec/services/district_report_service_spec.rb
+++ b/spec/services/district_report_service_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
 
 describe DistrictReportService, type: :model do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, organization: organization) }
   let(:june_1) { Time.parse("June 1, 2020") }
+  let(:organization) { create(:organization, name: "org-1") }
+  let(:facility_group_1) { FactoryBot.create(:facility_group, name: "facility_group_1", organization: organization) }
 
   def refresh_views
     ActiveRecord::Base.transaction do
@@ -11,9 +13,15 @@ describe DistrictReportService, type: :model do
     end
   end
 
+  it "normalizes the selected_date" do
+    service = DistrictReportService.new(facilities: facility_group_1.facilities, selected_date: june_1, organizations: [organization])
+    Timecop.freeze("June 30 2020 5:00 PM EST") do
+      expect(service.selected_date).to eq(june_1.end_of_month)
+    end
+  end
+
   it "correctly returns controlled patients from three month window" do
-    facility_group = FactoryBot.create(:facility_group, name: "Darrang")
-    facilities = FactoryBot.create_list(:facility, 5, facility_group: facility_group)
+    facilities = FactoryBot.create_list(:facility, 5, facility_group: facility_group_1)
     facility = facilities.first
     facility_2 = create(:facility)
 
@@ -48,15 +56,14 @@ describe DistrictReportService, type: :model do
 
     refresh_views
 
-    service = DistrictReportService.new(facilities: facility_group.facilities, selected_date: june_1)
+    service = DistrictReportService.new(facilities: facility_group_1.facilities, selected_date: june_1, organizations: [organization])
     expect(service.controlled_patients_count(jan_1)).to eq(controlled_in_jan_and_june.size)
     june_controlled = controlled_in_jan_and_june << controlled_just_for_june
     expect(service.controlled_patients_count(june_1)).to eq(june_controlled.size)
   end
 
   it "returns counts for last n months for controlled patients and registrations" do
-    facility_group = FactoryBot.create(:facility_group, name: "Darrang")
-    facilities = FactoryBot.create_list(:facility, 5, facility_group: facility_group)
+    facilities = FactoryBot.create_list(:facility, 5, facility_group: facility_group_1)
     facility = facilities.first
 
     jan_2019 = Time.parse("January 1st 2019")
@@ -83,7 +90,7 @@ describe DistrictReportService, type: :model do
 
     refresh_views
 
-    service = DistrictReportService.new(facilities: facility_group.facilities, selected_date: june_1)
+    service = DistrictReportService.new(facilities: facility_group_1.facilities, selected_date: june_1, organizations: [organization])
     result = service.call
 
     expected_controlled_patients = {
@@ -109,11 +116,11 @@ describe DistrictReportService, type: :model do
   end
 
   it "gets top district benchmarks" do
-    darrang = FactoryBot.create(:facility_group, name: "Darrang")
+    darrang = FactoryBot.create(:facility_group, name: "Darrang", organization: organization)
     darrang_facilities = FactoryBot.create_list(:facility, 2, facility_group: darrang)
-    kadapa = FactoryBot.create(:facility_group, name: "Kadapa")
+    kadapa = FactoryBot.create(:facility_group, name: "Kadapa", organization: organization)
     _kadapa_facilities = FactoryBot.create_list(:facility, 2, facility_group: kadapa)
-    koriya = FactoryBot.create(:facility_group, name: "Koriya")
+    koriya = FactoryBot.create(:facility_group, name: "Koriya", organization: organization)
     koriya_facilities = FactoryBot.create_list(:facility, 2, facility_group: koriya)
 
     Timecop.freeze("April 1sth 2020") do
@@ -131,7 +138,7 @@ describe DistrictReportService, type: :model do
 
     refresh_views
 
-    service = DistrictReportService.new(facilities: darrang.facilities, selected_date: june_1)
+    service = DistrictReportService.new(facilities: darrang.facilities, selected_date: june_1, organizations: [organization])
     result = service.call
     expect(result[:top_district_benchmarks][:district]).to eq(koriya)
     expect(result[:top_district_benchmarks][:controlled_percentage]).to eq(100.0)

--- a/spec/services/district_report_service_spec.rb
+++ b/spec/services/district_report_service_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 describe DistrictReportService, type: :model do
   let(:organization) { create(:organization, name: "org-1") }
   let(:user) do
-    create(:admin, :supervisor, organization: organization).tap { |user|
+    create(:admin, :supervisor, organization: organization).tap do |user|
       user.user_permissions << build(:user_permission, permission_slug: :view_cohort_reports, resource: organization)
-    }
+    end
   end
   let(:june_1) { Time.parse("June 1, 2020") }
   let(:facility_group_1) { FactoryBot.create(:facility_group, name: "facility_group_1", organization: organization) }


### PR DESCRIPTION
Ensures that `selected_date` is the `end_of_month` for each of the months we want to report on for this report. This keeps this consistent and correct for the benchmarks.

Also adds org scoping for the top benchmark district so that a top district would only be in an org that a CVHO manages. Otherwise as Simple grows an admin could see a 'top district' benchmark that is nowhere near where that admin oversees things.

**Story card:** https://www.pivotaltracker.com/story/show/173609276

## Because

We noticed some of the benchmarks were off in production

## This addresses

Ensuring we use the same selected_date across all the reporting
