### PR TITLE
Ranked facility fixes

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -228,11 +228,11 @@ class Facility < ApplicationRecord
 
   def opd_load_for_facility_size
     case facility_size
-    when "community" then 100
-    when "small" then 300
-    when "medium" then 500
-    when "large" then 1000
-    else 1000
+    when "community" then 450
+    when "small" then 1800
+    when "medium" then 3000
+    when "large" then 7500
+    else 450
     end
   end
 

--- a/app/models/reports/performance_score.rb
+++ b/app/models/reports/performance_score.rb
@@ -39,7 +39,7 @@ module Reports
         return registrations > 0 ? 100 : 0
       end
 
-      (registrations / target_registrations) * 100
+      [100, (registrations / target_registrations) * 100].min
     end
 
     def target_registrations

--- a/app/views/my_facilities/ranked_facilities/show.html.erb
+++ b/app/views/my_facilities/ranked_facilities/show.html.erb
@@ -17,6 +17,7 @@
         <colgroup>
           <col>
           <col>
+          <col>
           <col class="table-divider">
           <col>
           <col class="table-divider">
@@ -30,6 +31,7 @@
           <tr>
             <th></th>
             <th></th>
+            <th></th>
             <th colspan="2">BP controlled<sup>1</sup></th>
             <th colspan="2">Missed visits<sup>2</sup></th>
             <th colspan="2">Registrations</th>
@@ -37,7 +39,8 @@
             <th class="mobile">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</th>
           </tr>
           <tr data-sort-method="thead" class="sorts">
-            <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="score" data-sort-default>Rank</th>
+            <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="rank" data-sort-default>Rank</th>
+            <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="score">Score</th>
             <th class="row-label sort-label">Facilities</th>
             <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="controlled_patients_rate" colspan="2">
               Patients with BP<br>&lt;140/90 in <%= @period %>
@@ -54,10 +57,11 @@
         <tbody>
           <% @facilities.each_with_index do |facility, rank| %>
             <tr>
-              <td class="type-rank" data-sort-column-key="score" data-toggle="tooltip"
-                  title="Overall score: <%= number_with_precision(@scores_for_facility[facility.name].overall_score, precision: 2) %>"
-              >
+              <td class="type-rank" data-sort-column-key="rank">
                 <%= rank + 1 %>
+              </td>
+              <td class="type-rank" data-sort-column-key="score" data-toggle="tooltip">
+                <%= number_with_precision(@scores_for_facility[facility.name].overall_score, precision: 2) %>
               </td>
               <td class="type-title">
                 <%= link_to(reports_region_path(facility, report_scope: "facility"))do %>

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -324,16 +324,16 @@ RSpec.describe Facility, type: :model do
       facility.monthly_estimated_opd_load = nil
 
       facility.facility_size = "community"
-      expect(facility.opd_load).to eq(100)
+      expect(facility.opd_load).to eq(450)
 
       facility.facility_size = "small"
-      expect(facility.opd_load).to eq(300)
+      expect(facility.opd_load).to eq(1800)
 
       facility.facility_size = "medium"
-      expect(facility.opd_load).to eq(500)
+      expect(facility.opd_load).to eq(3000)
 
       facility.facility_size = "large"
-      expect(facility.opd_load).to eq(1000)
+      expect(facility.opd_load).to eq(7500)
     end
   end
 

--- a/spec/models/reports/performance_score_spec.rb
+++ b/spec/models/reports/performance_score_spec.rb
@@ -102,6 +102,12 @@ describe Reports::PerformanceScore, type: :model do
       @opd_load = 0
       expect(perf_score.registrations_rate).to eq(0)
     end
+
+    it "maxes at 100 if registrations exceeds target" do
+      @registrations = 500
+      @opd_load = 100
+      expect(perf_score.registrations_rate).to eq(100)
+    end
   end
 
   describe "#target_registrations" do


### PR DESCRIPTION
**Story card:** [ch1648](https://app.clubhouse.io/simpledotorg/story/1648/add-score-and-fix-registration-rate-bugs)

## Because

Registration rate should never exceed 100%. Also, we should show the score and fix OPD estimates.

## This addresses

- Show a `Score` column
- Max out registration rate at 100%
- Improve OPD estimates:
   - Community = 450/month
   - Small = 1800
   - Medium = 3000
   - Large = 7500
