### PR TITLE
Fix some more minor permissions-related regressions

### DIFF
--- a/app/controllers/admin/facilities_controller.rb
+++ b/app/controllers/admin/facilities_controller.rb
@@ -28,15 +28,17 @@ class Admin::FacilitiesController < AdminController
     end
 
     if current_admin.permissions_v2_enabled?
+      accessible_facilities = current_admin.accessible_facilities(:manage)
+
       if searching?
-        current_admin.accessible_facilities(:manage).search_by_name(search_query)
+        facilities = accessible_facilities.search_by_name(search_query)
         facility_groups = FacilityGroup.where(facilities: facilities)
 
         @organizations = Organization.where(facility_groups: facility_groups)
         @facility_groups = facility_groups.group_by(&:organization)
         @facilities = facilities.group_by(&:facility_group)
       else
-        accessible_facilities = current_admin.accessible_facilities(:manage)
+
         @facilities = accessible_facilities.group_by(&:facility_group)
 
         visible_facility_groups =

--- a/app/controllers/concerns/my_facilities_filtering.rb
+++ b/app/controllers/concerns/my_facilities_filtering.rb
@@ -31,7 +31,6 @@ module MyFacilitiesFiltering
         if current_admin.permissions_v2_enabled?
           current_admin.accessible_facilities(:view_reports).pluck(:zone).uniq.compact.sort
         else
-
           policy_scope([:manage, :facility, Facility]).pluck(:zone).uniq.compact.sort
         end
     end

--- a/app/controllers/concerns/my_facilities_filtering.rb
+++ b/app/controllers/concerns/my_facilities_filtering.rb
@@ -9,11 +9,12 @@ module MyFacilitiesFiltering
       :set_selected_sizes, :set_selected_zones, :set_only_new_facilities
 
     def filter_facilities(scope_namespace = [])
-      facilities = if current_admin.permissions_v2_enabled?
-        current_admin.accessible_facilities(:view_reports)
-      else
-        policy_scope(scope_namespace.concat([Facility]))
-      end
+      facilities =
+        if current_admin.permissions_v2_enabled?
+          current_admin.accessible_facilities(:view_reports)
+        else
+          policy_scope(scope_namespace.concat([Facility]))
+        end
 
       filtered_facilities = facilities_by_size(facilities)
       facilities_by_zone(filtered_facilities)
@@ -26,7 +27,13 @@ module MyFacilitiesFiltering
     end
 
     def populate_zones
-      @zones = policy_scope([:manage, :facility, Facility]).pluck(:zone).uniq.compact.sort
+      @zones =
+        if current_admin.permissions_v2_enabled?
+          current_admin.accessible_facilities(:view_reports).pluck(:zone).uniq.compact.sort
+        else
+
+          policy_scope([:manage, :facility, Facility]).pluck(:zone).uniq.compact.sort
+        end
     end
 
     def set_selected_sizes

--- a/app/controllers/email_authentications/invitations_controller.rb
+++ b/app/controllers/email_authentications/invitations_controller.rb
@@ -3,6 +3,9 @@ class EmailAuthentications::InvitationsController < Devise::InvitationsControlle
   before_action :🆕verify_params, only: [:create], if: -> { current_admin.permissions_v2_enabled? }
   helper_method :current_admin
 
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+  rescue_from UserAccess::NotAuthorizedError, with: :user_not_authorized
+
   def new
     if current_admin.permissions_v2_enabled?
       raise UserAccess::NotAuthorizedError unless current_admin.accessible_facilities(:manage).any?

--- a/app/controllers/my_facilities_controller.rb
+++ b/app/controllers/my_facilities_controller.rb
@@ -11,7 +11,9 @@ class MyFacilitiesController < AdminController
   PERIODS_TO_DISPLAY = {quarter: 3, month: 3, day: 14}.freeze
 
   skip_after_action :verify_authorized, if: -> { current_admin.permissions_v2_enabled? }
+  skip_after_action :verify_policy_scoped, if: -> { current_admin.permissions_v2_enabled? }
   after_action :verify_authorization_attempted, if: -> { current_admin.permissions_v2_enabled? }
+
   around_action :set_time_zone
   before_action :authorize_my_facilities
   before_action :set_selected_cohort_period, only: [:blood_pressure_control]

--- a/app/models/user_access.rb
+++ b/app/models/user_access.rb
@@ -84,6 +84,7 @@ class UserAccess
       ].flatten.uniq
 
     User
+      .admins
       .from(User
               .admins
               .select("DISTINCT ON (users.id) users.*")

--- a/app/models/user_access.rb
+++ b/app/models/user_access.rb
@@ -130,9 +130,8 @@ class UserAccess
     LEVELS[user.access_level.to_sym][:grant_access]
   end
 
-  # TODO: add better, more flexible constraints to this than just restricting to power_users
   def modify_access_level?
-    power_user?
+    power_user? || user.accessible_organizations(:manage).any?
   end
 
   def grant_access(new_user, selected_facility_ids)

--- a/app/presenters/admin_access_presenter.rb
+++ b/app/presenters/admin_access_presenter.rb
@@ -57,6 +57,7 @@ class AdminAccessPresenter < SimpleDelegator
 
   memoize def facility_group_tree
     visible_facilities
+      .where.not(facility_group: nil)
       .group_by(&:facility_group)
       .sort_by { |facility_group, _| facility_group.name }
       .to_h

--- a/app/presenters/user_analytics_presenter.rb
+++ b/app/presenters/user_analytics_presenter.rb
@@ -10,7 +10,7 @@ class UserAnalyticsPresenter < Struct.new(:current_facility)
   HTN_CONTROL_MONTHS_AGO = 12
   TROPHY_MILESTONES = [10, 25, 50, 100, 250, 500, 1_000, 2_000, 3_000, 4_000, 5_000]
   TROPHY_MILESTONE_INCR = 10_000
-  CACHE_VERSION = 2
+  CACHE_VERSION = 3
   EXPIRE_STATISTICS_CACHE_IN = 15.minutes
 
   def daily_stats_by_date(*stats)

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -7,25 +7,33 @@
         <%= form.label "Teleconsultation number" %>
         <div class="input-group">
           <%= form.text_field :teleconsultation_isd_code,
-                              id: :user_teleconsultation_isd_code,
-                              optional: true,
-                              class: "col-sm-2",
-                              wrapper: false %>
+              id: :user_teleconsultation_isd_code,
+              optional: true,
+              class: "col-sm-2",
+              wrapper: false %>
           <%= form.text_field :teleconsultation_phone_number,
-                              id: :user_teleconsultation_phone_number,
-                              wrapper: false,
-                              autocomplete: "off",
-                              optional: true %>
+              id: :user_teleconsultation_phone_number,
+              wrapper: false,
+              autocomplete: "off",
+              optional: true %>
         </div>
         <small class="form-text text-muted">If different from phone number</small>
       </div>
 
       <%= form.password_field :password, id: :user_password, pattern: "[0-9]{4}", label: "PIN", help: "4 digits only", autocomplete: "new-password", optional: true %>
       <%= form.password_field :password_confirmation, id: :user_password_confirmation, pattern: "[0-9]{4}", label: "PIN confirmation", optional: true %>
-      <%= form.select :registration_facility_id, policy_scope([:manage, :user, Facility]) \
+
+      <% if current_admin.permissions_v2_enabled? %>
+        <%= form.select :registration_facility_id, current_admin.accessible_facilities(:manage) \
           .sort_by { |facility| facility.name.sub /^Dr(.?)(\s*)/, '' } \
           .collect { |facility| [facility.name, facility.id] } %>
+      <% else %>
+        <%= form.select :registration_facility_id, policy_scope([:manage, :user, Facility]) \
+          .sort_by { |facility| facility.name.sub /^Dr(.?)(\s*)/, '' } \
+          .collect { |facility| [facility.name, facility.id] } %>
+      <% end %>
+
       <%= form.primary %>
-    <% end %>
+  <% end %>
   </div>
 </div>

--- a/lib/tasks/scripts/create_accesses_from_permissions.rb
+++ b/lib/tasks/scripts/create_accesses_from_permissions.rb
@@ -23,8 +23,8 @@ class CreateAccessesFromPermissions
 
   attr_reader :organization, :dryrun, :verbose
 
-  def initialize(organization: Organization.where(name: "IHCI"), dryrun: true, verbose: true)
-    @organization = Organization.where(id: organization)
+  def initialize(organization: Organization.find_by!(name: "IHCI"), dryrun: true, verbose: true)
+    @organization = Organization.find_by!(id: organization)
     @dryrun = dryrun
     @verbose = verbose
   end
@@ -56,7 +56,7 @@ class CreateAccessesFromPermissions
       log "Finished assigning accesses."
     end
 
-    log "Did not migrate the following custom admins: #{admins_with_custom_permissions.join(", ")}"
+    log "Did not migrate the following custom admins: #{admins_with_custom_permissions.join(", ").presence || "none"}"
   end
 
   private
@@ -134,7 +134,7 @@ class CreateAccessesFromPermissions
     # For the following access_levels, we can simply return the organization:
     # - organization_owner
     if [:organization_owner].include?(access_level)
-      return organization
+      return [organization]
     end
 
     # Owners can't have any accesses

--- a/lib/tasks/scripts/create_accesses_from_permissions.rb
+++ b/lib/tasks/scripts/create_accesses_from_permissions.rb
@@ -56,7 +56,7 @@ class CreateAccessesFromPermissions
       log "Finished assigning accesses."
     end
 
-    log "Did not migrate the following custom admins: #{admins_with_custom_permissions.join(", ").presence || "none"}"
+    log "Did not migrate the following custom admins: ['#{admins_with_custom_permissions.join("', '")}']"
   end
 
   private


### PR DESCRIPTION
**Story card:** TBD

## Because

Found some more regressions while click-testing around.

## This addresses

- Facility searching was broken, because typo
- User edit page was not wrapped in the flipper flag for permissions
- My Facilities for non power-users was scoping zones incorrectly
- Rescue authorization errors manually from the invitations controller
- Update the migration script to read better
- Also allow org-owners to modify access levels
- Scope `accessible_admins` with `User.admins` scope
- Remove unassociated facilities from the the FacilityGroup tree
