### PR TITLE
Assigned facility: Cohort report downloads

### DIFF
--- a/app/views/analytics/districts/show.csv.erb
+++ b/app/views/analytics/districts/show.csv.erb
@@ -73,7 +73,7 @@ end) %>
     "Total patients"
   ]
   dates = dates_for_periods(@period, 3, include_current_period: @show_current_period)
-  ["Patients with BP taken", "Registered patients"].each do |metric|
+  ["Patients with BP recorded", "Registered patients"].each do |metric|
     dates.each do |date|
       headers << "#{metric} #{format_period(@period, date)}"
     end

--- a/app/views/analytics/districts/show.csv.erb
+++ b/app/views/analytics/districts/show.csv.erb
@@ -2,7 +2,7 @@
 <% csv << ["Report generated at", Time.current] %>
 <% period = @period == :quarter ? 'Quarterly' : 'Monthly' %>
 <% csv << ["#{@organization_district.district_name} #{period} Cohort Report"] %>
-<% csv << ['Facility', 'Facility type'].concat(@cohort_analytics.each_with_index.flat_map do |(report_dates, analytics), index|
+<% csv << ['Facility', 'Facility type'].concat(@cohort_analytics.each_with_index.flat_map do |(_report_dates, _analytics), _|
   [
     'Cohort period',
     'Follow up period',
@@ -19,18 +19,24 @@
 end) %>
 <% csv << [] %>
 <% @facility_keys.each do |facility| %>
-<% csv << [facility[:name], facility[:type]].concat(@cohort_analytics.each_with_index.flat_map do |(report_dates, analytics), index|
+<% csv << [facility[:name], facility[:type]].concat(@cohort_analytics.each_with_index.flat_map do |(report_dates, analytics), _|
   cohort_start, report_start = report_dates
   registered = analytics.dig(:registered, facility[:id]) || 0
   followed_up = analytics.dig(:followed_up, facility[:id]) || 0
   defaulted = analytics.dig(:defaulted, facility[:id]) || 0
   controlled = analytics.dig(:controlled, facility[:id]) || 0
   uncontrolled = analytics.dig(:uncontrolled, facility[:id]) || 0
+
   if @period == :quarter
     report_period = quarter_string(report_start)
     cohort_period = quarter_string(cohort_start)
   else
-    report_period = [report_start.strftime("%b %-d"), (report_start + 1.month).end_of_month.strftime("%b %-d")].join("-")
+    report_end = (report_start + 1.month).end_of_month
+
+    formatted_report_start_date = report_start.strftime("%B #{report_start.day.ordinalize}")
+    formatted_report_end_date = report_end.strftime("%B #{report_end.day.ordinalize}")
+
+    report_period = [formatted_report_start_date, formatted_report_end_date].join(" – ")
     cohort_period = cohort_start.strftime("%b %Y")
   end
   if registered > 0
@@ -59,15 +65,15 @@ end) %>
 end) %>
 <% end %>
 <% csv << [] %>
-<% csv << ["#{@organization_district.district_name} Facilites Report"] %>
+<% csv << ["#{@organization_district.district_name} Facilities Report"] %>
 <%
   headers = [
     "Facility name",
     "Facility type",
-    "Total registered patients"
+    "Total patients"
   ]
   dates = dates_for_periods(@period, 3, include_current_period: @show_current_period)
-  ["Follow up patients", "Registered patients"].each do |metric|
+  ["Patients with BP taken", "Registered patients"].each do |metric|
     dates.each do |date|
       headers << "#{metric} #{format_period(@period, date)}"
     end
@@ -77,8 +83,8 @@ end) %>
 <% csv << [
     "All",
     nil,
-    @dashboard_analytics.sum { |_, row| row[:total_registered_patients] || 0 },
-    *dates.map { |period| analytics_totals(@dashboard_analytics, :follow_up_patients_by_period, period) },
+    @dashboard_analytics.sum { |_, row| row[:total_patients] || 0 },
+    *dates.map { |period| analytics_totals(@dashboard_analytics, :patients_with_bp_by_period, period) },
     *dates.map { |period| analytics_totals(@dashboard_analytics, :registered_patients_by_period, period) }
   ]
 %>
@@ -87,8 +93,8 @@ end) %>
     <% csv << [
         facility.name,
         facility.facility_type,
-        @dashboard_analytics.dig(facility.id, :total_registered_patients) || 0,
-        *dates.map { |period| @dashboard_analytics.dig(facility.id, :follow_up_patients_by_period, period) || 0 },
+        @dashboard_analytics.dig(facility.id, :total_patients) || 0,
+        *dates.map { |period| @dashboard_analytics.dig(facility.id, :patients_with_bp_by_period, period) || 0 },
         *dates.map { |period| @dashboard_analytics.dig(facility.id, :registered_patients_by_period, period) || 0 }
       ] %>
   <% end %>

--- a/app/views/analytics/facilities/show.csv.erb
+++ b/app/views/analytics/facilities/show.csv.erb
@@ -14,7 +14,7 @@
   'Uncontrolled rate',
   'Default rate'
 ] %>
-<% @cohort_analytics.each_with_index do |(report_dates, analytics), index| %>
+<% @cohort_analytics.each_with_index do |(report_dates, analytics), _| %>
   <%
     cohort_start, report_start = report_dates
     registered = analytics.dig(:registered, :total) || 0
@@ -22,13 +22,20 @@
     defaulted = analytics.dig(:defaulted, :total) || 0
     controlled = analytics.dig(:controlled, :total) || 0
     uncontrolled = analytics.dig(:uncontrolled, :total) || 0
+
     if @period == :quarter
       report_period = quarter_string(report_start)
       cohort_period = quarter_string(cohort_start)
     else
-      report_period = [report_start.strftime("%b %-d"), (report_start + 1.month).end_of_month.strftime("%b %-d")].join("-")
+      report_end = (report_start + 1.month).end_of_month
+
+      formatted_report_start_date = report_start.strftime("%B #{report_start.day.ordinalize}")
+      formatted_report_end_date = report_end.strftime("%B #{report_end.day.ordinalize}")
+
+      report_period = [formatted_report_start_date, formatted_report_end_date].join(" – ")
       cohort_period = cohort_start.strftime("%b %Y")
     end
+
     if registered > 0
       controlled_percent = (controlled.to_f / registered * 100).round
       uncontrolled_percent = (uncontrolled.to_f / registered * 100).round

--- a/spec/controllers/analytics/facilities_controller_spec.rb
+++ b/spec/controllers/analytics/facilities_controller_spec.rb
@@ -184,6 +184,13 @@ RSpec.describe Analytics::FacilitiesController, type: :controller do
         expect(assigns(:recent_blood_pressures).count).to eq(2)
       end
     end
+
+    context "csv download" do
+      it "renders a csv" do
+        get :show, params: {id: facility.id}, format: :csv
+        expect(response).to be_successful
+      end
+    end
   end
 
   describe "#patient_list" do


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/800/update-cohort-report-downloads-to-use-assigned-facility

## Because

We are making changes to our reports to incorporate assigned facility.

## This addresses

**Note**: Dependent on #1200 and #1202 to be merged to #1169 before this can be merged to #1169.

Changes the downloadable cohort reports ([monthly](http://simple.test/analytics/organizations/58734507-51b4-4893-a9b6-c183918e4dc2/districts/Darrang.csv?period=month) and [quarterly](http://simple.test/analytics/organizations/58734507-51b4-4893-a9b6-c183918e4dc2/districts/Darrang.csv?period=quarter)). [Ref](https://docs.google.com/document/d/1YZqm0t5NhTDUkn3Ww8yRqAszKCtAiOqChpFED6U-QXE/edit#heading=h.4h110o9ibmnm).

**District-level**

The headers have been changed from,

![Screenshot 2020-08-10 at 3 36 40 PM](https://user-images.githubusercontent.com/50663/89772245-51bc8580-db1f-11ea-8eef-bb146bd5be42.png)

To (ignore the data discrepancy, the screenshots were from two different envs), 

![Screenshot 2020-08-10 at 2 57 26 PM](https://user-images.githubusercontent.com/50663/89770256-1ff5ef80-db1c-11ea-85c8-8f34ef1dcac7.png)

**Facility-level**

No changes here to the data since it does not show user-level breakdown in this report, only cohort charts.

**Formatting**

Date intervals are formatted better, from this,
![Screenshot 2020-08-10 at 2 57 29 PM](https://user-images.githubusercontent.com/50663/89770254-1ec4c280-db1c-11ea-813b-cf56546fa401.png)

To this,

![Screenshot 2020-08-10 at 3 13 18 PM](https://user-images.githubusercontent.com/50663/89770250-1d939580-db1c-11ea-8fca-784290627428.png)