### PR TITLE
Edit Admin spacing fix

### DIFF
--- a/app/assets/stylesheets/partials/admin/_access_tree.scss
+++ b/app/assets/stylesheets/partials/admin/_access_tree.scss
@@ -9,6 +9,7 @@
 #facility-access-power-user {
   background: #d0e3f9;
   padding: 0.375rem 0.75rem;
+  margin-bottom: 12px;
   border-radius: 4px;
   font-weight: normal;
 


### PR DESCRIPTION
**Story card:** [ch1588](https://app.clubhouse.io/simpledotorg/story/1588/add-space-below-facility-access-and-delete-button)

## Because

There is no space between Power User banner and "Delete Button"

## This addresses

**Added bottom margin to Power user banner**

<img width="748" alt="image" src="https://user-images.githubusercontent.com/16785131/96272396-0b125e00-0f9c-11eb-9bf9-2ab1227a3812.png">
