### PR TITLE
Bugfix: Edit User autocomplete

### DIFF
--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-6">
-    <%= bootstrap_form_with(model: [:admin, user], local: true, label_errors: true) do |form| %>
+    <%= bootstrap_form_with(model: [:admin, user], local: true, label_errors: true, autocomplete: "off") do |form| %>
       <%= form.text_field :full_name, id: :user_name %>
       <%= form.text_field :phone_number, id: :user_phone_number, disabled: true %>
       <div class="form-group">


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1156

## Because

Browsers are trying to incorrectly autocomplete the PIN field in the Edit User form. [Bug reported on Slack](https://simpledotorg.slack.com/archives/CFHKJ5WJY/p1599124237058200)

## This addresses

Disables autocomplete in the Edit User form.
