### PR TITLE
Reports: Remove facility table subtitles

### DIFF
--- a/app/views/reports/regions/_facility_tables.html.erb
+++ b/app/views/reports/regions/_facility_tables.html.erb
@@ -11,9 +11,6 @@
         <h3 class="mb-8px c-black">
           BP controlled
         </h3>
-        <p class="c-grey-dark">
-          Hypertensive patients with BP &lt;140/90 at their most recent visit in the last 3 months
-        </p>
       </div>
       <div class="table-responsive">
         <table id="htn-controlled-table" class="table-compact">
@@ -82,9 +79,6 @@
         <h3 class="mb-8px c-black">
           BP not controlled
         </h3>
-        <p class="c-grey-dark">
-          Hypertensive patients with BP &ge;140/90 at their most recent visit in the last 3 months
-        </p>
       </div>
       <div class="table-responsive">
         <table id="htn-not-under-control-table" class="table-compact">
@@ -153,9 +147,6 @@
         <h3 class="c-black">
           Missed visits
         </h3>
-        <p class="mb-8px c-grey-dark">
-          Hypertensive patients with no visit in >3 months
-        </p>
       </div>
       <div class="table-responsive">
         <table id="no-bp-measure-table" class="table-compact">
@@ -224,9 +215,6 @@
         <h3 class="c-black">
           Monthly and cumulative patients
         </h3>
-        <p class="c-grey-dark">
-          All hypertensive patients assigned to facilities in <%= @region.name %>
-        </p>
       </div>
       <div class="table-responsive">
         <table id="cumulative-registrations-table" class="table-compact">


### PR DESCRIPTION
**Story card:** [ch1531](https://app.clubhouse.io/simpledotorg/story/1531/remove-comparison-table-subtitles)

## Because

Card titles are self-explanatory and numerator/denominator footer text show same info.

## This addresses

**Remove subtitle from facility comparison tables in District Reports**
![image](https://user-images.githubusercontent.com/16785131/95474317-f8bc7280-0952-11eb-9916-eebc99cfc54c.png)