### PR TITLE
Fix lint warnings about deprecated URI.encode

### DIFF
--- a/app/services/exotel_api_service.rb
+++ b/app/services/exotel_api_service.rb
@@ -106,10 +106,10 @@ class ExotelAPIService
   end
 
   def phone_number_details_url(phone_number)
-    URI.parse("#{base_uri}/Numbers/#{URI.encode(phone_number)}#{RESPONSE_FORMAT}")
+    URI.parse("#{base_uri}/Numbers/#{ERB::Util.url_encode(phone_number)}#{RESPONSE_FORMAT}")
   end
 
   def whitelist_details_url(phone_number)
-    URI.parse("#{base_uri}/CustomerWhitelist/#{URI.encode(phone_number)}#{RESPONSE_FORMAT}")
+    URI.parse("#{base_uri}/CustomerWhitelist/#{ERB::Util.url_encode(phone_number)}#{RESPONSE_FORMAT}")
   end
 end

--- a/spec/services/exotel_api_service_spec.rb
+++ b/spec/services/exotel_api_service_spec.rb
@@ -133,8 +133,8 @@ describe ExotelAPIService, type: :model do
 
   describe "get_phone_number_details" do
     let(:phone_number) { Faker::PhoneNumber.phone_number }
-    let(:whitelist_details_url) { URI.parse("https://api.exotel.com/v1/Accounts/#{account_sid}/CustomerWhitelist/#{CGI.escape(phone_number)}.json") }
-    let(:numbers_metadata_url) { URI.parse("https://api.exotel.com/v1/Accounts/#{account_sid}/Numbers/#{CGI.escape(phone_number)}.json") }
+    let(:whitelist_details_url) { URI.parse("https://api.exotel.com/v1/Accounts/#{account_sid}/CustomerWhitelist/#{ERB::Util.url_encode(phone_number)}.json") }
+    let(:numbers_metadata_url) { URI.parse("https://api.exotel.com/v1/Accounts/#{account_sid}/Numbers/#{ERB::Util.url_encode(phone_number)}.json") }
 
     let!(:whitelist_details_stub) do
       stub_request(:get, whitelist_details_url).with(headers: request_headers)


### PR DESCRIPTION
ERB::Util.url_encode should be fine here, and is the preferred
replacement

**Story card:** n/a

This is the final standardrb warning in our code base.