### PR TITLE
Add a health check endpoint

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,5 @@
+class HealthController < ApplicationController
+  def ping
+    render plain: "OK", status: :ok
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -217,4 +217,6 @@ Rails.application.routes.draw do
   authenticate :email_authentication, ->(a) { a.user.has_permission?(:view_flipper_ui) } do
     mount Flipper::UI.app(Flipper) => "/flipper"
   end
+
+  get "ping", to: "health#ping"
 end

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe HealthController, type: :controller do
+  describe "GET #ping" do
+    it "returns OK" do
+      get :ping
+
+      expect(response.body).to eq("OK")
+      expect(response).to be_successful
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** TBD

Adds a health check endpoint that we can wire up to simple availability alerts for our environments.