### PR TITLE
Add security env to cap and manifest

### DIFF
--- a/config/deploy/security.rb
+++ b/config/deploy/security.rb
@@ -1,0 +1,3 @@
+server "ec2-13-232-246-106.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db cron whitelist_phone_numbers]
+server "ec2-13-235-87-60.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db]
+server "ec2-15-207-249-249.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web sidekiq]

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -4,6 +4,7 @@ namespace :sidekiq do
   desc "Install sidekiq systemd files"
   task :install do
     on roles :sidekiq do
+      execute "mkdir -p .config/systemd/user"
       template "sidekiq@.service", "~/.config/systemd/user/sidekiq@.service"
       template "sidekiq.service", "~/.config/systemd/user/sidekiq.service"
 

--- a/public/manifest/security.json
+++ b/public/manifest/security.json
@@ -1,0 +1,10 @@
+{
+  "v1": [
+    {
+      "country_code": "IN",
+      "endpoint": "https://api-security.simple.org/api/",
+      "display_name": "India",
+      "isd_code": "91"
+    }
+  ]
+}


### PR DESCRIPTION
**Story card:** <story link>

## Because

We need to spin up a security env for the CyRAACS audit.

## This addresses

This adds the security env created in https://github.com/simpledotorg/deployment/pull/260 to cap and app manifest.
