### PR TITLE
Cleaner URLs for reports; remove the hacky 'region_slug'

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -2,7 +2,7 @@ class Reports::RegionsController < AdminController
   layout "application"
   skip_after_action :verify_policy_scoped
   before_action :set_force_cache
-  before_action :set_selected_date, except: :index
+  before_action :set_period, except: :index
   before_action :find_region, except: :index
   around_action :set_time_zone
 
@@ -49,8 +49,8 @@ class Reports::RegionsController < AdminController
 
   private
 
-  def set_selected_date
-    period_params = facility_params[:period]
+  def set_period
+    period_params = report_params[:period]
     @period = if period_params.present?
       Period.new(period_params)
     else
@@ -63,28 +63,28 @@ class Reports::RegionsController < AdminController
   end
 
   def find_region
-    slug = facility_params[:id]
+    slug = report_params[:id]
     klass = region_class.classify.constantize
     @region = klass.find_by!(slug: slug)
   end
 
   def region_class
-    @region_class ||= case facility_params[:report_scope]
+    @region_class ||= case report_params[:report_scope]
     when "district"
       "facility_group"
     when "facility"
       "facility"
     else
-      raise ActiveRecord::RecordNotFound, "unknown report scope #{facility_params[:report_scope]}"
+      raise ActiveRecord::RecordNotFound, "unknown report scope #{report_params[:report_scope]}"
     end
   end
 
-  def facility_params
-    params.permit(:selected_date, :id, :force_cache, {period: [:type, :value]}, :report_scope)
+  def report_params
+    params.permit(:id, :force_cache, :report_scope, {period: [:type, :value]})
   end
 
   def force_cache?
-    facility_params[:force_cache].present?
+    report_params[:force_cache].present?
   end
 
   def set_time_zone

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -63,12 +63,20 @@ class Reports::RegionsController < AdminController
   end
 
   def find_region
-    region_class, slug = facility_params[:id].split("-", 2)
-    unless region_class.in?(["facility_group", "facility"])
-      raise ActiveRecord::RecordNotFound
-    end
+    slug = facility_params[:id]
     klass = region_class.classify.constantize
     @region = klass.find_by!(slug: slug)
+  end
+
+  def region_class
+    @region_class ||= case facility_params[:report_scope]
+    when "district"
+      "facility_group"
+    when "facility"
+      "facility"
+    else
+      raise ActiveRecord::RecordNotFound, "unknown report scope #{facility_params[:report_scope]}"
+    end
   end
 
   def facility_params

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -153,10 +153,6 @@ class Facility < ApplicationRecord
     facilities
   end
 
-  def region_slug
-    "#{model_name.to_s.underscore}-#{slug}"
-  end
-
   def organization_exists
     organization = Organization.find_by(name: organization_name)
     errors.add(:organization, "doesn't exist") if organization_name.present? && organization.blank?

--- a/app/models/facility_group.rb
+++ b/app/models/facility_group.rb
@@ -27,10 +27,6 @@ class FacilityGroup < ApplicationRecord
   auto_strip_attributes :name, squish: true, upcase_first: true
   attribute :enable_diabetes_management, :boolean
 
-  def region_slug
-    "#{model_name.to_s.underscore}-#{slug}"
-  end
-
   def toggle_diabetes_management
     if enable_diabetes_management
       set_diabetes_management(true)

--- a/app/services/reports/region_service.rb
+++ b/app/services/reports/region_service.rb
@@ -37,7 +37,7 @@ module Reports
 
     private
 
-    # We want to return cohort result for the current quarter for the selected date, and then
+    # We want to return cohort result for the current quarter for the selected period, and then
     # the previous three quarters.
     def compile_cohort_trend_data
       Rails.cache.fetch(cohort_cache_key, version: cohort_cache_version, expires_in: 7.days, force: force_cache?) do

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -13,7 +13,7 @@
     <%= link_to 'All reports', dashboard_districts_path %>
     <% if @region.respond_to?(:facility_group) %>
       <i class="fas fa-chevron-right"></i>
-      <%= link_to @region.facility_group.name, reports_region_path(@region.facility_group.region_slug) %>
+      <%= link_to @region.facility_group.name, reports_region_path(@region.facility_group.slug, report_scope: "district") %>
     <% end %>
     <i class="fas fa-chevron-right"></i>
     <%= @region.name %>

--- a/app/views/reports/regions/index.html.erb
+++ b/app/views/reports/regions/index.html.erb
@@ -16,7 +16,7 @@
         <div class="card">
           <h2><%= organization.name %></h2>
           <% policy_scope([:cohort_report, organization.facility_groups]).order(:name).each do |district| %>
-            <%= link_to(reports_region_path(district.region_slug), class: "link-row") do %>
+            <%= link_to(reports_region_path(district, report_scope: "district"), class: "link-row") do %>
               <i class='fas fa-angle-right light'></i>
               <%= district.name %>
             <% end %>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -206,7 +206,7 @@
       Facilities
     </h2>
     <% @region.facilities.order(:name).each do |facility| %>
-      <%= link_to(reports_region_path(facility.region_slug), class: "link-row") do %>
+      <%= link_to(reports_region_path(facility, report_scope: "facility"), class: "link-row") do %>
         <i class='fas fa-angle-right light'></i>
         <%= facility.name %>
       <% end %>

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -15,6 +15,7 @@ module ParameterFiltering
     metadata_version
     process_token
     recorded_at
+    report_scope
     status
     updated_at
   ].freeze

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,11 +160,9 @@ Rails.application.routes.draw do
   get "/dashboard/districts/", to: redirect("/reports/districts/")
   get "/dashboard/districts/:slug", to: redirect("/reports/districts/%{slug}")
   get "/reports/districts/", to: redirect("/reports/regions/")
-  # get "/reports/districts/:slug", to: redirect("/reports/regions/facility_group-%{slug}")
 
   namespace :reports do
     resources :regions, only: [:index]
-
     get "regions/:report_scope/:id", to: "regions#show", as: :region
     get "regions/:report_scope/:id/details", to: "regions#details", as: :region_details
     get "regions/:report_scope/:id/cohort", to: "regions#cohort", as: :region_cohort

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,15 +160,14 @@ Rails.application.routes.draw do
   get "/dashboard/districts/", to: redirect("/reports/districts/")
   get "/dashboard/districts/:slug", to: redirect("/reports/districts/%{slug}")
   get "/reports/districts/", to: redirect("/reports/regions/")
-  get "/reports/districts/:slug", to: redirect("/reports/regions/facility_group-%{slug}")
+  # get "/reports/districts/:slug", to: redirect("/reports/regions/facility_group-%{slug}")
 
   namespace :reports do
-    resources :regions do
-      member do
-        get "cohort"
-        get "details"
-      end
-    end
+    resources :regions, only: [:index]
+
+    get "regions/:report_scope/:id", to: "regions#show", as: :region
+    get "regions/:report_scope/:id/details", to: "regions#details", as: :region_details
+    get "regions/:report_scope/:id/cohort", to: "regions#cohort", as: :region_cohort
   end
 
   namespace :my_facilities do

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
       Timecop.freeze("June 1 2020") do
         sign_in(cvho.email_authentication)
-        get :details, params: {id: @facility.facility_group.region_slug}
+        get :details, params: {id: @facility.facility_group.slug, report_scope: "district"}
       end
       expect(response).to be_successful
     end
@@ -65,7 +65,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
       Timecop.freeze("June 1 2020") do
         sign_in(cvho.email_authentication)
-        get :cohort, params: {id: @facility.facility_group.region_slug}
+        get :cohort, params: {id: @facility.facility_group.slug, report_scope: "district"}
       end
       expect(response).to be_successful
     end
@@ -95,7 +95,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
       Timecop.freeze("June 1 2020") do
         sign_in(cvho.email_authentication)
-        get :show, params: {id: @facility.facility_group.region_slug}
+        get :show, params: {id: @facility.facility_group.slug, report_scope: "district"}
       end
       expect(response).to be_successful
       data = assigns(:data)
@@ -111,7 +111,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
       Timecop.freeze("June 1 2020") do
         sign_in(cvho.email_authentication)
-        get :show, params: {id: @facility.facility_group.region_slug, period: {type: "quarter", value: "Q1-2020"}}
+        get :show, params: {id: @facility.facility_group.slug, report_scope: "district", period: {type: "quarter", value: "Q1-2020"}}
         data = assigns(:data)
         expect(data[:controlled_patients][Period.quarter("Q1-2020")]).to eq(1)
       end
@@ -126,7 +126,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
       Timecop.freeze("June 1 2020") do
         sign_in(cvho.email_authentication)
-        get :show, params: {id: @facility.region_slug}
+        get :show, params: {id: @facility.slug, report_scope: "facility"}
       end
       expect(response).to be_successful
       data = assigns(:data)

--- a/spec/services/reports/region_service_spec.rb
+++ b/spec/services/reports/region_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Reports::RegionService, type: :model do
     end
   end
 
-  it "normalizes the selected_date" do
+  it "sets the period" do
     period = Period.month(june_1)
     service = Reports::RegionService.new(region: facility_group_1, period: period)
     Timecop.freeze("June 30 2020 5:00 PM EST") do


### PR DESCRIPTION
Never really liked that approach to dealing with the polymorphic
routes...this is a bit more explicit and the URLs we end up with are
much cleaner

