### PR TITLE
Fix up and simplify Datadog config

### DIFF
--- a/config/initializers/00_datadog.rb
+++ b/config/initializers/00_datadog.rb
@@ -1,12 +1,13 @@
 require "ddtrace"
 require "datadog/statsd"
 
-unless Rails.env.development? || Rails.env.test?
-  Datadog.configure do |c|
-    c.use :rails,
-      analytics_enabled: true,
-      service_name: "#{SIMPLE_SERVER_ENV}-rails-app"
-  end
+# We want Datadog to run everywhere, but we won't have the DD agent running
+# in dev and test so we don't want to send payloads there.
+SEND_DATA_TO_DD_AGENT = !(Rails.env.development? || Rails.env.test?)
+
+Datadog.configure do |c|
+  c.tracer.enabled = SEND_DATA_TO_DD_AGENT
+  c.use :rails, analytics_enabled: true
 end
 
 require "statsd"

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -24,10 +24,16 @@ Sidekiq.configure_client do |config|
   config.redis = SidekiqConfig.connection_pool
 end
 
+SIDEKIQ_STATS_KEY = "worker"
+SIDEKIQ_STATS_PREFIX = "#{SIMPLE_SERVER_ENV}.#{CountryConfig.current[:abbreviation]}"
+
 Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
     chain.add SetLocalTimezone
-    chain.add Sidekiq::Statsd::ServerMiddleware, env: Rails.env, prefix: "worker", statsd: Statsd.instance.statsd
+    # The env and prefix are used to create keys in the format of env.prefix.worker_name.[stat_name]
+    # We want 'sidekiq' to be the top level, and then have our env specific information,
+    # which is we pass in a static string to `env` and the actual server env to `prefix`.
+    chain.add Sidekiq::Statsd::ServerMiddleware, env: SIDEKIQ_STATS_KEY, prefix: SIDEKIQ_STATS_PREFIX, statsd: Statsd.instance.statsd
   end
   config.redis = SidekiqConfig.connection_pool
 end


### PR DESCRIPTION
[ch1356](https://app.clubhouse.io/simpledotorg/story/1356/setup-datadog-in-production)

I realized that overriding our service name for Datadog was a mistake -- we don't need to include the `env` as we have tags for that.  Also, its just too long. We can use the default, which will use the app name, so it will be `simple-server`.

**NOTE** This will mean our old logs and metrics will be wrong so we won't be able to easily see history with the old service name and the new, but better to fix this now then to try to do it later.

This also has some other tweaks to make our setup more better.