### PR TITLE
Bugfix redux: Disable autocomplete on Edit User

### DIFF
--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-6">
-    <%= bootstrap_form_with(model: [:admin, user], local: true, label_errors: true, autocomplete: "off") do |form| %>
+    <%= bootstrap_form_with(model: [:admin, user], local: true, label_errors: true) do |form| %>
       <%= form.text_field :full_name, id: :user_name %>
       <%= form.text_field :phone_number, id: :user_phone_number, disabled: true %>
       <div class="form-group">
@@ -14,12 +14,13 @@
           <%= form.text_field :teleconsultation_phone_number,
                               id: :user_teleconsultation_phone_number,
                               wrapper: false,
+                              autocomplete: "off",
                               optional: true %>
         </div>
         <small class="form-text text-muted">If different from phone number</small>
       </div>
 
-      <%= form.password_field :password, id: :user_password, pattern: "[0-9]{4}", label: "PIN", help: "4 digits only", optional: true %>
+      <%= form.password_field :password, id: :user_password, pattern: "[0-9]{4}", label: "PIN", help: "4 digits only", autocomplete: "new-password", optional: true %>
       <%= form.password_field :password_confirmation, id: :user_password_confirmation, pattern: "[0-9]{4}", label: "PIN confirmation", optional: true %>
       <%= form.select :registration_facility_id, policy_scope([:manage, :user, Facility]) \
           .sort_by { |facility| facility.name.sub /^Dr(.?)(\s*)/, '' } \


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1156

## Because

The Edit user form is being autocompleted. This was tried fixing in #1289 but that didn't work as expected.

## This addresses

Turns out `autocomplete="off"` on the form does not work as intended as of 2020: https://stackoverflow.com/a/57810447. 

This sets `autocomplete="new-password"` on the password field and `autocomplete="off"` on the field before as per [MDN's latest guidelines](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion). This disables autofill by default. The autocomplete suggestions still show up. It seems like there is no way to hide those in 2020, at least not if your field is called `email`, `phone_number` or `password`.


![image](https://user-images.githubusercontent.com/16774200/92222258-5d039680-eebc-11ea-992e-9d28783f7a0f.png)
