### PR TITLE
Fix broken downloads in Mobile-view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -242,7 +242,7 @@ footer {
   .container {
     margin-bottom: 36px;
     white-space: nowrap;
-    overflow-x: scroll;
+    overflow-x: auto;
   }
 }
 

--- a/app/views/layouts/overdue.html.erb
+++ b/app/views/layouts/overdue.html.erb
@@ -15,7 +15,7 @@
       </a>
     </div>
 
-    <section class="mt-5">
+    <section class="mb-4">
       <% if current_facility %>
         <% if @patient_summaries.present? && current_admin.accessible_facilities(:manage_overdue_list).include?(current_facility) %>
           <h4>Download</h4>
@@ -58,6 +58,7 @@
               </div>
             </div>
           </div>
+
           <div class="modal-footer">
             <a href="?" type="button" class="btn btn-secondary">Clear all</a>
             <button type="submit" form="search-filters-mobile" class="btn btn-primary">DONE</button>
@@ -113,4 +114,5 @@
     </div>
   </div>
 <% end %>
+
 <%= render template: "layouts/application" %>

--- a/app/views/layouts/overdue.html.erb
+++ b/app/views/layouts/overdue.html.erb
@@ -14,6 +14,21 @@
         <i class="fas fa-filter"></i> Search filters
       </a>
     </div>
+
+    <section class="mt-5">
+      <% if current_facility %>
+        <% if @patient_summaries.present? && current_admin.accessible_facilities(:manage_overdue_list).include?(current_facility) %>
+          <h4>Download</h4>
+          <%= link_to(@index_params.merge(format: "csv"), class: "", data: { confirm: I18n.t('admin.phi_download_alert') }) do %>
+            Download Results
+          <% end %>
+        <% end %>
+      <% else %>
+        <h4>Download</h4>
+        <em>Select a facility to download patients list</em>
+      <% end %>
+    </section>
+
     <!-- Filter Modal -->
     <div class="modal fade" id="filter-modal" tabindex="-1" role="dialog" aria-labelledby="filter-modal" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered" role="document">

--- a/app/views/reports/regions/_downloads.html.erb
+++ b/app/views/reports/regions/_downloads.html.erb
@@ -1,4 +1,4 @@
-<div class="dropdown show show mb-24px bs-small mb-lg-0">
+<div class="dropdown show mb-24px bs-small mb-lg-0">
   <a class="btn btn-sm dropdown-toggle c-black bg-white" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <i class="fa fa-arrow-circle-down w-16px ta-center mr-4px c-grey-medium"></i>
     Downloads

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -41,10 +41,7 @@
       </p>
     </div>
     <div class="d-flex actions order-1 mb-24px order-lg-2 mb-lg-0">
-      <div class="d-none d-lg-block order-lg-2 ml-lg-8px">
-        <%= render "downloads" %>
-      </div>
-      <div class="dropdown show w-100pt mb-24px mb-lg-0 w-lg-auto">
+      <div class="dropdown show mb-24px mb-lg-0 w-lg-auto">
         <a
           class="d-block d-lg-inline-block btn btn-sm dropdown-toggle c-black bg-white bs-small"
           href="#"
@@ -94,6 +91,9 @@
             <% end %>
           </div>
         <% end %>
+      </div>
+      <div class="ml-8px">
+        <%= render "downloads" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
**Story card:** [ch1728](https://app.clubhouse.io/simpledotorg/story/1728/downloads-reports-overdue-don-t-work-on-mobile-view)

Fixes broken downloads on mobile-view:

* Reports

![Screenshot 2020-10-27 at 12 52 31 PM](https://user-images.githubusercontent.com/50663/97269287-4a219880-1853-11eb-97d1-822464c47c7f.png)

![Screenshot 2020-10-27 at 12 52 28 PM](https://user-images.githubusercontent.com/50663/97269349-66bdd080-1853-11eb-876c-1edf44032b34.png)

* Overdue

![Screenshot 2020-10-27 at 12 48 48 PM](https://user-images.githubusercontent.com/50663/97268981-c49de880-1852-11eb-955f-ecefda96478c.png)

![Screenshot 2020-10-27 at 12 49 06 PM](https://user-images.githubusercontent.com/50663/97269001-ce275080-1852-11eb-9d66-381b5ab85f5d.png)

* Misc: remove empty scrollbar showing up on Chrome

![image](https://user-images.githubusercontent.com/16774200/97269107-fa42d180-1852-11eb-9355-df0262bd7f32.png)