### PR TITLE
Back off on materialized view refresh:

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -29,7 +29,7 @@ end
 #   runner "Reports::RegionCacheWarmer.call"
 # end
 
-every 3.hours, roles: [:cron] do
+every [:sunday, :wednesday], at: local("05:00am"), roles: [:cron] do
   rake "refresh_materialized_db_views"
 end
 


### PR DESCRIPTION
Do it twice a week at 5 am India time.

This is to help us get the DB perf back in order.  We may not want to back it off this much long term, but for now twice a week is fine so we have some breathing room.

https://github.com/simpledotorg/simple-server/issues/1255
