### PR TITLE
Don't show current period of registrations

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -46,10 +46,10 @@ class Reports::RegionsController < AdminController
                                                         period: @period).call
       }
     else
-      @show_current_period = true
+      @show_current_period = false
       @dashboard_analytics = @region.dashboard_analytics(period: :month,
                                                          prev_periods: 6,
-                                                         include_current_period: true)
+                                                         include_current_period: false)
     end
   end
 


### PR DESCRIPTION
This keeps it consistent with what the currently selected period is

**Story card:** [ch1327](https://app.clubhouse.io/simpledotorg/story/1327/show-last-6-months-not-including-current-month-in-new-registrations-card)
