### PR TITLE
Install Skylight

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem "scenic"
 gem "sentry-raven"
 gem "sidekiq"
 gem "sidekiq-throttled"
+gem "skylight"
 gem "slack-notifier"
 gem "strong_password", "~> 0.0.8"
 gem "timecop", "~> 0.9.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,6 +476,10 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
+    skylight (4.3.1)
+      skylight-core (= 4.3.1)
+    skylight-core (4.3.1)
+      activesupport (>= 4.2.0)
     slack-notifier (2.3.2)
     spring (2.1.0)
     spring-commands-rspec (1.0.4)
@@ -622,6 +626,7 @@ DEPENDENCIES
   sidekiq
   sidekiq-throttled
   simplecov
+  skylight
   slack-notifier
   spring
   spring-commands-rspec


### PR DESCRIPTION
## Because

We're exploring https://www.skylight.io as an alternative to New Relic

## This addresses

Initial setup of Skylight. The necessary `SKYLIGHT_AUTHENTICATION` key is in 1password.
