### PR TITLE
Use the new cohort_patients key instead of registered

### DIFF
--- a/app/views/reports/regions/cohort.csv.erb
+++ b/app/views/reports/regions/cohort.csv.erb
@@ -16,7 +16,7 @@
 <% @cohort_analytics.each_with_index do |(report_dates, analytics), index| %>
   <%
     cohort_start, report_start = report_dates
-    registered = analytics.dig(:registered, :total) || 0
+    registered = analytics.dig(:cohort_patients, :total) || 0
     followed_up = analytics.dig(:followed_up, :total) || 0
     defaulted = analytics.dig(:defaulted, :total) || 0
     controlled = analytics.dig(:controlled, :total) || 0

--- a/app/views/reports/regions/facility_group_cohort.csv.erb
+++ b/app/views/reports/regions/facility_group_cohort.csv.erb
@@ -20,7 +20,7 @@ end) %>
 <% @facility_keys.each do |facility| %>
 <% csv << [facility[:name], facility[:type]].concat(@cohort_analytics.each_with_index.flat_map do |(report_dates, analytics), index|
   cohort_start, report_start = report_dates
-  registered = analytics.dig(:registered, facility[:id]) || 0
+  registered = analytics.dig(:cohort_patients, facility[:id]) || 0
   followed_up = analytics.dig(:followed_up, facility[:id]) || 0
   defaulted = analytics.dig(:defaulted, facility[:id]) || 0
   controlled = analytics.dig(:controlled, facility[:id]) || 0

--- a/app/views/shared/graphics/_graphics_control_rate_card.html.erb
+++ b/app/views/shared/graphics/_graphics_control_rate_card.html.erb
@@ -3,7 +3,7 @@
     <%= t('dashboard.graphics.graphics_title_html',
           current_quarter_string: quarter_string(date),
           previous_quarter_string: quarter_string(date.prev_quarter),
-          patients_in_previous_quarter: current_cohort_analytics.dig(:registered, :total) || current_cohort_analytics[:registered]
+          patients_in_previous_quarter: current_cohort_analytics.dig(:cohort_patients, :total) || current_cohort_analytics[:registered]
         ) %>
   </div>
 


### PR DESCRIPTION
**Story card:** [ch1600](https://app.clubhouse.io/simpledotorg/story/1600/fix-patients-column-in-cohort-downloads)

## Because

Some downloads were trying to use an older version of the cohort query results

## This addresses

Updating download touchpoints to use the correct cohort query results:
* Monthly cohort reports
* Quarterly cohort reports
* Whatsapp graphics (web and downloadable)

These touchpoints are using the `CohortAnalyticsQuery`. I think we should decommission that thing in favor of the `CohortService`. What do you think? 
