### PR TITLE
Disable the cache warming task

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -23,9 +23,11 @@ every :week, at: local("01:00 am"), roles: [:whitelist_phone_numbers] do
   rake "exotel_tasks:update_all_patients_phone_number_details"
 end
 
-every :day, at: local("02:00 am"), roles: [:cron] do
-  runner "Reports::RegionCacheWarmer.call"
-end
+# Disable cache warming while we inspect the outage on 2020-08-27
+#
+# every :day, at: local("02:00 am"), roles: [:cron] do
+#   runner "Reports::RegionCacheWarmer.call"
+# end
 
 every 3.hours, roles: [:cron] do
   rake "refresh_materialized_db_views"


### PR DESCRIPTION
**Story card:** none

## Because

We had an outage on 2020-08-27 that seems correlated to this cache warming task

## This addresses

Disables the nightly cache warming task while we inspect this outage
