### PR TITLE
Bug: Total count not updating when user has only facility-level access tree

### DIFF
--- a/app/assets/javascripts/common/admins.js
+++ b/app/assets/javascripts/common/admins.js
@@ -99,6 +99,12 @@ AdminAccess.prototype = {
   updateParentCheckedState: function (element, selector) {
     // find parent and sibling checkboxes
     const parent = (element.closest(["ul"]).parentNode).querySelector(selector)
+
+    if (parent === element) {
+      this.updateSelectAllCheckbox()
+      return
+    }
+
     const siblings = nodeListToArray(selector, parent.closest("li").querySelector(["ul"]))
 
     // get checked state of siblings
@@ -115,8 +121,6 @@ AdminAccess.prototype = {
     // recurse until check is the top most parent
     if (element !== parent) {
       this.updateParentCheckedState(parent, selector)
-    } else {
-      this.updateSelectAllCheckbox()
     }
   },
 


### PR DESCRIPTION
**Story card:** <story link>

## Because

Total count not updating when the user has only facility-level access tree

## This addresses

Fixed by adding a guard clause to check if checked element has a parent
