### PR TITLE
Re-add delete admin button

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -56,7 +56,8 @@ class AdminsController < AdminController
   end
 
   def destroy
-    @admin.destroy
+    authorize { current_admin.manage_organization? && current_admin.accessible_admins(:manage).include?(@admin) }
+    @admin.discard
     redirect_to admins_url, notice: "Admin was successfully deleted."
   end
 
@@ -70,7 +71,7 @@ class AdminsController < AdminController
       return
     end
 
-    if access_level_changed? && !current_admin.modify_access_level?
+    if access_level_changed? && !current_admin.manage_organization?
       raise UserAccess::NotAuthorizedError
     end
 

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -56,7 +56,7 @@ class AdminsController < AdminController
   end
 
   def destroy
-    authorize { current_admin.manage_organization? && current_admin.accessible_admins(:manage).include?(@admin) }
+    authorize { current_admin.manage_organization? && current_admin.accessible_admins(:manage).find_by_id(@admin.id) }
     @admin.discard
     redirect_to admins_url, notice: "Admin was successfully deleted."
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,7 +111,7 @@ class User < ApplicationRecord
     :accessible_protocol_drugs,
     :access_across_organizations?,
     :access_across_facility_groups?,
-    :modify_access_level?,
+    :manage_organization?,
     :grant_access,
     :permitted_access_levels, to: :user_access, allow_nil: false
 

--- a/app/models/user_access.rb
+++ b/app/models/user_access.rb
@@ -130,7 +130,7 @@ class UserAccess
     LEVELS[user.access_level.to_sym][:grant_access]
   end
 
-  def modify_access_level?
+  def manage_organization?
     power_user? || user.accessible_organizations(:manage).any?
   end
 

--- a/app/views/admins/_form.html.erb
+++ b/app/views/admins/_form.html.erb
@@ -53,7 +53,7 @@
       <%= access_level_select(form, current_admin.permitted_access_levels,
           {
               required: true,
-              disabled: !current_admin.modify_access_level?,
+              disabled: !current_admin.manage_organization?,
               current_access_level: admin.access_level
           }) %>
 
@@ -78,6 +78,10 @@
           <% end %>
         </div>
       </div>
+
+      <% if current_admin.manage_organization? && current_admin.accessible_admins(:manage).find_by_id(admin.id) %>
+        <%= link_to 'Delete Admin', admin_path(admin), method: :delete, data: {confirm: "Are you sure you want to delete #{@admin.full_name}?"}, class: "btn btn-danger" %>
+      <% end %>
 
       <%= form.submit "Send Invite", class: "btn btn-primary", id: "form-submit", hidden: :hidden %>
     <% end %>


### PR DESCRIPTION
**Story card:** [ch1547](https://app.clubhouse.io/simpledotorg/story/1547)

## Because

We disabled the "Delete admin" button while changing the permissions model

## This addresses

Adds the "Delete admin" button using the new permission model
