### PR TITLE
Fix UI regression in ProtocolDrugs creation

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -78,7 +78,7 @@ class AdminController < ApplicationController
     begin
       capture = yield(blk)
 
-      unless capture
+      unless current_admin.power_user? || capture
         raise UserAccess::NotAuthorizedError
       end
 

--- a/app/views/admin/protocol_drugs/index.html.erb
+++ b/app/views/admin/protocol_drugs/index.html.erb
@@ -37,7 +37,7 @@
 <br>
 
 <% if current_admin.permissions_v2_enabled? %>
-  <% if current_admin.accessible_organizations(:manage).any? %>
+  <% if current_admin.accessible_organizations(:manage).any? || current_admin.power_user? %>
     <%= link_to 'New protocol drug', new_admin_protocol_drug_path %>
   <% end %>
 <% else %>

--- a/app/views/admin/protocols/index.html.erb
+++ b/app/views/admin/protocols/index.html.erb
@@ -2,7 +2,7 @@
   <h1 class="page-title">Protocols</h1>
   <nav class="page-nav">
     <% if current_admin.permissions_v2_enabled? %>
-      <% if current_admin.accessible_organizations(:manage).any? %>
+      <% if current_admin.accessible_organizations(:manage).any? || current_admin.power_user? %>
         <%= link_to 'Add protocol', new_admin_protocol_path, class: "btn btn-sm btn-primary" %>
       <% end %>
     <% else %>

--- a/app/views/admin/protocols/show.html.erb
+++ b/app/views/admin/protocols/show.html.erb
@@ -13,7 +13,7 @@
   </div>
   <nav class="page-nav">
     <% if current_admin.permissions_v2_enabled? %>
-      <% if current_admin.power_user? %>
+      <% if current_admin.accessible_organizations(:manage).any? || current_admin.power_user? %>
         <%= link_to "Edit protocol", edit_admin_protocol_path(@protocol), class: "btn btn-sm btn-primary", id: "Edit protocol" %>
         <%= link_to 'New protocol drug', new_admin_protocol_protocol_drug_path(@protocol), class: "btn btn-sm btn-primary", id: "New protocol drug" %>
       <% end %>

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe AdminController, type: :controller do
     end
   end
 
-  let(:user) { create(:admin) }
+  let(:user) { create(:admin, :manager) }
 
   before do
     sign_in(user.email_authentication)
@@ -57,6 +57,14 @@ RSpec.describe AdminController, type: :controller do
     end
 
     it "continues to render as usual when truthy is returned" do
+      routes.draw { get "authorized" => "admin#authorized" }
+
+      get :authorized
+      expect(response.body).to match(/Hello, authorized/)
+    end
+
+    it "continues to render as usual when user is power_user" do
+      user.update!(access_level: :power_user)
       routes.draw { get "authorized" => "admin#authorized" }
 
       get :authorized

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -65,10 +65,10 @@ RSpec.describe AdminController, type: :controller do
 
     it "continues to render as usual when user is power_user" do
       user.update!(access_level: :power_user)
-      routes.draw { get "authorized" => "admin#authorized" }
+      routes.draw { get "not_authorized" => "admin#not_authorized" }
 
-      get :authorized
-      expect(response.body).to match(/Hello, authorized/)
+      get :not_authorized
+      expect(response.body).to match(/Not, authorized/)
     end
   end
 


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1315/ui-regression-in-protocoldrug-creation

## Because

A UI regression with the new permissions hides the button to create new protocol drugs from Organization Managers

## This addresses

- Fixes the UI regression
- Bypasses `authorize_2` checks for power_users