### PR TITLE
Disable the TaggedLogging patch on review apps (ie Heroku)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,6 @@ module SimpleServer
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    # Don't generate system test files.
     config.generators do |g|
       g.system_tests false
       g.helper false

--- a/config/initializers/tagged_logging_patch.rb
+++ b/config/initializers/tagged_logging_patch.rb
@@ -1,11 +1,13 @@
 # Patch TaggedLogging for compatibility with JSON logging
 # See https://github.com/tilfin/ougai/wiki/Use-as-Rails-logger for details
 
-module ActiveSupport::TaggedLogging::Formatter
-  def call(severity, time, progname, data)
-    data = {msg: data.to_s} unless data.is_a?(Hash)
-    tags = current_tags
-    data[:tags] = tags if tags.present?
-    _call(severity, time, progname, data)
+unless SIMPLE_SERVER_ENV == "review"
+  module ActiveSupport::TaggedLogging::Formatter
+    def call(severity, time, progname, data)
+      data = {msg: data.to_s} unless data.is_a?(Hash)
+      tags = current_tags
+      data[:tags] = tags if tags.present?
+      _call(severity, time, progname, data)
+    end
   end
 end


### PR DESCRIPTION
**Story card:** [ch1579](https://app.clubhouse.io/simpledotorg/story/1579/review-apps-are-breaking)

It appears the tagged logging patch for datadog + tagged logging is breaking Heroku review apps.

Trying to disable that patch to get things back up and running.

