### PR TITLE
Ranked Facilities hotfix

### DIFF
--- a/app/controllers/my_facilities/ranked_facilities_controller.rb
+++ b/app/controllers/my_facilities/ranked_facilities_controller.rb
@@ -35,7 +35,7 @@ class MyFacilities::RankedFacilitiesController < AdminController
                                                                      period: @period).call
 
       @scores_for_facility[facility.name] = Reports::PerformanceScore.new(region: facility,
-                                                                          result: @data_for_facility[facility.name])
+                                                                          reports_result: @data_for_facility[facility.name])
     end
 
     # Sort facilities by overall score, highest to lowest


### PR DESCRIPTION
## Because

A bug made its way into #1372:
- https://sentry.io/organizations/resolve-to-save-lives/issues/1939890604/?project=1217715&query=is%3Aunresolved

## This addresses

Fixed the changed argument name to `reports_result`
