### PR TITLE
Assigned facility: Overdue list

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -20,7 +20,7 @@ class AppointmentsController < AdminController
     @patient_summaries = PatientSummaryQuery.call(relation: scope, filters: @search_filters)
 
     if current_facility
-      @patient_summaries = @patient_summaries.where(next_appointment_facility_id: current_facility.id)
+      @patient_summaries = @patient_summaries.where(assigned_facility_id: current_facility.id)
     end
     @patient_summaries = @patient_summaries.order(risk_level: :desc, next_appointment_scheduled_date: :desc, id: :asc)
 

--- a/db/migrate/20200810095935_update_patient_summaries_to_version_4.rb
+++ b/db/migrate/20200810095935_update_patient_summaries_to_version_4.rb
@@ -1,0 +1,5 @@
+class UpdatePatientSummariesToVersion4 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :patient_summaries, version: 4, revert_to_version: 3
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_17_062323) do
+ActiveRecord::Schema.define(version: 2020_08_10_095935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -734,6 +734,7 @@ ActiveRecord::Schema.define(version: 2020_07_17_062323) do
           END AS current_age,
       p.gender,
       p.status,
+      p.assigned_facility_id,
       latest_phone_number.number AS latest_phone_number,
       addresses.village_or_colony,
       addresses.street_address,

--- a/db/views/patient_summaries_v04.sql
+++ b/db/views/patient_summaries_v04.sql
@@ -1,0 +1,115 @@
+SELECT
+p.recorded_at,
+CONCAT(date_part('year', p.recorded_at), ' Q', EXTRACT(QUARTER FROM p.recorded_at)) AS registration_quarter,
+p.full_name,
+(
+    CASE
+      WHEN p.date_of_birth IS NOT NULL THEN date_part('year', age(p.date_of_birth))
+      ELSE p.age + date_part('years', age(NOW(), p.age_updated_at))
+    END
+) AS current_age,
+p.gender,
+p.status,
+p.assigned_facility_id AS assigned_facility_id,
+latest_phone_number.number AS latest_phone_number,
+addresses.village_or_colony AS village_or_colony,
+addresses.street_address AS street_address,
+addresses.district AS district,
+addresses.state AS state,
+reg_facility.name AS registration_facility_name,
+reg_facility.facility_type AS registration_facility_type,
+reg_facility.district AS registration_district,
+reg_facility.state AS registration_state,
+latest_blood_pressure.systolic AS latest_blood_pressure_systolic,
+latest_blood_pressure.diastolic AS latest_blood_pressure_diastolic,
+latest_blood_pressure.recorded_at AS latest_blood_pressure_recorded_at,
+CONCAT(date_part('year', latest_blood_pressure.recorded_at), ' Q', EXTRACT(QUARTER FROM latest_blood_pressure.recorded_at)) AS latest_blood_pressure_quarter,
+latest_blood_pressure_facility.name AS latest_blood_pressure_facility_name,
+latest_blood_pressure_facility.facility_type AS latest_blood_pressure_facility_type,
+latest_blood_pressure_facility.district AS latest_blood_pressure_district,
+latest_blood_pressure_facility.state AS latest_blood_pressure_state,
+latest_blood_sugar.blood_sugar_type AS latest_blood_sugar_type,
+latest_blood_sugar.blood_sugar_value AS latest_blood_sugar_value,
+latest_blood_sugar.recorded_at AS latest_blood_sugar_recorded_at,
+CONCAT(date_part('year', latest_blood_sugar.recorded_at), ' Q', EXTRACT(QUARTER FROM latest_blood_sugar.recorded_at)) AS latest_blood_sugar_quarter,
+latest_blood_sugar_facility.name AS latest_blood_sugar_facility_name,
+latest_blood_sugar_facility.facility_type AS latest_blood_sugar_facility_type,
+latest_blood_sugar_facility.district AS latest_blood_sugar_district,
+latest_blood_sugar_facility.state AS latest_blood_sugar_state,
+greatest(0, date_part('day', NOW() - next_appointment.scheduled_date)) AS days_overdue,
+next_appointment.id AS next_appointment_id,
+next_appointment.scheduled_date AS next_appointment_scheduled_date,
+next_appointment.status AS next_appointment_status,
+next_appointment.remind_on AS next_appointment_remind_on,
+next_appointment_facility.id AS next_appointment_facility_id,
+next_appointment_facility.name AS next_appointment_facility_name,
+next_appointment_facility.facility_type AS next_appointment_facility_type,
+next_appointment_facility.district AS next_appointment_district,
+next_appointment_facility.state AS next_appointment_state,
+
+(
+    CASE
+      WHEN next_appointment.scheduled_date IS NULL THEN 0
+      WHEN next_appointment.scheduled_date > date_trunc('day', NOW() - interval '30 days') THEN 0
+      WHEN (latest_blood_pressure.systolic >= 180 OR latest_blood_pressure.diastolic >= 110) THEN 1
+      WHEN (
+        (mh.prior_heart_attack = 'yes' OR mh.prior_stroke = 'yes')
+        AND (latest_blood_pressure.systolic >= 140 OR latest_blood_pressure.diastolic >= 90)
+      ) THEN 1
+      WHEN (
+        (latest_blood_sugar.blood_sugar_type = 'random' AND latest_blood_sugar.blood_sugar_value >= 300)
+        OR (latest_blood_sugar.blood_sugar_type = 'post_prandial' AND latest_blood_sugar.blood_sugar_value >= 300)
+        OR (latest_blood_sugar.blood_sugar_type = 'fasting' AND latest_blood_sugar.blood_sugar_value >= 200)
+        OR (latest_blood_sugar.blood_sugar_type = 'hba1c' AND latest_blood_sugar.blood_sugar_value >= 9.0)
+      ) THEN 1
+      ELSE 0
+    END
+) AS risk_level,
+
+latest_bp_passport.identifier AS latest_bp_passport,
+p.id
+
+FROM patients p
+
+LEFT OUTER JOIN addresses ON addresses.id = p.address_id
+LEFT OUTER JOIN facilities reg_facility ON reg_facility.id = p.registration_facility_id
+LEFT OUTER JOIN medical_histories mh ON mh.patient_id = p.id
+
+LEFT OUTER JOIN (
+    SELECT DISTINCT ON (patient_id) *
+    FROM patient_phone_numbers
+    ORDER BY patient_id, device_created_at DESC
+) AS latest_phone_number
+ON latest_phone_number.patient_id = p.id
+
+LEFT OUTER JOIN (
+    SELECT DISTINCT ON (patient_id) *
+    FROM blood_pressures
+    ORDER BY patient_id, recorded_at DESC
+) AS latest_blood_pressure
+ON latest_blood_pressure.patient_id = p.id
+LEFT OUTER JOIN facilities latest_blood_pressure_facility ON latest_blood_pressure_facility.id = latest_blood_pressure.facility_id
+
+LEFT OUTER JOIN (
+    SELECT DISTINCT ON (patient_id) *
+    FROM blood_sugars
+    ORDER BY patient_id, recorded_at DESC
+) AS latest_blood_sugar
+ON latest_blood_sugar.patient_id = p.id
+LEFT OUTER JOIN facilities latest_blood_sugar_facility ON latest_blood_sugar_facility.id = latest_blood_sugar.facility_id
+
+LEFT OUTER JOIN (
+    SELECT DISTINCT ON (patient_id) *
+    FROM patient_business_identifiers
+    WHERE identifier_type = 'simple_bp_passport'
+    ORDER BY patient_id, device_created_at DESC
+) AS latest_bp_passport
+ON latest_bp_passport.patient_id = p.id
+
+LEFT OUTER JOIN (
+    SELECT DISTINCT ON (patient_id) *
+    FROM appointments
+    ORDER BY patient_id, scheduled_date DESC
+) AS next_appointment
+ON next_appointment.patient_id = p.id
+LEFT OUTER JOIN facilities next_appointment_facility ON next_appointment_facility.id = next_appointment.facility_id;

--- a/spec/controllers/appointments_controller_spec.rb
+++ b/spec/controllers/appointments_controller_spec.rb
@@ -11,9 +11,11 @@ RSpec.describe AppointmentsController, type: :controller do
   describe "GET #index" do
     render_views
 
+    let!(:appointment_facility) { create(:facility, facility_group: facility_group) }
     let!(:facility_1) { create(:facility, facility_group: facility_group) }
+    let!(:facility_1_patients) { create_list(:patient, 3, assigned_facility: facility_1) }
     let!(:overdue_appointments_in_facility_1) do
-      appointments = create_list(:appointment, 3, :overdue, facility: facility_1)
+      appointments = facility_1_patients.map { |patient| create(:appointment, :overdue, patient: patient, facility: appointment_facility) }
       appointments.each do |appointment|
         create(:blood_pressure, patient: appointment.patient, facility: facility_1)
         create(:blood_pressure, patient: appointment.patient, facility: facility_1)
@@ -22,8 +24,9 @@ RSpec.describe AppointmentsController, type: :controller do
     end
 
     let!(:facility_2) { create(:facility, facility_group: facility_group) }
+    let!(:facility_2_patients) { create_list(:patient, 3, assigned_facility: facility_2) }
     let!(:overdue_appointments_in_facility_2) do
-      appointments = create_list(:appointment, 3, :overdue, facility: facility_2)
+      appointments = facility_2_patients.map { |patient| create(:appointment, :overdue, patient: patient, facility: appointment_facility) }
       appointments.each do |appointment|
         create(:blood_pressure, patient: appointment.patient, facility: facility_2)
         create(:blood_pressure, patient: appointment.patient, facility: facility_2)
@@ -51,7 +54,7 @@ RSpec.describe AppointmentsController, type: :controller do
         expect(response.body).to include("recorded at #{facility_2.name}")
       end
 
-      it "displays appointments for only the selected facility" do
+      it "displays appointments for only the selected assigned facility" do
         get :index, params: {
           facility_id: facility_1.id,
           per_page: "All"


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/801

## Because

We are making our dashboard reports assigned facility compliant.

## This addresses

This changes the definition of overdue patients at a facility in the overdue list ([PRD](https://docs.google.com/document/d/1YZqm0t5NhTDUkn3Ww8yRqAszKCtAiOqChpFED6U-QXE/edit#heading=h.7cwjocnpi9wr)). This necessitates adding the `assigned_facility_id` to `PatientSummary`.

Before:
All overdue patients whose next appointment is at the facility f AND

After:
All overdue patients whose assigned facility is f AND
Next appointment is at any facility AND
