### PR TITLE
Fix some broken Patient Line List things

### DIFF
--- a/app/controllers/reports/patient_lists_controller.rb
+++ b/app/controllers/reports/patient_lists_controller.rb
@@ -22,7 +22,12 @@ class Reports::PatientListsController < AdminController
       {facility_id: @region.id}
     end
 
-    PatientListDownloadJob.perform_later(recipient_email, region_class, download_params)
+    PatientListDownloadJob.perform_later(
+      recipient_email,
+      region_class,
+      download_params,
+      with_medication_history: params[:medication_history] ? true : false
+    )
     redirect_back(
       fallback_location: reports_region_path(@region, report_scope: params[:report_scope]),
       notice: I18n.t("patient_list_email.notice",
@@ -34,7 +39,7 @@ class Reports::PatientListsController < AdminController
   private
 
   def filtered_params
-    params.permit(:id, :report_scope)
+    params.permit(:id, :report_scope, :medication_history)
   end
 
   def region_class

--- a/app/controllers/reports/patient_lists_controller.rb
+++ b/app/controllers/reports/patient_lists_controller.rb
@@ -26,7 +26,7 @@ class Reports::PatientListsController < AdminController
       recipient_email,
       region_class,
       download_params,
-      with_medication_history: params[:medication_history] ? true : false
+      with_medication_history: with_medication_history?
     )
     redirect_back(
       fallback_location: reports_region_path(@region, report_scope: params[:report_scope]),
@@ -37,6 +37,10 @@ class Reports::PatientListsController < AdminController
   end
 
   private
+
+  def with_medication_history?
+    params[:medication_history] == "true"
+  end
 
   def filtered_params
     params.permit(:id, :report_scope, :medication_history)

--- a/app/views/patient_list_download_mailer/patient_list.html.erb
+++ b/app/views/patient_list_download_mailer/patient_list.html.erb
@@ -2,7 +2,7 @@
 
 <div>&nbsp;</div>
 
-<div style="font-size:110%;"><%= t("patient_list_email.requested", model_type: @model_type, model_name: @model_name) %></div>
+<div style="font-size:110%;"><%= t("patient_list_email.requested", model_type: @model_type.titleize, model_name: @model_name) %></div>
 
 <div>&nbsp;</div>
 

--- a/spec/controllers/reports/patient_lists_controller_spec.rb
+++ b/spec/controllers/reports/patient_lists_controller_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Reports::PatientListsController, type: :controller do
       expect(PatientListDownloadJob).to receive(:perform_later).with(
         admin_with_pii.email,
         "facility_group",
-        {id: facility_group.id}
+        {id: facility_group.id},
+        with_medication_history: false
       )
       admin_with_pii.accesses.create!(resource: facility_group)
       sign_in(admin_with_pii.email_authentication)

--- a/spec/controllers/reports/patient_lists_controller_spec.rb
+++ b/spec/controllers/reports/patient_lists_controller_spec.rb
@@ -21,8 +21,11 @@ RSpec.describe Reports::PatientListsController, type: :controller do
 
   context "show" do
     it "works for facility groups the admin has access to" do
-      expect(PatientListDownloadJob).to receive(:perform_later).with(admin_with_pii.email,
-        "facility_group", {id: facility_group.id})
+      expect(PatientListDownloadJob).to receive(:perform_later).with(
+        admin_with_pii.email,
+        "facility_group",
+        {id: facility_group.id}
+      )
       admin_with_pii.accesses.create!(resource: facility_group)
       sign_in(admin_with_pii.email_authentication)
       get :show, params: {id: facility_group.slug, report_scope: "district"}
@@ -45,6 +48,18 @@ RSpec.describe Reports::PatientListsController, type: :controller do
       expect {
         get :show, params: {id: facility_group_2.slug, report_scope: "district"}
       }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "should queue line list with medication history if medication_history is true" do
+      expect(PatientListDownloadJob).to receive(:perform_later).with(
+        admin_with_pii.email,
+        "facility_group",
+        {id: facility_group.id},
+        with_medication_history: true
+      )
+      admin_with_pii.accesses.create!(resource: facility_group)
+      sign_in(admin_with_pii.email_authentication)
+      get :show, params: {id: facility_group.slug, report_scope: "district", medication_history: true}
     end
   end
 end


### PR DESCRIPTION
**Story card:** [ch1698](https://app.clubhouse.io/simpledotorg/story/1698/patient-line-list-w-med-history-doesn-t-download-the-right-file)

## Because

- Downloading the Patient Line List with Medical History downloads the wrong Line List.
- The title for the model type on the email template for downloading PLL is awkwardly formatted

## This addresses

Fixes the two bugs.
