### PR TITLE
Auto approve users on review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -63,6 +63,9 @@
     "EMAIL_SUBJECT_PREFIX": {
       "value": "[REVIEW]"
     },
+    "ENABLE_AUTO_APPROVE_USER_FOR_QA=true" : {
+      "value": "true"
+    },
     "ENABLE_CACHED_QUERIES_FOR_DASHBOARD": {
       "value": "true"
     },

--- a/app.json
+++ b/app.json
@@ -78,6 +78,9 @@
     "ENABLE_EXOTEL_WHITELIST_API": {
       "value": "false"
     },
+    "ENABLE_FIXED_OTP_ON_REQUEST_FOR_QA" : {
+      "value": "true"
+    },
     "ENABLE_GENERATE_ENCOUNTER_ID_ENDPOINT": {
       "value": "true"
     },

--- a/app.json
+++ b/app.json
@@ -63,7 +63,7 @@
     "EMAIL_SUBJECT_PREFIX": {
       "value": "[REVIEW]"
     },
-    "ENABLE_AUTO_APPROVE_USER_FOR_QA=true" : {
+    "ENABLE_AUTO_APPROVE_USER_FOR_QA" : {
       "value": "true"
     },
     "ENABLE_CACHED_QUERIES_FOR_DASHBOARD": {


### PR DESCRIPTION
**Story card:** -

## Because

We want to auto approve users on the review apps for the app's sync test suite.

## This addresses

Enables `AUTO_APPROVE_USER_FOR_QA` on review apps.
