### PR TITLE
Allow messaging "non-contactable" patients if needed

### DIFF
--- a/lib/tasks/scripts/message_patients.rb
+++ b/lib/tasks/scripts/message_patients.rb
@@ -3,14 +3,14 @@ class MessagePatients
     new(*args).call
   end
 
-  attr_reader :patients, :message, :channel, :contactable, :dryrun, :verbose, :report
+  attr_reader :patients, :message, :channel, :only_contactable, :dryrun, :verbose, :report
   VALID_CHANNELS = [:whatsapp, :sms]
 
-  def initialize(patients, message, channel: :whatsapp, contactable: true, dryrun: false, verbose: true)
+  def initialize(patients, message, channel: :whatsapp, only_contactable: true, dryrun: false, verbose: true)
     @patients = patients
     @message = message
     @channel = channel
-    @contactable = contactable
+    @only_contactable = only_contactable
     @dryrun = dryrun
     @verbose = verbose
     @report = {}
@@ -40,6 +40,8 @@ class MessagePatients
     contactable_patients.each do |patient|
       phone_number = phone_number_for(patient)
 
+      next unless phone_number
+
       begin
         response =
           if whatsapp?
@@ -60,7 +62,7 @@ class MessagePatients
   end
 
   def contactable_patients
-    @contactable_patients ||= if contactable
+    @contactable_patients ||= if only_contactable
       patients.contactable
     else
       patients
@@ -68,7 +70,7 @@ class MessagePatients
   end
 
   def phone_number_for(patient)
-    if contactable
+    if only_contactable
       patient.latest_mobile_number
     else
       patient.latest_phone_number

--- a/lib/tasks/scripts/message_patients.rb
+++ b/lib/tasks/scripts/message_patients.rb
@@ -3,13 +3,14 @@ class MessagePatients
     new(*args).call
   end
 
-  attr_reader :patients, :message, :channel, :dryrun, :verbose, :report
+  attr_reader :patients, :message, :channel, :contactable, :dryrun, :verbose, :report
   VALID_CHANNELS = [:whatsapp, :sms]
 
-  def initialize(patients, message, channel: :whatsapp, dryrun: false, verbose: true)
+  def initialize(patients, message, channel: :whatsapp, contactable: true, dryrun: false, verbose: true)
     @patients = patients
     @message = message
     @channel = channel
+    @contactable = contactable
     @dryrun = dryrun
     @verbose = verbose
     @report = {}
@@ -37,7 +38,7 @@ class MessagePatients
 
   def send_messages
     contactable_patients.each do |patient|
-      phone_number = patient.latest_mobile_number
+      phone_number = phone_number_for(patient)
 
       begin
         response =
@@ -59,7 +60,19 @@ class MessagePatients
   end
 
   def contactable_patients
-    @contactable_patients ||= patients.contactable
+    @contactable_patients ||= if contactable
+      patients.contactable
+    else
+      patients
+    end
+  end
+
+  def phone_number_for(patient)
+    if contactable
+      patient.latest_mobile_number
+    else
+      patient.latest_phone_number
+    end
   end
 
   def whatsapp?

--- a/spec/tasks/scripts/message_patients_spec.rb
+++ b/spec/tasks/scripts/message_patients_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe MessagePatients do
           .to eq({queued: [patients.first.id]})
       end
 
-      it "messages all patients if `contactable: false`" do
+      it "messages all patients if `only_contactable: false`" do
         patients = create_list(:patient, 2)
 
         patients.second.phone_numbers.each do |phone_number|
@@ -73,8 +73,21 @@ RSpec.describe MessagePatients do
         mock_notification_service(patients.first)
         mock_notification_service(patients.second)
 
-        expect(MessagePatients.call(Patient.all, message, channel: :sms, contactable: false, verbose: false).report)
+        expect(MessagePatients.call(Patient.all, message, channel: :sms, only_contactable: false, verbose: false).report)
           .to eq({queued: [patients.first.id, patients.second.id]})
+      end
+
+      it "no-ops if a patient does not have a phone number" do
+        patients = create_list(:patient, 2)
+
+        patients.second.phone_numbers.each do |phone_number|
+          phone_number.destroy!
+        end
+
+        mock_notification_service(patients.first)
+
+        expect(MessagePatients.call(Patient.all, message, channel: :sms, only_contactable: false, verbose: false).report)
+          .to eq({queued: [patients.first.id]})
       end
     end
 

--- a/spec/tasks/scripts/message_patients_spec.rb
+++ b/spec/tasks/scripts/message_patients_spec.rb
@@ -12,8 +12,10 @@ RSpec.describe MessagePatients do
         mock_notification_service(patients.first)
         mock_notification_service(patients.second)
 
-        expect(MessagePatients.call(Patient.all, message, verbose: false).report)
-          .to eq({queued: [patients.first.id, patients.second.id]})
+        report = MessagePatients.call(Patient.all, message, verbose: false).report
+
+        expect(report[:queued]).to contain_exactly(patients.first.id, patients.second.id)
+        expect(report[:exception]).to be_nil
       end
 
       it "logs exceptions in the error report" do
@@ -22,8 +24,9 @@ RSpec.describe MessagePatients do
         mock_notification_service(patients.first)
         mock_notification_service(patients.second, exception: true)
 
-        expect(MessagePatients.call(Patient.all, message, verbose: false).report)
-          .to eq({queued: [patients.first.id], exception: [patients.second.id]})
+        report = MessagePatients.call(Patient.all, message, verbose: false).report
+        expect(report[:queued]).to contain_exactly(patients.first.id)
+        expect(report[:exception]).to contain_exactly(patients.second.id)
       end
     end
 
@@ -34,8 +37,9 @@ RSpec.describe MessagePatients do
         mock_notification_service(patients.first)
         mock_notification_service(patients.second)
 
-        expect(MessagePatients.call(Patient.all, message, channel: :sms, verbose: false).report)
-          .to eq({queued: [patients.first.id, patients.second.id]})
+        report = MessagePatients.call(Patient.all, message, channel: :sms, verbose: false).report
+        expect(report[:queued]).to contain_exactly(patients.first.id, patients.second.id)
+        expect(report[:exception]).to be_nil
       end
 
       it "logs exceptions in the error report" do
@@ -44,8 +48,9 @@ RSpec.describe MessagePatients do
         mock_notification_service(patients.first)
         mock_notification_service(patients.second, exception: true)
 
-        expect(MessagePatients.call(Patient.all, message, channel: :sms, verbose: false).report)
-          .to eq({queued: [patients.first.id], exception: [patients.second.id]})
+        report = MessagePatients.call(Patient.all, message, channel: :sms, verbose: false).report
+        expect(report[:queued]).to contain_exactly(patients.first.id)
+        expect(report[:exception]).to contain_exactly(patients.second.id)
       end
     end
 
@@ -59,8 +64,9 @@ RSpec.describe MessagePatients do
 
         mock_notification_service(patients.first)
 
-        expect(MessagePatients.call(Patient.all, message, channel: :sms, verbose: false).report)
-          .to eq({queued: [patients.first.id]})
+        report = MessagePatients.call(Patient.all, message, channel: :sms, verbose: false).report
+        expect(report[:queued]).to contain_exactly(patients.first.id)
+        expect(report[:exception]).to be_nil
       end
 
       it "messages all patients if `only_contactable: false`" do
@@ -73,8 +79,9 @@ RSpec.describe MessagePatients do
         mock_notification_service(patients.first)
         mock_notification_service(patients.second)
 
-        expect(MessagePatients.call(Patient.all, message, channel: :sms, only_contactable: false, verbose: false).report)
-          .to eq({queued: [patients.first.id, patients.second.id]})
+        report = MessagePatients.call(Patient.all, message, channel: :sms, only_contactable: false, verbose: false).report
+        expect(report[:queued]).to contain_exactly(patients.first.id, patients.second.id)
+        expect(report[:exception]).to be_nil
       end
 
       it "no-ops if a patient does not have a phone number" do
@@ -86,8 +93,9 @@ RSpec.describe MessagePatients do
 
         mock_notification_service(patients.first)
 
-        expect(MessagePatients.call(Patient.all, message, channel: :sms, only_contactable: false, verbose: false).report)
-          .to eq({queued: [patients.first.id]})
+        report = MessagePatients.call(Patient.all, message, channel: :sms, only_contactable: false, verbose: false).report
+        expect(report[:queued]).to contain_exactly(patients.first.id)
+        expect(report[:exception]).to be_nil
       end
     end
 


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/297/bangladesh-sms-blast

## Because

BD Phone numbers are not all marked as "mobile" numbers.

## This addresses

Adding a `contactable` flag to the `MessagePatients` service that does two things:

* Decides whether to scope the passed-in `patients` with the `contactable` scope, and
* Decides whether to use the patient's latest _mobile_ number, or phone number.
