### PR TITLE
Deploy script: Escape CHANGELOG before shelling out

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -10,6 +10,7 @@
 # ± bin/deploy help
 #
 require 'pathname'
+require 'shellwords'
 
 class DeployError < StandardError
 end
@@ -161,7 +162,7 @@ This is generated from the diff between #{last_deployed_sha}..HEAD
       end
 
     # create tag
-    execute_safely("git tag -a #{@tag_to_deploy} -m \"#{changelog}\"", confirm: true)
+    execute_safely("git tag -a #{@tag_to_deploy} -m \"#{changelog.shellescape}\"", confirm: true)
     puts "Created tag #{@tag_to_deploy}."
 
     # push tag


### PR DESCRIPTION
## Because

Today our deploy script fails if there are weird characters or double quotes in the CHANGELOG.

## This addresses

This uses Ruby's `shellwords` library to automatically escape the CHANGELOG.
