### PR TITLE
Fix Region Backfill

### DIFF
--- a/app/services/region_backfill.rb
+++ b/app/services/region_backfill.rb
@@ -104,7 +104,7 @@ class RegionBackfill
     region_name = name || source.name
 
     region = DryRunRegion.new(Region.new(name: region_name, type: region_type), dry_run: dry_run?, logger: logger)
-    region.set_slug
+    region.slug = source.slug if source
     region.source = source if source
     region.path = [parent.path, region.name_to_path_label].compact.join(".")
 

--- a/app/services/region_backfill.rb
+++ b/app/services/region_backfill.rb
@@ -89,12 +89,12 @@ class RegionBackfill
   def create_region_types
     logger.info msg: "create_region_types"
     unless dry_run?
-      root = RegionType.create! name: "Root", path: "Root"
-      org = RegionType.create! name: "Organization", parent: root
-      state = RegionType.create! name: "State", parent: org
-      district = RegionType.create! name: "District", parent: state
-      block = RegionType.create! name: "Block", parent: district
-      _facility = RegionType.create! name: "Facility", parent: block
+      root = RegionType.find_by_name("Root") || RegionType.create!(name: "Root", path: "Root")
+      org = RegionType.find_by_name("Organization") || RegionType.create!(name: "Organization", parent: root)
+      state = RegionType.find_by_name("State") || RegionType.create!(name: "State", parent: org)
+      district = RegionType.find_by_name("District") || RegionType.create!(name: "District", parent: state)
+      block = RegionType.find_by_name("Block") || RegionType.create!(name: "Block", parent: district)
+      _facility = RegionType.find_by_name("Facility") || RegionType.create!(name: "Facility", parent: block)
     end
   end
 


### PR DESCRIPTION
**Story card:** [ch1455](https://app.clubhouse.io/simpledotorg/epic/1339/block-level-syncing)

## Because

The Region backfill is spinning up a separate district and zone for each facility.

## This addresses

Fixes the backfill script to check if the region exists before creating a new one. This also makes the script idempotent so we can run this script more than once to backfill as and when the CVHOs send us newer block data.
