### PR TITLE
Manually mark mobile numbers

### DIFF
--- a/app/services/mark_patient_mobile_numbers.rb
+++ b/app/services/mark_patient_mobile_numbers.rb
@@ -6,10 +6,21 @@ class MarkPatientMobileNumbers
   def call
     return unless ENV["FORCE_MARK_PATIENT_MOBILE_NUMBERS"] == "true"
 
+    count = eligible_numbers.count
+    notify("Force-marking #{count} as mobile numbers")
+
     eligible_numbers.update_all(phone_type: "mobile")
+
+    notify("Finished force-marking #{count} as mobile numbers")
   end
+
+  private
 
   def eligible_numbers
     PatientPhoneNumber.where.not(phone_type: "mobile")
+  end
+
+  def notify(msg)
+    Rails.logger.info msg: msg, class: self.class.name
   end
 end

--- a/app/services/mark_patient_mobile_numbers.rb
+++ b/app/services/mark_patient_mobile_numbers.rb
@@ -4,7 +4,7 @@ class MarkPatientMobileNumbers
   end
 
   def call
-    return unless ENV["FORCE_MARK_PATIENT_MOBILE_NUMBERS"] == "true"
+    return unless Flipper.enabled?(:force_mark_patient_mobile_numbers)
 
     count = eligible_numbers.count
     notify("Force-marking #{count} as mobile numbers")

--- a/app/services/mark_patient_mobile_numbers.rb
+++ b/app/services/mark_patient_mobile_numbers.rb
@@ -1,0 +1,15 @@
+class MarkPatientMobileNumbers
+  def self.call
+    new.call
+  end
+
+  def call
+    return unless ENV["FORCE_MARK_PATIENT_MOBILE_NUMBERS"] == "true"
+
+    eligible_numbers.update_all(phone_type: "mobile")
+  end
+
+  def eligible_numbers
+    PatientPhoneNumber.where.not(phone_type: "mobile")
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -23,6 +23,10 @@ every :week, at: local("01:00 am"), roles: [:whitelist_phone_numbers] do
   rake "exotel_tasks:update_all_patients_phone_number_details"
 end
 
+every :day, at: local("01:00 am"), roles: [:cron] do
+  runner "MarkPatientMobileNumbers.call"
+end
+
 every :day, at: local("02:00 am"), roles: [:cron] do
   runner "Reports::RegionCacheWarmer.call"
 end

--- a/spec/services/mark_patient_mobile_numbers_spec.rb
+++ b/spec/services/mark_patient_mobile_numbers_spec.rb
@@ -4,6 +4,7 @@ describe MarkPatientMobileNumbers, type: :model do
   it "marks non-mobile patient phone numbers as mobile" do
     mobile_number = create(:patient_phone_number, phone_type: "mobile")
     non_mobile_number = create(:patient_phone_number, phone_type: "landline")
+    allow(ENV).to receive(:[]).and_call_original
     allow(ENV).to receive(:[]).with("FORCE_MARK_PATIENT_MOBILE_NUMBERS").and_return "true"
 
     MarkPatientMobileNumbers.call
@@ -14,14 +15,15 @@ describe MarkPatientMobileNumbers, type: :model do
 
   it "doesn't touch mobile numbers" do
     mobile_number = create(:patient_phone_number, phone_type: "mobile")
+    allow(ENV).to receive(:[]).and_call_original
     allow(ENV).to receive(:[]).with("FORCE_MARK_PATIENT_MOBILE_NUMBERS").and_return "true"
 
     expect { MarkPatientMobileNumbers.call }.not_to change { mobile_number.reload.updated_at }
   end
 
   it "does nothing if config is not set" do
-    mobile_number = create(:patient_phone_number, phone_type: "mobile")
     non_mobile_number = create(:patient_phone_number, phone_type: "landline")
+    allow(ENV).to receive(:[]).and_call_original
     allow(ENV).to receive(:[]).with("FORCE_MARK_PATIENT_MOBILE_NUMBERS").and_return "something else"
 
     expect { MarkPatientMobileNumbers.call }.not_to change { non_mobile_number.reload.phone_type }

--- a/spec/services/mark_patient_mobile_numbers_spec.rb
+++ b/spec/services/mark_patient_mobile_numbers_spec.rb
@@ -4,27 +4,27 @@ describe MarkPatientMobileNumbers, type: :model do
   it "marks non-mobile patient phone numbers as mobile" do
     mobile_number = create(:patient_phone_number, phone_type: "mobile")
     non_mobile_number = create(:patient_phone_number, phone_type: "landline")
-    allow(ENV).to receive(:[]).and_call_original
-    allow(ENV).to receive(:[]).with("FORCE_MARK_PATIENT_MOBILE_NUMBERS").and_return "true"
+    Flipper.enable(:force_mark_patient_mobile_numbers)
 
     MarkPatientMobileNumbers.call
 
     expect(mobile_number.reload.phone_type).to eq("mobile")
     expect(non_mobile_number.reload.phone_type).to eq("mobile")
+
+    Flipper.disable(:force_mark_patient_mobile_numbers)
   end
 
   it "doesn't touch mobile numbers" do
     mobile_number = create(:patient_phone_number, phone_type: "mobile")
-    allow(ENV).to receive(:[]).and_call_original
-    allow(ENV).to receive(:[]).with("FORCE_MARK_PATIENT_MOBILE_NUMBERS").and_return "true"
+    Flipper.enable(:force_mark_patient_mobile_numbers)
 
     expect { MarkPatientMobileNumbers.call }.not_to change { mobile_number.reload.updated_at }
+
+    Flipper.disable(:force_mark_patient_mobile_numbers)
   end
 
-  it "does nothing if config is not set" do
+  it "does nothing if feature flag is not set" do
     non_mobile_number = create(:patient_phone_number, phone_type: "landline")
-    allow(ENV).to receive(:[]).and_call_original
-    allow(ENV).to receive(:[]).with("FORCE_MARK_PATIENT_MOBILE_NUMBERS").and_return "something else"
 
     expect { MarkPatientMobileNumbers.call }.not_to change { non_mobile_number.reload.phone_type }
   end

--- a/spec/services/mark_patient_mobile_numbers_spec.rb
+++ b/spec/services/mark_patient_mobile_numbers_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe MarkPatientMobileNumbers, type: :model do
+  it "marks non-mobile patient phone numbers as mobile" do
+    mobile_number = create(:patient_phone_number, phone_type: "mobile")
+    non_mobile_number = create(:patient_phone_number, phone_type: "landline")
+    allow(ENV).to receive(:[]).with("FORCE_MARK_PATIENT_MOBILE_NUMBERS").and_return "true"
+
+    MarkPatientMobileNumbers.call
+
+    expect(mobile_number.reload.phone_type).to eq("mobile")
+    expect(non_mobile_number.reload.phone_type).to eq("mobile")
+  end
+
+  it "doesn't touch mobile numbers" do
+    mobile_number = create(:patient_phone_number, phone_type: "mobile")
+    allow(ENV).to receive(:[]).with("FORCE_MARK_PATIENT_MOBILE_NUMBERS").and_return "true"
+
+    expect { MarkPatientMobileNumbers.call }.not_to change { mobile_number.reload.updated_at }
+  end
+
+  it "does nothing if config is not set" do
+    mobile_number = create(:patient_phone_number, phone_type: "mobile")
+    non_mobile_number = create(:patient_phone_number, phone_type: "landline")
+    allow(ENV).to receive(:[]).with("FORCE_MARK_PATIENT_MOBILE_NUMBERS").and_return "something else"
+
+    expect { MarkPatientMobileNumbers.call }.not_to change { non_mobile_number.reload.phone_type }
+  end
+end


### PR DESCRIPTION
**Story card:** [ch1534](https://app.clubhouse.io/simpledotorg/story/1534/investigate-and-fix-non-ihci-reminders)

## Because

Non-IHCI environments don't have a way to identify mobile numbers. IHCI uses Exotel.

## This addresses

Marking all patient phone numbers as mobile every night, if `FORCE_MARK_PATIENT_MOBILE_NUMBERS=true`
