### PR TITLE
Reports: Add region total rows and copy/styling updates

### DIFF
--- a/app/views/reports/regions/_facility_tables.html.erb
+++ b/app/views/reports/regions/_facility_tables.html.erb
@@ -178,6 +178,17 @@
             </tr>
           </thead>
           <tbody>
+            <tr class="row-total" data-sort-method="none">
+              <td class="type-title">
+                <%= @region.name %>
+              </td>
+              <td class="ta-left">
+                <%= number_to_percentage(@data.last_value(:missed_visits_rate), precision: 0) %>
+              </td>
+              <td class="ta-left">
+                <%= number_with_delimiter(@data.last_value(:missed_visits)) %>
+              </td>
+            </tr>
             <% @region.facilities.order(:name).each do |facility| %>
               <tr>
                 <td class="ta-left">

--- a/app/views/reports/regions/_facility_tables.html.erb
+++ b/app/views/reports/regions/_facility_tables.html.erb
@@ -66,10 +66,10 @@
         </table>
       </div>
       <div class="pt-12px">
-        <p class="mb-8px fs-12px c-grey-dark">
+        <p class="mb-8px fs-14px c-grey-dark">
           <strong>Numerator:</strong> Patients with BP &lt;140/90 at their most recent visit in the last 3 months
         </p>
-        <p class="mb-0px fs-12px c-grey-dark">
+        <p class="mb-0px fs-14px c-grey-dark">
           <strong>Denominator:</strong> All hypertensive patients assigned to <%= @region.name %> registered before
           the last 3 months
         </p>
@@ -137,10 +137,10 @@
         </table>
       </div>
       <div class="pt-12px">
-        <p class="mb-8px fs-12px c-grey-dark">
+        <p class="mb-8px fs-14px c-grey-dark">
           <strong>Numerator:</strong> Patients with BP &ge;140/90 at their most recent visit in the last 3 months
         </p>
-        <p class="mb-0px fs-12px c-grey-dark">
+        <p class="mb-0px fs-14px c-grey-dark">
           <strong>Denominator:</strong> All hypertensive patients assigned to <%= @region.name %> registered before
           the last 3 months
         </p>
@@ -208,10 +208,10 @@
         </table>
       </div>
       <div class="pt-12px">
-        <p class="mb-8px fs-12px c-grey-dark">
+        <p class="mb-8px fs-14px c-grey-dark">
           <strong>Numerator:</strong> Patients with no visit in >3 months
         </p>
-        <p class="mb-0px fs-12px c-grey-dark">
+        <p class="mb-0px fs-14px c-grey-dark">
           <strong>Denominator:</strong> All hypertensive patients assigned to <%= @region.name %> registered before
           the last 3 months
         </p>
@@ -279,7 +279,7 @@
         </table>
       </div>
       <div class="mb-2 pt-12px">
-        <p class="us-none fs-12px c-transparent">
+        <p class="us-none fs-14px c-transparent">
           <strong>Denominator:</strong> All hypertensive patients assigned to <%= @region.name %> registered before
           the last 3 months
         </p>

--- a/app/views/reports/regions/_facility_tables.html.erb
+++ b/app/views/reports/regions/_facility_tables.html.erb
@@ -36,6 +36,17 @@
             </tr>
           </thead>
           <tbody>
+            <tr class="row-total" data-sort-method="none">
+              <td class="type-title">
+                <%= @region.name %>
+              </td>
+              <td class="ta-left">
+                <%= number_to_percentage(@data.last_value(:controlled_patients_rate), precision: 0) %>
+              </td>
+              <td class="ta-left">
+                <%= number_with_delimiter(@data.last_value(:controlled_patients)) %>
+              </td>
+            </tr>
             <% @region.facilities.order(:name).each do |facility| %>
               <tr>
                 <td class="ta-left">

--- a/app/views/reports/regions/_facility_tables.html.erb
+++ b/app/views/reports/regions/_facility_tables.html.erb
@@ -249,6 +249,17 @@
             </tr>
           </thead>
           <tbody>
+            <tr class="row-total" data-sort-method="none">
+              <td class="type-title">
+                <%= @region.name %>
+              </td>
+              <td class="ta-left">
+                <%= number_with_delimiter(@data.last_value(:registrations)) %>
+              </td>
+              <td class="ta-left">
+                <%= number_with_delimiter(@data.last_value(:cumulative_registrations)) %>
+              </td>
+            </tr>
             <% @region.facilities.order(:name).each do |facility| %>
               <tr>
                 <td class="ta-left">

--- a/app/views/reports/regions/_facility_tables.html.erb
+++ b/app/views/reports/regions/_facility_tables.html.erb
@@ -107,6 +107,17 @@
             </tr>
           </thead>
           <tbody>
+            <tr class="row-total" data-sort-method="none">
+              <td class="type-title">
+                <%= @region.name %>
+              </td>
+              <td class="ta-left">
+                <%= number_to_percentage(@data.last_value(:uncontrolled_patients_rate), precision: 0) %>
+              </td>
+              <td class="ta-left">
+                <%= number_with_delimiter(@data.last_value(:uncontrolled_patients)) %>
+              </td>
+            </tr>
             <% @region.facilities.order(:name).each do |facility| %>
               <tr>
                 <td class="ta-left">

--- a/app/views/reports/regions/_follow_ups_table.html.erb
+++ b/app/views/reports/regions/_follow_ups_table.html.erb
@@ -53,7 +53,7 @@
       <tbody>
 
       <tr class="row-total" data-sort-method="none">
-        <td class="row-title row-total">All</td>
+        <td class="row-title row-total"><%= @region.name %></td>
 
         <!--Patients with BP taken-->
         <% dates_for_periods(period, 6, include_current_period: @show_current_period).each do |date| %>

--- a/app/views/reports/regions/_new_registrations_table.html.erb
+++ b/app/views/reports/regions/_new_registrations_table.html.erb
@@ -42,7 +42,7 @@
       <tbody>
 
       <tr class="row-total" data-sort-method="none">
-        <td class="row-title row-total">All</td>
+        <td class="row-title row-total"><%= @region.name %></td>
 
         <!--Total assigned patients-->
         <td class="row-total" style="text-align: center;">

--- a/app/views/reports/regions/_registrations_table.html.erb
+++ b/app/views/reports/regions/_registrations_table.html.erb
@@ -38,7 +38,7 @@
       <tbody>
 
       <tr class="row-total" data-sort-method="none">
-        <td class="row-title row-total">All</td>
+        <td class="row-title row-total"><%= @region.name %></td>
 
         <!--New registrations-->
         <% dates_for_periods(period, 6, include_current_period: @show_current_period).each do |date| %>

--- a/app/views/reports/regions/cohort.html.erb
+++ b/app/views/reports/regions/cohort.html.erb
@@ -52,7 +52,7 @@
                     data-toggle="tooltip"
                     data-placement="top"
                     data-trigger="hover focus click"
-                    title="<%= number_with_delimiter(cohort["uncontrolled"]) %> patients visited with HTN not under control"
+                    title="<%= number_with_delimiter(cohort["uncontrolled"]) %> patients visited with BP not controlled"
                     style="width: <%= uncontrolled_percent %>;"
                   >
                     <%= (cohort["uncontrolled"] > 1 && uncontrolled_percent == 0) ? "< 1" : uncontrolled_percent %>
@@ -62,7 +62,7 @@
                     data-toggle="tooltip"
                     data-placement="top"
                     data-trigger="hover focus click"
-                    title="<%= number_with_delimiter(cohort["controlled"]) %> patients visited with HTN controlled"
+                    title="<%= number_with_delimiter(cohort["controlled"]) %> patients visited with BP controlled"
                     style="width: <%= controlled_percent %>;"
                   >
                     <%= (cohort["controlled"] > 0 && controlled_percent == 0) ? "< 1" : controlled_percent %>

--- a/app/views/reports/regions/cohort.html.erb
+++ b/app/views/reports/regions/cohort.html.erb
@@ -85,11 +85,11 @@
       </p>
       <p class="mb-8px c-black mr-lg-4 mb-lg-0">
         <span class="p-relative t-1px d-inline-block w-12px h-12px mr-4px br-2px bg-red-medium"></span>
-        HTN not under control
+        BP not controlled
       </p>
       <p class="m-0px c-black mb-lg-0">
         <span class="p-relative t-1px d-inline-block w-12px h-12px mr-4px br-2px bg-green-dark"></span>
-        HTN controlled
+        BP controlled
       </p>
     </div>
   </div>

--- a/app/views/reports/regions/cohort.html.erb
+++ b/app/views/reports/regions/cohort.html.erb
@@ -42,7 +42,7 @@
                     data-toggle="tooltip"
                     data-placement="top"
                     data-trigger="hover focus click"
-                    title="<%= number_with_delimiter(cohort["no_bp"]) %> <% if cohort["no_bp"] == 1 %>patient<% else %>patients<% end %> didn't have a BP taken"
+                    title="<%= number_with_delimiter(cohort["no_bp"]) %> <%= "person".pluralize(cohort["no_bp"]) %> didn't have a BP taken"
                     style="width: <%= no_bp_percent %>;"
                   >
                     <%= (cohort["no_bp"] > 0 && no_bp_percent == 0) ? "< 1" : no_bp_percent %>
@@ -52,7 +52,7 @@
                     data-toggle="tooltip"
                     data-placement="top"
                     data-trigger="hover focus click"
-                    title="<%= number_with_delimiter(cohort["uncontrolled"]) %> <% if cohort["uncontrolled"] == 1 %>patient<% else %>patients<% end %> visited with BP not controlled"
+                    title="<%= number_with_delimiter(cohort["uncontrolled"]) %> <%= "person".pluralize(cohort["uncontrolled"]) %> visited with BP not controlled"
                     style="width: <%= uncontrolled_percent %>;"
                   >
                     <%= (cohort["uncontrolled"] > 1 && uncontrolled_percent == 0) ? "< 1" : uncontrolled_percent %>
@@ -62,7 +62,7 @@
                     data-toggle="tooltip"
                     data-placement="top"
                     data-trigger="hover focus click"
-                    title="<%= number_with_delimiter(cohort["controlled"]) %> <% if cohort["controlled"] == 1 %>patient<% else %>patients<% end %> visited with BP controlled"
+                    title="<%= number_with_delimiter(cohort["controlled"]) %> <%= "person".pluralize(cohort["controlled"]) %> visited with BP controlled"
                     style="width: <%= controlled_percent %>;"
                   >
                     <%= (cohort["controlled"] > 0 && controlled_percent == 0) ? "< 1" : controlled_percent %>

--- a/app/views/reports/regions/cohort.html.erb
+++ b/app/views/reports/regions/cohort.html.erb
@@ -42,7 +42,7 @@
                     data-toggle="tooltip"
                     data-placement="top"
                     data-trigger="hover focus click"
-                    title="<%= number_with_delimiter(cohort["no_bp"]) %> patients didn't have a BP taken"
+                    title="<%= number_with_delimiter(cohort["no_bp"]) %> <% if cohort["no_bp"] == 1 %>patient<% else %>patients<% end %> didn't have a BP taken"
                     style="width: <%= no_bp_percent %>;"
                   >
                     <%= (cohort["no_bp"] > 0 && no_bp_percent == 0) ? "< 1" : no_bp_percent %>
@@ -52,7 +52,7 @@
                     data-toggle="tooltip"
                     data-placement="top"
                     data-trigger="hover focus click"
-                    title="<%= number_with_delimiter(cohort["uncontrolled"]) %> patients visited with BP not controlled"
+                    title="<%= number_with_delimiter(cohort["uncontrolled"]) %> <% if cohort["uncontrolled"] == 1 %>patient<% else %>patients<% end %> visited with BP not controlled"
                     style="width: <%= uncontrolled_percent %>;"
                   >
                     <%= (cohort["uncontrolled"] > 1 && uncontrolled_percent == 0) ? "< 1" : uncontrolled_percent %>
@@ -62,7 +62,7 @@
                     data-toggle="tooltip"
                     data-placement="top"
                     data-trigger="hover focus click"
-                    title="<%= number_with_delimiter(cohort["controlled"]) %> patients visited with BP controlled"
+                    title="<%= number_with_delimiter(cohort["controlled"]) %> <% if cohort["controlled"] == 1 %>patient<% else %>patients<% end %> visited with BP controlled"
                     style="width: <%= controlled_percent %>;"
                   >
                     <%= (cohort["controlled"] > 0 && controlled_percent == 0) ? "< 1" : controlled_percent %>


### PR DESCRIPTION
**Story card:** [ch1399](https://app.clubhouse.io/simpledotorg/story/1399/add-all-rows-to-facility-comparison-tables)

## Because

1. It makes it easier to see (and verify) accuracy of facility data
2. It shows the region's name as the "All" header (per CVHOs request)

## This addresses

**Add total rows to facility comparison tables**
![image](https://user-images.githubusercontent.com/16785131/95381471-33bc9880-08b6-11eb-8a5c-6c7cdd1bf21c.png)

**Replace "All" with region's name in District Report tables**
![image](https://user-images.githubusercontent.com/16785131/95381542-4afb8600-08b6-11eb-8fee-e722478c3d74.png)

**Replace "All" with region's name in Facility Report tables**
![image](https://user-images.githubusercontent.com/16785131/95381592-5fd81980-08b6-11eb-9594-bcf3663cb47b.png)

**Update cohort chart key label and tooltip copy**
![image](https://user-images.githubusercontent.com/16785131/95381913-d7a64400-08b6-11eb-8997-e0e55d5b7873.png)
![image](https://user-images.githubusercontent.com/16785131/95381989-f4427c00-08b6-11eb-8235-4ed6d1186215.png)

**Format cohort chart tooltips to properly display "patient" in singular/plural**
![image](https://user-images.githubusercontent.com/16785131/95461334-1afac400-0944-11eb-9518-7febda636d2b.png)