### PR TITLE
Fix BP sync bug

### DIFF
--- a/app/models/concerns/observeable.rb
+++ b/app/models/concerns/observeable.rb
@@ -7,9 +7,17 @@ module Observeable
 
   included do
     def find_or_update_observation!(encounter, user)
-      build_observation(encounter: encounter, user: user) if observation.blank?
-      observation.update!(encounter: encounter)
-      observation
+      with_discarded_observations do
+        build_observation(encounter: encounter, user: user) if observation.blank?
+        observation.update!(encounter: encounter)
+        observation
+      end
     end
+  end
+
+  private
+
+  def with_discarded_observations
+    Observation.unscoped { yield }
   end
 end

--- a/spec/models/blood_pressure_spec.rb
+++ b/spec/models/blood_pressure_spec.rb
@@ -119,4 +119,17 @@ RSpec.describe BloodPressure, type: :model do
       end
     end
   end
+
+  context "#find_or_update_observation!" do
+    let(:blood_pressure) { create(:blood_pressure, :with_encounter) }
+    let!(:encounter) { blood_pressure.encounter }
+    let!(:observation) { blood_pressure.observation }
+    let!(:user) { blood_pressure.user }
+
+    it "should throw an RecordNotUnique error" do
+      observation.discard
+      blood_pressure.reload
+      expect { blood_pressure.find_or_update_observation!(encounter, user) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
 end

--- a/spec/models/blood_pressure_spec.rb
+++ b/spec/models/blood_pressure_spec.rb
@@ -126,10 +126,15 @@ RSpec.describe BloodPressure, type: :model do
     let!(:observation) { blood_pressure.observation }
     let!(:user) { blood_pressure.user }
 
-    it "should throw an RecordNotUnique error" do
+    it "updates discarded observations also" do
       observation.discard
       blood_pressure.reload
-      expect { blood_pressure.find_or_update_observation!(encounter, user) }.to raise_error(ActiveRecord::RecordNotUnique)
+
+      encounter.encountered_on = 1.year.ago
+      encounter.save
+      blood_pressure.find_or_update_observation!(encounter, user)
+
+      expect(encounter.encountered_on).to eq 1.year.ago.to_date
     end
   end
 end


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1263/fix-failing-bp-sync-for-ihci-user

## Because

BP sync is constantly failing with a `500` for a particular user. This bug was spotted via Mixpanel. 
Sentry Issue: https://sentry.io/organizations/resolve-to-save-lives/issues/1797395001

## This addresses

This is happening due to an edge case in generating `observations` on the server:
- This patient was soft deleted and so were all the associated BPs and observations.
- The user tries to sync a BP with a soft deleted observation.
- We try to create/update an observation for the BP in `MergeEncounterService`. Since we don't include discarded observations while checking if an observation exists (in `find_or_update_observation!`), we don't find the existing observation and we try to create one. This fails with a unique constraint error since an observation for the BP already exists.

This fixes `find_or_update_observation!`  to include discarded observations while finding.