### PR TITLE
Make Block a required field

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -64,6 +64,7 @@ class Facility < ApplicationRecord
 
   auto_strip_attributes :name, squish: true, upcase_first: true
   auto_strip_attributes :district, squish: true, upcase_first: true
+  auto_strip_attributes :zone, squish: true, titleize: true
 
   with_options if: :import do |facility|
     facility.validates :organization_name, presence: true

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -81,6 +81,7 @@ class Facility < ApplicationRecord
   validates :district, presence: true
   validates :state, presence: true
   validates :country, presence: true
+  validates :zone, presence: true
   validates :pin, numericality: true, allow_blank: true
 
   validates :facility_size, inclusion: {in: facility_sizes.values,
@@ -137,7 +138,7 @@ class Facility < ApplicationRecord
      facility_type: "facility_type",
      street_address: "street_address (optional)",
      village_or_colony: "village_or_colony (optional)",
-     zone: "zone_or_block (optional)",
+     zone: "zone_or_block",
      district: "district",
      state: "state",
      country: "country",
@@ -153,7 +154,7 @@ class Facility < ApplicationRecord
      facility_type: "facility_type",
      street_address: "street_address (optional)",
      village_or_colony: "village_or_colony (optional)",
-     zone: "zone_or_block (optional)",
+     zone: "zone_or_block",
      district: "district",
      state: "state",
      country: "country",

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -64,7 +64,7 @@ class Facility < ApplicationRecord
 
   auto_strip_attributes :name, squish: true, upcase_first: true
   auto_strip_attributes :district, squish: true, upcase_first: true
-  auto_strip_attributes :zone, squish: true, titleize: true
+  auto_strip_attributes :zone, squish: true, upcase_first: true
 
   with_options if: :import do |facility|
     facility.validates :organization_name, presence: true

--- a/app/views/admin/facilities/_form.html.erb
+++ b/app/views/admin/facilities/_form.html.erb
@@ -12,7 +12,7 @@
       <h3 class="mt-5">Address</h3>
       <%= form.text_field :street_address, id: :facility_street_address %>
       <%= form.text_field :village_or_colony, id: :facility_village_or_colony %>
-      <%= form.text_field :zone, id: :facility_zone %>
+      <%= form.text_field :zone, id: :facility_zone, required: true %>
       <%= form.text_field :district, id: :facility_district, required: true %>
       <%= form.text_field :state, id: :facility_state, required: true %>
       <%= form.text_field :country, id: :facility_country, required: true %>

--- a/config/initializers/auto_strip_attributes.rb
+++ b/config/initializers/auto_strip_attributes.rb
@@ -2,8 +2,4 @@ AutoStripAttributes::Config.setup do
   set_filter(upcase_first: false) do |value|
     !value.blank? && value.respond_to?(:upcase_first) ? value.upcase_first : value
   end
-
-  set_filter(titleize: false) do |value|
-    !value.blank? && value.respond_to?(:titleize) ? value.titleize : value
-  end
 end

--- a/config/initializers/auto_strip_attributes.rb
+++ b/config/initializers/auto_strip_attributes.rb
@@ -2,4 +2,8 @@ AutoStripAttributes::Config.setup do
   set_filter(upcase_first: false) do |value|
     !value.blank? && value.respond_to?(:upcase_first) ? value.upcase_first : value
   end
+
+  set_filter(titleize: false) do |value|
+    !value.blank? && value.respond_to?(:titleize) ? value.titleize : value
+  end
 end

--- a/config/locales/en_BD.yml
+++ b/config/locales/en_BD.yml
@@ -7,7 +7,7 @@ en_BD:
         size: "Size *"
         street_address: "House and road number"
         village_or_colony: "Village or ward"
-        zone: "Union"
+        zone: "Union *"
         district: "Upazila *"
         state: "District *"
         country: "Country *"

--- a/config/locales/en_ET.yml
+++ b/config/locales/en_ET.yml
@@ -7,7 +7,7 @@ en_ET:
         size: "Size *"
         street_address: "House and road number"
         village_or_colony: "Kebele"
-        zone: "Zone"
+        zone: "Zone *"
         district: "Woreda *"
         state: "Region *"
         country: "Country *"

--- a/config/locales/en_IN.yml
+++ b/config/locales/en_IN.yml
@@ -7,7 +7,7 @@ en_IN:
         size: "Size *"
         street_address: "House number and street"
         village_or_colony: "Colony, village or ward"
-        zone: "Block"
+        zone: "Block *"
         district: "District *"
         state: "State *"
         country: "Country *"

--- a/spec/fixtures/files/upload_facilities_invalid_test.csv
+++ b/spec/fixtures/files/upload_facilities_invalid_test.csv
@@ -1,2 +1,2 @@
-organization,facility_group,facility_name,facility_type,street_address (optional),village_or_colony (optional),zone_or_block (optional),district,state,country,pin (optional),latitude (optional),longitude (optional),size (optional),enable_diabetes_management (true/false)
+organization,facility_group,facility_name,facility_type,street_address (optional),village_or_colony (optional),zone_or_block,district,state,country,pin (optional),latitude (optional),longitude (optional),size (optional),enable_diabetes_management (true/false)
 OrgOne,FGOne,Test Facility,CHC,,,,Bhatinda,Punjab,India,,,,,false

--- a/spec/fixtures/files/upload_facilities_test.csv
+++ b/spec/fixtures/files/upload_facilities_test.csv
@@ -1,3 +1,3 @@
-organization,facility_group,facility_name,facility_type,street_address (optional),village_or_colony (optional),zone_or_block (optional),district,state,country,pin (optional),latitude (optional),longitude (optional),size (optional),enable_diabetes_management (true/false)
-OrgOne,FGTwo,Test Facility,CHC,,,,Bhatinda,Punjab,India,,,,,true
-OrgOne,FGTwo,Test Facility 2,CHC,,,,Bhatinda,Punjab,India,,,,,
+organization,facility_group,facility_name,facility_type,street_address (optional),village_or_colony (optional),zone_or_block,district,state,country,pin (optional),latitude (optional),longitude (optional),size (optional),enable_diabetes_management (true/false)
+OrgOne,FGTwo,Test Facility,CHC,,,Zone 1,Bhatinda,Punjab,India,,,,,true
+OrgOne,FGTwo,Test Facility 2,CHC,,,Zone 2,Bhatinda,Punjab,India,,,,,

--- a/spec/validators/admin/csv/facility_validator_spec.rb
+++ b/spec/validators/admin/csv/facility_validator_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Admin::CSV::FacilityValidator do
        district: "district",
        state: "state",
        country: "country",
+       zone: "zone",
        import: true}
     end
 


### PR DESCRIPTION
**Story card:** [ch1343](https://app.clubhouse.io/simpledotorg/story/1343/clean-up-existing-facility-block-zone-data)

## Because

We are soon going to be cleaning up all our block data to be first-class models. But in the meanwhile, let's at least disallow people from leaving empty blocks because they are harder to clean-up later.

## This addresses

Makes the block (or zone) field mandatory in upload / UI.
