### PR TITLE
Telemed: Fix facility medical officers API 

### DIFF
--- a/app/controllers/api/v4/facility_medical_officers_controller.rb
+++ b/app/controllers/api/v4/facility_medical_officers_controller.rb
@@ -14,7 +14,7 @@ class Api::V4::FacilityMedicalOfficersController < APIController
      medical_officers: transform_medical_officers(facility.teleconsultation_medical_officers),
      created_at: Time.current,
      updated_at: Time.current,
-     deleted_at: Time.current}
+     deleted_at: nil}
   end
 
   def transform_medical_officers(medical_officers)

--- a/spec/controllers/api/v4/facility_medical_officers_controller_spec.rb
+++ b/spec/controllers/api/v4/facility_medical_officers_controller_spec.rb
@@ -40,5 +40,18 @@ RSpec.describe Api::V4::FacilityMedicalOfficersController, type: :controller do
       expect(medical_officers[facility_2.id].map { |m| m["id"] }).to match_array facility_2_teleconsultation_mos.map(&:id)
       expect(medical_officers[facility_without_any_mos.id]).to be_empty
     end
+
+    it "sets the appropriate timestamp fields" do
+      Timecop.freeze do
+        get :sync_to_user
+
+        response_body = JSON(response.body)
+        medical_officers = response_body["facility_medical_officers"]
+
+        expect(medical_officers.map { |medical_officer| Time.parse(medical_officer["created_at"]).to_i }).to all eq Time.current.to_i
+        expect(medical_officers.map { |medical_officer| Time.parse(medical_officer["updated_at"]).to_i }).to all eq Time.current.to_i
+        expect(medical_officers.map { |medical_officer| medical_officer["deleted_at"] }).to all be nil
+      end
+    end
   end
 end


### PR DESCRIPTION
**Story card:** -

## Because

The `v4/facility_medical_officers` endpoint is sending resources with an incorrect `deleted_at`. The `deleted_at` should always be `null` since this is an artificial resource that will always be synced.
![image](https://user-images.githubusercontent.com/16774200/93991986-9c7e1e00-fdaa-11ea-82f1-fcb91948d506.png)

[Slack ref](https://simpledotorg.slack.com/archives/CV9V1DWLV/p1600850974004900)

## This addresses

This fixes the `deleted_at` to be `null`.
