### PR TITLE
Fix Bulk upload instructions

### DIFF
--- a/app/views/admin/facilities/upload.html.erb
+++ b/app/views/admin/facilities/upload.html.erb
@@ -50,9 +50,9 @@
   <li class="mt-1">
     The enable_diabetes_management
     <% if Flipper.enabled?(:teleconsult_facility_mo_search) %>
-      and enable_teleconsultation fields
-    <% else %>
       field
+    <% else %>
+      and enable_teleconsultation fields
     <% end %>
     will be treated as "not enabled" if blank.
   </li>


### PR DESCRIPTION
**Story card:** -

## Because

Instructions for the `enable_teleconsultation` field in bulk facility upload are incorrectly feature flagged
![image](https://user-images.githubusercontent.com/16774200/94652915-5f6cdb00-0318-11eb-8339-a43d1d478745.png)

## This addresses

This fixes the feature flagging (an if-else swapo).
