### PR TITLE
BUG: Fix Dashboard icon styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -375,7 +375,7 @@ h6.dropdown-header {
     font-size: 75%;
 }
 
-.dropdown i {
+.main-menu-icon {
     min-width: 3em;
     text-align: center;
     color: $blue;

--- a/app/views/shared/_nav_bar.html.erb
+++ b/app/views/shared/_nav_bar.html.erb
@@ -41,36 +41,36 @@
                 Settings
               </h6>
               <%= link_to (admin_facilities_path), class: "dropdown-item #{active_controller?("admin/facilities")}" do %>
-                <i class="fas fa-hospital"></i> Facilities
+                <i class="fas fa-hospital main-menu-icon"></i> Facilities
               <% end %>
               <% if current_admin.accessible_organizations(:manage).any? || current_admin.power_user? %>
                 <%= link_to (admin_organizations_path), class: "dropdown-item #{active_controller?("admin/organizations")}", id: "nav-organizations-link" do %>
-                  <i class="fas fa-network-wired"></i> Organizations
+                  <i class="fas fa-network-wired main-menu-icon"></i> Organizations
                 <% end %>
               <% end %>
               <% if current_admin.accessible_organizations(:manage).any? || current_admin.power_user? %>
                 <%= link_to (admin_protocols_path), class: "dropdown-item #{active_controller?("admin/protocols")}" do %>
-                  <i class="fas fa-prescription-bottle-alt"></i> Protocol medications
+                  <i class="fas fa-prescription-bottle-alt main-menu-icon"></i> Protocol medications
                 <% end %>
               <% end %>
               <% if current_admin.accessible_facilities(:manage).any? || current_admin.power_user? %>
                 <%= link_to (admins_path), class: "dropdown-item #{active_controller?("admins")}" do %>
-                  <i class="fas fa-user-friends"></i> Dashboard admins
+                  <i class="fas fa-user-friends main-menu-icon"></i> Dashboard admins
                 <% end %>
               <% end %>
               <% if current_admin.accessible_users(:manage).any? || current_admin.power_user? %>
                 <%= link_to (admin_users_path), class: "dropdown-item #{active_controller?("admin/users")}", id: "mobile-app-users" do %>
-                  <i class="fas fa-user-md"></i> Mobile app users
+                  <i class="fas fa-user-md main-menu-icon"></i> Mobile app users
                 <% end %> 
               <% end %>
               <% if current_admin.power_user? %>
                 <%= link_to ("/sidekiq"), class: "dropdown-item #{active_controller?("sidekiq")}" do %>
-                  <i class="fas fa-running"></i> Sidekiq
+                  <i class="fas fa-running main-menu-icon"></i> Sidekiq
                 <% end %>
               <% end %>
               <% if current_admin.power_user? %>
                 <%= link_to ("/flipper"), class: "dropdown-item #{active_controller?("flipper")}" do %>
-                  <i class="fas fa-pennant"></i> Flipper
+                  <i class="fas fa-flag main-menu-icon"></i> Flipper
                 <% end %> 
               <% end %>
             <% end %>
@@ -79,27 +79,27 @@
                 Resources
               </h6>
               <%= link_to (resources_path), class: "dropdown-item #{active_controller?("resources")}" do %>
-                <i class="fas fa-chalkboard-teacher"></i> Training materials
+                <i class="fas fa-chalkboard-teacher main-menu-icon"></i> Training materials
               <% end %>
               <div class="dropdown-divider"></div>
               <h6 class="dropdown-header">
                 Legal
               </h6>
               <a href="https://www.simple.org/privacy/" class="dropdown-item" target="_blank">
-                <i class="fas fa-external-link-alt"></i> Privacy Policy
+                <i class="fas fa-external-link-alt main-menu-icon"></i> Privacy Policy
               </a>
               <a href="https://www.simple.org/license/" class="dropdown-item" target="_blank">
-                <i class="fas fa-external-link-alt"></i> License
+                <i class="fas fa-external-link-alt main-menu-icon"></i> License
               </a>
               <div class="dropdown-divider"></div>
               <h6 class="dropdown-header">
                 Account
               </h6>
               <span class="dropdown-item disabled">
-                <i class="fas fa-user-circle"></i> <%= current_admin.email %>
+                <i class="fas fa-user-circle main-menu-icon"></i> <%= current_admin.email %>
               </span>
               <%= link_to(destroy_email_authentication_session_path, method: :delete, class: "dropdown-item", id: "nav-more-logout") do %>
-                <i class="fas fa-door-open"></i> Logout
+                <i class="fas fa-door-open main-menu-icon"></i> Logout
               <% end %>
           </div>
 				</li>


### PR DESCRIPTION
**Story card:** [ch1737](https://app.clubhouse.io/simpledotorg/story/1737/dashboard-reports-fix-dashboard-icon-styling)

## Because

**The main nav menu icon styling is incorrectly used by all dropdown icons**

![image](https://user-images.githubusercontent.com/16785131/97310478-a7a8eb80-1839-11eb-9ee7-421e91346f4b.png)

![image](https://user-images.githubusercontent.com/16785131/97310513-b0012680-1839-11eb-88e2-cee181a494b9.png)

## This addresses

**Isolates mobile nav menu icon styling**

![image](https://user-images.githubusercontent.com/16785131/97310306-716b6c00-1839-11eb-8847-f995eea5d42b.png)

**Dashboard dropdown styles are respected**

![image](https://user-images.githubusercontent.com/16785131/97310445-9f50b080-1839-11eb-8e21-e7a539102d86.png)
