### PR TITLE
Reports bugfix: Make sure we don't return more data than report window

### DIFF
--- a/app/models/reports/result.rb
+++ b/app/models/reports/result.rb
@@ -127,7 +127,7 @@ module Reports
       }
     end
 
-    # "Missed visits" is the remaining registerd patients when we subtract out the other three groups.
+    # "Missed visits" is the remaining registered patients when we subtract out the other three groups.
     def calculate_missed_visits(range)
       self.missed_visits = range.each_with_object(Hash.new(0)) { |(period, visit_count), hsh|
         registrations = adjusted_registrations_for(period)

--- a/app/services/reports/region_service.rb
+++ b/app/services/reports/region_service.rb
@@ -26,7 +26,7 @@ module Reports
       result.visited_without_bp_taken = NoBPMeasureService.new(region, periods: range).call
       result.calculate_percentages(:visited_without_bp_taken)
 
-      start_period = result.earliest_registration_period || range.begin
+      start_period = [result.earliest_registration_period || range.begin].max
       calc_range = (start_period..range.end)
       result.calculate_missed_visits(calc_range)
       result.calculate_missed_visits_percentages(calc_range)

--- a/app/services/reports/region_service.rb
+++ b/app/services/reports/region_service.rb
@@ -26,7 +26,7 @@ module Reports
       result.visited_without_bp_taken = NoBPMeasureService.new(region, periods: range).call
       result.calculate_percentages(:visited_without_bp_taken)
 
-      start_period = [result.earliest_registration_period || range.begin].max
+      start_period = [result.earliest_registration_period, range.begin].max
       calc_range = (start_period..range.end)
       result.calculate_missed_visits(calc_range)
       result.calculate_missed_visits_percentages(calc_range)

--- a/app/services/reports/region_service.rb
+++ b/app/services/reports/region_service.rb
@@ -26,7 +26,7 @@ module Reports
       result.visited_without_bp_taken = NoBPMeasureService.new(region, periods: range).call
       result.calculate_percentages(:visited_without_bp_taken)
 
-      start_period = [result.earliest_registration_period, range.begin].max
+      start_period = [result.earliest_registration_period, range.begin].compact.max
       calc_range = (start_period..range.end)
       result.calculate_missed_visits(calc_range)
       result.calculate_missed_visits_percentages(calc_range)


### PR DESCRIPTION
**Story card:** [ch1722](https://app.clubhouse.io/simpledotorg/story/1722/showing-too-many-months-of-data-in-some-district-reports)

Bug fix for showing too much data for the missed visits chart.