### PR TITLE
Facility size filtering fix

### DIFF
--- a/app/controllers/concerns/my_facilities_filtering.rb
+++ b/app/controllers/concerns/my_facilities_filtering.rb
@@ -37,7 +37,11 @@ module MyFacilitiesFiltering
     end
 
     def facilities_by_size(facilities)
-      facilities.where(facility_size: @selected_sizes)
+      if (@facility_sizes - @selected_sizes).empty?
+        facilities
+      else
+        facilities.where(facility_size: @selected_sizes)
+      end
     end
 
     def facilities_by_zone(facilities)


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/979/my-facilities-registrations-don-t-include-facilities-without-a-size

Facilities without sizes set are excluded from My Facilities pages because of the default size filtering that takes place. This is a quickfix to address the problem.

**If all sizes are selected, don't filter by size.**

This ensures that facilities without a size are also included in these lists.

We could be stricter with data validation, and fill in missing sizes in production, etc, etc, but I'd rather let administrators take care of that aspect of data hygiene themselves.