### PR TITLE
Reports dropdown alignment fix

### DIFF
--- a/app/views/reports/regions/_downloads.html.erb
+++ b/app/views/reports/regions/_downloads.html.erb
@@ -2,7 +2,7 @@
   <a class="btn btn-sm dropdown-toggle c-black bg-white" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Downloads
   </a>
-  <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
     <%= link_to(reports_region_download_path(@region, report_scope: params[:report_scope], period: :quarter, format: :csv), class: "dropdown-item") do %>
       <i class="far fa-file mr-4px c-grey-medium"></i>
       Quarterly cohort report

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -58,7 +58,7 @@
           <% end %>
         </a>
         <% if action_name == "cohort" %>
-          <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+          <div class="dropdown-menu dropdown-menu-right w-100pt" aria-labelledby="dropdownMenuLink">
             <% [:month, :quarter].each do |period_type|
               period = Period.new(type: period_type, value: @period.to_date)
               selected = true if period == @period
@@ -73,7 +73,7 @@
             <% end %>
           </div>
         <% else %>
-          <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+          <div class="dropdown-menu dropdown-menu-right w-100pt" aria-labelledby="dropdownMenuLink">
             <%= form_for(@period, url: request.params, method: :get, enforce_utf8: false) do |f| %>
               <%= f.hidden_field :type, { id: "dropdown-period-type" } %>
 


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1311/downloads-dropdown-off-screen

## Because

1. Mobile dropdown menu should be full-width
2. Dropdown menu on large screens shouldn't cutoff from browser view

## This addresses

**Before**
![image](https://user-images.githubusercontent.com/16785131/94338988-a713ff80-ffc4-11ea-80c7-9cb08fc8c3ca.png)
![image](https://user-images.githubusercontent.com/16785131/94338978-8c418b00-ffc4-11ea-8995-c9684e97c0ff.png)
![image](https://user-images.githubusercontent.com/16785131/94338981-99f71080-ffc4-11ea-98b9-e729d66e60d0.png)

**After**
![image](https://user-images.githubusercontent.com/16785131/94338955-569ca200-ffc4-11ea-893b-a5cde25cf8cc.png)
![image](https://user-images.githubusercontent.com/16785131/94338937-3371f280-ffc4-11ea-82fe-7f9b9af5d71a.png)
![image](https://user-images.githubusercontent.com/16785131/94338946-4be20d00-ffc4-11ea-9ef1-6c3d4a2a0ae9.png)