### PR TITLE
District filtering bugfix

### DIFF
--- a/app/controllers/my_facilities/ranked_facilities_controller.rb
+++ b/app/controllers/my_facilities/ranked_facilities_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class MyFacilities::RankedFacilitiesController < AdminController
-  include DistrictFiltering
   include Pagination
   include MyFacilitiesFiltering
 
@@ -10,9 +9,7 @@ class MyFacilities::RankedFacilitiesController < AdminController
   DEFAULT_ANALYTICS_TIME_ZONE = "Asia/Kolkata"
   PERIODS_TO_DISPLAY = {quarter: 3, month: 3, day: 14}.freeze
 
-  skip_after_action :verify_authorized, if: -> { current_admin.permissions_v2_enabled? }
-  skip_after_action :verify_policy_scoped, if: -> { current_admin.permissions_v2_enabled? }
-  after_action :verify_authorization_attempted, if: -> { current_admin.permissions_v2_enabled? }
+  after_action :verify_authorization_attempted
 
   around_action :set_time_zone
   before_action :authorize_my_facilities
@@ -67,11 +64,7 @@ class MyFacilities::RankedFacilitiesController < AdminController
   end
 
   def authorize_my_facilities
-    if current_admin.permissions_v2_enabled?
-      authorize_v2 { current_admin.accessible_facilities(:view_reports).any? }
-    else
-      authorize(:dashboard, :view_my_facilities?)
-    end
+    authorize { current_admin.accessible_facilities(:view_reports).any? }
   end
 
   def set_period

--- a/app/views/my_facilities/ranked_facilities/show.html.erb
+++ b/app/views/my_facilities/ranked_facilities/show.html.erb
@@ -6,12 +6,11 @@
     <div class="card card-responsive">
       <div>
         <h3>Ranked facilities</h3>
-          <p>
-            Facilities are ranked using their BP controlled, missed visits, and % of target registrations values.
-            <br>
-            The highest score is 100, where the score = (50% &times; BP controlled) + (30% &times; (100% - missed visits)) + (20% &times; % of target registrations)
-          </p>
-        </li>
+        <p>
+          Facilities are ranked using their BP controlled, missed visits, and % of target registrations values.
+          <br>
+          The highest score is 100, where the score = (50% &times; BP controlled) + (30% &times; (100% - missed visits)) + (20% &times; % of target registrations)
+        </p>
       </div>
 
       <table class="mt-3 mt-lg-4 table table-compact table-responsive-md table-hover analytics-table" id="ranked-facilities-table">

--- a/spec/controllers/my_facilities/ranked_facilities_controller_spec.rb
+++ b/spec/controllers/my_facilities/ranked_facilities_controller_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec::Matchers.define :facilities do |facilities|
+  match { |actual| actual.map(&:id) == facilities.map(&:id) }
+end
+
+RSpec.describe MyFacilities::RankedFacilitiesController, type: :controller do
+  let(:facility_group) { create(:facility_group) }
+  let!(:facilities) { create_list(:facility, 3, facility_group: facility_group) }
+  let(:supervisor) { create(:admin, :manager, :with_access, resource: facility_group) }
+
+  render_views
+
+  before do
+    sign_in(supervisor.email_authentication)
+    Flipper.enable(:ranked_facilities)
+  end
+
+  after do
+    Flipper.disable(:ranked_facilities)
+  end
+
+  describe "GET #show" do
+    it "returns a success response" do
+      create(:facility, facility_group: facility_group)
+
+      get :show, params: {}
+
+      expect(response).to be_successful
+    end
+  end
+end


### PR DESCRIPTION
## Because

Hot fix for #1394 - The new RankedFacilitiesController was using some artifacts (`DistrictFiltering` module) that were removed in #1394.

## This addresses

Removing the DistrictFiltering and adding a simple controller test to ensure it's not broken.
