### PR TITLE
Add index to rx drugs

### DIFF
--- a/db/migrate/20200902174738_add_index_to_prescription_drugs.rb
+++ b/db/migrate/20200902174738_add_index_to_prescription_drugs.rb
@@ -1,0 +1,7 @@
+class AddIndexToPrescriptionDrugs < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :prescription_drugs, :updated_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_02_074027) do
+ActiveRecord::Schema.define(version: 2020_09_02_174738) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -438,6 +438,7 @@ ActiveRecord::Schema.define(version: 2020_09_02_074027) do
     t.uuid "user_id"
     t.index ["deleted_at"], name: "index_prescription_drugs_on_deleted_at"
     t.index ["patient_id"], name: "index_prescription_drugs_on_patient_id"
+    t.index ["updated_at"], name: "index_prescription_drugs_on_updated_at"
     t.index ["user_id"], name: "index_prescription_drugs_on_user_id"
   end
 


### PR DESCRIPTION
More performance fixes from searching around in new relic - this looks like it primarily impacts sync.

Add an index on prescription_drugs `updated_at` for these types of slow queries:


<img width="1419" alt="image" src="https://user-images.githubusercontent.com/69/92018532-e11e1880-ed1a-11ea-9565-eec5cb289c25.png">

/cc #1255 