### PR TITLE
BUG: Remove Reports early access banner

### DIFF
--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -1,12 +1,3 @@
-<div class="alert alert-primary">
-  <span class="fw-bold">Early access:</span> Thanks for your patience as we improve this page. The following features are coming soon:
-  <ul class="mt-4px mb-0px pl-16px">
-    <li>More detailed cohorts</li>
-    <li>Top district and facility benchmarks</li>
-    <li>Lost to follow-up rate</li>
-    <li>State and block level reports</li>
-  </ul>
-</div>
 <div class="dashboard">
   <nav class="breadcrumb mb-0px">
     <%= link_to 'All reports', dashboard_districts_path %>

--- a/app/views/reports/regions/index.html.erb
+++ b/app/views/reports/regions/index.html.erb
@@ -1,13 +1,3 @@
-<div class="alert alert-primary">
-  <span class="fw-bold">Early access:</span> Thanks for your patience as we improve this page. The following features are coming soon:
-  <ul class="mt-4px mb-0px pl-16px">
-    <li>More detailed cohorts</li>
-    <li>Top district and facility benchmarks</li>
-    <li>Lost to follow-up rate</li>
-    <li>Facility comparison tables</li>
-    <li>State and block level reports</li>
-  </ul>
-</div>
 <div class="container">
   <div class="row">
     <div class="col-sm-5 col-lg-7">


### PR DESCRIPTION
**Story card:** [ch1736](https://app.clubhouse.io/simpledotorg/story/1736/dashboard-reports-remove-blue-early-access-banner)

## Because

**Reports index page shouldn't display an early access banner**

![image](https://user-images.githubusercontent.com/16785131/97308599-6d3e4f00-1837-11eb-88bb-ec5672ea2f70.png)

**Reports detail pages shouldn't display an early access banner**

![image](https://user-images.githubusercontent.com/16785131/97308633-762f2080-1837-11eb-813c-8b43a87e6c78.png)

## This addresses

**Removes early access banner from Reports index page**

![image](https://user-images.githubusercontent.com/16785131/97308392-3405df00-1837-11eb-9a78-04087f6d29f1.png)

![image](https://user-images.githubusercontent.com/16785131/97308345-27818680-1837-11eb-8ada-a3520579f117.png)

**Removes early access banner from Reports detail pages**

![image](https://user-images.githubusercontent.com/16785131/97308442-3ff1a100-1837-11eb-9f13-6c6513d9ec08.png)

![image](https://user-images.githubusercontent.com/16785131/97308482-4aac3600-1837-11eb-8293-5cc7343c227c.png)
