### PR TITLE
Fix typo in Datadog config

### DIFF
--- a/config/initializers/00_datadog.rb
+++ b/config/initializers/00_datadog.rb
@@ -10,7 +10,7 @@ Datadog.configure do |c|
   c.tracer.enabled = SEND_DATA_TO_DD_AGENT
   c.version = SimpleServer.git_ref(short: true)
   c.use :rails, analytics_enabled: true
-  c.use :rack, headers: {request: ["X-USER-ID", "X-FACILITY-ID", "X-SYNC-GROUP-ID"], response: ["Content-Type", "X-Request-ID"]}
+  c.use :rack, headers: {request: ["X-USER-ID", "X-FACILITY-ID", "X-SYNC-REGION-ID"], response: ["Content-Type", "X-Request-ID"]}
 end
 
 require "statsd"


### PR DESCRIPTION
**Story card:** -

## Because

The sync region header [added to Datadog logs](https://github.com/simpledotorg/simple-server/pull/1465/files) is called called `SYNC-REGION-ID` and not `SYNC-GROUP-ID`.

## This addresses

Fixes the typo.