### PR TITLE
Reports: Copy updates

### DIFF
--- a/app/assets/javascripts/reports.js
+++ b/app/assets/javascripts/reports.js
@@ -284,7 +284,7 @@ function formatRateTooltipText(tooltipItem, data, sumData) {
 }
 
 function formatSumTooltipText(tooltipItem) {
-  return `${formatNumberWithCommas(tooltipItem.value)} patients registered in ${tooltipItem.label}`;
+  return `${formatNumberWithCommas(tooltipItem.value)} cumulative registrations in ${tooltipItem.label}`;
 }
 
 function formatValueAsPercent(value) {

--- a/app/assets/stylesheets/partials/_reports.scss
+++ b/app/assets/stylesheets/partials/_reports.scss
@@ -28,6 +28,7 @@
 // Spacing
 .m-0px { margin: 0px; }
 .mt-0px { margin-top: 0px; }
+.mt-4px { margin-top: 4px; }
 .mt-8px { margin-top: 8px; }
 .mr-4px { margin-right: 4px; }
 .mr-12px { margin-right: 12px; }
@@ -49,6 +50,7 @@
 .pt-20px { padding-top: 20px; }
 .pt-24px { padding-top: 24px; }
 .pb-8px { padding-bottom: 8px; }
+.pl-16px { padding-left: 16px; }
 .px-1px { padding-right: 1px; padding-left: 1px; }
 .px-20px { padding-right: 20px; padding-left: 20px; }
 // Width

--- a/app/assets/stylesheets/partials/_reports.scss
+++ b/app/assets/stylesheets/partials/_reports.scss
@@ -144,6 +144,7 @@
   .h-lg-full { width: 100%; }
   // Spacing
   .mt-lg-0px { margin-top: 0px; }
+  .mt-lg-48px { margin-top: 48px; }
   .mr-lg-24px { margin-right: 24px; }
   .mb-lg-0 { margin-bottom: 0; }
   .mb-lg-4px { margin-bottom: 4px; }

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -35,6 +35,7 @@ class Reports::RegionsController < AdminController
     @registrations = @data[:cumulative_registrations]
     @quarterly_registrations = @data[:quarterly_registrations]
     @last_registration_value = @data[:cumulative_registrations].values&.last || 0
+    @adjusted_registration_date = @data[:adjusted_registrations].keys[-4]
   end
 
   def cohort

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -22,6 +22,7 @@ class Reports::RegionsController < AdminController
     @quarterly_registrations = @data[:quarterly_registrations]
     @last_registration_value = @data[:cumulative_registrations].values&.last || 0
     @new_registrations = @last_registration_value - @data[:cumulative_registrations].values[-2]
+    @adjusted_registration_date = @data[:adjusted_registrations].keys[-4]
   end
 
   def details

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -1,5 +1,11 @@
 <div class="alert alert-primary">
-  <span class="fw-bold">Early access:</span> This page is under active development, thanks for your patience as we work on improving it
+  <span class="fw-bold">Early access:</span> Thanks for your patience as we improve this page. The following features are coming soon:
+  <ul class="mt-4px mb-0px pl-16px">
+    <li>More detailed cohorts</li>
+    <li>Lost to follow-up rate</li>
+    <li>Facility comparison tables</li>
+    <li>State and block level reports</li>
+  </ul>
 </div>
 <div class="dashboard">
   <nav class="breadcrumb mb-0px">

--- a/app/views/reports/regions/details.html.erb
+++ b/app/views/reports/regions/details.html.erb
@@ -4,7 +4,7 @@
     Visit details of all HTN patients
   </h3>
   <p class="mb-0px c-grey-dark">
-    <%= number_with_delimiter(@data[:adjusted_registrations].values.last) %> patients registered until the end of <%= @data[:adjusted_registrations].keys[-4] %>
+    <%= number_with_delimiter(@data[:adjusted_registrations].values.last) %> patients registered until the end of <%= @adjusted_registration_date %>
   </p>
   <% if @last_registration_value %>
     <div class="d-flex fd-column fd-lg-row">

--- a/app/views/reports/regions/details.html.erb
+++ b/app/views/reports/regions/details.html.erb
@@ -1,82 +1,78 @@
 <%= render "header"%>
-<div class="card d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0">
-  <div>
-    <div class="mb-2">
-        <h3 class="m-8px c-black">
-          Visit details of all HTN patients
-        </h3>
-        <p class="c-grey-dark">
-          <%= number_with_delimiter(@data[:adjusted_registrations].values.last) %> patients registered until the end of <%= @data[:adjusted_registrations].keys[-4] %>
-        </p>
+<div class="card">
+  <h3 class="m-8px c-black">
+    Visit details of all HTN patients
+  </h3>
+  <p class="mb-0px c-grey-dark">
+    <%= number_with_delimiter(@data[:adjusted_registrations].values.last) %> patients registered until the end of <%= @data[:adjusted_registrations].keys[-4] %>
+  </p>
+  <% if @last_registration_value %>
+    <div class="d-flex fd-column fd-lg-row">
+      <div class="order-lg-2 w-lg-224px mt-lg-48px ml-lg-24px">
+        <div class="d-flex align-baseline mb-8px mb-lg-16px">
+          <div class="w-12px h-12px mr-12px br-2px bg-grey-medium"></div>
+          <div class="d-flex flex-1 align-baseline fd-lg-column">
+            <p class="w-48px m-0px fw-bold fs-20px lh-1 mb-lg-4px w-lg-full">
+              <%= percentage_or_na(@data[:missed_visits_rate].values.last, precision: 0) %>
+            </p>
+            <p class="flex-1 m-0px fs-14px">
+              Last BP &gt;3 months ago
+            </p>
+          </div>
+        </div>
+        <div class="d-flex align-baseline mb-8px mb-lg-16px">
+          <div class="w-12px h-12px mr-12px br-2px bg-grey-dark"></div>
+          <div class="d-flex flex-1 align-baseline fd-lg-column">
+            <p class="w-48px m-0px fw-bold fs-20px lh-1 mb-lg-4px w-lg-full">
+              <%= number_to_percentage(@data[:visited_without_bp_taken_rate].values.last, precision: 0) %>
+            </p>
+            <p class="flex-1 m-0px fs-14px">
+              Visited in the last 3 months but no BP measure
+              <span
+                data-toggle="tooltip"
+                data-placement="top"
+                data-trigger="hover"
+                title="Patients registered until the end of <%= @data[:adjusted_registrations].keys[-4] %> with an appointment scheduled, updated medicines, or blood sugar taken"
+              >
+                <i class="fas fa-info-circle ml-4px fs-12px c-grey-dark"></i>
+              </span>
+            </p>
+          </div>
+        </div>
+        <div class="d-flex align-baseline mb-8px mb-lg-16px">
+          <div class="w-12px h-12px mr-12px br-2px bg-red-medium"></div>
+          <div class="d-flex flex-1 align-baseline fd-lg-column">
+            <p class="w-48px m-0px fw-bold fs-20px lh-1 mb-lg-4px w-lg-full">
+              <%= number_to_percentage(@data[:uncontrolled_patients_rate].values.last, precision: 0) %>
+            </p>
+            <p class="flex-1 m-0px fs-14px">
+              Visited with BP &ge;140/90 in last 3 months
+            </p>
+          </div>
+        </div>
+        <div class="d-flex align-baseline mb-8px mb-lg-16px">
+          <div class="w-12px h-12px mr-12px br-2px bg-green-medium"></div>
+          <div class="d-flex flex-1 align-baseline fd-lg-column">
+            <p class="w-48px m-0px fw-bold fs-20px lh-1 mb-lg-4px w-lg-full">
+              <%= number_to_percentage(@data[:controlled_patients_rate].values.last, precision: 0) %>
+            </p>
+            <p class="flex-1 m-0px fs-14px">
+              Visited with BP &lt;140/90 in last 3 months
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="flex-lg-1 order-lg-1">
+        <canvas id="missedVisitDetails"></canvas>
+      </div>
     </div>
-    <% if @last_registration_value %>
-      <div class="d-flex fd-column fd-lg-row">
-        <div class="order-lg-2 w-lg-224px ml-lg-24px">
-          <div class="d-flex align-baseline mb-8px mb-lg-16px">
-            <div class="w-12px h-12px mr-12px br-2px bg-grey-medium"></div>
-            <div class="d-flex flex-1 align-baseline fd-lg-column">
-              <p class="w-48px m-0px fw-bold fs-20px lh-1 mb-lg-4px w-lg-full">
-                <%= percentage_or_na(@data[:missed_visits_rate].values.last, precision: 0) %>
-              </p>
-              <p class="flex-1 m-0px fs-14px">
-                Last BP &gt;3 months ago
-              </p>
-            </div>
-          </div>
-          <div class="d-flex align-baseline mb-8px mb-lg-16px">
-            <div class="w-12px h-12px mr-12px br-2px bg-grey-dark"></div>
-            <div class="d-flex flex-1 align-baseline fd-lg-column">
-              <p class="w-48px m-0px fw-bold fs-20px lh-1 mb-lg-4px w-lg-full">
-                <%= number_to_percentage(@data[:visited_without_bp_taken_rate].values.last, precision: 0) %>
-              </p>
-              <p class="flex-1 m-0px fs-14px">
-                Visited in the last 3 months but no BP measure
-                <span
-                  data-toggle="tooltip"
-                  data-placement="top"
-                  data-trigger="hover"
-                  title="Patients registered until the end of <%= @data[:adjusted_registrations].keys[-4] %> with an appointment scheduled, updated medicines, or blood sugar taken"
-                >
-                  <i class="fas fa-info-circle ml-4px fs-12px c-grey-dark"></i>
-                </span>
-              </p>
-            </div>
-          </div>
-          <div class="d-flex align-baseline mb-8px mb-lg-16px">
-            <div class="w-12px h-12px mr-12px br-2px bg-red-medium"></div>
-            <div class="d-flex flex-1 align-baseline fd-lg-column">
-              <p class="w-48px m-0px fw-bold fs-20px lh-1 mb-lg-4px w-lg-full">
-                <%= number_to_percentage(@data[:uncontrolled_patients_rate].values.last, precision: 0) %>
-              </p>
-              <p class="flex-1 m-0px fs-14px">
-                Visited with BP &ge;140/90 in last 3 months
-              </p>
-            </div>
-          </div>
-          <div class="d-flex align-baseline mb-8px mb-lg-16px">
-            <div class="w-12px h-12px mr-12px br-2px bg-green-medium"></div>
-            <div class="d-flex flex-1 align-baseline fd-lg-column">
-              <p class="w-48px m-0px fw-bold fs-20px lh-1 mb-lg-4px w-lg-full">
-                <%= number_to_percentage(@data[:controlled_patients_rate].values.last, precision: 0) %>
-              </p>
-              <p class="flex-1 m-0px fs-14px">
-                Visited with BP &lt;140/90 in last 3 months
-              </p>
-            </div>
-          </div>
-        </div>
-        <div class="flex-lg-1 order-lg-1">
-          <canvas id="missedVisitDetails"></canvas>
-        </div>
-      </div>
-    <% else %>
-      <div class="d-flex align-center justify-center w-100pt h-200px h-lg-380px bl-1px bb-1px bl-grey-medium bb-grey-medium">
-        <p class="c-grey-medium">
-          No data available
-        </p>
-      </div>
-    <% end %>
-  </div>
+  <% else %>
+    <div class="d-flex align-center justify-center w-100pt h-200px h-lg-380px bl-1px bb-1px bl-grey-medium bb-grey-medium">
+      <p class="c-grey-medium">
+        No data available
+      </p>
+    </div>
+  <% end %>
 </div>
 <div id="data-json" style="display: none;">
   <%= raw @data.to_json %>

--- a/app/views/reports/regions/details.html.erb
+++ b/app/views/reports/regions/details.html.erb
@@ -2,9 +2,12 @@
 <div class="card d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0">
   <div>
     <div class="mb-2">
-      <h3>
-        Visit details of all HTN patients
-      </h3>
+        <h3 class="m-8px c-black">
+          Visit details of all HTN patients
+        </h3>
+        <p class="c-grey-dark">
+          <%= number_with_delimiter(@data[:adjusted_registrations].values.last) %> patients registered until the end of <%= @data[:adjusted_registrations].keys[-4] %>
+        </p>
     </div>
     <% if @last_registration_value %>
       <div class="d-flex fd-column fd-lg-row">
@@ -32,7 +35,7 @@
                   data-toggle="tooltip"
                   data-placement="top"
                   data-trigger="hover"
-                  title="Patients with an appointment scheduled, updated medicines, or blood sugar taken"
+                  title="Patients registered until the end of <%= @data[:adjusted_registrations].keys[-4] %> with an appointment scheduled, updated medicines, or blood sugar taken"
                 >
                   <i class="fas fa-info-circle ml-4px fs-12px c-grey-dark"></i>
                 </span>

--- a/app/views/reports/regions/index.html.erb
+++ b/app/views/reports/regions/index.html.erb
@@ -1,5 +1,11 @@
 <div class="alert alert-primary">
-  <span class="fw-bold">Early access:</span> This page is under active development, thanks for your patience as we work on improving it
+  <span class="fw-bold">Early access:</span> Thanks for your patience as we improve this page. The following features are coming soon:
+  <ul class="mt-4px mb-0px pl-16px">
+    <li>More detailed cohorts</li>
+    <li>Lost to follow-up rate</li>
+    <li>Facility comparison tables</li>
+    <li>State and block level reports</li>
+  </ul>
 </div>
 <div class="container">
   <div class="row">

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -53,7 +53,7 @@
           No recent BP
         </h3>
         <p class="c-grey-dark">
-          HTN patients with no BP measure recorded in the last 3 months
+          HTN patients with no recent BP measure recorded
         </p>
         <div>
           <div class="d-flex align-baseline mb-8px mb-lg-4px">

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -27,7 +27,7 @@
                 data-toggle="tooltip"
                 data-placement="top"
                 data-trigger="hover"
-                title="Patients registered until the end of <%= @data[:adjusted_registrations].keys[-4] %>"
+                title="Patients registered until the end of <%= @adjusted_registration_date %>"
               >
                 <i class="fas fa-info-circle ml-4px fs-12px c-grey-dark"></i>
               </span>
@@ -87,7 +87,7 @@
                   data-toggle="tooltip"
                   data-placement="top"
                   data-trigger="hover"
-                  title="Patients registered until the end of <%= @data[:adjusted_registrations].keys[-4] %> with an appointment scheduled, updated medicines, or blood sugar taken"
+                  title="Patients registered 3 months prior with an appointment scheduled, updated medicines, or blood sugar taken"
                 >
                   <i class="fas fa-info-circle ml-4px fs-12px c-grey-dark"></i>
                 </span>
@@ -129,7 +129,7 @@
                 data-toggle="tooltip"
                 data-placement="top"
                 data-trigger="hover"
-                title="Patients registered until the end of <%= @data[:adjusted_registrations].keys[-4] %>"
+                title="Patients registered until the end of <%= @adjusted_registration_date %>"
               >
                 <i class="fas fa-info-circle ml-4px fs-12px c-grey-dark"></i>
               </span>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -23,6 +23,14 @@
           <p class="m-0px <% if @data.last_value(:controlled_patients_rate) %>c-black<% else %>c-grey-medium<% end %>">
             <% if @data.last_value(:controlled_patients_rate) %>
               <span class="fw-bold"><%= number_with_delimiter(@data.last_value(:controlled_patients)) %></span> of <%= number_with_delimiter(@data.last_value(:adjusted_registrations)) %> patients
+              <span
+                data-toggle="tooltip"
+                data-placement="top"
+                data-trigger="hover"
+                title="Patients registered until the end of <%= @data[:adjusted_registrations].keys[-4] %>"
+              >
+                <i class="fas fa-info-circle ml-4px fs-12px c-grey-dark"></i>
+              </span>
             <% else %>
               No control rate data available
             <% end %>
@@ -79,7 +87,7 @@
                   data-toggle="tooltip"
                   data-placement="top"
                   data-trigger="hover"
-                  title="Patients with an appointment scheduled, updated medicines, or blood sugar taken"
+                  title="Patients registered until the end of <%= @data[:adjusted_registrations].keys[-4] %> with an appointment scheduled, updated medicines, or blood sugar taken"
                 >
                   <i class="fas fa-info-circle ml-4px fs-12px c-grey-dark"></i>
                 </span>
@@ -116,9 +124,15 @@
           </p>
           <p class="m-0px <% if @data.last_value(:uncontrolled_patients_rate) %>c-black<% else %>c-grey-medium<% end %>">
             <% if @data.last_value(:uncontrolled_patients_rate) %>
-              <span class="fw-bold">
-                <%= number_with_delimiter(@data.last_value(:uncontrolled_patients)) %>
-                </span> of <%= number_with_delimiter(@data.last_value(:adjusted_registrations)) %> patients
+              <span class="fw-bold"><%= number_with_delimiter(@data.last_value(:uncontrolled_patients)) %></span> of <%= number_with_delimiter(@data.last_value(:adjusted_registrations)) %> patients
+              <span
+                data-toggle="tooltip"
+                data-placement="top"
+                data-trigger="hover"
+                title="Patients registered until the end of <%= @data[:adjusted_registrations].keys[-4] %>"
+              >
+                <i class="fas fa-info-circle ml-4px fs-12px c-grey-dark"></i>
+              </span>
             <% else %>
               No control rate data available
             <% end %>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -63,7 +63,7 @@
                 <%= percentage_or_na(@data[:missed_visits_rate].values.last, precision: 0) %>
               </p>
               <p class="flex-1 m-0px fs-14px">
-                Last BP &gt;3 months ago
+                No visit &gt;3 months
               </p>
             </div>
           </div>
@@ -74,7 +74,7 @@
                 <%= percentage_or_na(@data[:visited_without_bp_taken_rate].values.last, precision: 0) %>
               </p>
               <p class="flex-1 m-0px fs-14px">
-                Visited in the last 3 months but no BP measure
+                Visited in the last 3 months
                 <span
                   data-toggle="tooltip"
                   data-placement="top"


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/epic/48/dashboard-reports-v1

## Because

Improving copy per Daniel/Reena's feedback prior to initial release

## This addresses

**"No recent BP"**
*Label copy => "No visit >3 months" and "Visited in the last 3 months"*
![image](https://user-images.githubusercontent.com/16785131/90280710-63f93500-de39-11ea-88b5-bdc989143b8d.png)

**"Cumulative registrations"**
*Update tooltip to read "XX cumulative registrations in XX"*
![image](https://user-images.githubusercontent.com/16785131/90259325-cf320f80-de17-11ea-8ca5-073785e2d17f.png)

**Cards 1 - 3, "Visit details"**
*Add info tooltip with “Patients registered until the end of April 2020” to Cards 1 - 3 and "Visit details..." card*
![image](https://user-images.githubusercontent.com/16785131/90273993-d401be00-de2d-11ea-9c77-a6edaf02bf31.png)

**Denominator tooltips**
*Update cards 1 - 3 and "Visit details" to include denominator. Example "5% control rate (102 of XX patients) in July 2020"*
![image](https://user-images.githubusercontent.com/16785131/90272624-a61b7a00-de2b-11ea-95cf-22007aac786a.png)

**"Visit details of all HTN patients"**
*Added subtitle; Made some minor spacing polishes and cleaned up HTML*
![image](https://user-images.githubusercontent.com/16785131/90273903-b0d70e80-de2d-11ea-978a-e03e470d529b.png)

**Updated 'Early access' banner copy**
*Added list of upcoming features*
![image](https://user-images.githubusercontent.com/16785131/90275518-6efb9780-de30-11ea-82a7-c4b7ef5e81e1.png)