### PR TITLE
Fix broken API docs

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-
 require "shellwords"
 
 MAIN_BRANCH = "master"
@@ -15,6 +14,7 @@ end
 # ------------------
 # Changelog
 # ------------------
+`git fetch --tags`
 last_release = `git describe --tags --abbrev=0 --match "release-*"`.strip
 
 changelog = `git log #{last_release}..HEAD --oneline --decorate=no`

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -1313,7 +1313,7 @@
         "array"
       ],
       "items": {
-        "$ref": "#/definitions/teleconsultation_medical_officer"
+        "$ref": "#/definitions/facility_medical_officer"
       }
     }
   },


### PR DESCRIPTION
**Story card:** -

## Because
Our swagger docs broke. This is because we missed committing the latest `swagger.json` with the teleconsult API changes.
![image](https://user-images.githubusercontent.com/16774200/92718156-0f38d380-f37f-11ea-98af-a8986dedaa48.png)

## This addresses

This runs a `rake docs` and updates `swagger.json`.

