### PR TITLE
Fix report region finding

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -70,7 +70,7 @@ class Reports::RegionsController < AdminController
   end
 
   def find_region
-    region_class, slug = facility_params[:id].split("-")
+    region_class, slug = facility_params[:id].split("-", 2)
     unless region_class.in?(["facility_group", "facility"])
       raise ActiveRecord::RecordNotFound
     end


### PR DESCRIPTION
The existing splitting logic to find the right facility or facility group would break if the facility or facility group name was more than one word long. This PR patches this bug, so facilities like "PHC Obvious" are found correctly.