### PR TITLE
Gate Admin::FacilitiesController correctly

### DIFF
--- a/app/controllers/admin/facilities_controller.rb
+++ b/app/controllers/admin/facilities_controller.rb
@@ -3,8 +3,12 @@ class Admin::FacilitiesController < AdminController
   include Pagination
   include SearchHelper
 
-  before_action :set_facility, only: [:show, :edit, :update, :destroy]
-  before_action :set_facility_group, only: [:show, :edit, :update]
+  before_action :set_facility, only: [:show, :edit, :update, :destroy], unless: -> { Flipper.enabled?(:new_permissions_system_aug_2020, current_admin) }
+  before_action :set_facility_group, only: [:show, :new, :create, :edit, :update, :destroy], unless: -> { Flipper.enabled?(:new_permissions_system_aug_2020, current_admin) }
+
+  before_action :set_facility_new_permissions, only: [:show, :edit, :update, :destroy], if: -> { Flipper.enabled?(:new_permissions_system_aug_2020, current_admin) }
+  before_action :set_facility_group_new_permissions, only: [:show, :new, :create, :edit, :update, :destroy], if: -> { Flipper.enabled?(:new_permissions_system_aug_2020, current_admin) }
+
   before_action :initialize_upload, :validate_file_type, :validate_file_size, :parse_file,
     :validate_facility_rows, if: :file_exists?, only: [:upload]
 
@@ -134,28 +138,26 @@ class Admin::FacilitiesController < AdminController
   private
 
   def new_facility(attributes = nil)
-    @facility_group =
-      current_admin
-        .accessible_facility_groups(:manage)
-        .friendly
-        .find(params[:facility_group_id])
-
     @facility_group.facilities.new(attributes).tap do |facility|
       facility.country ||= Rails.application.config.country[:name]
     end
   end
 
+  def set_facility_new_permissions
+    @facility = authorize1 { current_admin.accessible_facilities(:manage).friendly.find(params[:id]) }
+  end
+
+  def set_facility_group_new_permissions
+    @facility_group = current_admin.accessible_facility_groups(:manage).friendly.find(params[:facility_group_id])
+  end
+
   def set_facility
-    if Flipper.enabled?(:new_permissions_system_aug_2020, current_admin)
-      @facility = authorize1 { current_admin.accessible_facilities(:manage).friendly.find(params[:id]) }
-    else
-      @facility = Facility.friendly.find(params[:id])
-      authorize([:manage, :facility, @facility])
-    end
+    @facility = Facility.friendly.find(params[:id])
+    authorize([:manage, :facility, @facility])
   end
 
   def set_facility_group
-    @facility_group = @facility.facility_group
+    @facility_group = FacilityGroup.friendly.find(params[:facility_group_id])
   end
 
   def facility_params


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1154/couldn-t-create-a-facility-in-a-facilitygroup-because-we-accidentally-un-gated-the-the-controller-and-made-them-use-the-new

## Because

A permissions bug is causing new permissions methods to be invoked for users who haven't been migrated.

## This addresses

Gating the Admin::FacilityController actions correctly so the new permissions aren't invoked accidentally.
