### PR TITLE
Tiny copy edit to make it clear patients should go to the Google Play…

### DIFF
--- a/config/locales/api/help/en.html
+++ b/config/locales/api/help/en.html
@@ -49,7 +49,7 @@
             </a>
             <h3><span style="color: #FF3355; font-size: 90%; float: right;">NEW!</span> App for your patients</h3>
             <p>Patients can now chart their own BPs and blood sugars with a simple app called the "BP Passport" app.</p>
-            <p>Ask your patients to go to the Google or Apple app store and install the "BP Passport" app.</p>
+            <p>Ask your patients to go to the Google Play Store or Apple App Store and install the "BP Passport" app.</p>
             <p class="card-footer-button"><a href="#" onclick="openWindow('help-bp-passport-app'); return false">Learn more...</a></p>
             
         </div>


### PR DESCRIPTION


**Story card:** NONE

## Because

Praveen pointed out that it would be clearer if we wrote "Google Play Store" instead of generic app store.

## This addresses

Minor confusion
