### PR TITLE
Fix facility bulk upload 

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -136,7 +136,7 @@ class Facility < ApplicationRecord
       facility = CSV_IMPORT_COLUMNS.map { |attribute, column_name| [attribute, row[column_name]] }.to_h
       next if facility.values.all?(&:blank?)
 
-      facilities << facility.merge(enable_diabetes_management: facility[:enable_diabetes] || false,
+      facilities << facility.merge(enable_diabetes_management: facility[:enable_diabetes_management] || false,
                                    enable_teleconsultation: facility[:enable_teleconsultation] || false,
                                    import: true)
     end

--- a/spec/fixtures/files/upload_facilities_test.csv
+++ b/spec/fixtures/files/upload_facilities_test.csv
@@ -1,3 +1,3 @@
 organization,facility_group,facility_name,facility_type,street_address (optional),village_or_colony (optional),zone_or_block (optional),district,state,country,pin (optional),latitude (optional),longitude (optional),size (optional),enable_diabetes_management (true/false),enable_teleconsultation (true/false),teleconsultation_phone_number,teleconsultation_isd_code
-OrgOne,FGTwo,Test Facility,CHC,,,,Bhatinda,Punjab,India,,,,,false,,,
+OrgOne,FGTwo,Test Facility,CHC,,,,Bhatinda,Punjab,India,,,,,true,,,
 OrgOne,FGTwo,Test Facility 2,CHC,,,,Bhatinda,Punjab,India,,,,,,true,9999999999,91

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -170,6 +170,32 @@ RSpec.describe Facility, type: :model do
   describe ".parse_facilities" do
     let(:upload_file) { fixture_file_upload("files/upload_facilities_test.csv", "text/csv") }
 
+    it "parses the facilities" do
+      facilities = described_class.parse_facilities(upload_file)
+      expect(facilities.first).to include(organization_name: "OrgOne",
+                                          facility_group_name: "FGTwo",
+                                          name: "Test Facility",
+                                          facility_type: "CHC",
+                                          district: "Bhatinda",
+                                          state: "Punjab",
+                                          country: "India",
+                                          enable_diabetes_management: "true",
+                                          teleconsultation_phone_number: nil,
+                                          teleconsultation_isd_code: nil,
+                                          import: true)
+      expect(facilities.second).to include(organization_name: "OrgOne",
+                                           facility_group_name: "FGTwo",
+                                           name: "Test Facility 2",
+                                           facility_type: "CHC",
+                                           district: "Bhatinda",
+                                           state: "Punjab",
+                                           country: "India",
+                                           enable_teleconsultation: "true",
+                                           teleconsultation_phone_number: "9999999999",
+                                           teleconsultation_isd_code: "91",
+                                           import: true)
+    end
+
     it "defaults enable_teleconsultation to false if blank" do
       facilities = described_class.parse_facilities(upload_file)
       expect(facilities.first[:enable_teleconsultation]).to be false


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/424

## Because

We aren't picking up the `enable_diabetes_management` column correctly in the facilities bulk upload CSV. This bug was reported on [Slack](https://simpledotorg.slack.com/archives/CFHKJ5WJY/p1594976983096500).

## This addresses

The column is always being defaulted to false, due to an incorrect key name. This fixes the bug.
