### PR TITLE
Inline seeds in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ mailcatcher
 
 Now you should be able to see test emails at http://localhost:1080
 
+### Testing Web Views
+
+When testing web views like the progress tab or help screens, you will need to authenticate yourself with specific
+request headers. You can run the following command to get a set of request headers for a user that you can attach to
+your requests.
+
+```
+$ bundle exec rails get_user_credentials
+```
+
+The command will output a set of request headers that you can attach to your requests using tools like
+[Postman](https://www.postman.com/) or [ModHeader](https://bewisse.com/modheader/).
+
+```
+Attach the following request headers to your requests:
+Authorization: Bearer 9b54814d4b422ee37dad46e7ebee673c59eed088c264e479880cbe7fb5ac1ce7
+X-User-ID: 452b96c2-e0cf-49e7-ab73-c328acd3f1e5
+X-Facility-ID: dcda7d9d-48f9-47d2-b1cc-93d90c94386e
+```
+
 ### Review Apps
 
 #### Testing messages
@@ -105,7 +125,7 @@ DEFAULT_COUNTRY = US
 DEFAULT_COUNTRY = UK
 ```
 
-Updating this config will automatically restart the review app and should allow one to receive messages in their appropriate ISD codes. 
+Updating this config will automatically restart the review app and should allow one to receive messages in their appropriate ISD codes.
 
 ### Configuration
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -10,8 +10,14 @@ namespace :db do
       "Make sure there are some users created with those two roles; see db:seed."
     end
 
-    User.where(role: [ENV["SEED_GENERATED_ACTIVE_USER_ROLE"], ENV["SEED_GENERATED_INACTIVE_USER_ROLE"]])
-      .each { |user| SeedUsersDataJob.perform_async(user.id) }
+    User.where(role: [ENV["SEED_GENERATED_ACTIVE_USER_ROLE"], ENV["SEED_GENERATED_INACTIVE_USER_ROLE"]]).each do |user|
+      if Rails.env.development?
+        puts "Synchronous"
+        SeedUsersDataJob.new.perform(user.id)
+      else
+        SeedUsersDataJob.perform_async(user.id)
+      end
+    end
   end
 
   desc 'Purge all user data; Example: rake "db:purge_users_data'

--- a/lib/tasks/get_user_credentials.rake
+++ b/lib/tasks/get_user_credentials.rake
@@ -1,4 +1,4 @@
-desc 'Get user credentials to attach to request headers'
+desc "Get user credentials to attach to request headers"
 task get_user_credentials: :environment do
   abort "This task can only be run in development!" unless Rails.env.development?
 

--- a/lib/tasks/get_user_credentials.rake
+++ b/lib/tasks/get_user_credentials.rake
@@ -1,0 +1,11 @@
+desc 'Get user credentials to attach to request headers'
+task get_user_credentials: :environment do
+  abort "This task can only be run in development!" unless Rails.env.development?
+
+  user = User.sync_approval_status_allowed.joins(:phone_number_authentications).sample
+
+  puts "Attach the following request headers to your requests:"
+  puts "Authorization: Bearer #{user.access_token}"
+  puts "X-User-ID: #{user.id}"
+  puts "X-Facility-ID: #{user.registration_facility.id}"
+end


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/756/quickfix-seed-generation-in-local-development-environment

## Because

Our seed generation task doesn't work locally for some reason.

## This addresses

* Make seed jobs synchronous in dev
* Add a convenience task to spit out a set of request headers to authenticate web views, etc
