### PR TITLE
Reports: "Visit details..." bug

### DIFF
--- a/app/views/reports/regions/_visit_details_card.html.erb
+++ b/app/views/reports/regions/_visit_details_card.html.erb
@@ -103,7 +103,7 @@
             BP not controlled
           </p>
           <div class="mb-12px d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold <% if @data.last_value(:uncontrolled_patients_rate) %>c-red<% else %>c-grey-medium<% end %> mr-lg-12px" data-uncontrolled-rate="<%= number_to_percentage(@data.last_value(:uncontrolled_patients_rate), precision: 0) %> c-print-black">
+            <p class="mb-0px fs-32px fw-bold <% if @data.last_value(:uncontrolled_patients_rate) %>c-red<% else %>c-grey-medium<% end %> mr-lg-12px c-print-black" data-uncontrolled-rate="<%= number_to_percentage(@data.last_value(:uncontrolled_patients_rate), precision: 0) %>">
               <% if @data.last_value(:uncontrolled_patients_rate) %>
                 <%= number_to_percentage(@data.last_value(:uncontrolled_patients_rate), precision: 0) %>
               <% else %>
@@ -148,7 +148,7 @@
             BP controlled
           </p>
           <div class="mb-12px d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold <% if @data.last_value(:controlled_patients_rate) %>c-green-dark<% else %>c-grey-medium<% end %> mr-lg-12px" data-controlled-rate="<%= number_to_percentage(@data.last_value(:controlled_patients_rate), precision: 0) %> c-print-black">
+            <p class="mb-0px fs-32px fw-bold <% if @data.last_value(:controlled_patients_rate) %>c-green-dark<% else %>c-grey-medium<% end %> mr-lg-12px c-print-black" data-controlled-rate="<%= number_to_percentage(@data.last_value(:controlled_patients_rate), precision: 0) %>">
               <% if @data.last_value(:controlled_patients_rate) %>
                 <%= number_to_percentage(@data.last_value(:controlled_patients_rate), precision: 0) %>
               <% else %>


### PR DESCRIPTION
**Story card:** [ch1568](https://app.clubhouse.io/simpledotorg/story/1568/visit-details-rates-are-showing-css-values)

## Because

CSS values from the print-friendly PR are showing in the rate fields for BP control and BP not controlled
<img width="1133" alt="image" src="https://user-images.githubusercontent.com/16785131/95753999-67117580-0c70-11eb-8b29-251a8a4534f7.png">

## This addresses

* Moved `c-print-black` into the `class` attribute
