### PR TITLE
Migrate Appointments Controller

### DIFF
--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -1,13 +1,23 @@
 <h1>Overdue patients</h1>
 <p>Patients that are overdue for a follow-up visit.</p>
 
-<%= render('shared/paginate_and_filter_by_facility',
-           form_url: appointments_path,
-           current_admin: current_admin,
-           facility_id: @facility_id,
-           per_page: @per_page,
-           form_id: "search-filters",
-           scope_namespace: [:overdue_list, Facility]) %>
+<% if Flipper.enabled?(:new_permissions_system_aug_2020, current_admin) %>
+  <%= render('shared/paginate_and_filter_by_facility',
+             form_url: appointments_path,
+             current_admin: current_admin,
+             facility_id: @facility_id,
+             per_page: @per_page,
+             form_id: "search-filters",
+             scope_namespace: current_admin.accessible_facilities(:manage_overdue_list)) %>
+<% else %>
+  <%= render('shared/paginate_and_filter_by_facility',
+             form_url: appointments_path,
+             current_admin: current_admin,
+             facility_id: @facility_id,
+             per_page: @per_page,
+             form_id: "search-filters",
+             scope_namespace: [:overdue_list, Facility]) %>
+<% end %>
 
 <% if @patient_summaries.present? %>
   <h2>Patient list</h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -85,7 +85,7 @@
 
               <% if current_admin.accessible_facilities(:manage_overdue_list).any? %>
                 <li class="nav-item">
-                  <%= link_to "Overdue patients", appointments_path, class: "nav-link #{active_controller?("appointments")}" %>
+                  <%= link_to "Overdue", appointments_path, class: "nav-link #{active_controller?("appointments")}" %>
                 </li>
               <% end %>
 

--- a/app/views/layouts/overdue.html.erb
+++ b/app/views/layouts/overdue.html.erb
@@ -81,10 +81,19 @@
 
       <section class="mt-5">
         <% if current_facility %>
-          <% if @patient_summaries.present? && policy([:overdue_list, @patient_summaries.first]).download? %>
-            <h4>Download</h4>
-            <%= link_to(@index_params.merge(format: "csv"), class: "", data: { confirm: I18n.t('admin.phi_download_alert') }) do %>
-              Download Results
+          <% if Flipper.enabled?(:new_permissions_system_aug_2020, current_admin) %>
+            <% if @patient_summaries.present? && current_admin.accessible_facilities(:manage_overdue_list).include?(current_facility) %>
+              <h4>Download</h4>
+              <%= link_to(@index_params.merge(format: "csv"), class: "", data: { confirm: I18n.t('admin.phi_download_alert') }) do %>
+                Download Results
+              <% end %>
+            <% end %>
+          <% else %>
+            <% if @patient_summaries.present? && policy([:overdue_list, @patient_summaries.first]).download? %>
+              <h4>Download</h4>
+              <%= link_to(@index_params.merge(format: "csv"), class: "", data: { confirm: I18n.t('admin.phi_download_alert') }) do %>
+                Download Results
+              <% end %>
             <% end %>
           <% end %>
         <% else %>

--- a/app/views/shared/_paginate_and_filter_by_facility.html.erb
+++ b/app/views/shared/_paginate_and_filter_by_facility.html.erb
@@ -5,16 +5,29 @@
   %>
   <div class="form-row">
     <div id="facility-selector" class="form-group col-md-6">
-      <%= form.select :facility_id,
-                      policy_scope(scope_namespace).sort_by(&:name).map { |facility| [facility.name, facility.id] },
-                      {
-                          hide_label: true,
-                          include_blank: "All facilities",
-                          selected: facility_id,
-                          wrapper: false
-                      },
-                      html_options
-      %>
+      <% if Flipper.enabled?(:new_permissions_system_aug_2020, current_admin) %>
+        <%= form.select :facility_id,
+                        scope_namespace.order(:name).map { |facility| [facility.name, facility.id] },
+                        {
+                            hide_label: true,
+                            include_blank: "All facilities",
+                            selected: facility_id,
+                            wrapper: false
+                        },
+                        html_options
+        %>
+      <% else %>
+        <%= form.select :facility_id,
+                        policy_scope(scope_namespace).sort_by(&:name).map { |facility| [facility.name, facility.id] },
+                        {
+                            hide_label: true,
+                            include_blank: "All facilities",
+                            selected: facility_id,
+                            wrapper: false
+                        },
+                        html_options
+        %>
+      <% end %>
     </div>
     <div id="limit-selector" class="form-group col-md-3">
       <%= form.select :per_page,

--- a/spec/features/appointments_with_new_permissions_spec.rb
+++ b/spec/features/appointments_with_new_permissions_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.feature "Overdue appointments", type: :feature do
+  let!(:ihmi) { create(:organization, name: "IHMI") }
+  let!(:ihmi_group) { create(:facility_group, organization: ihmi) }
+  let!(:facility) { create(:facility, facility_group: ihmi_group) }
+  let!(:call_center) { create(:admin, :call_center) }
+
+  before do
+    call_center.accesses.create(resource: ihmi)
+    ENV["IHCI_ORGANIZATION_UUID"] = ihmi.id
+    enable_flag(:new_permissions_system_aug_2020, call_center)
+  end
+
+  after do
+    disable_flag(:new_permissions_system_aug_2020, call_center)
+  end
+
+  describe "index" do
+    before { sign_in(call_center.email_authentication) }
+
+    it "shows Overdue tab" do
+      visit root_path
+
+      expect(page).to have_content("Overdue patients")
+    end
+
+    describe "Overdue patients tab" do
+      let!(:authorized_facility_group) { ihmi_group }
+
+      let!(:facility_1) { create(:facility, facility_group: authorized_facility_group) }
+
+      let!(:overdue_patient_in_facility_1) do
+        patient = create(:patient, full_name: "patient_1", registration_facility: facility_1)
+        create(:appointment, :overdue, facility: facility_1, patient: patient, scheduled_date: 10.days.ago)
+        create(:blood_pressure, :critical, facility: facility_1, patient: patient)
+        patient
+      end
+
+      let!(:non_overdue_patient_in_facility_1) { create(:patient, full_name: "patient_2", registration_facility: facility_1) }
+
+      let!(:facility_2) { create(:facility, facility_group: authorized_facility_group) }
+
+      let!(:overdue_patient_in_facility_2) do
+        patient = create(:patient, full_name: "patient_3", registration_facility: facility_2)
+        create(:appointment, :overdue, facility: facility_2, patient: patient, scheduled_date: 5.days.ago)
+        create(:blood_pressure, :hypertensive, facility: facility_2, patient: patient)
+        patient
+      end
+
+      let!(:unauthorized_facility_group) { create(:facility_group) }
+
+      let!(:unauthorized_facility) { create(:facility, facility_group: unauthorized_facility_group) }
+
+      let!(:overdue_patient_in_unauthorized_facility) do
+        patient = create(:patient, full_name: "patient_4", registration_facility: unauthorized_facility)
+        create(:appointment, :overdue, facility: unauthorized_facility, patient: patient)
+        patient
+      end
+
+      before do
+        visit appointments_path
+      end
+
+      it "shows all overdue patients" do
+        expect(page).to have_content(overdue_patient_in_facility_1.full_name)
+        expect(page).to have_content(overdue_patient_in_facility_2.full_name)
+      end
+
+      it "shows registration date for overdue patients" do
+        expect(page).to have_content("Registered on")
+      end
+
+      it "does not show non-overdue patients" do
+        expect(page).not_to have_content(non_overdue_patient_in_facility_1.full_name)
+      end
+
+      it "does not show overdue patients in unauthorized facilities" do
+        expect(page).not_to have_content(overdue_patient_in_unauthorized_facility.full_name)
+      end
+
+      it "does not allow you to download the overdue list for all facilities" do
+        expect(page).to have_content(/select a facility/i)
+        expect(page).not_to have_selector("a", text: "Download Overdue List")
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1133/migrate-the-appointmentscontroller-and-its-actions
## Because

We're preparing all controllers for new permissions so we can darklaunch to production

## This addresses

Migrates the AppointmentsController and it's views to use the new permissions (gated by a Flipper flag)
