### PR TITLE
Migrate approval notifier emails to also use new permissions

### DIFF
--- a/app/mailers/approval_notifier_mailer.rb
+++ b/app/mailers/approval_notifier_mailer.rb
@@ -29,9 +29,9 @@ class ApprovalNotifierMailer < ApplicationMailer
 
   def supervisor_emails
     permissions_users = UserPermission.where(permission_slug: :approve_health_workers, resource: user.facility_group).map(&:user)
-    accesses_users = User.admins.where(access_level: :manager)
+    accesses_users = User.admins.manager_access
       .select { |admin| admin.accessible_facilities(:manage).include?(user.facility) }
-      .reject { |admin| admin.accesses.map(&:resource_type).include?("Organization") }
+      .reject { |admin| admin.accesses.map(&:resource).include?(user.organization) }
 
     users = (permissions_users + accesses_users).uniq.compact
     users.map(&:email).join(",")
@@ -39,10 +39,10 @@ class ApprovalNotifierMailer < ApplicationMailer
 
   def organization_owner_emails
     permissions_users = UserPermission.where(permission_slug: :approve_health_workers, resource: user.organization).map(&:user)
-    accesses_users = User.admins.where(access_level: :manager)
+    accesses_users = User.admins.manager_access
       .select { |admin|
       admin.accessible_facilities(:manage).include?(user.facility) &&
-        admin.accesses.map(&:resource_type).include?("Organization")
+        admin.accesses.map(&:resource).include?(user.organization)
     }
 
     users = (permissions_users + accesses_users).uniq.compact
@@ -51,7 +51,7 @@ class ApprovalNotifierMailer < ApplicationMailer
 
   def owner_emails
     permissions_users = UserPermission.where(permission_slug: :approve_health_workers, resource: nil).map(&:user)
-    accesses_users = User.admins.where(access_level: :power_user)
+    accesses_users = User.admins.power_user_access
 
     users = (permissions_users + accesses_users).uniq.compact
     users.map(&:email).join(",")

--- a/app/mailers/approval_notifier_mailer.rb
+++ b/app/mailers/approval_notifier_mailer.rb
@@ -23,18 +23,37 @@ class ApprovalNotifierMailer < ApplicationMailer
 
   private
 
+  # permissions_users are admins as per the old permissions system
+  # accesses_users are admins as per the new permissions system
+  # we need to send emails to the superset of the two till we flip everyone over to new permissions
+
   def supervisor_emails
-    users = UserPermission.where(permission_slug: :approve_health_workers, resource: user.facility_group).map(&:user)
+    permissions_users = UserPermission.where(permission_slug: :approve_health_workers, resource: user.facility_group).map(&:user)
+    accesses_users = User.admins.where(access_level: :manager)
+                       .select { |admin| admin.accessible_facilities(:manage).include?(user.facility) }
+                       .reject { |admin| admin.accesses.map(&:resource_type).include?("Organization") }
+
+    users = (permissions_users + accesses_users).uniq.compact
     users.map(&:email).join(",")
   end
 
   def organization_owner_emails
-    users = UserPermission.where(permission_slug: :approve_health_workers, resource: user.organization).map(&:user)
+    permissions_users = UserPermission.where(permission_slug: :approve_health_workers, resource: user.organization).map(&:user)
+    accesses_users = User.admins.where(access_level: :manager)
+                       .select { |admin|
+                         admin.accessible_facilities(:manage).include?(user.facility) &&
+                           admin.accesses.map(&:resource_type).include?("Organization")
+                       }
+
+    users = (permissions_users + accesses_users).uniq.compact
     users.map(&:email).join(",")
   end
 
   def owner_emails
-    users = UserPermission.where(permission_slug: :approve_health_workers, resource: nil).map(&:user)
+    permissions_users = UserPermission.where(permission_slug: :approve_health_workers, resource: nil).map(&:user)
+    accesses_users = User.admins.where(access_level: :power_user)
+
+    users = (permissions_users + accesses_users).uniq.compact
     users.map(&:email).join(",")
   end
 end

--- a/app/mailers/approval_notifier_mailer.rb
+++ b/app/mailers/approval_notifier_mailer.rb
@@ -40,10 +40,7 @@ class ApprovalNotifierMailer < ApplicationMailer
   def organization_owner_emails
     permissions_users = UserPermission.where(permission_slug: :approve_health_workers, resource: user.organization).map(&:user)
     accesses_users = User.admins.manager_access
-      .select { |admin|
-      admin.accessible_facilities(:manage).include?(user.facility) &&
-        admin.accesses.map(&:resource).include?(user.organization)
-    }
+      .select { |admin| admin.accessible_organizations(:manage).where(id: user.organization).any? }
 
     users = (permissions_users + accesses_users).uniq.compact
     users.map(&:email).join(",")

--- a/app/mailers/approval_notifier_mailer.rb
+++ b/app/mailers/approval_notifier_mailer.rb
@@ -30,8 +30,8 @@ class ApprovalNotifierMailer < ApplicationMailer
   def supervisor_emails
     permissions_users = UserPermission.where(permission_slug: :approve_health_workers, resource: user.facility_group).map(&:user)
     accesses_users = User.admins.where(access_level: :manager)
-                       .select { |admin| admin.accessible_facilities(:manage).include?(user.facility) }
-                       .reject { |admin| admin.accesses.map(&:resource_type).include?("Organization") }
+      .select { |admin| admin.accessible_facilities(:manage).include?(user.facility) }
+      .reject { |admin| admin.accesses.map(&:resource_type).include?("Organization") }
 
     users = (permissions_users + accesses_users).uniq.compact
     users.map(&:email).join(",")
@@ -40,10 +40,10 @@ class ApprovalNotifierMailer < ApplicationMailer
   def organization_owner_emails
     permissions_users = UserPermission.where(permission_slug: :approve_health_workers, resource: user.organization).map(&:user)
     accesses_users = User.admins.where(access_level: :manager)
-                       .select { |admin|
-                         admin.accessible_facilities(:manage).include?(user.facility) &&
-                           admin.accesses.map(&:resource_type).include?("Organization")
-                       }
+      .select { |admin|
+      admin.accessible_facilities(:manage).include?(user.facility) &&
+        admin.accesses.map(&:resource_type).include?("Organization")
+    }
 
     users = (permissions_users + accesses_users).uniq.compact
     users.map(&:email).join(",")

--- a/spec/mailers/approval_notifier_mailer_spec.rb
+++ b/spec/mailers/approval_notifier_mailer_spec.rb
@@ -3,18 +3,34 @@ RSpec.describe ApprovalNotifierMailer, type: :mailer do
   describe "ApprovalNotifier emails" do
     let!(:old_power_user) { create(:admin, :owner) }
     let!(:new_power_user) { create(:admin, :power_user) }
+
     let!(:organization) { create(:organization) }
     let!(:old_org_owner) { create(:admin, :organization_owner, organization: organization) }
     let!(:org_manager) { create(:admin, :manager) }
     let!(:org_manager_access) { create(:access, user: org_manager, resource: organization) }
+    let!(:other_organization) { create(:organization) }
+    let!(:old_other_org_owner) { create(:admin, :organization_owner, organization: other_organization) }
+    let!(:other_org_manager) { create(:admin, :manager) }
+    let!(:other_org_manager_access) { create(:access, user: other_org_manager, resource: other_organization) }
+
     let!(:facility_group) { create(:facility_group, organization: organization) }
     let!(:old_fg_supervisor) { create(:admin, :supervisor, facility_group: facility_group) }
     let!(:fg_manager) { create(:admin, :manager) }
     let!(:fg_manager_access) { create(:access, user: fg_manager, resource: facility_group) }
+    let!(:other_facility_group) { create(:facility_group, organization: other_organization) }
+    let!(:old_other_fg_supervisor) { create(:admin, :supervisor, facility_group: other_facility_group) }
+    let!(:other_fg_manager) { create(:admin, :manager) }
+    let!(:other_fg_manager_access) { create(:access, user: other_fg_manager, resource: other_facility_group) }
+
     let!(:facility) { create(:facility, facility_group: facility_group) }
     let!(:facility_manager) { create(:admin, :manager) }
-    let!(:facility_manager_access) { create(:access, user: facility_manager, resource: facility_group) }
+    let!(:facility_manager_access) { create(:access, user: facility_manager, resource: facility) }
+    let!(:other_facility) { create(:facility, facility_group: other_facility_group) }
+    let!(:other_facility_manager) { create(:admin, :manager) }
+    let!(:other_facility_manager_access) { create(:access, user: other_facility_manager, resource: other_facility) }
+
     let!(:user) { create(:user, :sync_requested, organization: organization, registration_facility: facility) }
+    let!(:other_user) { create(:user, :sync_requested, organization: other_organization, registration_facility: other_facility) }
 
     describe "registration_approval_email" do
       let(:mail) { described_class.registration_approval_email(user_id: user.id) }

--- a/spec/mailers/approval_notifier_mailer_spec.rb
+++ b/spec/mailers/approval_notifier_mailer_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+RSpec.describe ApprovalNotifierMailer, type: :mailer do
+  describe 'emails' do
+    let!(:old_power_user) { create(:admin, :owner) }
+    let!(:new_power_user) { create(:admin, :power_user) }
+    let!(:organization) { create(:organization) }
+    let!(:old_org_owner) { create(:admin, :organization_owner, organization: organization) }
+    let!(:org_manager) { create(:admin, :manager) }
+    let!(:org_manager_access) { create(:access, user: org_manager, resource: organization) }
+    let!(:facility_group) { create(:facility_group, organization: organization) }
+    let!(:old_fg_supervisor) { create(:admin, :supervisor, facility_group: facility_group) }
+    let!(:fg_manager) { create(:admin, :manager) }
+    let!(:fg_manager_access) { create(:access, user: fg_manager, resource: facility_group) }
+    let!(:facility) { create(:facility, facility_group: facility_group) }
+    let!(:facility_manager) { create(:admin, :manager) }
+    let!(:facility_manager_access) { create(:access, user: facility_manager, resource: facility_group) }
+    let!(:user) { create(:user, :sync_requested, organization: organization, registration_facility: facility) }
+
+    describe "registration_approval_email" do
+      let(:mail) { described_class.registration_approval_email(user_id: user.id) }
+
+      it "renders the headers" do
+        expect(mail.subject).to eq("New Registration: User #{user.full_name} is requesting access to #{organization.name} facilities.")
+        expect(mail.from).to eq(["help@simple.org"])
+        expect(mail.to).to contain_exactly(facility_manager.email, fg_manager.email, old_fg_supervisor.email)
+        expect(mail.cc).to contain_exactly(org_manager.email, old_org_owner.email)
+        expect(mail.bcc).to include(old_power_user.email, new_power_user.email)
+      end
+
+      it "renders the body, and contains a link to the user's edit page" do
+        expect(mail.body).to include("New User Registered")
+        expect(mail.body).to include("/admin/users/#{user.id}")
+      end
+    end
+
+    describe "reset_password_approval_email" do
+      let(:mail) { described_class.reset_password_approval_email(user_id: user.id) }
+
+      it "renders the headers" do
+        expect(mail.subject).to eq("PIN Reset: User #{user.full_name} is requesting access.")
+        expect(mail.from).to eq(["help@simple.org"])
+        expect(mail.to).to contain_exactly(facility_manager.email, fg_manager.email, old_fg_supervisor.email)
+        expect(mail.cc).to contain_exactly(org_manager.email, old_org_owner.email)
+        expect(mail.bcc).to include(old_power_user.email, new_power_user.email)
+      end
+
+      it "renders the body, and contains a link to the user's edit page" do
+        expect(mail.body).to include("User has reset PIN.")
+        expect(mail.body).to include("/admin/users/#{user.id}")
+      end
+    end
+  end
+end

--- a/spec/mailers/approval_notifier_mailer_spec.rb
+++ b/spec/mailers/approval_notifier_mailer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 RSpec.describe ApprovalNotifierMailer, type: :mailer do
-  describe 'emails' do
+  describe "ApprovalNotifier emails" do
     let!(:old_power_user) { create(:admin, :owner) }
     let!(:new_power_user) { create(:admin, :power_user) }
     let!(:organization) { create(:organization) }

--- a/spec/mailers/previews/approval_notifier_preview.rb
+++ b/spec/mailers/previews/approval_notifier_preview.rb
@@ -1,10 +1,12 @@
 # Preview all emails at http://localhost:3000/rails/mailers/approval_notifier
 class ApprovalNotifierPreview < ActionMailer::Preview
   def registration_approval_email
-    ApprovalNotifierMailer.with(user: User.first).registration_approval_email
+    user = User.non_admins.lazy.select { |user| user.facility.present? }.first
+    ApprovalNotifierMailer.with(user: user).registration_approval_email(user_id: user.id)
   end
 
   def reset_password_approval_email
-    ApprovalNotifierMailer.with(user: User.first).reset_password_approval_email
+    user = User.non_admins.lazy.select { |user| user.facility.present? }.first
+    ApprovalNotifierMailer.with(user: user).reset_password_approval_email(user_id: user.id)
   end
 end


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1245/migrate-user-approval-emails-to-incorporate-admins-with-new-permissions

## Because

The user approval emails depend on old permissions to decide who needs to get approval notification emails.

## This addresses

Adds admins with new permissions to the list of admins who need to see these emails.
