### PR TITLE
Gate RegionsController for new permissions

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -15,7 +15,6 @@ class Reports::RegionsController < AdminController
     if Flipper.enabled?(:new_permissions_system_aug_2020, current_admin)
       authorize1 { current_admin.accessible_facilities(:view_reports).any? }
       @organizations = current_admin.accessible_facilities(:view_reports)
-        .includes(facility_group: :organization)
         .flat_map(&:organization)
         .uniq
         .compact

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -8,14 +8,30 @@ class Reports::RegionsController < AdminController
   before_action :find_region, except: :index
   around_action :set_time_zone
 
-  def index
-    authorize(:dashboard, :show?)
+  skip_after_action :verify_authorized, if: -> { Flipper.enabled?(:new_permissions_system_aug_2020, current_admin) }
+  after_action :verify_authorization_attempted, if: -> { Flipper.enabled?(:new_permissions_system_aug_2020, current_admin) }
 
-    @organizations = policy_scope([:cohort_report, Organization]).order(:name)
+  def index
+    if Flipper.enabled?(:new_permissions_system_aug_2020, current_admin)
+      authorize1 { current_admin.accessible_facilities(:view_reports).any? }
+      @organizations = current_admin.accessible_facilities(:view_reports)
+        .includes(facility_group: :organization)
+        .flat_map(&:organization)
+        .uniq
+        .compact
+        .sort_by(&:name)
+    else
+      authorize(:dashboard, :show?)
+      @organizations = policy_scope([:cohort_report, Organization]).order(:name)
+    end
   end
 
   def show
-    authorize(:dashboard, :show?)
+    if Flipper.enabled?(:new_permissions_system_aug_2020, current_admin)
+      authorize1 { current_admin.accessible_facilities(:view_reports).any? }
+    else
+      authorize(:dashboard, :show?)
+    end
 
     @data = Reports::RegionService.new(region: @region,
                                        period: @period).call
@@ -39,7 +55,11 @@ class Reports::RegionsController < AdminController
   end
 
   def details
-    authorize(:dashboard, :show?)
+    if Flipper.enabled?(:new_permissions_system_aug_2020, current_admin)
+      authorize1 { current_admin.accessible_facilities(:view_reports).any? }
+    else
+      authorize(:dashboard, :show?)
+    end
 
     @data = Reports::RegionService.new(region: @region,
                                        period: @period).call
@@ -55,7 +75,11 @@ class Reports::RegionsController < AdminController
   end
 
   def cohort
-    authorize(:dashboard, :show?)
+    if Flipper.enabled?(:new_permissions_system_aug_2020, current_admin)
+      authorize1 { current_admin.accessible_facilities(:view_reports).any? }
+    else
+      authorize(:dashboard, :show?)
+    end
 
     @data = Reports::RegionService.new(region: @region,
                                        period: @period).call

--- a/app/views/reports/regions/details.html.erb
+++ b/app/views/reports/regions/details.html.erb
@@ -75,10 +75,18 @@
   <% end %>
 </div>
 <% if @region.is_a?(Facility) %>
-  <% if policy([:cohort_report, @region]).view_health_worker_activity? %>
-    <%= render "shared/recent_bp_log",
-                  blood_pressures: @recent_blood_pressures,
-                  display_model: :facility %>
+  <% if Flipper.enabled?(:new_permissions_system_aug_2020, current_admin) %>
+    <% if current_admin.accessible_facilities(:view_reports).include?(@region) %>
+      <%= render "shared/recent_bp_log",
+                 blood_pressures: @recent_blood_pressures,
+                 display_model: :facility %>
+    <% end %>
+  <% else %>
+    <% if policy([:cohort_report, @region]).view_health_worker_activity? %>
+      <%= render "shared/recent_bp_log",
+                 blood_pressures: @recent_blood_pressures,
+                 display_model: :facility %>
+    <% end %>
   <% end %>
 <% end %>
 <div id="data-json" style="display: none;">

--- a/app/views/reports/regions/index.html.erb
+++ b/app/views/reports/regions/index.html.erb
@@ -17,7 +17,6 @@
           <h2><%= organization.name %></h2>
           <% if Flipper.enabled?(:new_permissions_system_aug_2020, current_admin) %>
             <% current_admin.accessible_facilities(:view_reports)
-               .includes(facility_group: :organization)
                .where(facility_groups: {organization: organization})
                .flat_map(&:facility_group)
                .uniq

--- a/app/views/reports/regions/index.html.erb
+++ b/app/views/reports/regions/index.html.erb
@@ -15,10 +15,26 @@
       <section>
         <div class="card">
           <h2><%= organization.name %></h2>
-          <% policy_scope([:cohort_report, organization.facility_groups]).order(:name).each do |district| %>
-            <%= link_to(reports_region_path(district, report_scope: "district"), class: "link-row") do %>
-              <i class='fas fa-angle-right light'></i>
-              <%= district.name %>
+          <% if Flipper.enabled?(:new_permissions_system_aug_2020, current_admin) %>
+            <% current_admin.accessible_facilities(:view_reports)
+               .includes(facility_group: :organization)
+               .where(facility_groups: {organization: organization})
+               .flat_map(&:facility_group)
+               .uniq
+               .compact
+               .sort_by(&:name)
+               .each do |district| %>
+              <%= link_to(reports_region_path(district, report_scope: "district"), class: "link-row") do %>
+                <i class='fas fa-angle-right light'></i>
+                <%= district.name %>
+              <% end %>
+            <% end %>
+          <% else %>
+            <% policy_scope([:cohort_report, organization.facility_groups]).order(:name).each do |district| %>
+              <%= link_to(reports_region_path(district, report_scope: "district"), class: "link-row") do %>
+                <i class='fas fa-angle-right light'></i>
+                <%= district.name %>
+              <% end %>
             <% end %>
           <% end %>
         </div>


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1134/migrate-the-regionscontroller-and-its-actions

## Because

We're preparing all controllers for new permissions so we can darklaunch to production

## This addresses

Migrates the RegionsController and it's views to use the new permissions (gated by a Flipper flag)