### PR TITLE
Configure lograge / json formatting for sandbox only (to start)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "jbuilder", "~> 2.5"
 gem "jquery-rails"
 gem "kaminari"
 gem "lodash-rails"
+gem "lograge", require: false
 gem "newrelic_rpm"
 gem "passenger"
 gem "pg", ">= 0.18", "< 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,11 @@ GEM
       ruby_dep (~> 1.2)
     lodash-rails (4.17.15)
       railties (>= 3.1)
+    lograge (0.11.2)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -595,6 +600,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.2)
   lodash-rails
+  lograge
   memery
   memory_profiler
   newrelic_rpm

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,6 +6,12 @@ Rails.application.configure do
     ENV["SIMPLE_SERVER_HOST"] = "#{ENV["HEROKU_APP_NAME"]}.herokuapp.com"
   end
 
+  if ENV["SIMPLE_SERVER_ENV"] == "sandbox"
+    require "lograge"
+    config.lograge.enabled = true
+    config.lograge.formatter = Lograge::Formatters::Json.new
+    config.colorize_logging = false
+  end
   # Code is not reloaded between requests.
   config.cache_classes = true
 


### PR DESCRIPTION
To support better log collection and aggregation.  The default rails log formatting is not very machine readable, whereas JSON formatting is.

This only configures it for sandbox so we can test things out.