### PR TITLE
Bugfix: Facility follow up numbers

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -79,8 +79,18 @@ class Facility < ApplicationRecord
   delegate :protocol, to: :facility_group, allow_nil: true
   delegate :organization, to: :facility_group, allow_nil: true
   delegate :follow_ups_by_period, to: :patients, prefix: :patient
-  delegate :diabetes_follow_ups_by_period, to: :patients
-  delegate :hypertension_follow_ups_by_period, to: :patients
+
+  def hypertension_follow_ups_by_period(*args)
+    patients
+      .hypertension_follow_ups_by_period(*args)
+      .where(blood_pressures: {facility: self})
+  end
+
+  def diabetes_follow_ups_by_period(*args)
+    patients
+      .diabetes_follow_ups_by_period(*args)
+      .where(blood_sugars: {facility: self})
+  end
 
   friendly_id :name, use: :slugged
 

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -53,34 +53,6 @@ RSpec.describe Facility, type: :model do
 
         expect(facility.patient_follow_ups_by_period(:month).count).to eq(expected_output)
       end
-
-      it "counts the patients' hypertension follow ups at the facility only" do
-        facilities = create_list(:facility, 2)
-        patient = create(:patient, :hypertension, recorded_at: 10.months.ago)
-
-        create(:blood_pressure, :with_encounter, recorded_at: 3.months.ago, facility: facilities.first, patient: patient)
-        create(:blood_pressure, :with_encounter, recorded_at: 1.month.ago, facility: facilities.second, patient: patient)
-
-        expect(facilities.first.hypertension_follow_ups_by_period(:month, last: 4).count[1.month.ago.beginning_of_month.to_date]).to eq 0
-        expect(facilities.second.hypertension_follow_ups_by_period(:month, last: 4).count[3.months.ago.beginning_of_month.to_date]).to eq 0
-
-        expect(facilities.first.hypertension_follow_ups_by_period(:month, last: 4).count[3.month.ago.beginning_of_month.to_date]).to eq 1
-        expect(facilities.second.hypertension_follow_ups_by_period(:month, last: 4).count[1.months.ago.beginning_of_month.to_date]).to eq 1
-      end
-
-      it "counts the patients' diabetes follow ups at the facility only" do
-        facilities = create_list(:facility, 2)
-        patient = create(:patient, :diabetes, recorded_at: 10.months.ago)
-
-        create(:blood_sugar, :with_encounter, recorded_at: 3.months.ago, facility: facilities.first, patient: patient)
-        create(:blood_sugar, :with_encounter, recorded_at: 1.month.ago, facility: facilities.second, patient: patient)
-
-        expect(facilities.first.diabetes_follow_ups_by_period(:month, last: 4).count[1.month.ago.beginning_of_month.to_date]).to eq 0
-        expect(facilities.second.diabetes_follow_ups_by_period(:month, last: 4).count[3.months.ago.beginning_of_month.to_date]).to eq 0
-
-        expect(facilities.first.diabetes_follow_ups_by_period(:month, last: 4).count[3.month.ago.beginning_of_month.to_date]).to eq 1
-        expect(facilities.second.diabetes_follow_ups_by_period(:month, last: 4).count[1.months.ago.beginning_of_month.to_date]).to eq 1
-      end
     end
 
     context "#hypertension_follow_ups_by_period" do
@@ -104,6 +76,20 @@ RSpec.describe Facility, type: :model do
 
         expect(facility.hypertension_follow_ups_by_period(:month).count).to eq(expected_output)
       end
+
+      it "counts the patients' hypertension follow ups at the facility only" do
+        facilities = create_list(:facility, 2)
+        patient = create(:patient, :hypertension, recorded_at: 10.months.ago)
+
+        create(:blood_pressure, :with_encounter, recorded_at: 3.months.ago, facility: facilities.first, patient: patient)
+        create(:blood_pressure, :with_encounter, recorded_at: 1.month.ago, facility: facilities.second, patient: patient)
+
+        expect(facilities.first.hypertension_follow_ups_by_period(:month, last: 4).count[1.month.ago.beginning_of_month.to_date]).to eq 0
+        expect(facilities.second.hypertension_follow_ups_by_period(:month, last: 4).count[3.months.ago.beginning_of_month.to_date]).to eq 0
+
+        expect(facilities.first.hypertension_follow_ups_by_period(:month, last: 4).count[3.month.ago.beginning_of_month.to_date]).to eq 1
+        expect(facilities.second.hypertension_follow_ups_by_period(:month, last: 4).count[1.months.ago.beginning_of_month.to_date]).to eq 1
+      end
     end
 
     context "#diabetes_follow_ups_by_period" do
@@ -126,6 +112,20 @@ RSpec.describe Facility, type: :model do
         }
 
         expect(facility.diabetes_follow_ups_by_period(:month).count).to eq(expected_output)
+      end
+
+      it "counts the patients' diabetes follow ups at the facility only" do
+        facilities = create_list(:facility, 2)
+        patient = create(:patient, :diabetes, recorded_at: 10.months.ago)
+
+        create(:blood_sugar, :with_encounter, recorded_at: 3.months.ago, facility: facilities.first, patient: patient)
+        create(:blood_sugar, :with_encounter, recorded_at: 1.month.ago, facility: facilities.second, patient: patient)
+
+        expect(facilities.first.diabetes_follow_ups_by_period(:month, last: 4).count[1.month.ago.beginning_of_month.to_date]).to eq 0
+        expect(facilities.second.diabetes_follow_ups_by_period(:month, last: 4).count[3.months.ago.beginning_of_month.to_date]).to eq 0
+
+        expect(facilities.first.diabetes_follow_ups_by_period(:month, last: 4).count[3.month.ago.beginning_of_month.to_date]).to eq 1
+        expect(facilities.second.diabetes_follow_ups_by_period(:month, last: 4).count[1.months.ago.beginning_of_month.to_date]).to eq 1
       end
     end
   end

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -53,6 +53,34 @@ RSpec.describe Facility, type: :model do
 
         expect(facility.patient_follow_ups_by_period(:month).count).to eq(expected_output)
       end
+
+      it "counts the patients' hypertension follow ups at the facility only" do
+        facilities = create_list(:facility, 2)
+        patient = create(:patient, :hypertension, recorded_at: 10.months.ago)
+
+        create(:blood_pressure, :with_encounter, recorded_at: 3.months.ago, facility: facilities.first, patient: patient)
+        create(:blood_pressure, :with_encounter, recorded_at: 1.month.ago, facility: facilities.second, patient: patient)
+
+        expect(facilities.first.hypertension_follow_ups_by_period(:month, last: 4).count[1.month.ago.beginning_of_month.to_date]).to eq 0
+        expect(facilities.second.hypertension_follow_ups_by_period(:month, last: 4).count[3.months.ago.beginning_of_month.to_date]).to eq 0
+
+        expect(facilities.first.hypertension_follow_ups_by_period(:month, last: 4).count[3.month.ago.beginning_of_month.to_date]).to eq 1
+        expect(facilities.second.hypertension_follow_ups_by_period(:month, last: 4).count[1.months.ago.beginning_of_month.to_date]).to eq 1
+      end
+
+      it "counts the patients' diabetes follow ups at the facility only" do
+        facilities = create_list(:facility, 2)
+        patient = create(:patient, :diabetes, recorded_at: 10.months.ago)
+
+        create(:blood_sugar, :with_encounter, recorded_at: 3.months.ago, facility: facilities.first, patient: patient)
+        create(:blood_sugar, :with_encounter, recorded_at: 1.month.ago, facility: facilities.second, patient: patient)
+
+        expect(facilities.first.diabetes_follow_ups_by_period(:month, last: 4).count[1.month.ago.beginning_of_month.to_date]).to eq 0
+        expect(facilities.second.diabetes_follow_ups_by_period(:month, last: 4).count[3.months.ago.beginning_of_month.to_date]).to eq 0
+
+        expect(facilities.first.diabetes_follow_ups_by_period(:month, last: 4).count[3.month.ago.beginning_of_month.to_date]).to eq 1
+        expect(facilities.second.diabetes_follow_ups_by_period(:month, last: 4).count[1.months.ago.beginning_of_month.to_date]).to eq 1
+      end
     end
 
     context "#hypertension_follow_ups_by_period" do


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/673

## Because

The hypertension and diabetes follow up numbers are incorrect on the Progress Tab. This bug was reported on [slack](https://simpledotorg.slack.com/archives/CFHKJ5WJY/p1596459406164200).

## This addresses

Currently progress tab follow ups are calculated in the `Patient` model. The query to find patient follow ups is correct. However when we find a facility's follow ups (through `Facility`), the BPs/BSs are not being scoped by that facility correctly.

We fetch the patients of a facility through encounters i.e we get patients who have had an encounter at that facility **at any point in time**. Hence fetching follow ups for a facility gets us patients who visited that facility in any month rather than the specific month we're querying for.

Example 
```
Patient p visited Facility f1 in June
Patient p visited Facility f2 in July

f1 follow ups in June should be 1
f2 follow ups in July should be 1

f1 follow ups in July should be 0
f2 follow ups in June should be 0
```

However

```
f1 follow ups in Jul are 1 because patient followed up in f2 in Jul
f2 follow ups in Jun are 1 because patient followed up in f1 in Jun
```

This was an extremely esoteric case to track down (and hard to explain). We will need to thoroughly test this with real data. We've added unit tests that check this specific case. Happy to walk through this over a call. 

Update: Tested this fix on prod data.

## Impact

This impacts follow up numbers for facilities where patients tend to switch facilities for their visits (that number is ~8% of the patients in IHCI prod). This is currently only displayed on the Progress Tab. No other dashboards are affected.