### PR TITLE
Log fixes and tweaks to get Datadog trace correlation working

### DIFF
--- a/app/services/control_rate_service.rb
+++ b/app/services/control_rate_service.rb
@@ -19,7 +19,7 @@ class ControlRateService
     end
     @quarterly_report = @periods.begin.quarter?
     @results = Reports::Result.new(@periods)
-    logger.info class: self.class, event: "created", region: region.id, region_name: region.name,
+    logger.info class: self.class, msg: "created", region: region.id, region_name: region.name,
                 periods: periods.inspect, facilities: facilities.map(&:id)
   end
 
@@ -101,7 +101,6 @@ class ControlRateService
   def bp_quarterly_query(period)
     quarter = period.value
     cohort_quarter = quarter.previous_quarter
-    Rails.logger.info " ===> quarter #{period} number #{quarter.number}"
     LatestBloodPressuresPerPatientPerQuarter
       .where(assigned_facility_id: facilities)
       .where(year: quarter.year, quarter: quarter.number)

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -2,7 +2,7 @@ if ["sandbox", "production"].include?(SIMPLE_SERVER_ENV)
   require "ddtrace"
   require "datadog/statsd"
   Datadog.configure do |c|
-    c.use :rails, service_name: "#{SIMPLE_SERVER_ENV}-rails-app", log_injection: true
+    c.use :rails, service_name: "#{SIMPLE_SERVER_ENV}-rails-app"
   end
 else
   require "datadog/statsd"

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,9 +1,8 @@
+require "ddtrace"
+require "datadog/statsd"
+
 if ["sandbox", "production"].include?(SIMPLE_SERVER_ENV)
-  require "ddtrace"
-  require "datadog/statsd"
   Datadog.configure do |c|
     c.use :rails, service_name: "#{SIMPLE_SERVER_ENV}-rails-app"
   end
-else
-  require "datadog/statsd"
 end

--- a/lib/json_logger.rb
+++ b/lib/json_logger.rb
@@ -17,7 +17,7 @@ class JsonLogger < Ougai::Logger
         },
         ddsource: ["ruby"]
       }
-      data = data.merge(datadog_trace_info)
+      data.merge!(datadog_trace_info) unless Rails.env.test? # don't merge the datadog trace info in test, as it clutters up logs
       if RequestStore.store[:current_user_id]
         data[:current_user_id] = RequestStore.store[:current_user_id]
       end

--- a/lib/json_logger.rb
+++ b/lib/json_logger.rb
@@ -5,10 +5,24 @@ class JsonLogger < Ougai::Logger
   def initialize(*args)
     super
     @before_log = lambda do |data|
+      correlation = Datadog.tracer.active_correlation
+      datadog_trace_info = {
+        dd: {
+          # To preserve precision during JSON serialization, use strings for large numbers
+          trace_id: correlation.trace_id.to_s,
+          span_id: correlation.span_id.to_s,
+          env: correlation.env.to_s,
+          service: correlation.service.to_s,
+          version: correlation.version.to_s
+        },
+        ddsource: ["ruby"]
+      }
+      data = data.merge(datadog_trace_info)
       if RequestStore.store[:current_user_id]
         data[:current_user_id] = RequestStore.store[:current_user_id]
       end
     end
+
     after_initialize if respond_to? :after_initialize
   end
 


### PR DESCRIPTION
**Story card:** [ch1322](https://app.clubhouse.io/simpledotorg/story/1322/setup-datadog-in-sandbox)

## Because

We want datadog tracing between logs and the app analytics

## This addresses

Trying to get the dd trace context merged correctly.

See https://docs.datadoghq.com/tracing/setup/ruby/#trace-correlation for details on all this.


