### PR TITLE
Update the Semaphore build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Simple Server
 
-[![Build Status](https://semaphoreci.com/api/v1/resolvetosavelives/simple-server/branches/master/badge.svg)](https://semaphoreci.com/resolvetosavelives/simple-server)
+[![Build Status](https://resolvetosavelives.semaphoreci.com/badges/simple-server/branches/master.svg)](https://resolvetosavelives.semaphoreci.com/projects/simple-server)
 
 This is the backend for the Simple app to help track hypertensive patients across a population.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Simple Server
 
 [![Build Status](https://resolvetosavelives.semaphoreci.com/badges/simple-server/branches/master.svg)](https://resolvetosavelives.semaphoreci.com/projects/simple-server)
+[![Ruby Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://github.com/testdouble/standard)
 
 This is the backend for the Simple app to help track hypertensive patients across a population.
 


### PR DESCRIPTION
## Because

The build status badge in the README is broken.

## This addresses

Update it to use the new badge from Semaphore 2.0. Also, add a standardrb [badge](https://github.com/testdouble/standard#is-there-a-readme-badge).
