### PR TITLE
Ignore breaking data migration

### DIFF
--- a/db/data/20200528063206_set_patient_soft_deletion_info.rb
+++ b/db/data/20200528063206_set_patient_soft_deletion_info.rb
@@ -1,15 +1,19 @@
 class SetPatientSoftDeletionInfo < ActiveRecord::Migration[5.2]
   def up
-    bot_user = User.find_or_create_by!(full_name: "Data Migration Bot",
-                                       sync_approval_status: "denied",
-                                       sync_approval_status_reason: "Bot user doesn't require sync") { |user|
-      user.device_created_at = Time.current
-      user.device_updated_at = Time.current
-    }
-
-    Patient.with_discarded.discarded.in_batches(of: 1_000) do |batch|
-      batch.update_all(deleted_by_user_id: bot_user.id, deleted_reason: "unknown")
-    end
+    # This migration conflicts with the validations added on User later
+    # (teleconsultation_phone_number). Commenting this out since it's a
+    # one time migration that's already been run on all envs.
+    #
+    # bot_user = User.find_or_create_by!(full_name: "Data Migration Bot",
+    #                                    sync_approval_status: "denied",
+    #                                    sync_approval_status_reason: "Bot user doesn't require sync") { |user|
+    #   user.device_created_at = Time.current
+    #   user.device_updated_at = Time.current
+    # }
+    #
+    # Patient.with_discarded.discarded.in_batches(of: 1_000) do |batch|
+    #   batch.update_all(deleted_by_user_id: bot_user.id, deleted_reason: "unknown")
+    # end
   end
 
   def down

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,1 @@
-# encoding: UTF-8
 DataMigrate::Data.define(version: 20200703072612)

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,2 @@
+# encoding: UTF-8
 DataMigrate::Data.define(version: 20200703072612)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -142,9 +142,7 @@ ActiveRecord::Schema.define(version: 2020_09_17_184207) do
     t.index ["user_id"], name: "index_communications_on_user_id"
   end
 
-  create_table "data_migrations", id: false, force: :cascade do |t|
-    t.string "version", null: false
-    t.index ["version"], name: "unique_data_migrations", unique: true
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
   create_table "email_authentications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
**Story card:** NA

## Because

We found an old one-time data migration that breaks on a fresh `db:migrate`. This happens due to a conflict between the `users` schema in the data migration and newly added validations in the User model.

## This addresses

This ignores the one time migration to fix `db:migrate`. This is safe to ignore since it has been already run on all envs.
