### PR TITLE
Add ethiopia english locale

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module SimpleServer
 
     # Locale configuration
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
-    config.i18n.available_locales = %w[en mr-IN pa-Guru-IN bn-BD kn-IN en_BD en_IN en-IND bn-IN hi-IN ta-IN te-IN am-ET om-ET ti-ET]
+    config.i18n.available_locales = %w[en mr-IN pa-Guru-IN bn-BD kn-IN en_BD en_IN en_ET en-IND bn-IN hi-IN ta-IN te-IN am-ET om-ET ti-ET]
     config.i18n.fallbacks = [:en]
     config.i18n.default_locale = :en
   end


### PR DESCRIPTION
## Because

We don't have an english locale for ethiopia in our `available_locales`. This was found in a sentry error on [ethiopia demo](https://simpledotorg.slack.com/archives/CFHMC60P5/p1597230017006500)

## This addresses

This adds `en_ET` to the list of available locales.
