### PR TITLE
Bugfix: CSV formatting

### DIFF
--- a/app/views/analytics/districts/show.csv.erb
+++ b/app/views/analytics/districts/show.csv.erb
@@ -1,10 +1,8 @@
-<%= [
-  'Report generated at:',
-  Time.current
-].to_csv -%>
+<% csv = CSV.generate(headers: true) do |csv| %>
+<% csv << ["Report generated at", Time.current] %>
 <% period = @period == :quarter ? 'Quarterly' : 'Monthly' %>
-<%= ["#{@organization_district.district_name} #{period} Cohort Report"].to_csv -%>
-<%= ['Facility', 'Facility type'].concat(@cohort_analytics.each_with_index.flat_map do |(report_dates, analytics), index|
+<% csv << ["#{@organization_district.district_name} #{period} Cohort Report"] %>
+<% csv << ['Facility', 'Facility type'].concat(@cohort_analytics.each_with_index.flat_map do |(report_dates, analytics), index|
   [
     'Cohort period',
     'Follow up period',
@@ -18,10 +16,10 @@
     '% Defaulted',
     nil
   ]
-end).to_csv -%>
-
+end) %>
+<% csv << [] %>
 <% @facility_keys.each do |facility| %>
-<%= [facility[:name], facility[:type]].concat(@cohort_analytics.each_with_index.flat_map do |(report_dates, analytics), index|
+<% csv << [facility[:name], facility[:type]].concat(@cohort_analytics.each_with_index.flat_map do |(report_dates, analytics), index|
   cohort_start, report_start = report_dates
   registered = analytics.dig(:registered, facility[:id]) || 0
   followed_up = analytics.dig(:followed_up, facility[:id]) || 0
@@ -58,10 +56,10 @@ end).to_csv -%>
     default_percent,
     nil
   ]
-end).to_csv -%>
+end) %>
 <% end %>
-
-<%= ["#{@organization_district.district_name} Facilites Report"].to_csv -%>
+<% csv << [] %>
+<% csv << ["#{@organization_district.district_name} Facilites Report"] %>
 <%
   headers = [
     "Facility name",
@@ -75,26 +73,25 @@ end).to_csv -%>
     end
   end
 %>
-<%= headers.to_csv -%>
-<%=
-  [
+<% csv << headers %>
+<% csv << [
     "All",
     nil,
     @dashboard_analytics.sum { |_, row| row[:total_registered_patients] || 0 },
     *dates.map { |period| analytics_totals(@dashboard_analytics, :follow_up_patients_by_period, period) },
     *dates.map { |period| analytics_totals(@dashboard_analytics, :registered_patients_by_period, period) }
-  ].to_csv
--%>
+  ]
+%>
 <% policy_scope([:cohort_report, Facility.order(:name)]).each do |facility| %>
   <% if @dashboard_analytics[facility.id].present? %>
-    <%=
-      [
+    <% csv << [
         facility.name,
         facility.facility_type,
         @dashboard_analytics.dig(facility.id, :total_registered_patients) || 0,
         *dates.map { |period| @dashboard_analytics.dig(facility.id, :follow_up_patients_by_period, period) || 0 },
         *dates.map { |period| @dashboard_analytics.dig(facility.id, :registered_patients_by_period, period) || 0 }
-      ].to_csv
-    -%>
+      ] %>
   <% end %>
 <% end %>
+<% end.html_safe %>
+<%= csv %>

--- a/app/views/analytics/facilities/show.csv.erb
+++ b/app/views/analytics/facilities/show.csv.erb
@@ -1,10 +1,8 @@
-<%= [
-  'Report generated at:',
-  Time.current
-].to_csv -%>
+<% csv = CSV.generate(headers: true) do |csv| %>
+<% csv << ["Report generated at:", Time.current] %>
 <% period = @period == :quarter ? 'Quarterly' : 'Monthly' %>
-<%= ["#{@facility.name} #{period} Cohort Report"].to_csv -%>
-<%= [
+<% csv << ["#{@facility.name} #{period} Cohort Report"] %>
+<% csv << [
   'Cohort period',
   'Follow up period',
   'Patients in cohort',
@@ -15,7 +13,7 @@
   'Control rate',
   'Uncontrolled rate',
   'Default rate'
-].to_csv -%>
+] %>
 <% @cohort_analytics.each_with_index do |(report_dates, analytics), index| %>
   <%
     cohort_start, report_start = report_dates
@@ -41,7 +39,7 @@
       default_percent = 0
     end
   %>
-<%= [
+<% csv << [
   cohort_period,
   report_period,
   registered,
@@ -52,5 +50,7 @@
   "#{controlled_percent}%",
   "#{uncontrolled_percent}%",
   "#{default_percent}%"
-].to_csv -%>
+] %>
 <% end %>
+<% end.html_safe %>
+<%= csv %>

--- a/app/views/appointments/index.csv.erb
+++ b/app/views/appointments/index.csv.erb
@@ -29,7 +29,6 @@
     ('High' if patient_summary.risk_level > 0),
     patient_summary.street_address,
     patient_summary.village_or_colony,
-    patient_summary.latest_phone_number,
-    "Patient Summary"
+    patient_summary.latest_phone_number
   ].to_csv -%>
 <% end %>

--- a/app/views/appointments/index.csv.erb
+++ b/app/views/appointments/index.csv.erb
@@ -1,8 +1,9 @@
-<%= [
+<% csv = CSV.generate do |csv| %>
+<% csv << [
   "Report generated at:",
   Time.current
-].to_csv -%>
-<%= [
+] %>
+<% csv << [
   "Patient name",
   "Gender",
   "Age",
@@ -15,9 +16,9 @@
   "Patient address",
   "Patient village or colony",
   "Patient phone"
-].to_csv -%>
+] %>
 <% @patient_summaries.each do |patient_summary| %>
-  <%= [
+  <% csv << [
     patient_summary.full_name,
     patient_summary.gender.capitalize,
     patient_summary.current_age.to_i,
@@ -30,5 +31,7 @@
     patient_summary.street_address,
     patient_summary.village_or_colony,
     patient_summary.latest_phone_number
-  ].to_csv -%>
+  ] %>
 <% end %>
+<% end.html_safe %>
+<%= csv %>

--- a/app/views/appointments/index.csv.erb
+++ b/app/views/appointments/index.csv.erb
@@ -1,37 +1,37 @@
 <% csv = CSV.generate do |csv| %>
-<% csv << [
-  "Report generated at:",
-  Time.current
-] %>
-<% csv << [
-  "Patient name",
-  "Gender",
-  "Age",
-  "Days overdue",
-  "Registration date",
-  "Last BP",
-  "Last BP taken at",
-  "Last BP date",
-  "Risk level",
-  "Patient address",
-  "Patient village or colony",
-  "Patient phone"
-] %>
-<% @patient_summaries.each do |patient_summary| %>
   <% csv << [
-    patient_summary.full_name,
-    patient_summary.gender.capitalize,
-    patient_summary.current_age.to_i,
-    patient_summary.days_overdue.to_i,
-    handle_impossible_registration_date(patient_summary.recorded_at),
-    "#{patient_summary.latest_blood_pressure_systolic}/#{patient_summary.latest_blood_pressure_diastolic}",
-    patient_summary.latest_blood_pressure_facility_name,
-    display_date(patient_summary.latest_blood_pressure_recorded_at),
-    ('High' if patient_summary.risk_level > 0),
-    patient_summary.street_address,
-    patient_summary.village_or_colony,
-    patient_summary.latest_phone_number
+    "Report generated at:",
+    Time.current
   ] %>
-<% end %>
+  <% csv << [
+    "Patient name",
+    "Gender",
+    "Age",
+    "Days overdue",
+    "Registration date",
+    "Last BP",
+    "Last BP taken at",
+    "Last BP date",
+    "Risk level",
+    "Patient address",
+    "Patient village or colony",
+    "Patient phone"
+  ] %>
+  <% @patient_summaries.each do |patient_summary| %>
+    <% csv << [
+      patient_summary.full_name,
+      patient_summary.gender.capitalize,
+      patient_summary.current_age.to_i,
+      patient_summary.days_overdue.to_i,
+      handle_impossible_registration_date(patient_summary.recorded_at),
+      "#{patient_summary.latest_blood_pressure_systolic}/#{patient_summary.latest_blood_pressure_diastolic}",
+      patient_summary.latest_blood_pressure_facility_name,
+      display_date(patient_summary.latest_blood_pressure_recorded_at),
+      ('High' if patient_summary.risk_level > 0),
+      patient_summary.street_address,
+      patient_summary.village_or_colony,
+      patient_summary.latest_phone_number
+    ] %>
+  <% end %>
 <% end.html_safe %>
 <%= csv %>


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/205

## Because

There appears to be problems escaping characters in the overdue list CSV which causes column data to bleed into other columns. Cohort downloads also has a quote escaping issue in the column headers:

![image](https://user-images.githubusercontent.com/16774200/88279375-92d02f80-cd01-11ea-9dd4-79cd31e340cc.png)

## This addresses

This fixes the CSV generation in these downloads. Since these CSVs are rendered via ERB, templating a row sanitises special characters. For example `"` becomes a `&quot;` which some CSV clients handle correctly, some can't. Strings with a comma in between are read as separate cells because they are not wrapped in `"`.

This sanitisation is desirable in HTML views since they are executed in the browser. File downloads should contain the raw strings. Running the string through an `html_safe` spits the correct unsanitised strings into the CSV.
