### PR TITLE
Make sure we grab initial count of registrations

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -36,7 +36,7 @@ class Reports::RegionsController < AdminController
     @registrations = @data[:cumulative_registrations]
     @quarterly_registrations = @data[:quarterly_registrations]
     @top_region_benchmarks = @data[:top_region_benchmarks]
-    @last_registration_value = @data[:registrations].values&.last || 0
+    @last_registration_value = @data[:cumulative_registrations].values&.last || 0
   end
 
   def cohort
@@ -49,13 +49,13 @@ class Reports::RegionsController < AdminController
     @registrations = @data[:cumulative_registrations]
     @quarterly_registrations = @data[:quarterly_registrations]
     @top_region_benchmarks = @data[:top_region_benchmarks]
-    @last_registration_value = @data[:registrations].values&.last || 0
+    @last_registration_value = @data[:cumulative_registrations].values&.last || 0
   end
 
   private
 
   def set_selected_date
-    period_params = facility_params[:period].presence || {type: :month, value: Date.current.last_month}
+    period_params = facility_params[:period].presence || {type: :month, value: Date.current.last_month.beginning_of_month}
     # TODO this will all go away, no need for building Period from the params
     @period = if period_params[:type] == "quarter"
       Period.new(type: period_params[:type], value: Quarter.parse(period_params[:value]))

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -58,7 +58,7 @@ class Period
     if quarter?
       Period.new(type: type, value: value.succ)
     else
-      Period.new(type: type, value: value.next_month)
+      Period.new(type: type, value: value.advance(months: 1))
     end
   end
 

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -1,13 +1,4 @@
 class Period
-  module ToPeriodExtensions
-    def to_period
-      Period.month(self)
-    end
-  end
-
-  Date.include ToPeriodExtensions
-  Time.include ToPeriodExtensions
-
   include Comparable
   include ActiveModel::Model
   validates :type, presence: true, inclusion: {in: [:month, :quarter], message: "must be month or quarter"}

--- a/app/services/control_rate_service.rb
+++ b/app/services/control_rate_service.rb
@@ -13,7 +13,9 @@ class ControlRateService
     # Normalize between a single period and range of periods
     @periods = if !periods.is_a?(Range)
       @single_period = periods
-      Range.new(periods, periods)
+      # If calling code is asking for a single period,
+      # we set the range to be the current period to the start of the next period.
+      Range.new(periods, periods.succ)
     else
       periods
     end
@@ -43,8 +45,8 @@ class ControlRateService
       }
 
       data[:registrations] = registration_counts
-      data[:cumulative_registrations] = sum_cumulative_registrations(registration_counts)
-      data[:registrations].each do |(period, count)|
+      data[:cumulative_registrations] = sum_cumulative_registrations
+      periods.each do |(period, count)|
         data[:controlled_patients][period] = controlled_patients(period).count
         registration_count = if quarterly_report?
           # get the cohort counts for quarterly reports
@@ -56,30 +58,28 @@ class ControlRateService
         data[:uncontrolled_patients][period] = uncontrolled_patients(period).count
         data[:uncontrolled_patients_rate][period] = percentage(uncontrolled_patients(period).count, registration_count)
       end
+      first_registration_period = registration_counts.keys.first
+      if first_registration_period
+        data.each {|(_key, hsh)| hsh.delete_if { |period, count| period < first_registration_period } }
+      end
       data
     end
   end
 
-  def sum_cumulative_registrations(registration_counts)
+  def sum_cumulative_registrations
     initial_count = region.registered_patients.with_hypertension.where("recorded_at < ?", periods.begin.to_date).count
-    registration_counts.each_with_object({}) { |(period, count), running_totals|
-      running_total = running_totals[period.previous] || initial_count
-      running_totals[period] = count + running_total
+    periods.each_with_object({}) { |period, running_totals|
+      previous_registrations = running_totals[period.previous] || initial_count
+      current_registrations = registration_counts[period] || 0
+      running_totals[period] = current_registrations + previous_registrations
     }
   end
 
   def registration_counts
-    @registration_counts ||= if single_period?
-      count = region.registered_patients.with_hypertension.where("recorded_at <= ?", single_period.to_date).count
-      {
-        single_period => count
-      }
-    else
-      range = (periods.begin.value.to_date..periods.end.value.to_date)
-      formatter = lambda { |v| quarterly_report? ? Period.quarter(v) : Period.month(v) }
-      result = region.registered_patients.with_hypertension.group_by_period(periods.begin.type, :recorded_at, {range: range, format: formatter}).count
-      result.drop_while { |period, count| count == 0 }.to_h
-    end
+    range = (periods.begin.value.to_date..periods.end.value.to_date)
+    formatter = lambda { |v| quarterly_report? ? Period.quarter(v) : Period.month(v) }
+    result = region.registered_patients.with_hypertension.group_by_period(periods.begin.type, :recorded_at, {range: range, format: formatter}).count
+    result.drop_while { |period, count| count == 0 }.to_h
   end
 
   def controlled_patients(period)

--- a/app/services/control_rate_service.rb
+++ b/app/services/control_rate_service.rb
@@ -1,5 +1,5 @@
 class ControlRateService
-  CACHE_VERSION = 2
+  CACHE_VERSION = 3
   PERCENTAGE_PRECISION = 1
 
   # Can be initialized with _either_ a Period range or a single Period to calculate

--- a/app/services/control_rate_service.rb
+++ b/app/services/control_rate_service.rb
@@ -60,7 +60,7 @@ class ControlRateService
       end
       first_registration_period = registration_counts.keys.first
       if first_registration_period
-        data.each {|(_key, hsh)| hsh.delete_if { |period, count| period < first_registration_period } }
+        data.each { |(_key, hsh)| hsh.delete_if { |period, count| period < first_registration_period } }
       end
       data
     end

--- a/app/services/control_rate_service.rb
+++ b/app/services/control_rate_service.rb
@@ -61,8 +61,10 @@ class ControlRateService
   end
 
   def sum_cumulative_registrations(registration_counts)
-    registration_counts.each_with_object(Hash.new(0)) { |(period, count), running_totals|
-      running_totals[period] = count + running_totals[period.previous]
+    initial_count = region.registered_patients.with_hypertension.where("recorded_at < ?", periods.begin.to_date).count
+    registration_counts.each_with_object({}) { |(period, count), running_totals|
+      running_total = running_totals[period.previous] || initial_count
+      running_totals[period] = count + running_total
     }
   end
 

--- a/app/services/region_report_service.rb
+++ b/app/services/region_report_service.rb
@@ -1,7 +1,7 @@
 class RegionReportService
   include SQLHelpers
   MAX_MONTHS_OF_DATA = 24
-  CACHE_VERSION = 3
+  CACHE_VERSION = 4
 
   def initialize(region:, period:, current_user:)
     @current_user = current_user

--- a/app/services/top_region_service.rb
+++ b/app/services/top_region_service.rb
@@ -27,16 +27,16 @@ class TopRegionService
       result[:controlled_patients_rate][period]
     }
     top_region_for_registrations, registrations_result = all_region_data.max_by { |region, result|
-      result[:registrations][period]
+      result[:cumulative_registrations][period]
     }
     {
       control_rate: {
         region: top_region_for_rate,
         value: control_rate_result[:controlled_patients_rate][period]
       },
-      registrations: {
+      cumulative_registrations: {
         region: top_region_for_registrations,
-        value: registrations_result[:registrations][period]
+        value: registrations_result[:cumulative_registrations][period]
       }
     }
   end

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -44,7 +44,8 @@
 
           <% (0..12).each do |num|
               selected = false
-              date = Date.current.end_of_month.advance(months: -num)
+              date = Date.current.beginning_of_month.advance(months: -num)
+              p date
               period = Period.new(type: :month, value: date)
           %>
             <button class="dropdown-item query-filter-month <%= 'active' if selected %>" name="period[value]"

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -45,7 +45,6 @@
           <% (0..12).each do |num|
               selected = false
               date = Date.current.beginning_of_month.advance(months: -num)
-              p date
               period = Period.new(type: :month, value: date)
           %>
             <button class="dropdown-item query-filter-month <%= 'active' if selected %>" name="period[value]"

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -1,4 +1,5 @@
 <%= render "header" %>
+
 <div class="d-lg-flex flex-lg-wrap">
   <div class="d-lg-flex w-lg-50 pr-lg-2">
     <div class="card d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0">
@@ -185,7 +186,7 @@
             <% if @last_registration_value.zero? %>
               No registration data available
             <% else %>
-              <span class="fw-bold"><%= number_with_delimiter(@new_registrations) %> new patients</span> registered in <%= @registrations.keys&.last %> 
+              <span class="fw-bold"><%= number_with_delimiter(@new_registrations) %> new patients</span> registered in <%= @registrations.keys&.last %>
             <% end %>
           </p>
         </div>

--- a/config/initializers/time_and_date_extensions.rb
+++ b/config/initializers/time_and_date_extensions.rb
@@ -1,0 +1,8 @@
+module TimeAndDateExtensions
+  def to_period
+    Period.month(to_date)
+  end
+end
+
+Date.include TimeAndDateExtensions
+Time.include TimeAndDateExtensions

--- a/spec/models/period_spec.rb
+++ b/spec/models/period_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe Period, type: :model do
   let(:q1_2019_period) { Period.quarter(quarter_1_2019) }
   let(:q1_2020_period) { Period.quarter(quarter_1_2020) }
 
+  it "times and dates can convert themselves into periods" do
+    expect(jan_1_2019.to_period).to eq(Date.parse("January 1st 2019").to_period)
+    expect(jan_1_2019.to_period.value).to eq(Date.parse("January 1st 2019").to_period.value)
+  end
+
   it "validations" do
     period = Period.new(type: "invalid", value: jan_1_2020)
     expect(period).to be_invalid

--- a/spec/services/control_rate_service_spec.rb
+++ b/spec/services/control_rate_service_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe ControlRateService, type: :model do
   let(:user) { create(:admin, :supervisor, organization: organization) }
   let(:facility_group_1) { FactoryBot.create(:facility_group, name: "facility_group_1", organization: organization) }
 
-  let(:june_2018) { Time.parse("June 1, 2018") }
-  let(:june_1) { Time.parse("June 1, 2020") }
+  let(:june_1_2018) { Time.parse("June 1, 2018") }
+  let(:june_1_2020) { Time.parse("June 1, 2020") }
   let(:june_30_2020) { Time.parse("June 30, 2020") }
   let(:july_2020) { Time.parse("July 15, 2020") }
   let(:jan_2019) { Time.parse("January 1st, 2019") }
@@ -24,8 +24,16 @@ RSpec.describe ControlRateService, type: :model do
 
   it "counts registrations and cumulative registrations" do
     facility = FactoryBot.create(:facility, facility_group: facility_group_1)
-    april_15_2020 = Time.parse("April 15th 2020")
-    Timecop.freeze(april_15_2020) do
+    Timecop.freeze("January 1st 2018") do
+      create_list(:patient, 2, recorded_at: Time.current, registration_facility: facility, registration_user: user)
+    end
+    Timecop.freeze("May 30th 2018") do
+      create_list(:patient, 2, recorded_at: Time.current, registration_facility: facility, registration_user: user)
+    end
+    Timecop.freeze(june_1_2018) do
+      create_list(:patient, 2, recorded_at: Time.current, registration_facility: facility, registration_user: user)
+    end
+    Timecop.freeze("April 15th 2020") do
       create_list(:patient, 2, recorded_at: Time.current, registration_facility: facility, registration_user: user)
     end
     Timecop.freeze("May 1 2020") do
@@ -35,15 +43,17 @@ RSpec.describe ControlRateService, type: :model do
 
     refresh_views
 
-    range = (Period.month(june_2018)..Period.month(june_30_2020))
+    range = (Period.month(june_1_2018)..Period.month(june_30_2020))
     service = ControlRateService.new(facility_group_1, periods: range)
     result = service.call
     april_period = Date.parse("April 1 2020").to_period
     may_period = Date.parse("May 1 2020").to_period
+    expect(result[:registrations][june_1_2018.to_date.to_period]).to eq(2)
+    expect(result[:cumulative_registrations][june_1_2018.to_date.to_period]).to eq(6)
     expect(result[:registrations][april_period]).to eq(2)
-    expect(result[:cumulative_registrations][april_period]).to eq(2)
+    expect(result[:cumulative_registrations][april_period]).to eq(8)
     expect(result[:registrations][may_period]).to eq(3)
-    expect(result[:cumulative_registrations][may_period]).to eq(5)
+    expect(result[:cumulative_registrations][may_period]).to eq(11)
   end
 
   it "does not include months without registration data" do
@@ -58,7 +68,7 @@ RSpec.describe ControlRateService, type: :model do
 
     refresh_views
 
-    range = (Period.month(june_2018)..Period.month(june_30_2020))
+    range = (Period.month(june_1_2018)..Period.month(june_30_2020))
     result = nil
     Timecop.freeze("July 1st 2020") do
       service = ControlRateService.new(facility_group_1, periods: range)
@@ -88,7 +98,7 @@ RSpec.describe ControlRateService, type: :model do
       create(:blood_pressure, :under_control, facility: facility, patient: patient_from_other_facility, recorded_at: 2.days.ago)
     end
 
-    Timecop.freeze(june_1) do
+    Timecop.freeze(june_1_2020) do
       controlled_in_jan_and_june.map do |patient|
         create(:blood_pressure, :under_control, facility: facility, patient: patient, recorded_at: 2.days.ago, user: user)
         create(:blood_pressure, :hypertensive, facility: facility, patient: patient, recorded_at: 4.days.ago, user: user)
@@ -115,12 +125,12 @@ RSpec.describe ControlRateService, type: :model do
     expect(result[:controlled_patients_rate][Period.month(jan_2020)]).to eq(40.0)
 
     # 3 controlled patients in june and 10 cumulative registered patients
-    expect(result[:cumulative_registrations][Period.month(june_1)]).to eq(10)
-    expect(result[:registrations][Period.month(june_1)]).to eq(0)
-    expect(result[:controlled_patients][Period.month(june_1)]).to eq(3)
-    expect(result[:controlled_patients_rate][Period.month(june_1)]).to eq(30.0)
-    expect(result[:uncontrolled_patients][Period.month(june_1)]).to eq(5)
-    expect(result[:uncontrolled_patients_rate][Period.month(june_1)]).to eq(50.0)
+    expect(result[:cumulative_registrations][Period.month(june_1_2020)]).to eq(10)
+    expect(result[:registrations][Period.month(june_1_2020)]).to eq(0)
+    expect(result[:controlled_patients][Period.month(june_1_2020)]).to eq(3)
+    expect(result[:controlled_patients_rate][Period.month(june_1_2020)]).to eq(30.0)
+    expect(result[:uncontrolled_patients][Period.month(june_1_2020)]).to eq(5)
+    expect(result[:uncontrolled_patients_rate][Period.month(june_1_2020)]).to eq(50.0)
   end
 
   it "quarterly control rate looks only at patients registered in the previous quarter" do
@@ -133,17 +143,17 @@ RSpec.describe ControlRateService, type: :model do
       create(:blood_pressure, :under_control, facility: facility, patient: patient, recorded_at: Time.parse("September 1 2020"), user: user)
     end
 
-    controlled_in_q3 = create_list(:patient, 3, recorded_at: june_1, registration_facility: facility, registration_user: user)
+    controlled_in_q3 = create_list(:patient, 3, recorded_at: june_1_2020, registration_facility: facility, registration_user: user)
     controlled_in_q3.each do |patient|
       create(:blood_pressure, :under_control, facility: facility, patient: patient, recorded_at: Time.parse("September 1 2020"), user: user)
     end
 
-    controlled_in_q3_other_facility = create_list(:patient, 3, recorded_at: june_1, registration_facility: facility_2, registration_user: user)
+    controlled_in_q3_other_facility = create_list(:patient, 3, recorded_at: june_1_2020, registration_facility: facility_2, registration_user: user)
     controlled_in_q3_other_facility.each do |patient|
       create(:blood_pressure, :under_control, facility: facility_2, patient: patient, recorded_at: Time.parse("September 1 2020"), user: user)
     end
 
-    uncontrolled_in_q3 = create_list(:patient, 7, recorded_at: june_1, registration_facility: facility, registration_user: user)
+    uncontrolled_in_q3 = create_list(:patient, 7, recorded_at: june_1_2020, registration_facility: facility, registration_user: user)
     uncontrolled_in_q3.each do |patient|
       create(:blood_pressure, :hypertensive, facility: facility, patient: patient, recorded_at: Time.parse("September 1 2020"), user: user)
     end

--- a/spec/services/top_region_service_spec.rb
+++ b/spec/services/top_region_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe TopRegionService, type: :model do
     koriya_facilities = FactoryBot.create_list(:facility, 2, facility_group: koriya)
 
     Timecop.freeze("April 1st 2020") do
-      darrang_patients = create_list(:patient, 2, recorded_at: 1.month.ago, registration_facility: darrang_facilities.first, registration_user: user)
+      darrang_patients = create_list(:patient, 2, recorded_at: Time.current, registration_facility: darrang_facilities.first, registration_user: user)
       darrang_patients.each do |patient|
         create(:blood_pressure, :hypertensive, facility: darrang_facilities.first, patient: patient, recorded_at: Time.current)
       end
@@ -39,7 +39,7 @@ RSpec.describe TopRegionService, type: :model do
 
     refresh_views
 
-    service = TopRegionService.new([organization], Period.month(june_1.end_of_month))
+    service = TopRegionService.new([organization], Period.month(june_1))
     result = service.call
     expect(result[:control_rate][:region]).to eq(koriya)
     expect(result[:control_rate][:value]).to eq(100.0)
@@ -93,7 +93,7 @@ RSpec.describe TopRegionService, type: :model do
     result = service.call
     expect(result[:control_rate][:region]).to eq(darrang_facility_1)
     expect(result[:control_rate][:value]).to eq(75.0)
-    expect(result[:registrations][:region]).to eq(kadapa_facility)
-    expect(result[:registrations][:value]).to eq(6)
+    expect(result[:cumulative_registrations][:region]).to eq(kadapa_facility)
+    expect(result[:cumulative_registrations][:value]).to eq(6)
   end
 end


### PR DESCRIPTION
We were missing data from before the period range.  This grabs
cumulative registrations from before the reporting window.

**Story card:** https://app.clubhouse.io/simpledotorg/story/662/handle-properly-returning-registrations-for-a-window-of-data

Should fix this bug to make sure our registration counts are accurate.