### PR TITLE
Add API docs for Telemed MVP APIs

### DIFF
--- a/app/models/prescription_drug.rb
+++ b/app/models/prescription_drug.rb
@@ -4,6 +4,13 @@ class PrescriptionDrug < ApplicationRecord
 
   ANONYMIZED_DATA_FIELDS = %w[id patient_id created_at registration_facility_name user_id medicine_name dosage]
 
+  enum frequency: {
+    OD: "OD",
+    BD: "BD",
+    QDS: "QDS",
+    TDS: "TDS"
+  }, _prefix: true
+
   belongs_to :facility, optional: true
   belongs_to :patient, optional: true
   belongs_to :user, optional: true

--- a/app/models/teleconsultation.rb
+++ b/app/models/teleconsultation.rb
@@ -1,0 +1,14 @@
+class Teleconsultation
+  TELECONSULTATION_ANSWERS = {
+    yes: "yes",
+    no: "no",
+    unknown: "unknown"
+  }.freeze
+
+  TYPES = {
+    audio: "audio",
+    video: "video",
+    message: "message"
+  }.freeze
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,9 +6,8 @@ class User < ApplicationRecord
     phone_number_authentication: "PhoneNumberAuthentication"
   }
 
-  APP_USER_CAPABILITIES = {
-    can_teleconsult: "can_teleconsult"
-  }.freeze
+  APP_USER_CAPABILITIES = [:can_teleconsult].freeze
+  APP_USER_CAPABILITY_VALUES = %w[yes no]
 
   enum sync_approval_status: {
     requested: "requested",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,10 @@ class User < ApplicationRecord
     phone_number_authentication: "PhoneNumberAuthentication"
   }
 
+  APP_USER_CAPABILITIES = {
+    can_teleconsult: "can_teleconsult"
+  }.freeze
+
   enum sync_approval_status: {
     requested: "requested",
     allowed: "allowed",

--- a/app/schema/api/v3/models.rb
+++ b/app/schema/api/v3/models.rb
@@ -253,7 +253,7 @@ class Api::V3::Models
          is_deleted: {type: :boolean},
          patient_id: {"$ref" => "#/definitions/uuid"},
          facility_id: {"$ref" => "#/definitions/uuid"},
-         frequencies: {type: :string, enum: PrescriptionDrug.frequencies.keys},
+         frequency: {type: :string, enum: PrescriptionDrug.frequencies.keys},
          prescribed_for_days: {type: :integer}
        },
        required: %w[id created_at updated_at name is_protocol_drug is_deleted patient_id facility_id]}

--- a/app/schema/api/v3/models.rb
+++ b/app/schema/api/v3/models.rb
@@ -254,7 +254,7 @@ class Api::V3::Models
          patient_id: {"$ref" => "#/definitions/uuid"},
          facility_id: {"$ref" => "#/definitions/uuid"},
          frequency: {type: :string, enum: PrescriptionDrug.frequencies.keys},
-         prescribed_for_days: {type: :integer}
+         duration_in_days: {type: :integer}
        },
        required: %w[id created_at updated_at name is_protocol_drug is_deleted patient_id facility_id]}
     end

--- a/app/schema/api/v3/models.rb
+++ b/app/schema/api/v3/models.rb
@@ -252,7 +252,9 @@ class Api::V3::Models
          is_protocol_drug: {type: :boolean},
          is_deleted: {type: :boolean},
          patient_id: {"$ref" => "#/definitions/uuid"},
-         facility_id: {"$ref" => "#/definitions/uuid"}
+         facility_id: {"$ref" => "#/definitions/uuid"},
+         frequencies: {type: :string, enum: PrescriptionDrug.frequencies.keys},
+         prescribed_for_days: {type: :integer}
        },
        required: %w[id created_at updated_at name is_protocol_drug is_deleted patient_id facility_id]}
     end

--- a/app/schema/api/v3/models.rb
+++ b/app/schema/api/v3/models.rb
@@ -254,7 +254,8 @@ class Api::V3::Models
          patient_id: {"$ref" => "#/definitions/uuid"},
          facility_id: {"$ref" => "#/definitions/uuid"},
          frequency: {type: :string, enum: PrescriptionDrug.frequencies.keys},
-         duration_in_days: {type: :integer}
+         duration_in_days: {type: :integer},
+         teleconsultation_id: {"$ref" => "#/definitions/nullable_uuid"}
        },
        required: %w[id created_at updated_at name is_protocol_drug is_deleted patient_id facility_id]}
     end

--- a/app/schema/api/v4/models.rb
+++ b/app/schema/api/v4/models.rb
@@ -205,7 +205,7 @@ class Api::V4::Models
          registration_facility_id: {"$ref" => "#/definitions/uuid"},
          sync_approval_status: {type: [:string, "null"]},
          sync_approval_status_reason: {type: [:string, "null"]},
-         teleconsult_phone_number: {"$ref" => "#/definitions/non_empty_string"},
+         teleconsultation_phone_number: {"$ref" => "#/definitions/non_empty_string"},
          capabilities: app_user_capabilities
        },
        required: %w[id

--- a/app/schema/api/v4/models.rb
+++ b/app/schema/api/v4/models.rb
@@ -228,7 +228,7 @@ class Api::V4::Models
       }
     end
 
-    def teleconsultation_medical_officers
+    def teleconsultation_medical_officer
       {
         type: :object,
         properties: {
@@ -308,7 +308,8 @@ class Api::V4::Models
        activate_user: activate_user,
        app_user_capabilities: {type: ["null", :array], items: {type: :string}, enum: User::APP_USER_CAPABILITIES.keys},
        medical_officer: medical_officer,
-       teleconsultation_medical_officers: teleconsultation_medical_officers,
+       teleconsultation_medical_officer: teleconsultation_medical_officer,
+       teleconsultation_medical_officers: array_of("teleconsultation_medical_officer"),
        teleconsultation: teleconsultation,
        teleconsultations: array_of("teleconsultation")}
     end

--- a/app/schema/api/v4/models.rb
+++ b/app/schema/api/v4/models.rb
@@ -223,7 +223,7 @@ class Api::V4::Models
         properties: {
           id: {"$ref" => "#/definitions/uuid"},
           full_name: {"$ref" =>  "#/definitions/non_empty_string" },
-          phone_number: {"$ref" =>  "#/definitions/non_empty_string" }
+          teleconsultation_phone_number: {"$ref" =>  "#/definitions/non_empty_string" }
         }
       }
     end

--- a/app/schema/api/v4/models.rb
+++ b/app/schema/api/v4/models.rb
@@ -206,7 +206,7 @@ class Api::V4::Models
          sync_approval_status: {type: [:string, "null"]},
          sync_approval_status_reason: {type: [:string, "null"]},
          teleconsult_phone_number: {"$ref" => "#/definitions/non_empty_string"},
-         capabilities: array_of("app_user_capabilities")
+         capabilities: app_user_capabilities
        },
        required: %w[id
          created_at
@@ -293,6 +293,15 @@ class Api::V4::Models
        required: %w[id password]}
     end
 
+    def app_user_capability_values
+      {type: :string, enum: User::APP_USER_CAPABILITY_VALUES}
+    end
+
+    def app_user_capabilities
+      {type: :object,
+       properties: Hash[User::APP_USER_CAPABILITIES.product([app_user_capability_values])]}
+    end
+
     def definitions
       {timestamp: timestamp,
        uuid: uuid,
@@ -306,7 +315,7 @@ class Api::V4::Models
        user: user,
        find_user: find_user,
        activate_user: activate_user,
-       app_user_capabilities: {type: ["null", :array], items: {type: :string}, enum: User::APP_USER_CAPABILITIES.keys},
+       app_user_capabilities: app_user_capabilities,
        medical_officer: medical_officer,
        teleconsultation_medical_officer: teleconsultation_medical_officer,
        teleconsultation_medical_officers: array_of("teleconsultation_medical_officer"),

--- a/app/schema/api/v4/models.rb
+++ b/app/schema/api/v4/models.rb
@@ -265,7 +265,7 @@ class Api::V4::Models
               patient_took_medicines: {type: :string, enum: Teleconsultation::TELECONSULTATION_ANSWERS.keys},
               patient_consented: {type: :string, enum: Teleconsultation::TELECONSULTATION_ANSWERS.keys},
               medical_officer_number: {"$ref" => "#/definitions/non_empty_string"},
-              prescription_drugs: {type: :array, items: :string},
+              prescription_drugs: array_of("uuid")
             }
           },
           created_at: {"$ref" => "#/definitions/timestamp"},

--- a/app/schema/api/v4/models.rb
+++ b/app/schema/api/v4/models.rb
@@ -264,8 +264,7 @@ class Api::V4::Models
               teleconsultation_type: {type: :string, enum: Teleconsultation::TYPES.keys},
               patient_took_medicines: {type: :string, enum: Teleconsultation::TELECONSULTATION_ANSWERS.keys},
               patient_consented: {type: :string, enum: Teleconsultation::TELECONSULTATION_ANSWERS.keys},
-              medical_officer_number: {"$ref" => "#/definitions/non_empty_string"},
-              prescription_drugs: array_of("uuid")
+              medical_officer_number: {"$ref" => "#/definitions/non_empty_string"}
             }
           },
           created_at: {"$ref" => "#/definitions/timestamp"},

--- a/app/schema/api/v4/schema.rb
+++ b/app/schema/api/v4/schema.rb
@@ -59,6 +59,14 @@ class Api::V4::Schema
       sync_to_user_response(:blood_sugars)
     end
 
+    def teleconsultation_medical_officers_sync_to_user_response
+      sync_to_user_response(:teleconsultation_medical_officers)
+    end
+
+    def teleconsultation_sync_from_user_request
+      sync_from_user_request(:teleconsultations)
+    end
+
     def patient_activate_request
       {
         type: :object,

--- a/spec/api/v4/teleconsultation_medical_officers_spec.rb
+++ b/spec/api/v4/teleconsultation_medical_officers_spec.rb
@@ -1,0 +1,27 @@
+require "swagger_helper"
+
+describe "Teleconsultation Medical Officers v4 API", swagger_doc: "v4/swagger.json" do
+  path "teleconsultation_medical_officers/sync" do
+    get "Syncs Teleconsultation MOs data from server to device." do
+      tags "Teleconsult MOs"
+      security [access_token: [], user_id: [], facility_id: []]
+      parameter name: "HTTP_X_USER_ID", in: :header, type: :uuid
+      parameter name: "HTTP_X_FACILITY_ID", in: :header, type: :uuid
+
+      response "200", "teleconsult MOs received" do
+        let(:request_user) { create(:user) }
+        let(:request_facility) { create(:facility, facility_group: request_user.facility.facility_group) }
+        let(:HTTP_X_USER_ID) { request_user.id }
+        let(:HTTP_X_FACILITY_ID) { request_facility.id }
+        let(:Authorization) { "Bearer #{request_user.access_token}" }
+
+        schema Api::V4::Schema.teleconsultation_medical_officers_sync_to_user_response
+        let(:process_token) { Base64.encode64({other_facilities_processed_since: 10.minutes.ago}.to_json) }
+        let(:limit) { 10 }
+        run_test!
+      end
+
+      include_examples "returns 403 for get requests for forbidden users"
+    end
+  end
+end

--- a/spec/api/v4/teleconsultation_medical_officers_spec.rb
+++ b/spec/api/v4/teleconsultation_medical_officers_spec.rb
@@ -1,7 +1,7 @@
 require "swagger_helper"
 
 describe "Teleconsultation Medical Officers v4 API", swagger_doc: "v4/swagger.json" do
-  path "teleconsultation_medical_officers/sync" do
+  path "/teleconsultation_medical_officers/sync" do
     get "Syncs Teleconsultation MOs data from server to device." do
       tags "Teleconsult MOs"
       security [access_token: [], user_id: [], facility_id: []]
@@ -18,6 +18,7 @@ describe "Teleconsultation Medical Officers v4 API", swagger_doc: "v4/swagger.js
         schema Api::V4::Schema.teleconsultation_medical_officers_sync_to_user_response
         let(:process_token) { Base64.encode64({other_facilities_processed_since: 10.minutes.ago}.to_json) }
         let(:limit) { 10 }
+
         run_test!
       end
 

--- a/spec/api/v4/teleconsultations_spec.rb
+++ b/spec/api/v4/teleconsultations_spec.rb
@@ -1,0 +1,26 @@
+require "swagger_helper"
+
+describe "Teleconsultations v4 API", swagger_doc: "v4/swagger.json" do
+  path "teleconsultations/sync" do
+    post "Syncs Teleconsultations from device to server." do
+      tags "Teleconsultations"
+      security [access_token: [], user_id: [], facility_id: []]
+      parameter name: "HTTP_X_USER_ID", in: :header, type: :uuid
+      parameter name: "HTTP_X_FACILITY_ID", in: :header, type: :uuid
+      parameter name: :teleconsultations, in: :body, schema: Api::V4::Schema.teleconsultation_sync_from_user_request
+
+      response "200", "teleconsultations created" do
+        let(:request_user) { create(:user) }
+        let(:request_facility) { create(:facility, facility_group: request_user.facility.facility_group) }
+        let(:HTTP_X_USER_ID) { request_user.id }
+        let(:HTTP_X_FACILITY_ID) { request_facility.id }
+        let(:Authorization) { "Bearer #{request_user.access_token}" }
+        let(:teleconsultations) { {} }
+
+        run_test!
+      end
+
+      include_examples "returns 403 for post requests for forbidden users", :blood_sugars
+    end
+  end
+end

--- a/spec/api/v4/teleconsultations_spec.rb
+++ b/spec/api/v4/teleconsultations_spec.rb
@@ -1,7 +1,7 @@
 require "swagger_helper"
 
 describe "Teleconsultations v4 API", swagger_doc: "v4/swagger.json" do
-  path "teleconsultations/sync" do
+  path "/teleconsultations/sync" do
     post "Syncs Teleconsultations from device to server." do
       tags "Teleconsultations"
       security [access_token: [], user_id: [], facility_id: []]
@@ -20,7 +20,7 @@ describe "Teleconsultations v4 API", swagger_doc: "v4/swagger.json" do
         run_test!
       end
 
-      include_examples "returns 403 for post requests for forbidden users", :blood_sugars
+      include_examples "returns 403 for post requests for forbidden users", :teleconsultations
     end
   end
 end

--- a/swagger/v3/swagger.json
+++ b/swagger/v3/swagger.json
@@ -2117,7 +2117,7 @@
             "TDS"
           ]
         },
-        "prescribed_for_days": {
+        "duration_in_days": {
           "type": "integer"
         }
       },

--- a/swagger/v3/swagger.json
+++ b/swagger/v3/swagger.json
@@ -2108,7 +2108,7 @@
         "facility_id": {
           "$ref": "#/definitions/uuid"
         },
-        "frequencies": {
+        "frequency": {
           "type": "string",
           "enum": [
             "OD",

--- a/swagger/v3/swagger.json
+++ b/swagger/v3/swagger.json
@@ -2107,6 +2107,18 @@
         },
         "facility_id": {
           "$ref": "#/definitions/uuid"
+        },
+        "frequencies": {
+          "type": "string",
+          "enum": [
+            "OD",
+            "BD",
+            "QDS",
+            "TDS"
+          ]
+        },
+        "prescribed_for_days": {
+          "type": "integer"
         }
       },
       "required": [

--- a/swagger/v3/swagger.json
+++ b/swagger/v3/swagger.json
@@ -2119,6 +2119,9 @@
         },
         "duration_in_days": {
           "type": "integer"
+        },
+        "teleconsultation_id": {
+          "$ref": "#/definitions/nullable_uuid"
         }
       },
       "required": [

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -1327,7 +1327,7 @@
         }
       }
     },
-    "teleconsultation_medical_officers": {
+    "teleconsultation_medical_officer": {
       "type": "object",
       "properties": {
         "id": {
@@ -1365,6 +1365,15 @@
         "deleted_at": {
           "$ref": "#/definitions/nullable_timestamp"
         }
+      }
+    },
+    "teleconsultation_medical_officers": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "$ref": "#/definitions/teleconsultation_medical_officer"
       }
     },
     "teleconsultation": {

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -1246,7 +1246,7 @@
             "null"
           ]
         },
-        "teleconsult_phone_number": {
+        "teleconsultation_phone_number": {
           "$ref": "#/definitions/non_empty_string"
         },
         "capabilities": {

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -349,6 +349,118 @@
         }
       }
     },
+    "teleconsultation_medical_officers/sync": {
+      "get": {
+        "summary": "Syncs Teleconsultation MOs data from server to device.",
+        "tags": [
+          "Teleconsult MOs"
+        ],
+        "security": [
+          {
+            "access_token": [
+
+            ],
+            "user_id": [
+
+            ],
+            "facility_id": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "HTTP_X_USER_ID",
+            "in": "header",
+            "type": "uuid"
+          },
+          {
+            "name": "HTTP_X_FACILITY_ID",
+            "in": "header",
+            "type": "uuid"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "teleconsult MOs received",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "teleconsultation_medical_officers": {
+                  "$ref": "#/definitions/teleconsultation_medical_officers"
+                },
+                "process_token": {
+                  "$ref": "#/definitions/process_token"
+                }
+              },
+              "required": [
+                "teleconsultation_medical_officers",
+                "process_token"
+              ]
+            }
+          },
+          "403": {
+            "description": "user is not allowed to sync"
+          }
+        }
+      }
+    },
+    "teleconsultations/sync": {
+      "post": {
+        "summary": "Syncs Teleconsultations from device to server.",
+        "tags": [
+          "Teleconsultations"
+        ],
+        "security": [
+          {
+            "access_token": [
+
+            ],
+            "user_id": [
+
+            ],
+            "facility_id": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "HTTP_X_USER_ID",
+            "in": "header",
+            "type": "uuid"
+          },
+          {
+            "name": "HTTP_X_FACILITY_ID",
+            "in": "header",
+            "type": "uuid"
+          },
+          {
+            "name": "teleconsultations",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "teleconsultations": {
+                  "$ref": "#/definitions/teleconsultations"
+                }
+              },
+              "required": [
+                "teleconsultations"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "teleconsultations created"
+          },
+          "403": {
+            "description": "user is not allowed to sync"
+          }
+        }
+      }
+    },
     "/users/find": {
       "post": {
         "summary": "Find a existing user",
@@ -1133,6 +1245,18 @@
             "string",
             "null"
           ]
+        },
+        "teleconsult_phone_number": {
+          "$ref": "#/definitions/non_empty_string"
+        },
+        "capabilities": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/app_user_capabilities"
+          }
         }
       },
       "required": [
@@ -1176,6 +1300,157 @@
         "id",
         "password"
       ]
+    },
+    "app_user_capabilities": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      },
+      "enum": [
+        "can_teleconsult"
+      ]
+    },
+    "medical_officer": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "full_name": {
+          "$ref": "#/definitions/non_empty_string"
+        },
+        "phone_number": {
+          "$ref": "#/definitions/non_empty_string"
+        }
+      }
+    },
+    "teleconsultation_medical_officers": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "facility_id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "medical_officers": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "$ref": "#/definitions/uuid"
+              },
+              "full_name": {
+                "$ref": "#/definitions/non_empty_string"
+              },
+              "phone_number": {
+                "$ref": "#/definitions/non_empty_string"
+              }
+            }
+          }
+        },
+        "created_at": {
+          "$ref": "#/definitions/timestamp"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/timestamp"
+        },
+        "deleted_at": {
+          "$ref": "#/definitions/nullable_timestamp"
+        }
+      }
+    },
+    "teleconsultation": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "patient_id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "medical_officer_id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "request": {
+          "type": "object",
+          "properties": {
+            "requester_id": {
+              "$ref": "#/definitions/uuid"
+            },
+            "facility_id": {
+              "$ref": "#/definitions/uuid"
+            },
+            "requested_at": {
+              "$ref": "#/definitions/timestamp"
+            }
+          }
+        },
+        "record": {
+          "type": "object",
+          "properties": {
+            "recorded_at": {
+              "$ref": "#/definitions/timestamp"
+            },
+            "teleconsultation_type": {
+              "type": "string",
+              "enum": [
+                "audio",
+                "video",
+                "message"
+              ]
+            },
+            "patient_took_medicines": {
+              "type": "string",
+              "enum": [
+                "yes",
+                "no",
+                "unknown"
+              ]
+            },
+            "patient_consented": {
+              "type": "string",
+              "enum": [
+                "yes",
+                "no",
+                "unknown"
+              ]
+            },
+            "medical_officer_number": {
+              "$ref": "#/definitions/non_empty_string"
+            },
+            "prescription_drugs": {
+              "type": "array",
+              "items": "string"
+            }
+          }
+        },
+        "created_at": {
+          "$ref": "#/definitions/timestamp"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/timestamp"
+        },
+        "deleted_at": {
+          "$ref": "#/definitions/nullable_timestamp"
+        }
+      }
+    },
+    "teleconsultations": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "$ref": "#/definitions/teleconsultation"
+      }
     }
   },
   "securityDefinitions": {

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -1250,12 +1250,15 @@
           "$ref": "#/definitions/non_empty_string"
         },
         "capabilities": {
-          "type": [
-            "null",
-            "array"
-          ],
-          "items": {
-            "$ref": "#/definitions/app_user_capabilities"
+          "type": "object",
+          "properties": {
+            "can_teleconsult": {
+              "type": "string",
+              "enum": [
+                "yes",
+                "no"
+              ]
+            }
           }
         }
       },
@@ -1302,16 +1305,16 @@
       ]
     },
     "app_user_capabilities": {
-      "type": [
-        "null",
-        "array"
-      ],
-      "items": {
-        "type": "string"
-      },
-      "enum": [
-        "can_teleconsult"
-      ]
+      "type": "object",
+      "properties": {
+        "can_teleconsult": {
+          "type": "string",
+          "enum": [
+            "yes",
+            "no"
+          ]
+        }
+      }
     },
     "medical_officer": {
       "type": "object",

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -349,7 +349,7 @@
         }
       }
     },
-    "teleconsultation_medical_officers/sync": {
+    "/teleconsultation_medical_officers/sync": {
       "get": {
         "summary": "Syncs Teleconsultation MOs data from server to device.",
         "tags": [
@@ -405,7 +405,7 @@
         }
       }
     },
-    "teleconsultations/sync": {
+    "/teleconsultations/sync": {
       "post": {
         "summary": "Syncs Teleconsultations from device to server.",
         "tags": [

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -1325,7 +1325,7 @@
         "full_name": {
           "$ref": "#/definitions/non_empty_string"
         },
-        "phone_number": {
+        "teleconsultation_phone_number": {
           "$ref": "#/definitions/non_empty_string"
         }
       }
@@ -1353,7 +1353,7 @@
               "full_name": {
                 "$ref": "#/definitions/non_empty_string"
               },
-              "phone_number": {
+              "teleconsultation_phone_number": {
                 "$ref": "#/definitions/non_empty_string"
               }
             }

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -1439,8 +1439,13 @@
               "$ref": "#/definitions/non_empty_string"
             },
             "prescription_drugs": {
-              "type": "array",
-              "items": "string"
+              "type": [
+                "null",
+                "array"
+              ],
+              "items": {
+                "$ref": "#/definitions/uuid"
+              }
             }
           }
         },

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -1437,15 +1437,6 @@
             },
             "medical_officer_number": {
               "$ref": "#/definitions/non_empty_string"
-            },
-            "prescription_drugs": {
-              "type": [
-                "null",
-                "array"
-              ],
-              "items": {
-                "$ref": "#/definitions/uuid"
-              }
             }
           }
         },


### PR DESCRIPTION
**Story card:** TBD

## Because


## This addresses

Define the API contract for the telemedicine APIs. [Browsable docs link](https://simple-review-pr-1232.herokuapp.com/api-docs)

#### User
`v4/users/me` and `v4/users/activate` endpoint changes. (Add `teleconsultation_phone_number` and `capabilities`)
![image](https://user-images.githubusercontent.com/16774200/90769992-c1e0bd80-e30e-11ea-9cd8-995968969100.png)


#### Teleconsultation Log
- `POST v4/teleconsultations/sync` endpoint added (push only)
![image](https://user-images.githubusercontent.com/16774200/93430005-9f2ad000-f8df-11ea-8e2c-1a63eda4fe1d.png)


#### Teleconsultation Medical Officers
- `GET v4/teleconsultation_medical_officers/sync` endpoint added (pull only)  `phone_number` -> `teleconsultation_phone_number`
![image](https://user-images.githubusercontent.com/16774200/91143067-8e67af80-e6cf-11ea-8159-55936c8bd1b9.png)


#### Prescription Drugs
- `v3/prescription_drugs/sync` endpoint changes. (Add `frequency`, `prescribed_for_days` and `teleconsultation_id`)
![image](https://user-images.githubusercontent.com/16774200/93430023-a81ba180-f8df-11ea-9467-22d7044eeb44.png)



### DB Schema

This will be accompanied by the following schema changes:

- Add `teleconsultation_phone_number` to `users` table.
- Add a join table `facilities_teleconsultation_medical_officers` (`Facility has_and_belongs_to_many User`)
```
user_id, facility_id
```

- Add table `teleconsultations`.
```
id, patient_id, medical_officer_id, requester_id, facility_id, requested_at, recorded_at, teleconsult_type, patient_took_medicines, patient_consented, medical_officer_number, deleted_at
```
- Add `teleconsultation_id` to `prescription_drugs` (default null). (`Teleconsultation has_many PrescriptionDrug`)
- Add `frequency` and `duration_in_days` to `prescription_drugs`.