### PR TITLE
Remove prescription drug foreign key

### DIFF
--- a/db/migrate/20201009131102_remove_prescription_drug_foreign_key.rb
+++ b/db/migrate/20201009131102_remove_prescription_drug_foreign_key.rb
@@ -1,0 +1,5 @@
+class RemovePrescriptionDrugForeignKey < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :prescription_drugs, :teleconsultations
+  end
+end

--- a/db/migrate/20201009131854_remove_teleconsultation_foreign_key.rb
+++ b/db/migrate/20201009131854_remove_teleconsultation_foreign_key.rb
@@ -1,0 +1,5 @@
+class RemoveTeleconsultationForeignKey < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :teleconsultations, :patients
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_01_194549) do
+ActiveRecord::Schema.define(version: 2020_10_09_131102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -589,7 +589,6 @@ ActiveRecord::Schema.define(version: 2020_10_01_194549) do
   add_foreign_key "patients", "addresses"
   add_foreign_key "patients", "facilities", column: "assigned_facility_id"
   add_foreign_key "patients", "facilities", column: "registration_facility_id"
-  add_foreign_key "prescription_drugs", "teleconsultations"
   add_foreign_key "protocol_drugs", "protocols"
   add_foreign_key "regions", "region_types"
   add_foreign_key "teleconsultations", "facilities"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_09_131102) do
+ActiveRecord::Schema.define(version: 2020_10_09_131854) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -592,7 +592,6 @@ ActiveRecord::Schema.define(version: 2020_10_09_131102) do
   add_foreign_key "protocol_drugs", "protocols"
   add_foreign_key "regions", "region_types"
   add_foreign_key "teleconsultations", "facilities"
-  add_foreign_key "teleconsultations", "patients"
   add_foreign_key "teleconsultations", "users", column: "medical_officer_id"
   add_foreign_key "teleconsultations", "users", column: "requested_medical_officer_id"
   add_foreign_key "teleconsultations", "users", column: "requester_id"


### PR DESCRIPTION
**Story card:** [ch1548](https://app.clubhouse.io/simpledotorg/story/1548/remove-prescription-drugs-teleconsultation-id-foreign-key-constraint)

## Because

We added a foreign key constraint between:
- prescription drugs and teleconsultations
- teleconsultations and patients

We shouldn't do it because sync resources should be loosely coupled.

## This addresses

This removes the foreign keys.
