### PR TITLE
Inline-ify the clashing function

### DIFF
--- a/app/assets/javascripts/common/analytics.js
+++ b/app/assets/javascripts/common/analytics.js
@@ -1,7 +1,5 @@
-window.addEventListener("DOMContentLoaded", initializeTables);
-
-function initializeTables() {
+window.addEventListener("DOMContentLoaded", function() {
   if($('#analytics-table').length) {
     new Tablesort(document.getElementById('analytics-table'), { descending: true })
   }
-}
+});


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1128/broken-tablesort

On investigation, it appears that the `initializeTables` function that was being used to initialize tablesort is now clashing with an `initializeTables` method in reports.js.

This PR simply inlines the initialization of tablesort to avoid naming clashes, but it's a good reminder that we need to start writing properly scoped JS 😄 
