### PR TITLE
Add flash message notice for patient list downloads

### DIFF
--- a/app/controllers/reports/patient_lists_controller.rb
+++ b/app/controllers/reports/patient_lists_controller.rb
@@ -30,7 +30,7 @@ class Reports::PatientListsController < AdminController
       notice: I18n.t("patient_list_email.notice",
         model_type: filtered_params[:report_scope],
         model_name: @region.name)
-      )
+    )
   end
 
   private

--- a/app/controllers/reports/patient_lists_controller.rb
+++ b/app/controllers/reports/patient_lists_controller.rb
@@ -25,7 +25,12 @@ class Reports::PatientListsController < AdminController
     end
 
     PatientListDownloadJob.perform_later(recipient_email, region_class, download_params)
-    redirect_back(fallback_location: reports_region_path(@region, report_scope: params[:report_scope]))
+    redirect_back(
+      fallback_location: reports_region_path(@region, report_scope: params[:report_scope]),
+      notice: I18n.t("patient_list_email.notice",
+        model_type: filtered_params[:report_scope],
+        model_name: @region.name)
+      )
   end
 
   private

--- a/spec/controllers/reports/patient_lists_controller_spec.rb
+++ b/spec/controllers/reports/patient_lists_controller_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Reports::PatientListsController, type: :controller do
       sign_in(admin.email_authentication)
       get :show, params: {id: facility.slug, report_scope: "facility"}
       expect(response).to redirect_to(reports_region_path(facility.slug, report_scope: "facility"))
+      expect(flash[:notice]).to match("You will soon be emailed a copy of the patient line list for facility")
     end
 
     it "returns CSV of registered patients in facility_group" do
@@ -50,6 +51,7 @@ RSpec.describe Reports::PatientListsController, type: :controller do
       sign_in(admin.email_authentication)
       get :show, params: {id: facility_group.slug, report_scope: "district"}
       expect(response).to redirect_to(reports_region_path(facility_group.slug, report_scope: "district"))
+      expect(flash[:notice]).to match("You will soon be emailed a copy of the patient line list for district")
     end
   end
 


### PR DESCRIPTION
**Story card:** [ch1321](https://app.clubhouse.io/simpledotorg/story/1321/no-flash-message-when-downloading-patient-line-list)

Quick fix to show flash notice after the download is triggered.