### PR TITLE
Bypass accessible_*.any? UI checks for power_users

### DIFF
--- a/app/views/admin/facilities/index.html.erb
+++ b/app/views/admin/facilities/index.html.erb
@@ -3,7 +3,7 @@
 
   <div class="page-nav">
     <% if current_admin.permissions_v2_enabled? %>
-      <% if current_admin.accessible_facility_groups(:manage).any? %>
+      <% if current_admin.accessible_facility_groups(:manage).any? || current_admin.power_user? %>
         <%= link_to 'Bulk add facilities', upload_admin_facilities_path, class: "btn btn-sm btn-default" %>
       <% end %>
     <% else %>
@@ -13,7 +13,7 @@
     <% end %>
 
     <% if current_admin.permissions_v2_enabled? %>
-      <% if current_admin.accessible_organizations(:manage).any? %>
+      <% if current_admin.accessible_organizations(:manage).any? || current_admin.power_user? %>
         <%= link_to new_admin_facility_group_path, class: "btn btn-sm btn-success" do %>
           <i class="fas fa-plus mr-1"></i>
           Add facility group

--- a/app/views/admin/facilities/upload.html.erb
+++ b/app/views/admin/facilities/upload.html.erb
@@ -35,7 +35,7 @@
   </li>
   <li>Facility Groups for the facilities must already exist.
     <% if current_admin.permissions_v2_enabled? %>
-      <% if current_admin.accessible_organizations(:manage).any? %>
+      <% if current_admin.accessible_organizations(:manage).any? || current_admin.power_user? %>
         Click here to create a facility group:
         <%= link_to '+ Facility group', new_admin_facility_group_path, class: "btn btn-sm btn-outline-primary" %>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,7 +60,7 @@
         <% if email_authentication_signed_in? %>
           <ul class="navbar-nav mr-auto">
             <% if current_admin.permissions_v2_enabled? %>
-              <% if current_admin.accessible_facilities(:view_reports).any? %>
+              <% if current_admin.accessible_facilities(:view_reports).any? || current_admin.power_user? %>
                 <li class="nav-item">
                   <%= link_to "Home", my_facilities_overview_path, class: "nav-link #{active_controller?("my_facilities")}" %>
                 </li>
@@ -79,7 +79,7 @@
                 </li>
               <% end %>
 
-              <% if current_admin.accessible_facilities(:manage_overdue_list).any? %>
+              <% if current_admin.accessible_facilities(:manage_overdue_list).any? || current_admin.power_user? %>
                 <li class="nav-item">
                   <%= link_to "Overdue", appointments_path, class: "nav-link #{active_controller?("appointments")}" %>
                 </li>
@@ -89,25 +89,25 @@
                 <%= link_to "Resources", resources_path, class: "nav-link #{active_controller?("resources")}" %>
               </li>
 
-              <% if current_admin.accessible_facilities(:manage).any? %>
+              <% if current_admin.accessible_facilities(:manage).any? || current_admin.power_user? %>
                 <li class="nav-item dropdown">
                   <a class="nav-link dropdown-toggle dropdown-more" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Settings
                   </a>
 
                   <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                    <% if current_admin.accessible_organizations(:manage).any? %>
+                    <% if current_admin.accessible_organizations(:manage).any? || current_admin.power_user? %>
                       <%= link_to "Organizations", admin_organizations_path, class: "dropdown-item #{active_controller?("admin/organizations")}" %>
                       <%= link_to "Protocols", admin_protocols_path, class: "dropdown-item #{active_controller?("admin/protocols")}" %>
                     <% end %>
 
                     <%= link_to "Facilities", admin_facilities_path, class: "dropdown-item #{active_controller?("admin/facilities")}" %>
 
-                    <% if current_admin.accessible_facilities(:manage).any? %>
+                    <% if current_admin.accessible_facilities(:manage).any? || current_admin.power_user? %>
                       <%= link_to "Admins", admins_path, class: "dropdown-item #{active_controller?("email_authentications")}" %>
                     <% end %>
 
-                    <% if current_admin.accessible_users(:manage).any? %>
+                    <% if current_admin.accessible_users(:manage).any? || current_admin.power_user? %>
                       <%= link_to "Users", admin_users_path, class: "dropdown-item #{active_controller?("users")}" %>
                     <% end %>
 


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/1410/allow-power-users-to-use-navigate-the-dashboard-when-no-data-is-present

## Because

UI level `accessible_*.any?` checks block dashboard usage when no data (organizations, facilities etc) exists.

## This addresses

Allows `power_users` to navigate the dashboard even when no data exists.
