### PR TITLE
Quick release fix: We are trying to add the tag twice, which fails

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -56,6 +56,7 @@ exit unless gets.chomp.downcase == "y"
 # ------------------
 # Conclusion
 # ------------------
-puts "Created release #{release_tag}."
+puts
+puts "Successfully created release #{release_tag}."
 puts "Visit https://resolvetosavelives.semaphoreci.com/projects/simple-server to deploy the release to production."
 puts "Publish the changelog to the #releases channel."

--- a/bin/release
+++ b/bin/release
@@ -51,7 +51,6 @@ puts "Creating release #{release_tag}. Continue? (y/N):"
 exit unless gets.chomp.downcase == "y"
 
 `git tag -a #{release_tag} -m "#{changelog.shellescape}"`
-`git tag #{release_tag}`
 `git push origin refs/tags/#{release_tag}`
 
 # ------------------
@@ -59,4 +58,4 @@ exit unless gets.chomp.downcase == "y"
 # ------------------
 puts "Created release #{release_tag}."
 puts "Visit https://resolvetosavelives.semaphoreci.com/projects/simple-server to deploy the release to production."
-puts "Publish the changelog in the right channels."
+puts "Publish the changelog to the #releases channel."


### PR DESCRIPTION
The second git tag here will always fail, because we have already
created the tag as an annotated tag. This causes the script to bail out with an error:

```
[~/src/simpledotorg/simple-server (master)]> bin/release
CHANGELOG
---------
• Lower the explain threshold for New Relic to 0.25 (#1284)
• Add index to rx drugs (#1283)
• Allow Admins to Edit accesses (#1252)
• Migrate the Admin::UsersController and its actions (#1280)
• Index "twilio_sms_delivery_details.session_id" (#1277)
• Inline-ify the clashing function (#1279)
• More efficient strategy for inviting new admins (#1263)
• More efficient tree for displaying access resources (#1262)
• Permissions: flesh out roles and actions (#1208)
Creating release release-2020-09-02-1. Continue? (y/N):
y
fatal: tag 'release-2020-09-02-1' already exists
```

I'm also adding the #releases channel to the final help message.

