### PR TITLE
Fix flakey logging spec: remove the age assertion

### DIFF
--- a/spec/requests/filter_parameter_logging_spec.rb
+++ b/spec/requests/filter_parameter_logging_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe "Filter parameter logging spec", type: :request do
     output = stringio.string
     patients.each do |patient|
       expect(output).to_not match(/\b#{patient.full_name}\b/)
-      expect(output).to_not match(/\b#{patient.age}\b/) if patient.age
       expect(output).to_not match(/\b#{patient.date_of_birth}\b/) if patient.date_of_birth
       if patient.address
         expect(output).to_not match(/\b#{patient.address.street_address}\b/)


### PR DESCRIPTION
This provides too many false negatives, and if the rest of the pieces
here pass we can have good confidence the filtering is working

Fixes flakey failures like this: https://semaphoreci.com/resolvetosavelives/simple-server/branches/htn-not-under-control-card/builds/1

