### PR TITLE
Bugfix: encounter generation

### DIFF
--- a/app/validators/api/v3/blood_pressure_payload_validator.rb
+++ b/app/validators/api/v3/blood_pressure_payload_validator.rb
@@ -21,6 +21,7 @@ class Api::V3::BloodPressurePayloadValidator < Api::V3::PayloadValidator
 
   def facility_exists
     unless Facility.exists?(facility_id)
+      logger.info "Blood pressure #{id} synced at nonexistent facility #{facility_id}"
       errors.add(:facility_does_not_exist, "Facility does not exist")
     end
   end

--- a/app/validators/api/v3/blood_pressure_payload_validator.rb
+++ b/app/validators/api/v3/blood_pressure_payload_validator.rb
@@ -21,7 +21,7 @@ class Api::V3::BloodPressurePayloadValidator < Api::V3::PayloadValidator
 
   def facility_exists
     unless Facility.exists?(facility_id)
-      logger.info "Blood pressure #{id} synced at nonexistent facility #{facility_id}"
+      Rails.logger.info "Blood pressure #{id} synced at nonexistent facility #{facility_id}"
       errors.add(:facility_does_not_exist, "Facility does not exist")
     end
   end

--- a/app/validators/api/v3/blood_pressure_payload_validator.rb
+++ b/app/validators/api/v3/blood_pressure_payload_validator.rb
@@ -13,8 +13,15 @@ class Api::V3::BloodPressurePayloadValidator < Api::V3::PayloadValidator
   )
 
   validate :validate_schema
+  validate :facility_exists
 
   def schema
     Api::V3::Models.blood_pressure
+  end
+
+  def facility_exists
+    unless Facility.exists?(facility_id)
+      errors.add(:facility_does_not_exist, "Facility does not exist")
+    end
   end
 end

--- a/app/validators/api/v3/blood_sugar_payload_validator.rb
+++ b/app/validators/api/v3/blood_sugar_payload_validator.rb
@@ -13,8 +13,15 @@ class Api::V3::BloodSugarPayloadValidator < Api::V3::PayloadValidator
   )
 
   validate :validate_schema
+  validate :facility_exists
 
   def schema
     Api::V3::Models.blood_sugar
+  end
+
+  def facility_exists
+    unless Facility.exists?(facility_id)
+      errors.add(:facility_does_not_exist, "Facility does not exist")
+    end
   end
 end

--- a/app/validators/api/v3/blood_sugar_payload_validator.rb
+++ b/app/validators/api/v3/blood_sugar_payload_validator.rb
@@ -21,7 +21,7 @@ class Api::V3::BloodSugarPayloadValidator < Api::V3::PayloadValidator
 
   def facility_exists
     unless Facility.exists?(facility_id)
-      logger.info "Blood sugar #{id} synced at nonexistent facility #{facility_id}"
+      Rails.logger.info "Blood sugar #{id} synced at nonexistent facility #{facility_id}"
       errors.add(:facility_does_not_exist, "Facility does not exist")
     end
   end

--- a/app/validators/api/v3/blood_sugar_payload_validator.rb
+++ b/app/validators/api/v3/blood_sugar_payload_validator.rb
@@ -21,6 +21,7 @@ class Api::V3::BloodSugarPayloadValidator < Api::V3::PayloadValidator
 
   def facility_exists
     unless Facility.exists?(facility_id)
+      logger.info "Blood sugar #{id} synced at nonexistent facility #{facility_id}"
       errors.add(:facility_does_not_exist, "Facility does not exist")
     end
   end

--- a/app/validators/api/v4/blood_sugar_payload_validator.rb
+++ b/app/validators/api/v4/blood_sugar_payload_validator.rb
@@ -13,8 +13,15 @@ class Api::V4::BloodSugarPayloadValidator < Api::V3::PayloadValidator
   )
 
   validate :validate_schema
+  validate :facility_exists
 
   def schema
     Api::V4::Models.blood_sugar
+  end
+
+  def facility_exists
+    unless Facility.exists?(facility_id)
+      errors.add(:facility_does_not_exist, "Facility does not exist")
+    end
   end
 end

--- a/app/validators/api/v4/blood_sugar_payload_validator.rb
+++ b/app/validators/api/v4/blood_sugar_payload_validator.rb
@@ -21,7 +21,7 @@ class Api::V4::BloodSugarPayloadValidator < Api::V3::PayloadValidator
 
   def facility_exists
     unless Facility.exists?(facility_id)
-      logger.info "Blood sugar #{id} synced at nonexistent facility #{facility_id}"
+      Rails.logger.info "Blood sugar #{id} synced at nonexistent facility #{facility_id}"
       errors.add(:facility_does_not_exist, "Facility does not exist")
     end
   end

--- a/app/validators/api/v4/blood_sugar_payload_validator.rb
+++ b/app/validators/api/v4/blood_sugar_payload_validator.rb
@@ -21,6 +21,7 @@ class Api::V4::BloodSugarPayloadValidator < Api::V3::PayloadValidator
 
   def facility_exists
     unless Facility.exists?(facility_id)
+      logger.info "Blood sugar #{id} synced at nonexistent facility #{facility_id}"
       errors.add(:facility_does_not_exist, "Facility does not exist")
     end
   end

--- a/app/views/admin/facilities/upload.html.erb
+++ b/app/views/admin/facilities/upload.html.erb
@@ -50,9 +50,9 @@
   <li class="mt-1">
     The enable_diabetes_management
     <% if Flipper.enabled?(:teleconsult_facility_mo_search) %>
-      and enable_teleconsultation fields
-    <% else %>
       field
+    <% else %>
+      and enable_teleconsultation fields
     <% end %>
     will be treated as "not enabled" if blank.
   </li>

--- a/spec/controllers/api/v3/blood_pressures_controller_spec.rb
+++ b/spec/controllers/api/v3/blood_pressures_controller_spec.rb
@@ -265,9 +265,7 @@ RSpec.describe Api::V3::BloodPressuresController, type: :controller do
 
     context "for a soft deleted facility" do
       before :each do
-        request.env["HTTP_X_USER_ID"] = request_user.id
-        request.env["HTTP_X_FACILITY_ID"] = request_facility.id
-        request.env["HTTP_AUTHORIZATION"] = "Bearer #{request_user.access_token}"
+        set_authentication_headers
       end
 
       it "returns an error and does not create the blood pressure" do

--- a/spec/controllers/api/v3/blood_pressures_controller_spec.rb
+++ b/spec/controllers/api/v3/blood_pressures_controller_spec.rb
@@ -262,6 +262,27 @@ RSpec.describe Api::V3::BloodPressuresController, type: :controller do
         end
       end
     end
+
+    context "for a soft deleted facility" do
+      before :each do
+        request.env["HTTP_X_USER_ID"] = request_user.id
+        request.env["HTTP_X_FACILITY_ID"] = request_facility.id
+        request.env["HTTP_AUTHORIZATION"] = "Bearer #{request_user.access_token}"
+      end
+
+      it "returns an error and does not create the blood pressure" do
+        facility = create(:facility)
+        blood_pressures = [build_blood_pressure_payload(FactoryBot.build(:blood_pressure, facility: facility))]
+        facility.discard
+
+        post(:sync_from_user, params: {blood_pressures: blood_pressures}, as: :json)
+
+        expect(BloodPressure.count).to eq 0
+        expect(Encounter.count).to eq 0
+        expect(response).to have_http_status(200)
+        expect(JSON(response.body)["errors"]).not_to be_empty
+      end
+    end
   end
 
   describe "GET sync: send data from server to device;" do

--- a/spec/controllers/api/v3/blood_pressures_controller_spec.rb
+++ b/spec/controllers/api/v3/blood_pressures_controller_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe Api::V3::BloodPressuresController, type: :controller do
       end
     end
 
-    context "for a soft deleted facility" do
+    context "for a discarded facility" do
       before :each do
         set_authentication_headers
       end

--- a/spec/controllers/api/v3/blood_sugars_controller_spec.rb
+++ b/spec/controllers/api/v3/blood_sugars_controller_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe Api::V3::BloodSugarsController, type: :controller do
       end
     end
 
-    context "for a soft deleted facility" do
+    context "for a discarded facility" do
       before :each do
         set_authentication_headers
       end

--- a/spec/controllers/api/v3/blood_sugars_controller_spec.rb
+++ b/spec/controllers/api/v3/blood_sugars_controller_spec.rb
@@ -244,9 +244,7 @@ RSpec.describe Api::V3::BloodSugarsController, type: :controller do
 
     context "for a soft deleted facility" do
       before :each do
-        request.env["HTTP_X_USER_ID"] = request_user.id
-        request.env["HTTP_X_FACILITY_ID"] = request_facility.id
-        request.env["HTTP_AUTHORIZATION"] = "Bearer #{request_user.access_token}"
+        set_authentication_headers
       end
 
       it "returns an error and does not create the blood sugar" do

--- a/spec/controllers/api/v4/blood_sugars_controller_spec.rb
+++ b/spec/controllers/api/v4/blood_sugars_controller_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe Api::V4::BloodSugarsController, type: :controller do
       end
     end
 
-    context "for a soft deleted facility" do
+    context "for a discarded facility" do
       before :each do
         set_authentication_headers
       end

--- a/spec/controllers/api/v4/blood_sugars_controller_spec.rb
+++ b/spec/controllers/api/v4/blood_sugars_controller_spec.rb
@@ -231,9 +231,7 @@ RSpec.describe Api::V4::BloodSugarsController, type: :controller do
 
     context "for a soft deleted facility" do
       before :each do
-        request.env["HTTP_X_USER_ID"] = request_user.id
-        request.env["HTTP_X_FACILITY_ID"] = request_facility.id
-        request.env["HTTP_AUTHORIZATION"] = "Bearer #{request_user.access_token}"
+        set_authentication_headers
       end
 
       it "returns an error and does not create the blood sugar" do

--- a/spec/controllers/api/v4/blood_sugars_controller_spec.rb
+++ b/spec/controllers/api/v4/blood_sugars_controller_spec.rb
@@ -228,6 +228,27 @@ RSpec.describe Api::V4::BloodSugarsController, type: :controller do
         end
       end
     end
+
+    context "for a soft deleted facility" do
+      before :each do
+        request.env["HTTP_X_USER_ID"] = request_user.id
+        request.env["HTTP_X_FACILITY_ID"] = request_facility.id
+        request.env["HTTP_AUTHORIZATION"] = "Bearer #{request_user.access_token}"
+      end
+
+      it "returns an error and does not create the blood sugar" do
+        facility = create(:facility)
+        blood_sugars = [build_blood_sugar_payload(FactoryBot.build(:blood_sugar, facility: facility))]
+        facility.discard
+
+        post(:sync_from_user, params: {blood_sugars: blood_sugars}, as: :json)
+
+        expect(BloodSugar.count).to eq 0
+        expect(Encounter.count).to eq 0
+        expect(response).to have_http_status(200)
+        expect(JSON(response.body)["errors"]).not_to be_empty
+      end
+    end
   end
 
   describe "GET sync: send data from server to device;" do

--- a/spec/payloads/api/v3/blood_pressure_payload_validator_spec.rb
+++ b/spec/payloads/api/v3/blood_pressure_payload_validator_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe Api::V3::BloodPressurePayloadValidator, type: :model do
+  describe "Data validations" do
+    it "validates that the blood pressure's facility exists" do
+      facility = create(:facility)
+      blood_pressure = build_blood_pressure_payload(create(:blood_pressure, facility: facility))
+      facility.discard
+
+      validator = Api::V3::BloodPressurePayloadValidator.new(blood_pressure)
+      expect(validator.valid?).to be false
+    end
+  end
+end

--- a/spec/payloads/api/v3/blood_pressure_payload_validator_spec.rb
+++ b/spec/payloads/api/v3/blood_pressure_payload_validator_spec.rb
@@ -7,7 +7,7 @@ describe Api::V3::BloodPressurePayloadValidator, type: :model do
       blood_pressure = build_blood_pressure_payload(create(:blood_pressure, facility: facility))
       facility.discard
 
-      validator = Api::V3::BloodPressurePayloadValidator.new(blood_pressure)
+      validator = described_class.new(blood_pressure)
       expect(validator.valid?).to be false
     end
   end

--- a/spec/payloads/api/v3/blood_sugar_payload_validator_spec.rb
+++ b/spec/payloads/api/v3/blood_sugar_payload_validator_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe Api::V3::BloodSugarPayloadValidator, type: :model do
+  describe "Data validations" do
+    it "validates that the blood sugar's facility exists" do
+      facility = create(:facility)
+      blood_sugar = build_blood_sugar_payload(create(:blood_sugar, facility: facility))
+      facility.discard
+
+      validator = described_class.new(blood_sugar)
+      expect(validator.valid?).to be false
+    end
+  end
+end

--- a/spec/payloads/api/v4/blood_sugar_payload_validator_spec.rb
+++ b/spec/payloads/api/v4/blood_sugar_payload_validator_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe Api::V4::BloodSugarPayloadValidator, type: :model do
+  describe "Data validations" do
+    it "validates that the blood sugar's facility exists" do
+      facility = create(:facility)
+      blood_sugar = build_blood_sugar_payload(create(:blood_sugar, facility: facility))
+      facility.discard
+
+      validator = described_class.new(blood_sugar)
+      expect(validator.valid?).to be false
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** [ch1442](https://app.clubhouse.io/simpledotorg/story/1442/fix-bp-sync-bug)

## Because

BP syncs are failing for some users with a `500` due to an edge case in encounter generation. When a user tries to sync BP/BS in a soft-deleted facility, saving the encounter fails due to a `belongs_to` rails validation on `facility_id`. This causes the observation creation to fail with:

```
insert or update on table "observations" violates foreign key constraint "fk_rails_47dc1837b8"
DETAIL:  Key (encounter_id)=(9859dd29-a0fd-5420-9c1b-00c425b87c6f) is not present in table "encounters".
```

For example, this is happening currently at the facility `CHC BHAM` which was soft deleted since a duplicate facility with the same name existed. Users who have BPs and BSs recorded at that facility on their device are currently receiving a 500 everytime those BPs/BSs are tried to be synced.

[Sentry ref](https://sentry.io/organizations/resolve-to-save-lives/issues/1914505499/?environment=production&project=1217715&query=is%3Aunresolved)

## This addresses

To mitigate failing syncs for those users, this adds a validation to BP and BS resources that checks for the facility's existence. By returning an error for the culprit BPs/BSs, the apps mark them as erroneous and eventually clear them from the device. 

There is no clean way to accept those BPs since the facility doesn't exist anymore. Having encounters without a facility in the system might have far-reaching effects on reporting etc.
