### PR TITLE
Rate-limit authentication APIs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ gem "wkhtmltoimage-binary"
 gem "memery"
 gem "bootstrap-select-rails"
 gem "render_async"
+gem "rack-attack"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,6 +310,8 @@ GEM
     puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.3)
+    rack-attack (6.3.1)
+      rack (>= 1.0, < 3)
     rack-mini-profiler (2.0.2)
       rack (>= 1.2.0)
     rack-protection (2.0.8.1)
@@ -612,6 +614,7 @@ DEPENDENCIES
   phonelib
   pry-rails
   puma
+  rack-attack
   rack-mini-profiler
   rails (= 5.2.4.4)
   rails-controller-testing

--- a/config/initializers/rate_limiter.rb
+++ b/config/initializers/rate_limiter.rb
@@ -9,11 +9,15 @@ module RateLimit
 end
 
 class Rack::Attack
-  throttle('throttle_logins', RateLimit.auth_api_options) do |req|
-    req.ip if req.post? && req.path.start_with?("/email_authentications/sign_in")
+  throttle("throttle_logins", RateLimit.auth_api_options) do |req|
+    if req.post? && req.path.start_with?("/email_authentications/sign_in")
+      req.ip
+    end
   end
 
-  throttle('throttle_password_modifications', RateLimit.auth_api_options) do |req|
-    req.ip if req.path.start_with?("/email_authentications/password")
+  throttle("throttle_password_modifications", RateLimit.auth_api_options) do |req|
+    if req.path.start_with?("/email_authentications/password")
+      req.ip
+    end
   end
 end if Rails.env.production?

--- a/config/initializers/rate_limiter.rb
+++ b/config/initializers/rate_limiter.rb
@@ -7,28 +7,26 @@ module RateLimit
   end
 end
 
-if Rails.env.production?
-  class Rack::Attack
-    self.throttled_response = lambda do |_request|
-      [429, {}, ["Too many requests. Please wait and try again later.\n"]]
-    end
+class Rack::Attack
+  self.throttled_response = lambda do |_request|
+    [429, {}, ["Too many requests. Please wait and try again later.\n"]]
+  end
 
-    throttle("throttle_logins", RateLimit.auth_api_options) do |req|
-      if req.post? && req.path.start_with?("/email_authentications/sign_in")
-        req.ip
-      end
+  throttle("throttle_logins", RateLimit.auth_api_options) do |req|
+    if req.post? && req.path.start_with?("/email_authentications/sign_in")
+      req.ip
     end
+  end
 
-    throttle("throttle_password_edit", RateLimit.auth_api_options) do |req|
-      if req.get? && req.path.start_with?("/email_authentications/password/edit")
-        req.ip
-      end
+  throttle("throttle_password_edit", RateLimit.auth_api_options) do |req|
+    if req.get? && req.path.start_with?("/email_authentications/password/edit")
+      req.ip
     end
+  end
 
-    throttle("throttle_password_reset", RateLimit.auth_api_options) do |req|
-      if (req.post? || req.put?) && req.path.start_with?("/email_authentications/password")
-        req.ip
-      end
+  throttle("throttle_password_reset", RateLimit.auth_api_options) do |req|
+    if (req.post? || req.put?) && req.path.start_with?("/email_authentications/password")
+      req.ip
     end
   end
 end

--- a/config/initializers/rate_limiter.rb
+++ b/config/initializers/rate_limiter.rb
@@ -1,0 +1,19 @@
+module RateLimit
+  def self.auth_api_options
+    # 5 requests / minute
+    limit_proc = proc { |_req| 5 }
+    period_proc = proc { |_req| 1.minute }
+
+    {limit: limit_proc, period: period_proc}
+  end
+end
+
+class Rack::Attack
+  throttle('throttle_logins', RateLimit.auth_api_options) do |req|
+    req.ip if req.post? && req.path.start_with?("/email_authentications/sign_in")
+  end
+
+  throttle('throttle_password_modifications', RateLimit.auth_api_options) do |req|
+    req.ip if req.path.start_with?("/email_authentications/password")
+  end
+end if Rails.env.production?

--- a/config/initializers/rate_limiter.rb
+++ b/config/initializers/rate_limiter.rb
@@ -7,26 +7,28 @@ module RateLimit
   end
 end
 
-class Rack::Attack
-  self.throttled_response = lambda do |_request|
-    [429, {}, ["Too many requests. Please wait and try again later.\n"]]
-  end
+if Rails.env.production?
+  class Rack::Attack
+    self.throttled_response = lambda do |_request|
+      [429, {}, ["Too many requests. Please wait and try again later.\n"]]
+    end
 
-  throttle("throttle_logins", RateLimit.auth_api_options) do |req|
-    if req.post? && req.path.start_with?("/email_authentications/sign_in")
-      req.ip
+    throttle("throttle_logins", RateLimit.auth_api_options) do |req|
+      if req.post? && req.path.start_with?("/email_authentications/sign_in")
+        req.ip
+      end
+    end
+
+    throttle("throttle_password_edit", RateLimit.auth_api_options) do |req|
+      if req.get? && req.path.start_with?("/email_authentications/password/edit")
+        req.ip
+      end
+    end
+
+    throttle("throttle_password_reset", RateLimit.auth_api_options) do |req|
+      if (req.post? || req.put?) && req.path.start_with?("/email_authentications/password")
+        req.ip
+      end
     end
   end
-
-  throttle("throttle_password_edit", RateLimit.auth_api_options) do |req|
-    if req.get? && req.path.start_with?("/email_authentications/password/edit")
-      req.ip
-    end
-  end
-
-  throttle("throttle_password_reset", RateLimit.auth_api_options) do |req|
-    if (req.post? || req.put?) && req.path.start_with?("/email_authentications/password")
-      req.ip
-    end
-  end
-end if Rails.env.production?
+end

--- a/spec/initializers/rate_limiter_spec.rb
+++ b/spec/initializers/rate_limiter_spec.rb
@@ -102,7 +102,7 @@ describe "RateLimiter", type: :controller do
 
           it "changes the request status to 429 for a PUT" do
             (limit * 2).times do |i|
-              post "/email_authentications/password"
+              put "/email_authentications/password"
 
               if i > limit
                 expect(last_response.status).to eq(429)

--- a/spec/initializers/rate_limiter_spec.rb
+++ b/spec/initializers/rate_limiter_spec.rb
@@ -8,10 +8,6 @@ describe "RateLimiter", type: :controller do
     Rails.application
   end
 
-  before(:each) do
-    allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
-  end
-
   describe "throttle authentication APIs" do
     context "admin logins by IP address" do
       let(:limit) { 5 }

--- a/spec/initializers/rate_limiter_spec.rb
+++ b/spec/initializers/rate_limiter_spec.rb
@@ -28,7 +28,7 @@ describe "RateLimiter", type: :controller do
       }
 
       before(:each, type: :controller) do
-        @request.remote_addr = '127.0.0.1'
+        @request.remote_addr = "127.0.0.1"
       end
 
       context "number of requests is lower than the limit" do
@@ -70,7 +70,7 @@ describe "RateLimiter", type: :controller do
       }
 
       before(:each, type: :controller) do
-        @request.remote_addr = '127.0.0.1'
+        @request.remote_addr = "127.0.0.1"
       end
 
       context "reset password" do

--- a/spec/initializers/rate_limiter_spec.rb
+++ b/spec/initializers/rate_limiter_spec.rb
@@ -1,0 +1,146 @@
+require "rails_helper"
+
+# Since Rate limiting is a controller middleware concern, we mark this test as a "controller"
+describe "RateLimiter", type: :controller do
+  include Rack::Test::Methods
+
+  def app
+    Rails.application
+  end
+
+  before(:each) do
+    allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+  end
+
+  describe "throttle authentication APIs" do
+    context "admin logins by IP address" do
+      let(:limit) { 5 }
+      let(:email) { "admin@admin" }
+      let(:password) { "admin4815162342" }
+      let(:admin) { create(:admin, email: email, password: password) }
+      let(:login_params) {
+        {
+          email_authentications: {
+            email: email,
+            password: password
+          }
+        }
+      }
+
+      before(:each, type: :controller) do
+        @request.remote_addr = '127.0.0.1'
+      end
+
+      context "number of requests is lower than the limit" do
+        it "does not change the request status" do
+          limit.times do
+            post "/email_authentications/sign_in", login_params
+
+            expect(last_response.status).to_not eq(429)
+          end
+        end
+      end
+
+      context "number of requests is higher than the limit" do
+        it "changes the request status to 429" do
+          (limit * 2).times do |i|
+            post "/email_authentications/sign_in", login_params
+
+            if i > limit
+              expect(last_response.status).to eq(429)
+              expect(last_response.body).to eq("Too many requests. Please wait and try again later.\n")
+            end
+          end
+        end
+      end
+    end
+
+    context "admin password modifications by IP address" do
+      let(:limit) { 5 }
+      let(:email) { "admin@admin" }
+      let(:password) { "admin4815162342" }
+      let(:admin) { create(:admin, email: email, password: password) }
+      let(:login_params) {
+        {
+          email_authentications: {
+            email: email,
+            password: password
+          }
+        }
+      }
+
+      before(:each, type: :controller) do
+        @request.remote_addr = '127.0.0.1'
+      end
+
+      context "reset password" do
+        context "number of requests is lower than the limit" do
+          it "does not change the request status for a POST" do
+            limit.times do
+              post "/email_authentications/password"
+
+              expect(last_response.status).to_not eq(429)
+            end
+          end
+
+          it "does not change the request status for a PUT" do
+            limit.times do
+              put "/email_authentications/password"
+
+              expect(last_response.status).to_not eq(429)
+            end
+          end
+        end
+
+        context "number of requests is higher than the limit" do
+          it "changes the request status to 429 for a POST" do
+            (limit * 2).times do |i|
+              post "/email_authentications/password"
+
+              if i > limit
+                expect(last_response.status).to eq(429)
+                expect(last_response.body).to eq("Too many requests. Please wait and try again later.\n")
+              end
+            end
+          end
+
+          it "changes the request status to 429 for a PUT" do
+            (limit * 2).times do |i|
+              post "/email_authentications/password"
+
+              if i > limit
+                expect(last_response.status).to eq(429)
+                expect(last_response.body).to eq("Too many requests. Please wait and try again later.\n")
+              end
+            end
+          end
+        end
+      end
+
+      context "edit page" do
+        context "number of requests is lower than the limit" do
+          it "does not change the request status" do
+            limit.times do
+              get "/email_authentications/password/edit", reset_password_token: "zzSUazFCxzom5XzmGTNQ"
+
+              expect(last_response.status).to_not eq(429)
+            end
+          end
+        end
+
+        context "number of requests is higher than the limit" do
+          it "changes the request status to 429" do
+            (limit * 2).times do |i|
+              get "/email_authentications/password/edit", reset_password_token: "zzSUazFCxzom5XzmGTNQ"
+
+              if i > limit
+                expect(last_response.status).to eq(429)
+                expect(last_response.body).to eq("Too many requests. Please wait and try again later.\n")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** [ch1564](https://app.clubhouse.io/simpledotorg/story/1564/rate-limit-authentication-related-endpoints)

## Because

None of our endpoints are rate-limited. We can potentially be DDoS'd or brute-force attacked to reset password.

## This addresses

Rate-limit the basic authentication-related endpoints.

- `/email_authentications/sign_in` – Limit logins (POST)
- `/email_authentications/password/edit` – Limit password edits (GET)
- `/email_authentications/password` – Limit actually resetting password (POST / PUT)

## Screenshots

![Screenshot 2020-10-13 at 2 55 52 PM](https://user-images.githubusercontent.com/50663/95842476-33b01300-0d64-11eb-9576-f981419da945.png)