### PR TITLE
Use 3-month-exclusion for registration numbers

### DIFF
--- a/app/presenters/user_analytics_presenter.rb
+++ b/app/presenters/user_analytics_presenter.rb
@@ -45,7 +45,7 @@ class UserAnalyticsPresenter < Struct.new(:current_facility)
     )
     registrations = monthly_htn_stats_by_date(
       :controlled_visits,
-      :cumulative_registrations,
+      :adjusted_registrations,
       Period.month(htn_control_monthly_period_list.last)
     )
 


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1089

The progress tab control rate total registrations number needs to be the "3 months excluded" version, not the "cumulative" version.