### PR TITLE
Links added to the app store buttons in HELP for the BP Passport App

### DIFF
--- a/config/locales/api/help/en.html
+++ b/config/locales/api/help/en.html
@@ -499,8 +499,8 @@
         <div class="card">
             <h3>Apple and Android</h3>
             <p style="margin-bottom: 2.5em;">Tell your patients to get the app by searching for <span class="code">BP Passsport</span> on the Google Play Store or Apple App Store.</p>
-            <a href="#" class="app-button button">%{icon_apple_icon_svg} Apple App Store</a>
-            <a href="#" class="app-button button">%{icon_google_play_icon_svg} Google Play Store</a>
+            <a href="https://apps.apple.com/us/app/bp-passport/id1510811893" class="app-button button">%{icon_apple_icon_svg} Apple App Store</a>
+            <a href="https://play.google.com/store/apps/details?id=org.simple.bppassport" class="app-button button">%{icon_google_play_icon_svg} Google Play Store</a>
         </div>
         
         <div class="card">

--- a/config/locales/api/help/en.html
+++ b/config/locales/api/help/en.html
@@ -49,7 +49,7 @@
             </a>
             <h3><span style="color: #FF3355; font-size: 90%; float: right;">NEW!</span> App for your patients</h3>
             <p>Patients can now chart their own BPs and blood sugars with a simple app called the "BP Passport" app.</p>
-            <p>Ask your patients to go to the Android or iOS app store and install the "BP Passport" app.</p>
+            <p>Ask your patients to go to the Google or Apple app store and install the "BP Passport" app.</p>
             <p class="card-footer-button"><a href="#" onclick="openWindow('help-bp-passport-app'); return false">Learn more...</a></p>
             
         </div>


### PR DESCRIPTION
**Story card:** NONE

## Because

Links were missing from the app store buttons in HELP

## This addresses

Missing links
