### PR TITLE
Remove Pundit permissions usage from reports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,11 @@ gem "bootstrap_form", ">= 4.5.0"
 gem "connection_pool"
 gem "data-anonymization", require: false
 gem "data_migrate"
-gem "ddtrace", require: false
+gem "ddtrace"
 gem "devise", ">= 4.7.1"
 gem "devise_invitable", "~> 1.7.0"
 gem "discard", "~> 1.0"
+gem "dogstatsd-ruby"
 gem "dotenv-rails"
 gem "factory_bot_rails", "~> 4.8", require: false
 gem "faker", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
     discard (1.2.0)
       activerecord (>= 4.2, < 7)
     docile (1.3.2)
+    dogstatsd-ruby (4.8.1)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.5)
@@ -578,6 +579,7 @@ DEPENDENCIES
   devise (>= 4.7.1)
   devise_invitable (~> 1.7.0)
   discard (~> 1.0)
+  dogstatsd-ruby
   dotenv-rails
   factory_bot_rails (~> 4.8)
   faker

--- a/app/views/analytics/districts/show.html.erb
+++ b/app/views/analytics/districts/show.html.erb
@@ -15,7 +15,7 @@
 
 <%= render 'shared/cohort_charts', cohort_analytics: @cohort_analytics, quarter: current_quarter, year: current_year %>
 
-<%= render 'shared/analytics_table',
+<%= render 'analytics_table',
            dashboard_analytics: @dashboard_analytics,
            period: @period,
            row_resource: current_admin.accessible_facilities(:view_reports).order(:name),

--- a/app/views/analytics/facilities/_analytics_table.html.erb
+++ b/app/views/analytics/facilities/_analytics_table.html.erb
@@ -57,11 +57,7 @@
         <% end %>
       </tr>
 
-      <% if current_admin.permissions_v2_enabled? %>
-        <% resources = row_resource %>
-      <% else %>
-        <% resources = policy_scope([:cohort_report, row_resource]) %>
-      <% end %>
+      <% resources = row_resource %>
 
       <% resources.each do |resource| %>
         <% if dashboard_analytics[resource.id].present? %>

--- a/app/views/analytics/facilities/show.html.erb
+++ b/app/views/analytics/facilities/show.html.erb
@@ -19,10 +19,11 @@
 
 <%= render 'shared/cohort_charts', cohort_analytics: @cohort_analytics %>
 
-<%= render 'shared/analytics_table',
+<%= render 'analytics_table',
            dashboard_analytics: @dashboard_analytics,
            period: @period,
            row_resource: current_admin.accessible_users(:view_reports).order(:full_name),
+           row_resource_subtitle: "Patient registrations by users in #{@facility.name}",
            row_resource_description: "Users",
            row_resource_display_field: :full_name,
            row_resource_link: :admin_user_path %>

--- a/config/deploy/security.rb
+++ b/config/deploy/security.rb
@@ -1,0 +1,3 @@
+server "ec2-13-232-246-106.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db cron whitelist_phone_numbers]
+server "ec2-13-235-87-60.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db]
+server "ec2-15-207-249-249.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web sidekiq]

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,5 +1,6 @@
-if SIMPLE_SERVER_ENV == "sandbox"
+if ["sandbox", "production"].include?(SIMPLE_SERVER_ENV)
   require "ddtrace"
+  require "datadog/statsd"
   Datadog.configure do |c|
     c.use :rails, service_name: "#{SIMPLE_SERVER_ENV}-rails-app", log_injection: true
   end

--- a/db/data/20200528063206_set_patient_soft_deletion_info.rb
+++ b/db/data/20200528063206_set_patient_soft_deletion_info.rb
@@ -1,15 +1,19 @@
 class SetPatientSoftDeletionInfo < ActiveRecord::Migration[5.2]
   def up
-    bot_user = User.find_or_create_by!(full_name: "Data Migration Bot",
-                                       sync_approval_status: "denied",
-                                       sync_approval_status_reason: "Bot user doesn't require sync") { |user|
-      user.device_created_at = Time.current
-      user.device_updated_at = Time.current
-    }
-
-    Patient.with_discarded.discarded.in_batches(of: 1_000) do |batch|
-      batch.update_all(deleted_by_user_id: bot_user.id, deleted_reason: "unknown")
-    end
+    # This migration conflicts with the validations added on User later
+    # (teleconsultation_phone_number). Commenting this out since it's a
+    # one time migration that's already been run on all envs.
+    #
+    # bot_user = User.find_or_create_by!(full_name: "Data Migration Bot",
+    #                                    sync_approval_status: "denied",
+    #                                    sync_approval_status_reason: "Bot user doesn't require sync") { |user|
+    #   user.device_created_at = Time.current
+    #   user.device_updated_at = Time.current
+    # }
+    #
+    # Patient.with_discarded.discarded.in_batches(of: 1_000) do |batch|
+    #   batch.update_all(deleted_by_user_id: bot_user.id, deleted_reason: "unknown")
+    # end
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -142,9 +142,7 @@ ActiveRecord::Schema.define(version: 2020_09_17_184207) do
     t.index ["user_id"], name: "index_communications_on_user_id"
   end
 
-  create_table "data_migrations", id: false, force: :cascade do |t|
-    t.string "version", null: false
-    t.index ["version"], name: "unique_data_migrations", unique: true
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
   create_table "email_authentications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -4,6 +4,7 @@ namespace :sidekiq do
   desc "Install sidekiq systemd files"
   task :install do
     on roles :sidekiq do
+      execute "mkdir -p .config/systemd/user"
       template "sidekiq@.service", "~/.config/systemd/user/sidekiq@.service"
       template "sidekiq.service", "~/.config/systemd/user/sidekiq.service"
 

--- a/public/manifest/security.json
+++ b/public/manifest/security.json
@@ -1,0 +1,10 @@
+{
+  "v1": [
+    {
+      "country_code": "IN",
+      "endpoint": "https://api-security.simple.org/api/",
+      "display_name": "India",
+      "isd_code": "91"
+    }
+  ]
+}


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1272/remove-pundit-permissions-usage-from-reports

## This addresses

Removes Pundit permissions from the following

- [x] My Facilities
- [x] Old reports (cohorts)
- [x] New reports