### PR TITLE
Revert "Remove old reports"

### DIFF
--- a/app/controllers/analytics/districts_controller.rb
+++ b/app/controllers/analytics/districts_controller.rb
@@ -1,0 +1,130 @@
+class Analytics::DistrictsController < AnalyticsController
+  include QuarterHelper
+  include GraphicsDownload
+
+  before_action :set_organization_district
+  before_action :set_force_cache
+  skip_after_action :verify_authorization_attempted
+
+  def show
+    @show_current_period = true
+
+    set_dashboard_analytics(@period, 6)
+    set_cohort_analytics(@period, @prev_periods)
+
+    respond_to do |format|
+      format.html
+      format.csv do
+        set_facility_keys
+        send_data render_to_string("show.csv.erb"), filename: download_filename
+      end
+    end
+  end
+
+  def share_anonymized_data
+    recipient_email = current_admin.email
+    recipient_name = recipient_email.split("@").first
+
+    AnonymizedDataDownloadJob.perform_later(recipient_name,
+      recipient_email,
+      {district_name: @organization_district.district_name,
+       organization_id: @organization_district.organization.id},
+      "district")
+
+    redirect_to analytics_organization_district_path(id: @organization_district.district_name),
+      notice: I18n.t("anonymized_data_download_email.district_notice",
+        district_name: @organization_district.district_name)
+  end
+
+  def patient_list
+    recipient_email = current_admin.email
+
+    PatientListDownloadJob.perform_later(recipient_email, "district", {
+      district_name: @organization_district.district_name,
+      organization_id: @organization_district.organization.id
+    })
+
+    redirect_to(
+      analytics_organization_district_path(id: @organization_district.district_name),
+      notice: I18n.t("patient_list_email.notice",
+        model_type: "district",
+        model_name: @organization_district.district_name)
+    )
+  end
+
+  def patient_list_with_history
+    recipient_email = current_admin.email
+
+    PatientListDownloadJob.perform_later(recipient_email, "district", {
+      district_name: @organization_district.district_name,
+      organization_id: @organization_district.organization.id
+    }, with_medication_history: true)
+
+    redirect_to(
+      analytics_organization_district_path(id: @organization_district.district_name),
+      notice: I18n.t("patient_list_email.notice",
+        model_type: "district",
+        model_name: @organization_district.district_name)
+    )
+  end
+
+  def whatsapp_graphics
+    set_cohort_analytics(:quarter, 3)
+    set_dashboard_analytics(:quarter, 4)
+
+    whatsapp_graphics_handler(
+      @organization_district.organization.name,
+      @organization_district.district_name
+    )
+  end
+
+  private
+
+  def set_organization_district
+    district_name = params[:id] || params[:district_id]
+    organization = Organization.find_by(id: params[:organization_id])
+    @organization_district = OrganizationDistrict.new(district_name, organization)
+  end
+
+  def set_cohort_analytics(period, prev_periods)
+    @cohort_analytics = @organization_district.cohort_analytics(period: period, prev_periods: prev_periods)
+  end
+
+  def set_dashboard_analytics(period, prev_periods)
+    @dashboard_analytics = @organization_district.dashboard_analytics(period: period,
+                                                                      prev_periods: prev_periods,
+                                                                      include_current_period: @show_current_period)
+  end
+
+  def set_facility_keys
+    district = {
+      id: :total,
+      name: "Total"
+    }.with_indifferent_access
+
+    facilities = @organization_district.facilities.order(:name).map { |facility|
+      {
+        id: facility.id,
+        name: facility.name,
+        type: facility.facility_type
+      }.with_indifferent_access
+    }
+
+    @facility_keys = [district, *facilities]
+  end
+
+  def download_filename
+    period = @period == :quarter ? "quarterly" : "monthly"
+    district = @organization_district.district_name
+    time = Time.current.to_s(:number)
+    "district-#{period}-cohort-report_#{district}_#{time}.csv"
+  end
+
+  def set_force_cache
+    RequestStore.store[:force_cache] = true if force_cache?
+  end
+
+  def force_cache?
+    params[:force_cache].present?
+  end
+end

--- a/app/controllers/analytics/facilities_controller.rb
+++ b/app/controllers/analytics/facilities_controller.rb
@@ -1,0 +1,105 @@
+class Analytics::FacilitiesController < AnalyticsController
+  include GraphicsDownload
+  include QuarterHelper
+  include Pagination
+
+  before_action :set_facility
+  before_action :set_force_cache
+
+  def show
+    @show_current_period = true
+
+    set_dashboard_analytics(@period, 6)
+    set_cohort_analytics(@period, @prev_periods)
+
+    @recent_blood_pressures = paginate(@facility.recent_blood_pressures)
+
+    respond_to do |format|
+      format.html
+      format.csv do
+        send_data render_to_string("show.csv.erb"), filename: download_filename
+      end
+    end
+  end
+
+  def share_anonymized_data
+    recipient_email = current_admin.email
+    recipient_name = recipient_email.split("@").first
+
+    AnonymizedDataDownloadJob.perform_later(recipient_name,
+      recipient_email,
+      {facility_id: @facility.id},
+      "facility")
+
+    redirect_to analytics_facility_path(id: @facility.id),
+      notice: I18n.t("anonymized_data_download_email.facility_notice", facility_name: @facility.name)
+  end
+
+  def patient_list
+    recipient_email = current_admin.email
+
+    PatientListDownloadJob.perform_later(recipient_email, "facility", facility_id: @facility.id)
+
+    redirect_to(
+      analytics_facility_path(@facility),
+      notice: I18n.t("patient_list_email.notice", model_type: "facility", model_name: @facility.name)
+    )
+  end
+
+  def patient_list_with_history
+    recipient_email = current_admin.email
+
+    PatientListDownloadJob.perform_later(recipient_email,
+      "facility",
+      {facility_id: @facility.id},
+      with_medication_history: true)
+
+    redirect_to(
+      analytics_facility_path(@facility),
+      notice: I18n.t("patient_list_email.notice", model_type: "facility", model_name: @facility.name)
+    )
+  end
+
+  def whatsapp_graphics
+    set_cohort_analytics(:quarter, 3)
+    set_dashboard_analytics(:quarter, 4)
+
+    whatsapp_graphics_handler(
+      @facility.organization.name,
+      @facility.name
+    )
+  end
+
+  private
+
+  def set_facility
+    facility_id = params[:id] || params[:facility_id]
+    @facility = Facility.friendly.find(facility_id)
+    authorize_v2 { current_admin.accessible_facilities(:view_reports).include?(@facility) }
+  end
+
+  def set_cohort_analytics(period, prev_periods)
+    @cohort_analytics = @facility.cohort_analytics(period: period, prev_periods: prev_periods)
+  end
+
+  def set_dashboard_analytics(period, prev_periods)
+    @dashboard_analytics = @facility.dashboard_analytics(period: period,
+                                                         prev_periods: prev_periods,
+                                                         include_current_period: @show_current_period)
+  end
+
+  def download_filename
+    period = @period == :quarter ? "quarterly" : "monthly"
+    facility = @facility.name
+    time = Time.current.to_s(:number)
+    "facility-#{period}-cohort-report_#{facility}_#{time}.csv"
+  end
+
+  def set_force_cache
+    RequestStore.store[:force_cache] = true if force_cache?
+  end
+
+  def force_cache?
+    params[:force_cache].present?
+  end
+end

--- a/app/helpers/reports/regions_helper.rb
+++ b/app/helpers/reports/regions_helper.rb
@@ -4,11 +4,6 @@ module Reports::RegionsHelper
     reports_region_path(facility, options)
   end
 
-  def reports_region_district_path(district, options = {})
-    options.with_defaults! report_scope: "district"
-    reports_region_path(district, options)
-  end
-
   def percentage_or_na(value, options)
     return "N/A" if value.blank?
     number_to_percentage(value, options)

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -94,7 +94,7 @@ class Facility < ApplicationRecord
   }
 
   delegate :protocol, to: :facility_group, allow_nil: true
-  delegate :organization, :organization_id, to: :facility_group, allow_nil: true
+  delegate :organization, to: :facility_group, allow_nil: true
   delegate :follow_ups_by_period, to: :patients, prefix: :patient
 
   def hypertension_follow_ups_by_period(*args)

--- a/app/views/analytics/_period_dropdown.html.erb
+++ b/app/views/analytics/_period_dropdown.html.erb
@@ -1,0 +1,13 @@
+<div class="dropdown show" style="float: right;">
+  <a class="btn dropdown-toggle btn-sm btn-outline-primary" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <%= @period == :quarter ? "Quarterly" : "Monthly" %> report
+  </a>
+
+  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
+    <% if @period == :quarter %>
+      <%= link_to "Monthly report", url_for(period: :month), class: "dropdown-item" %>
+    <% else %>
+      <%= link_to "Quarterly report", url_for(period: :quarter), class: "dropdown-item" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/analytics/districts/_follow_ups_table.html.erb
+++ b/app/views/analytics/districts/_follow_ups_table.html.erb
@@ -72,7 +72,7 @@
         <% if dashboard_analytics[resource.id].present? %>
           <tr>
             <td class="row-title">
-              <% if row_resource_link == :reports_region_facility_path %>
+              <% if row_resource_link == :analytics_facility_path %>
                 <%= link_to resource.send(row_resource_display_field),
                             send(row_resource_link, resource, period: @period) %>
               <% else %>

--- a/app/views/analytics/districts/_registrations_table.html.erb
+++ b/app/views/analytics/districts/_registrations_table.html.erb
@@ -1,16 +1,15 @@
 <div class="card mt-0 pr-0 pr-md-3">
-  <h3 class="mb-8px c-black">
-    <%= row_resource_description %>
-  </h3>
+  <h2>Patients registered</h2>
+
   <p class="c-grey-dark">
-    <%= row_resource_subtitle %>
+    Patients registered at a facility this <%= period %>. Note: this could include patients registered at this facility
+    and re-assigned to another facility.
   </p>
 
   <div class="table-responsive">
-    <table class="analytics-table table-compact">
+    <table id="registrations-table" class="analytics-table table-compact">
       <colgroup>
         <col>
-        <col class="table-divider">
         <col class="table-divider">
         <col>
         <col>
@@ -21,18 +20,15 @@
       <thead>
       <tr>
         <th></th>
-        <th class="row-label"><strong>Total</strong></th>
-        <th class="row-label" colspan="6"><strong>New registrations</strong></th>
+        <th class="row-label" colspan="6"><strong>Patients registered</strong></th>
       </tr>
 
       <tr class="sorts" data-sort-method="thead">
-        <th class="row-label sort-label sort-label-small" style="text-align: left;" data-sort-default>Name</th>
-        <!--Total assigned patients-->
-        <th class="row-label sort-label" data-sort-default data-sort-method="number">Total</th>
-
+        <th class="row-label sort-label" style="text-align: left;">Facilities</th>
         <!--New registrations-->
-        <% dates_for_periods(period, 6, include_current_period: @show_current_period).each do |date| %>
-          <th class="row-label sort-label sort-label-small" data-sort-method="number">
+        <% dates = dates_for_periods(period, 6, include_current_period: @show_current_period)%>
+        <% dates.each do |date| %>
+          <th class="row-label sort-label" <%= "data-sort-default" if date == dates.last %> data-sort-method="number">
             <%= format_period(period, date) %>
           </th>
         <% end %>
@@ -43,11 +39,6 @@
 
       <tr class="row-total" data-sort-method="none">
         <td class="row-title row-total">All</td>
-
-        <!--Total assigned patients-->
-        <td class="row-total" style="text-align: center;">
-          <%= dash_if_zero(dashboard_analytics.sum { |_, row| row[:total_registered_patients] || 0 }) %>
-        </td>
 
         <!--New registrations-->
         <% dates_for_periods(period, 6, include_current_period: @show_current_period).each do |date| %>
@@ -61,17 +52,12 @@
         <% if dashboard_analytics[resource.id].present? %>
           <tr>
             <td class="row-title">
-              <% if row_resource_link == :reports_region_facility_path %>
+              <% if row_resource_link == :analytics_facility_path %>
                 <%= link_to resource.send(row_resource_display_field),
                             send(row_resource_link, resource, period: @period) %>
               <% else %>
                 <%= link_to resource.send(row_resource_display_field), send(row_resource_link, resource) %>
               <% end %>
-            </td>
-
-            <!--Total assigned patients-->
-            <td style="text-align: center;">
-              <%= dash_if_zero(dashboard_analytics.dig(resource.id, :total_registered_patients)) %>
             </td>
 
             <!--New registrations-->

--- a/app/views/analytics/districts/show.csv.erb
+++ b/app/views/analytics/districts/show.csv.erb
@@ -1,0 +1,103 @@
+<% csv = CSV.generate(headers: true) do |csv| %>
+<% csv << ["Report generated at", Time.current] %>
+<% period = @period == :quarter ? 'Quarterly' : 'Monthly' %>
+<% csv << ["#{@organization_district.district_name} #{period} Cohort Report"] %>
+<% csv << ['Facility', 'Facility type'].concat(@cohort_analytics.each_with_index.flat_map do |(_report_dates, _analytics), _|
+  [
+    'Cohort period',
+    'Follow up period',
+    'Patients in cohort',
+    'Patients followed up',
+    'Patients controlled',
+    'Patients uncontrolled',
+    "Patients didn't attend",
+    '% BP Control',
+    '% BP Uncontrolled',
+    '% Defaulted',
+    nil
+  ]
+end) %>
+<% csv << [] %>
+<% @facility_keys.each do |facility| %>
+<% csv << [facility[:name], facility[:type]].concat(@cohort_analytics.each_with_index.flat_map do |(report_dates, analytics), _|
+  cohort_start, report_start = report_dates
+  registered = analytics.dig(:cohort_patients, facility[:id]) || 0
+  followed_up = analytics.dig(:followed_up, facility[:id]) || 0
+  defaulted = analytics.dig(:defaulted, facility[:id]) || 0
+  controlled = analytics.dig(:controlled, facility[:id]) || 0
+  uncontrolled = analytics.dig(:uncontrolled, facility[:id]) || 0
+
+  if @period == :quarter
+    report_period = quarter_string(report_start)
+    cohort_period = quarter_string(cohort_start)
+  else
+    report_end = (report_start + 1.month).end_of_month
+
+    formatted_report_start_date = report_start.strftime("%B #{report_start.day.ordinalize}")
+    formatted_report_end_date = report_end.strftime("%B #{report_end.day.ordinalize}")
+
+    report_period = [formatted_report_start_date, formatted_report_end_date].join(" – ")
+    cohort_period = cohort_start.strftime("%b-%Y")
+  end
+  if registered > 0
+    controlled_percent = (controlled.to_f / registered * 100).round
+    uncontrolled_percent = (uncontrolled.to_f / registered * 100).round
+    default_percent = (defaulted.to_f / registered * 100).round
+  else
+    controlled_percent = 0
+    uncontrolled_percent = 0
+    default_percent = 0
+  end
+
+  [
+    cohort_period,
+    report_period,
+    registered,
+    followed_up,
+    controlled,
+    uncontrolled,
+    defaulted,
+    controlled_percent,
+    uncontrolled_percent,
+    default_percent,
+    nil
+  ]
+end) %>
+<% end %>
+<% csv << [] %>
+<% csv << ["#{@organization_district.district_name} Facilities Report"] %>
+<%
+  headers = [
+    "Facility name",
+    "Facility type",
+    "Total patients"
+  ]
+  dates = dates_for_periods(@period, 3, include_current_period: @show_current_period)
+  ["Patients with BP recorded", "Registered patients"].each do |metric|
+    dates.each do |date|
+      headers << "#{metric} #{format_period(@period, date)}"
+    end
+  end
+%>
+<% csv << headers %>
+<% csv << [
+    "All",
+    nil,
+    @dashboard_analytics.sum { |_, row| row[:total_patients] || 0 },
+    *dates.map { |period| analytics_totals(@dashboard_analytics, :patients_with_bp_by_period, period) },
+    *dates.map { |period| analytics_totals(@dashboard_analytics, :registered_patients_by_period, period) }
+  ]
+%>
+<% current_admin.accessible_facilities(:view_reports).order(:name).each do |facility| %>
+  <% if @dashboard_analytics[facility.id].present? %>
+    <% csv << [
+        facility.name,
+        facility.facility_type,
+        @dashboard_analytics.dig(facility.id, :total_patients) || 0,
+        *dates.map { |period| @dashboard_analytics.dig(facility.id, :patients_with_bp_by_period, period) || 0 },
+        *dates.map { |period| @dashboard_analytics.dig(facility.id, :registered_patients_by_period, period) || 0 }
+      ] %>
+  <% end %>
+<% end %>
+<% end.html_safe %>
+<%= csv %>

--- a/app/views/analytics/districts/show.html.erb
+++ b/app/views/analytics/districts/show.html.erb
@@ -1,0 +1,83 @@
+<%= render "shared/old_reports_banner" %>
+
+<div class="dashboard">
+  <nav class="breadcrumb">
+    <%= link_to 'All districts', root_path %>
+    <i class="fas fa-chevron-right"></i>
+
+    <%= @organization_district.district_name %>
+  </nav>
+
+  <%= render "period_dropdown" %>
+
+  <h1><%= @organization_district.district_name %></h1>
+</div>
+
+<%= render 'shared/cohort_charts', cohort_analytics: @cohort_analytics, quarter: current_quarter, year: current_year %>
+<%= render 'follow_ups_table',
+           dashboard_analytics: @dashboard_analytics,
+           period: @period,
+           row_resource: current_admin.accessible_facilities(:view_reports).order(:name),
+           row_resource_display_field: :name,
+           row_resource_link: :analytics_facility_path %>
+<%= render 'registrations_table',
+           dashboard_analytics: @dashboard_analytics,
+           period: @period,
+           row_resource: current_admin.accessible_facilities(:view_reports).order(:name),
+           row_resource_display_field: :name,
+           row_resource_link: :analytics_facility_path %>
+
+<div class="downloads">
+  <h4>Downloads</h4>
+
+  <p>
+    <%= link_to(period: :quarter, format: :csv) do %>
+      <i class="far fa-file-excel mr-2"></i>
+      Quarterly cohort report
+    <% end %>
+  </p>
+  <p>
+    <%= link_to(period: :month, format: :csv) do %>
+      <i class="far fa-file-excel mr-2"></i>
+      Monthly cohort report
+    <% end %>
+  </p>
+
+  <% if current_admin
+      .accessible_facility_groups(:view_pii)
+      .where(organization: @organization_district.organization,
+             name: @organization_district.district_name)
+      .any? %>
+    <p>
+      <%= link_to analytics_organization_district_patient_list_path(organization_id: @organization_district.organization.id,
+                                                                    district_id: @organization_district.district_name) do %>
+        <i class="far fa-file-excel mr-2"></i>
+        Patient line list
+      <% end %>
+    </p>
+    <p>
+      <%= link_to analytics_organization_district_patient_list_with_history_path(organization_id: @organization_district.organization.id,
+                                                                                 district_id: @organization_district.district_name) do %>
+        <i class="far fa-file-excel mr-2"></i>
+        Patient line list (with medication history)
+      <% end %>
+    </p>
+    <% end %>
+
+  <% if FeatureToggle.enabled?('DASHBOARD_SNAPSHOT') %>
+    <% if current_admin
+        .accessible_facility_groups(:view_reports)
+        .where(organization: @organization_district.organization,
+               name: @organization_district.district_name)
+        .any? %>
+      <%=
+        render "shared/graphics/graphics_download_links",
+               graphics_path: -> (options) { analytics_organization_district_graphics_path(options) },
+               options: {
+                   organization_id: @organization_district.organization.id,
+                   district_id: @organization_district.district_name
+               }
+      %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/analytics/districts/whatsapp_graphics.html.erb
+++ b/app/views/analytics/districts/whatsapp_graphics.html.erb
@@ -1,0 +1,7 @@
+<%= render 'shared/graphics/graphics_partial',
+           cohort_analytics: @cohort_analytics,
+           dashboard_analytics: @dashboard_analytics,
+           organization_name: @organization_district.organization.name,
+           name: @organization_district.district_name,
+           quarter: @quarter,
+           year: @year %>

--- a/app/views/analytics/facilities/_analytics_table.html.erb
+++ b/app/views/analytics/facilities/_analytics_table.html.erb
@@ -1,15 +1,16 @@
 <div class="card mt-0 pr-0 pr-md-3">
-  <h2>Patients registered</h2>
-
+  <h3 class="mb-8px c-black">
+    <%= row_resource_description %>
+  </h3>
   <p class="c-grey-dark">
-    Patients registered at a facility this <%= period %>. Note: this could include patients registered at this facility
-    and re-assigned to another facility.
+    <%= row_resource_subtitle %>
   </p>
 
   <div class="table-responsive">
-    <table id="registrations-table" class="analytics-table table-compact">
+    <table class="analytics-table table-compact">
       <colgroup>
         <col>
+        <col class="table-divider">
         <col class="table-divider">
         <col>
         <col>
@@ -20,15 +21,18 @@
       <thead>
       <tr>
         <th></th>
-        <th class="row-label" colspan="6"><strong>Patients registered</strong></th>
+        <th class="row-label"><strong>Total</strong></th>
+        <th class="row-label" colspan="6"><strong>New registrations</strong></th>
       </tr>
 
       <tr class="sorts" data-sort-method="thead">
-        <th class="row-label sort-label" style="text-align: left;">Facilities</th>
+        <th class="row-label sort-label sort-label-small" style="text-align: left;" data-sort-default>Name</th>
+        <!--Total assigned patients-->
+        <th class="row-label sort-label" data-sort-default data-sort-method="number">Total</th>
+
         <!--New registrations-->
-        <% dates = dates_for_periods(period, 6, include_current_period: @show_current_period)%>
-        <% dates.each do |date| %>
-          <th class="row-label sort-label" <%= "data-sort-default" if date == dates.last %> data-sort-method="number">
+        <% dates_for_periods(period, 6, include_current_period: @show_current_period).each do |date| %>
+          <th class="row-label sort-label sort-label-small" data-sort-method="number">
             <%= format_period(period, date) %>
           </th>
         <% end %>
@@ -39,6 +43,11 @@
 
       <tr class="row-total" data-sort-method="none">
         <td class="row-title row-total">All</td>
+
+        <!--Total assigned patients-->
+        <td class="row-total" style="text-align: center;">
+          <%= dash_if_zero(dashboard_analytics.sum { |_, row| row[:total_registered_patients] || 0 }) %>
+        </td>
 
         <!--New registrations-->
         <% dates_for_periods(period, 6, include_current_period: @show_current_period).each do |date| %>
@@ -52,12 +61,17 @@
         <% if dashboard_analytics[resource.id].present? %>
           <tr>
             <td class="row-title">
-              <% if row_resource_link == :reports_region_facility_path %>
+              <% if row_resource_link == :analytics_facility_path %>
                 <%= link_to resource.send(row_resource_display_field),
                             send(row_resource_link, resource, period: @period) %>
               <% else %>
                 <%= link_to resource.send(row_resource_display_field), send(row_resource_link, resource) %>
               <% end %>
+            </td>
+
+            <!--Total assigned patients-->
+            <td style="text-align: center;">
+              <%= dash_if_zero(dashboard_analytics.dig(resource.id, :total_registered_patients)) %>
             </td>
 
             <!--New registrations-->

--- a/app/views/analytics/facilities/show.csv.erb
+++ b/app/views/analytics/facilities/show.csv.erb
@@ -1,0 +1,63 @@
+<% csv = CSV.generate(headers: true) do |csv| %>
+<% csv << ["Report generated at:", Time.current] %>
+<% period = @period == :quarter ? 'Quarterly' : 'Monthly' %>
+<% csv << ["#{@facility.name} #{period} Cohort Report"] %>
+<% csv << [
+  'Cohort period',
+  'Follow up period',
+  'Patients in cohort',
+  'Patients followed up',
+  'Patients controlled',
+  'Patients uncontrolled',
+  "Patients didn't attend",
+  'Control rate',
+  'Uncontrolled rate',
+  'Default rate'
+] %>
+<% @cohort_analytics.each_with_index do |(report_dates, analytics), _| %>
+  <%
+    cohort_start, report_start = report_dates
+    registered = analytics.dig(:cohort_patients, :total) || 0
+    followed_up = analytics.dig(:followed_up, :total) || 0
+    defaulted = analytics.dig(:defaulted, :total) || 0
+    controlled = analytics.dig(:controlled, :total) || 0
+    uncontrolled = analytics.dig(:uncontrolled, :total) || 0
+
+    if @period == :quarter
+      report_period = quarter_string(report_start)
+      cohort_period = quarter_string(cohort_start)
+    else
+      report_end = (report_start + 1.month).end_of_month
+
+      formatted_report_start_date = report_start.strftime("%B #{report_start.day.ordinalize}")
+      formatted_report_end_date = report_end.strftime("%B #{report_end.day.ordinalize}")
+
+      report_period = [formatted_report_start_date, formatted_report_end_date].join(" – ")
+      cohort_period = cohort_start.strftime("%b-%Y")
+    end
+
+    if registered > 0
+      controlled_percent = (controlled.to_f / registered * 100).round
+      uncontrolled_percent = (uncontrolled.to_f / registered * 100).round
+      default_percent = (defaulted.to_f / registered * 100).round
+    else
+      controlled_percent = 0
+      uncontrolled_percent = 0
+      default_percent = 0
+    end
+  %>
+<% csv << [
+  cohort_period,
+  report_period,
+  registered,
+  followed_up,
+  controlled,
+  uncontrolled,
+  defaulted,
+  "#{controlled_percent}%",
+  "#{uncontrolled_percent}%",
+  "#{default_percent}%"
+] %>
+<% end %>
+<% end.html_safe %>
+<%= csv %>

--- a/app/views/analytics/facilities/show.html.erb
+++ b/app/views/analytics/facilities/show.html.erb
@@ -1,0 +1,75 @@
+<%= render "shared/old_reports_banner" %>
+
+<div class="dashboard">
+  <nav class="breadcrumb">
+    <%= link_to 'All districts', root_path %>
+
+    <i class="fas fa-chevron-right"></i>
+    <%= link_to @facility.district,
+                analytics_organization_district_path(@facility.organization.id, @facility.district, period: @period) %>
+
+    <i class="fas fa-chevron-right"></i>
+    <%= @facility.name %>
+  </nav>
+
+  <%= render "period_dropdown" %>
+
+  <h1><%= @facility.name %></h1>
+</div>
+
+<%= render 'shared/cohort_charts', cohort_analytics: @cohort_analytics %>
+<%= render 'analytics_table',
+           dashboard_analytics: @dashboard_analytics,
+           period: @period,
+           row_resource: current_admin.accessible_users(:view_reports).order(:full_name),
+           row_resource_description: "Users",
+           row_resource_subtitle: "Patient registrations by users in #{@facility.name}",
+           row_resource_display_field: :full_name,
+           row_resource_link: :admin_user_path %>
+<% if current_admin.accessible_facilities(:view_pii).include?(@facility) %>
+  <%= render 'shared/recent_bp_log',
+             blood_pressures: @recent_blood_pressures,
+             display_model: :facility %>
+<% end %>
+
+<div class="downloads">
+  <h4>Downloads</h4>
+
+  <p>
+    <%= link_to(period: :quarter, format: :csv) do %>
+      <i class="far fa-file-excel mr-2"></i>
+      Quarterly cohort report
+    <% end %>
+  </p>
+  <p>
+    <%= link_to(period: :month, format: :csv) do %>
+      <i class="far fa-file-excel mr-2"></i>
+      Monthly cohort report
+    <% end %>
+  </p>
+
+  <% if current_admin.accessible_facilities(:view_pii).include?(@facility) %>
+    <p>
+      <%= link_to analytics_facility_patient_list_path(@facility) do %>
+        <i class="far fa-file-excel mr-2"></i>
+        Patient line list
+      <% end %>
+    </p>
+    <p>
+      <%= link_to analytics_facility_patient_list_with_history_path(@facility) do %>
+        <i class="far fa-file-excel mr-2"></i>
+        Patient line list (with medication history)
+      <% end %>
+    </p>
+  <% end %>
+
+  <% if FeatureToggle.enabled?('DASHBOARD_SNAPSHOT') %>
+    <% if current_admin.accessible_facilities(:view_reports).include?(@facility) %>
+      <%=
+        render "shared/graphics/graphics_download_links",
+               graphics_path: -> (options) { analytics_facility_graphics_path(options) },
+               options: { facility_id: @facility.id }
+      %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/analytics/facilities/whatsapp_graphics.html.erb
+++ b/app/views/analytics/facilities/whatsapp_graphics.html.erb
@@ -1,0 +1,7 @@
+<%= render 'shared/graphics/graphics_partial',
+           cohort_analytics: @cohort_analytics,
+           dashboard_analytics: @dashboard_analytics,
+           organization_name: @facility.organization.name,
+           name: @facility.name,
+           quarter: @quarter,
+           year: @year %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,7 +68,14 @@
                 <li class="nav-item">
                   <%= link_to(reports_regions_path, class: "nav-link #{active_controller?("regions")}") do %>
                     Reports
+                    <span class="position-relative badge badge-primary" style="top: -2px; margin-left: 2px;">
+                          New
+                        </span>
                   <% end %>
+                </li>
+
+                <li class="nav-item">
+                  <%= link_to "Old Reports", organizations_path, class: "nav-link #{active_controller?("organizations", "facility_groups")}" %>
                 </li>
               <% end %>
 
@@ -125,7 +132,16 @@
                 <li class="nav-item">
                   <%= link_to(reports_regions_path, class: "nav-link #{active_controller?("regions")}") do %>
                     Reports
+                    <span class="position-relative badge badge-primary" style="top: -2px; margin-left: 2px;">
+                          New
+                        </span>
                   <% end %>
+                </li>
+              <% end %>
+
+              <% if policy(:dashboard).show? %>
+                <li class="nav-item">
+                  <%= link_to "Old Reports", organizations_path, class: "nav-link #{active_controller?("organizations", "facility_groups")}" %>
                 </li>
               <% end %>
 

--- a/app/views/my_facilities/blood_pressure_control.html.erb
+++ b/app/views/my_facilities/blood_pressure_control.html.erb
@@ -121,7 +121,7 @@
                           overall_patients: @overall_patients_per_facility[facility.id].to_i,
                           overall_controlled_bps: @overall_controlled_bps_per_facility[facility.id].to_i } %>
           <tr>
-            <td class="type-title"><%= link_to facility.name, reports_region_facility_path(facility) %></td>
+            <td class="type-title"><%= link_to facility.name, analytics_facility_path(facility) %></td>
             <td class="type-percent" data-sort-column-key="controlled">
               <em><%= percentage(bp_stats[:controlled], bp_stats[:cohort_patients]) %></em>
             </td>

--- a/app/views/my_facilities/missed_visits.html.erb
+++ b/app/views/my_facilities/missed_visits.html.erb
@@ -114,7 +114,7 @@
 
         <% @facilities.each do |facility| %>
           <tr>
-            <td class="type-title"><%= link_to facility.name, reports_region_facility_path(facility) %></td>
+            <td class="type-title"><%= link_to facility.name, analytics_facility_path(facility) %></td>
             <% @display_periods.reverse.each do |period| %>
               <td class="type-percent" data-sort-column-key="<%= period.join %>">
                 <em><%=

--- a/app/views/my_facilities/registrations.html.erb
+++ b/app/views/my_facilities/registrations.html.erb
@@ -83,7 +83,7 @@
         </tr>
         <% @facilities.each do |facility| %>
           <tr>
-            <td class="type-title"><%= link_to facility.name, reports_region_path(facility, report_scope: "facility") %></td>
+            <td class="type-title"><%= link_to facility.name, analytics_facility_path(facility) %></td>
             <% @display_periods.reverse.each do |period| %>
               <% unless @selected_period == :day %>
                 <td class="type-percent" data-sort-column-key="<%= period.join %>">

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -4,17 +4,18 @@
   <div class="row">
     <div class="col-sm-5 col-lg-7">
       <% @organizations.each do |organization| %>
-        <section class="facility-groups">
-          <div class="card organization" title="<%= organization.name %>">
+        <section id="facility-groups">
+          <div class="card" title="<%= organization.name %>">
             <h2><%= organization.name %></h2>
-            <% @accessible_facilities.includes(facility_group: :organization)
+            <% @accessible_facilities
+                   .includes(facility_group: :organization)
                    .where(facility_groups: {organization: organization})
                    .flat_map(&:facilities)
                    .group_by(&:district)
                    .keys
                    .sort
                    .each do |district| %>
-              <%= link_to(reports_region_district_path(district), class: "link-row") do %>
+              <%= link_to(analytics_organization_district_path(organization.id, district), class: "link-row") do %>
                 <i class='fas fa-angle-right light'></i>
                 <%= district %>
               <% end %>

--- a/app/views/reports/regions/details.html.erb
+++ b/app/views/reports/regions/details.html.erb
@@ -8,13 +8,13 @@
 <% end %>
 
 <% unless @region.is_a?(Facility) %>
-  <%= render "follow_ups_table",
+  <%= render "analytics/districts/follow_ups_table",
              dashboard_analytics: @dashboard_analytics,
              period: @period.type,
              row_resource: current_admin.accessible_facilities(:view_reports).order(:name),
              row_resource_display_field: :name,
              row_resource_link: :reports_region_facility_path %>
-  <%= render "registrations_table",
+  <%= render "analytics/districts/registrations_table",
              dashboard_analytics: @dashboard_analytics,
              period: @period.type,
              row_resource: current_admin.accessible_facilities(:view_reports).order(:name),

--- a/app/views/reports/regions/index.html.erb
+++ b/app/views/reports/regions/index.html.erb
@@ -13,7 +13,7 @@
     <div class="col-sm-5 col-lg-7">
       <% @organizations.each do |organization| %>
       <section>
-        <div class="card org-card">
+        <div class="card">
           <h2><%= organization.name %></h2>
           <% current_admin.accessible_facilities(:view_reports)
              .where(facility_groups: {organization: organization})

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -234,7 +234,7 @@
 </div>
 <%= render "visit_details_card" %>
 <% if @region.is_a?(Facility) %>
-  <%= render "new_registrations_table",
+  <%= render "analytics/facilities/analytics_table",
              dashboard_analytics: @dashboard_analytics,
              period: :month,
              row_resource: current_admin.accessible_users(:view_reports).order(:full_name),

--- a/app/views/shared/_recent_bp_log.html.erb
+++ b/app/views/shared/_recent_bp_log.html.erb
@@ -55,7 +55,7 @@
               <td class="nowrap"><%= bp.user.present? ? link_to(bp.user.full_name, [:admin, bp.user]) : "unknown" %></td>
             <% end %>
             <% if display_model == :user %>
-              <td class="nowrap"><%= bp.facility.present? ? link_to(bp.facility.name, reports_region_facility_path(bp.facility)) : "unknown" %></td>
+              <td class="nowrap"><%= bp.facility.present? ? link_to(bp.facility.name, analytics_facility_path(bp.facility)) : "unknown" %></td>
             <% end %>
           </tr>
         <% end %>

--- a/app/views/shared/my_facilities/_inactive_facilities.html.erb
+++ b/app/views/shared/my_facilities/_inactive_facilities.html.erb
@@ -22,7 +22,7 @@
       <tbody>
       <% @inactive_facilities.sort_by(&:name).each do |facility| %>
         <tr>
-          <td><%= link_to facility.name, reports_region_facility_path(facility) %></td>
+          <td><%= link_to facility.name, analytics_facility_path(facility) %></td>
           <td class="text-right" data-sort-column-key="week">
             <%= @inactive_facilities_bp_counts[:last_week][facility.id].to_i %>
           </td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,24 @@ Rails.application.routes.draw do
     get "access_tree/:page", to: "admins#access_tree", on: :member, as: :access_tree
   end
 
+  namespace :analytics do
+    resources :facilities, only: [:show] do
+      get "graphics", to: "facilities#whatsapp_graphics"
+      get "patient_list", to: "facilities#patient_list"
+      get "patient_list_with_history", to: "facilities#patient_list_with_history"
+      get "share", to: "facilities#share_anonymized_data"
+    end
+
+    resources :organizations do
+      resources :districts, only: [:show] do
+        get "graphics", to: "districts#whatsapp_graphics"
+        get "patient_list", to: "districts#patient_list"
+        get "patient_list_with_history", to: "districts#patient_list_with_history"
+        get "share", to: "districts#share_anonymized_data"
+      end
+    end
+  end
+
   resources :appointments, only: [:index, :update]
   resources :patients do
     collection do

--- a/spec/controllers/analytics/districts_controller_spec.rb
+++ b/spec/controllers/analytics/districts_controller_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+
+RSpec.describe Analytics::DistrictsController, type: :controller do
+  let(:admin) { create(:admin, :power_user) }
+
+  let(:district_name) { "Bathinda" }
+  let(:organization) { create(:organization) }
+  let(:facility_group) { create(:facility_group, organization: organization) }
+  let(:facility) { create(:facility, facility_group: facility_group, district: district_name) }
+  let(:organization_district) { OrganizationDistrict.new(district_name, organization) }
+  let(:sanitized_district_name) { organization_district.district_name.downcase.split(" ").join("-") }
+
+  before do
+    #
+    # register patients
+    #
+    registered_patients = Timecop.travel(Date.new(2018, 11, 1)) {
+      create_list(:patient, 3, :hypertension, registration_facility: facility)
+    }
+
+    #
+    # add blood_pressures next month
+    #
+    Timecop.travel(Date.new(2019, 2, 1)) do
+      registered_patients.each { |patient| create(:blood_pressure, :under_control, patient: patient, facility: facility) }
+    end
+
+    Patient.where(id: registered_patients.map(&:id))
+  end
+
+  before do
+    sign_in(admin.email_authentication)
+  end
+
+  describe "#show" do
+    render_views
+
+    context "dashboard analytics" do
+      it "returns relevant analytics keys per facility" do
+        Timecop.travel(Date.new(2019, 3, 1)) do
+          get :show, params: {organization_id: organization.id, id: district_name}
+        end
+
+        expect(response.status).to eq(200)
+        expect(assigns(:dashboard_analytics)[facility.id].keys)
+          .to(match_array(%i[patients_with_bp_by_period registered_patients_by_period total_patients]))
+      end
+    end
+
+    context "csv download" do
+      it "renders a csv" do
+        get :show, params: {organization_id: organization.id, id: district_name}, format: :csv
+        expect(response).to be_successful
+      end
+    end
+
+    it "allow cache to be refreshed forcefully" do
+      request_store = {}
+      allow(RequestStore).to receive(:store).and_return(request_store)
+      get :show, params: {organization_id: organization.id, id: district_name, force_cache: true}
+      expect(request_store[:force_cache]).to eq(true)
+    end
+  end
+
+  describe "#patient_list" do
+    render_views
+
+    it "should queue job for line list download" do
+      expect(PatientListDownloadJob).to receive(:perform_later).with(admin.email,
+        "district",
+        district_name: district_name,
+        organization_id: organization.id)
+
+      get :patient_list, params: {organization_id: organization.id, district_id: district_name}
+    end
+  end
+
+  describe "#patient_list_with_history" do
+    render_views
+
+    it "should queue job for line list with history download" do
+      expect(PatientListDownloadJob).to receive(:perform_later).with(admin.email,
+        "district",
+        {
+          district_name: district_name,
+          organization_id: organization.id
+        },
+        with_medication_history: true)
+
+      get :patient_list_with_history, params: {organization_id: organization.id, district_id: district_name}
+    end
+  end
+
+  describe "#whatsapp_graphics" do
+    render_views
+
+    context "html requested" do
+      it "renders graphics_header partial" do
+        get :whatsapp_graphics, format: :html, params: {organization_id: organization.id, district_id: district_name}
+
+        expect(response).to be_ok
+        expect(response).to render_template("shared/graphics/_graphics_partial")
+      end
+    end
+
+    context "png requested" do
+      it "renders the image template for downloading" do
+        get :whatsapp_graphics, format: :png, params: {organization_id: organization.id, district_id: district_name}
+
+        expect(response).to be_ok
+        expect(response).to render_template("shared/graphics/image_template")
+      end
+    end
+  end
+end

--- a/spec/controllers/analytics/facilities_controller_spec.rb
+++ b/spec/controllers/analytics/facilities_controller_spec.rb
@@ -1,0 +1,142 @@
+require "rails_helper"
+
+RSpec.describe Analytics::FacilitiesController, type: :controller do
+  let(:user) { create(:user) }
+  let(:admin) { create(:admin, :power_user) }
+
+  let(:district_name) { "Bathinda" }
+  let(:organization) { create(:organization) }
+  let(:facility_group) { create(:facility_group, organization: organization) }
+  let(:facility) { create(:facility, facility_group: facility_group, district: district_name) }
+
+  let(:may_2019) { Date.new(2019, 5, 1) }
+  let(:apr_2019) { Date.new(2019, 4, 1) }
+  let(:mar_2019) { Date.new(2019, 3, 1) }
+  let(:feb_2019) { Date.new(2019, 2, 1) }
+  let(:jan_2019) { Date.new(2019, 1, 1) }
+  let(:dec_2018) { Date.new(2018, 12, 1) }
+  let(:nov_2018) { Date.new(2018, 11, 1) }
+  let(:oct_2018) { Date.new(2018, 10, 1) }
+  let(:sep_2018) { Date.new(2018, 9, 1) }
+
+  let!(:registered_patients) do
+    travel_to(feb_2019) {
+      create_list(:patient,
+        3,
+        :hypertension,
+        registration_facility: facility,
+        registration_user: user)
+    }
+  end
+
+  before do
+    #
+    # add blood_pressures next month
+    #
+    travel_to(mar_2019) do
+      registered_patients.each do |patient|
+        blood_pressure = create(:blood_pressure, :under_control, patient: patient, facility: facility, user: user)
+        create(:encounter, :with_observables, patient: patient, observable: blood_pressure, facility: facility)
+      end
+    end
+
+    Patient.where(id: registered_patients.map(&:id))
+  end
+
+  before do
+    sign_in(admin.email_authentication)
+  end
+
+  describe "#show" do
+    render_views
+
+    context "dashboard analytics" do
+      it "returns relevant analytics keys per facility" do
+        Timecop.travel(apr_2019) do
+          get :show, params: {id: facility.id}
+        end
+
+        expect(response.status).to eq(200)
+        expect(assigns(:dashboard_analytics)[user.id].keys)
+          .to(match_array(%i[registered_patients_by_period total_registered_patients]))
+      end
+    end
+
+    it "renders the cohort chart view" do
+      get :show, params: {id: facility.id}
+      expect(response).to render_template(partial: "shared/_cohort_charts")
+    end
+
+    it "renders the recent BP view" do
+      get :show, params: {id: facility.id}
+      expect(response).to render_template(partial: "shared/_recent_bp_log")
+    end
+
+    context "Recent bps" do
+      it "shouldn't include discarded patient's blood pressures" do
+        registered_patients.first.discard_data
+
+        get :show, params: {id: facility.id}
+        expect(assigns(:recent_blood_pressures).count).to eq(2)
+      end
+    end
+
+    context "csv download" do
+      it "renders a csv" do
+        get :show, params: {id: facility.id}, format: :csv
+        expect(response).to be_successful
+      end
+    end
+
+    it "allow cache to be refreshed forcefully" do
+      request_store = {}
+      allow(RequestStore).to receive(:store).and_return(request_store)
+      get :show, params: {id: facility.id, force_cache: true}
+      expect(request_store[:force_cache]).to eq(true)
+    end
+  end
+
+  describe "#patient_list" do
+    render_views
+    it "should queue job for line list download" do
+      expect(PatientListDownloadJob).to receive(:perform_later).with(admin.email, "facility", facility_id: facility.id)
+
+      get :patient_list, params: {facility_id: facility.id}
+    end
+  end
+
+  describe "#patient_list_with_history" do
+    render_views
+
+    it "should queue job for line list with history download" do
+      expect(PatientListDownloadJob).to receive(:perform_later).with(admin.email,
+        "facility",
+        {facility_id: facility.id},
+        with_medication_history: true)
+
+      get :patient_list_with_history, params: {facility_id: facility.id}
+    end
+  end
+
+  describe "#whatsapp_graphics" do
+    render_views
+
+    context "html requested" do
+      it "renders graphics_header partial" do
+        get :whatsapp_graphics, format: :html, params: {facility_id: facility.id}
+
+        expect(response).to be_ok
+        expect(response).to render_template("shared/graphics/_graphics_partial")
+      end
+    end
+
+    context "png requested" do
+      it "renders the image template for downloading" do
+        get :whatsapp_graphics, format: :png, params: {facility_id: facility.id}
+
+        expect(response).to be_ok
+        expect(response).to render_template("shared/graphics/image_template")
+      end
+    end
+  end
+end

--- a/spec/features/analytics/facilities_spec.rb
+++ b/spec/features/analytics/facilities_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.feature "Facility analytics", type: :feature do
+  let!(:owner) { create(:admin, :power_user) }
+  let!(:facility) { create(:facility) }
+  let!(:other_facility) { create(:facility) }
+  let!(:bp_1) { create(:blood_pressure, facility: facility, systolic: 145, diastolic: 95, recorded_at: Time.zone.parse("2019-03-15 8:00am +05:30")) }
+  let!(:bp_2) { create(:blood_pressure, facility: facility, systolic: 115, diastolic: 75, recorded_at: Time.zone.parse("2019-03-15 2:15pm +05:30")) }
+
+  let!(:encounter_1) { create(:encounter, :with_observables, observable: bp_1) }
+  let!(:encounter_2) { create(:encounter, :with_observables, observable: bp_2) }
+
+  before do
+    sign_in(owner.email_authentication)
+  end
+
+  describe "show a facility" do
+    before do
+      visit analytics_facility_path(facility)
+    end
+
+    context "recent BP log" do
+      it "displays the facility's recent BPs", :aggregate_failures do
+        within("#recent-bps") do
+          expect(page).to have_selector("th", text: /recorded by/i)
+          expect(page).to have_content("145/95")
+          expect(page).to have_content("115/75")
+        end
+      end
+
+      it "only displays one date per day, but multiple times", :aggregate_failures do
+        within("#recent-bps") do
+          expect(page).to have_content("15-MAR-2019", count: 1)
+          expect(page).to have_content("8:00 AM")
+          expect(page).to have_content("2:15 PM")
+        end
+      end
+    end
+  end
+
+  describe "allows period switching" do
+    before do
+      visit analytics_facility_path(facility)
+      click_link "Monthly report"
+      click_link "Quarterly report"
+    end
+
+    it "shows quarterly metrics" do
+      expect(page).to have_content("patients registered in")
+      expect(page).to have_content("Result from last visit in")
+    end
+
+    it "persists period selection across views" do
+      visit analytics_facility_path(other_facility)
+      expect(page).to have_content("patients registered in")
+      expect(page).to have_content("Result from last visit in")
+    end
+  end
+end

--- a/spec/features/organizations/index_spec.rb
+++ b/spec/features/organizations/index_spec.rb
@@ -23,8 +23,9 @@ RSpec.feature "Verify Dashboard", type: :feature do
 
     #
     # two organizations + 1 user approvals card
-    expect(dashboard.all_elements(css: ".card").size).to eq(3)
+    expect(dashboard.get_card_count).to eq(3)
     expect(page).to have_content("IHMI")
+    expect(page).to have_content("PATH")
   end
 
   it "Verify organisation name/count get updated in dashboard when new org is added via manage section" do
@@ -33,7 +34,7 @@ RSpec.feature "Verify Dashboard", type: :feature do
 
     # total number of organization present in dashboard
     visit organizations_path
-    original_org_count = dashboard.all_elements(css: ".card.organization").count
+    var_organization_count = dashboard.get_card_count
 
     dashboard_navigation.select_manage_option("Organizations")
 
@@ -48,12 +49,11 @@ RSpec.feature "Verify Dashboard", type: :feature do
     fg = create(:facility_group, organization: Organization.find_by_name("Test"))
     create(:facility, facility_group: fg)
 
-    dashboard_navigation.select_main_menu_tab("Reports")
+    dashboard_navigation.select_main_menu_tab("Old Reports")
 
     # assertion at dashboard screen
     expect(page).to have_content("Test")
-
-    expect(dashboard.get_organization_count).to eq(original_org_count + 1)
+    expect(dashboard.get_card_count).to eq(var_organization_count + 1)
   end
 
   it "SignIn as Owner and verify approval request in dashboard" do

--- a/spec/pages/organizations/index.rb
+++ b/spec/pages/organizations/index.rb
@@ -1,9 +1,9 @@
 module OrganizationsPage
   class Index < ApplicationPage
-    ORGANIZATIONS = {css: "div.card"}.freeze
+    CARDS = {css: "div.card"}.freeze
 
-    def get_organization_count
-      all_elements(ORGANIZATIONS).size
+    def get_card_count
+      all_elements(CARDS).size
     end
   end
 end


### PR DESCRIPTION
Due to some broken links [reported here](https://simpledotorg.slack.com/archives/CFHKJ5WJY/p1602049186071800), I'm reverting this PR, and updating the removal date to Oct 12.

I suspect the underlying issue has something to do with facility groups and districts not matching.

Reverts simpledotorg/simple-server#1378