### PR TITLE
Lower the slow query explain threshold for New Relic to 0.25

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -2,6 +2,10 @@ common: &default_settings
   license_key: <%= ENV['NEW_RELIC_LICENSE_KEY'] %>
   log_level: debug
   app_name: <%= ENV['NEW_RELIC_APP_NAME'] %>
+  transaction_trancer:
+    explain_threshold: 0.25
+  slow_sql:
+    explain_threshold: 0.25
 
 development:
   <<: *default_settings


### PR DESCRIPTION
The default is 0.5. Half a second is already a pretty slow query,
especially in the context of a web request. Lets collect some more data
for a while and see what comes up.

/cc #1255 