### PR TITLE
Update BD Demo server IP

### DIFF
--- a/config/deploy/bangladesh/demo.rb
+++ b/config/deploy/bangladesh/demo.rb
@@ -1,2 +1,2 @@
-server "ec2-13-127-62-208.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db cron seed_data]
+server "ec2-13-233-166-168.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db cron seed_data]
 server "ec2-3-6-91-15.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web sidekiq]


### PR DESCRIPTION
The BD demo server had hung, so we had to stop and start it.

This PR updates the IP address of the demo server in our cap configuration.