### PR TITLE
Bump cache version in UserAnalyticsPresenter

### DIFF
--- a/app/presenters/user_analytics_presenter.rb
+++ b/app/presenters/user_analytics_presenter.rb
@@ -10,7 +10,7 @@ class UserAnalyticsPresenter < Struct.new(:current_facility)
   HTN_CONTROL_MONTHS_AGO = 12
   TROPHY_MILESTONES = [10, 25, 50, 100, 250, 500, 1_000, 2_000, 3_000, 4_000, 5_000]
   TROPHY_MILESTONE_INCR = 10_000
-  CACHE_VERSION = 2
+  CACHE_VERSION = 3
   EXPIRE_STATISTICS_CACHE_IN = 15.minutes
 
   def daily_stats_by_date(*stats)


### PR DESCRIPTION
Hot fix for https://sentry.io/organizations/resolve-to-save-lives/issues/1895502841/?referrer=slack

I believe this error is happening because the structure returned by CohortService changed and we also changed how the presenter is returning this data, but we didn't bump this outer layer cache version.  So things are out of sync and we will have some caches w/ the old structure of the data.