### PR TITLE
Reports: Update 3rd card to "Missed visits"

### DIFF
--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -6,6 +6,8 @@ const darkRedColor = "rgba(255, 51, 85, 1)";
 const lightPurpleColor = "rgba(238, 229, 252, 1)";
 const darkPurpleColor = "rgba(83, 0, 224, 1)";
 const darkGreyColor = "rgba(108, 115, 122, 1)";
+const lightBlueColor = "rgba(233, 243, 255, 1)";
+const mediumBlueColor = "rgba(0, 117, 235, 1)";
 const mediumGreyColor = "rgba(173, 178, 184, 1)";
 const lightGreyColor = "rgba(240, 242, 245, 1)";
 
@@ -89,36 +91,29 @@ function initializeCharts() {
     new Chart(controlledGraphCanvas.getContext("2d"), controlledGraphConfig);
   }
 
-  const noRecentBPConfig = createGraphConfig([
-    {
-      data: data.visitButNoBPMeasureRate,
-      borderWidth: 0,
-      rgbaLineColor: darkGreyColor,
-      rgbaBackgroundColor: darkGreyColor,
-      hoverBackgroundColor: darkGreyColor,
-      label: "Visited in the last 3 months",
-    },
+  const missedVisitsConfig = createGraphConfig([
     {
       data: data.missedVisitsRate,
-      borderWidth: 0,
-      rgbaLineColor: mediumGreyColor,
-      rgbaBackgroundColor: mediumGreyColor,
-      label: "No visit >3 months ago",
+      borderWidth: 2,
+      rgbaLineColor: mediumBlueColor,
+      rgbaPointColor: lightBlueColor,
+      rgbaBackgroundColor: lightBlueColor,
+      label: "Missed visits",
     },
-  ], "bar");
-  noRecentBPConfig.options = createGraphOptions(
-    true,
+  ], "line");
+  missedVisitsConfig.options = createGraphOptions(
+    false,
     25,
     100,
     formatValueAsPercent,
     formatRateTooltipText,
-    [data.visitButNoBPMeasure, data.missedVisits],
+    [data.missedVisits],
     data.adjustedRegistrations,
   );
 
-  const noRecentBPGraphCanvas = document.getElementById("noRecentBPTrend");
-  if (noRecentBPGraphCanvas) {
-    new Chart(noRecentBPGraphCanvas.getContext("2d"), noRecentBPConfig);
+  const missedVisitsGraphCanvas = document.getElementById("missedVisitsTrend");
+  if (missedVisitsGraphCanvas) {
+    new Chart(missedVisitsGraphCanvas.getContext("2d"), missedVisitsConfig);
   }
 
   const uncontrolledGraphConfig = createGraphConfig([

--- a/app/assets/stylesheets/partials/_reports.scss
+++ b/app/assets/stylesheets/partials/_reports.scss
@@ -61,6 +61,7 @@
 .c-green-dark { color: $green-dark; }
 .c-purple { color: $purple; }
 .c-red { color: $red; }
+.c-blue { color: $blue; }
 .c-black { color: $black; }
 .c-transparent { color: transparent; }
 .c-grey-dark:hover { color: $grey-dark; }

--- a/app/views/reports/regions/_facility_tables.html.erb
+++ b/app/views/reports/regions/_facility_tables.html.erb
@@ -115,14 +115,14 @@
         </table>
       </div>
       <div class="pt-12px">
-      <p class="mb-8px fs-12px c-grey-dark">
-        <strong>Numerator:</strong> Patients with BP &ge;140/90 at their most recent visit in the last 3 months
-      </p>
-      <p class="mb-0px fs-12px c-grey-dark">
-        <strong>Denominator:</strong> All hypertensive patients assigned to <%= @region.name %> registered before
-        the last 3 months
-      </p>
-    </div>
+        <p class="mb-8px fs-12px c-grey-dark">
+          <strong>Numerator:</strong> Patients with BP &ge;140/90 at their most recent visit in the last 3 months
+        </p>
+        <p class="mb-0px fs-12px c-grey-dark">
+          <strong>Denominator:</strong> All hypertensive patients assigned to <%= @region.name %> registered before
+          the last 3 months
+        </p>
+      </div>
     </div>
   </div>
   <div class="d-lg-flex w-lg-50 pr-lg-2">
@@ -175,11 +175,14 @@
         </table>
       </div>
       <div class="pt-12px">
-      <p class="mb-0px fs-12px c-grey-dark">
-        <strong>Denominator:</strong> All hypertensive patients assigned to <%= @region.name %> registered before
-        the last 3 months
-      </p>
-    </div>
+        <p class="mb-8px fs-12px c-grey-dark">
+          <strong>Numerator:</strong> Patients with no visit in >3 months
+        </p>
+        <p class="mb-0px fs-12px c-grey-dark">
+          <strong>Denominator:</strong> All hypertensive patients assigned to <%= @region.name %> registered before
+          the last 3 months
+        </p>
+      </div>
     </div>
   </div>
   <div class="d-lg-flex w-lg-50 pl-lg-2">

--- a/app/views/reports/regions/_facility_tables.html.erb
+++ b/app/views/reports/regions/_facility_tables.html.erb
@@ -129,10 +129,10 @@
     <div class="card d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0">
       <div class="mb-2">
         <h3 class="c-black">
-          No BP measure
+          Missed visits
         </h3>
         <p class="mb-8px c-grey-dark">
-          Hypertensive patients with no recent BP measure  
+          Hypertensive patients with no visit in >3 months
         </p>
       </div>
       <div class="table-responsive">
@@ -151,7 +151,7 @@
                 % of patients with no visit in >3 months
               </th>
               <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-                % of patients with a visit but no BP taken
+                Total patients with no visit in >3 months
               </th>
             </tr>
           </thead>
@@ -167,7 +167,7 @@
                   <%= @data_for_facility[facility.name]["missed_visits_rate"].values.last %>%
                 </td>
                 <td class="ta-left">
-                  <%= @data_for_facility[facility.name]["visited_without_bp_taken_rate"].values.last %>%
+                  <%= @data_for_facility[facility.name]["missed_visits"].values.last %>
                 </td>
               </tr>
             <% end %>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -144,6 +144,9 @@
         </div>
         <div class="px-20px pb-8px pb-lg-0">
           <div class="mb-2">
+            <p class="mb-8px fs-12px c-grey-dark">
+              <strong>Numerator:</strong> Patients with no visit in >3 months
+            </p>
             <p class="fs-12px c-grey-dark">
               <strong>Denominator:</strong> All hypertensive patients assigned to <%= @region.name %> registered before
               the last 3 months

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -113,48 +113,34 @@
   <div class="d-lg-flex w-lg-50 pr-lg-2">
     <div class="mt-8px mx-0px mb-16px bg-white br-4px bs-small d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0">
       <div class="pt-20px px-20px">
-        <h3 class="mb-8px c-black">
-          No BP measure
-        </h3>
-        <p class="c-grey-dark">
-          Hypertensive patients with no recent BP measure
-        </p>
-        <div>
-          <div class="d-flex align-baseline mb-8px mb-lg-4px">
-            <div class="w-12px h-12px mr-12px br-2px bg-grey-medium"></div>
-            <div class="d-flex align-baseline">
-              <p class="w-40px m-0px fs-16px fw-bold">
-                <%= percentage_or_na(@data.last_value(:missed_visits_rate), precision: 0) %>
-              </p>
-              <p class="flex-1 m-0px fs-14px">
-                No visit &gt;3 months
-              </p>
-            </div>
-          </div>
-          <div class="d-flex align-baseline">
-            <div class="w-12px h-12px mr-12px br-2px bg-grey-dark"></div>
-            <div class="d-flex align-baseline">
-              <p class="w-40px m-0px fs-16px fw-bold">
-                <%= percentage_or_na(@data.last_value(:visited_without_bp_taken_rate), precision: 0) %>
-              </p>
-              <p class="flex-1 m-0px fs-14px">
-                Visited but no BP taken
-                <span
-                  data-toggle="tooltip"
-                  data-placement="top"
-                  data-trigger="hover"
-                  title="Patients registered 3 months prior with an appointment scheduled, updated medicines, or blood sugar taken"
-                >
-                  <i class="fas fa-info-circle ml-4px fs-12px c-grey-dark"></i>
-                </span>
-              </p>
-            </div>
-          </div>
+        <div class="mb-2">
+          <h3 class="mb-8px c-black">
+            Missed visits
+          </h3>
+          <p class="c-grey-dark">
+            Hypertensive patients with no visit in >3 months
+          </p>
+        </div>
+        <div class="mb-12px">
+          <p class="mb-0px fs-xlarge fw-bold <% if @data.last_value(:missed_visits_rate) %>c-blue<% else %>c-grey-medium<% end %>">
+            <% if @data.last_value(:missed_visits_rate) %>
+              <%= number_to_percentage(@data.last_value(:missed_visits_rate), precision: 0) %>
+            <% else %>
+              No data
+            <% end %>
+          </p>
+          <p class="m-0px <% if @data.last_value(:missed_visits_rate) %>c-black<% else %>c-grey-medium<% end %>">
+            <% if @data.last_value(:missed_visits_rate) %>
+              <span class="fw-bold"><%= number_with_delimiter(@data.last_value(:missed_visits)) %></span> of <%= number_with_delimiter(@data.last_value(:adjusted_registrations)) %> patients
+            <% else %>
+              No missed visits data available
+            <% end %>
+          </p>
         </div>
       </div>
       <div>
         <div class="h-200px mr-13px mb-16px ml-13px">
-          <canvas id="noRecentBPTrend"></canvas>
+          <canvas id="missedVisitsTrend"></canvas>
         </div>
         <div class="px-20px pb-8px pb-lg-0">
           <div class="mb-2">


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1369/update-3rd-card-to-missed-visits

## Because

"Visited but no BP taken" is information CVHOs don't need. We will only show "Missed visits" data in the 3rd card of the Reports "Overview" section.

## This addresses

**Update "Overview" Reports card**
* Update card's title and subtitle
* Add numerator copy to footer
* Remove "Visited but no BP taken" key
* Remove "Visited but no BP taken" from graph
* Make bar graph a line graph
* Update graph main color to `$blue`

![image](https://user-images.githubusercontent.com/16785131/94468532-931df880-0192-11eb-9e2a-9d5259b9d1b6.png)

**Update facility comparison table card**
* Update card's title and subtitle
* Add numerator copy to footer
* Replace "Visited but no BP taken" column with "Total patients with no visit in >3 months"

![image](https://user-images.githubusercontent.com/16785131/94468313-33bfe880-0192-11eb-8585-5b857d5c4d84.png)