### PR TITLE
Dynamic max_y_value round value

### DIFF
--- a/app/views/reports/facilities/show.html.erb
+++ b/app/views/reports/facilities/show.html.erb
@@ -136,10 +136,8 @@
         <%
           percent = 1.05
           max_y_value = case
-          when @last_registration_value >= 100
-            (@last_registration_value * percent).round(-2)
           when @last_registration_value >= 0
-            (@last_registration_value * percent).round
+            (@last_registration_value * percent).round((@last_registration_value.to_s.length-2)*-1)
           else
             0
           end

--- a/app/views/reports/facilities/show.html.erb
+++ b/app/views/reports/facilities/show.html.erb
@@ -134,10 +134,8 @@
       </div>
       <div>
         <%
-          percent = 1.05
-          max_y_value = case
-          when @last_registration_value >= 0
-            (@last_registration_value * percent).round((@last_registration_value.to_s.length-2)*-1)
+          max_y_value = if @last_registration_value >= 0
+            @last_registration_value.ceil(-1)
           else
             0
           end


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/362/cumulative-registration-chart-bug

## Because

Cumulative registration graphs weren't rendering properly.

## This addresses

Sets a dynamic `round` value for the `max_y_value`.

**Screenshots**
Before...
![image](https://user-images.githubusercontent.com/16785131/87350299-a91e0480-c525-11ea-96e5-cd5d1ae719a4.png)

After...
![image](https://user-images.githubusercontent.com/16785131/87350327-b4713000-c525-11ea-92c3-26c4a1634649.png)
