### PR TITLE
Overdue: Filter copy fix

### DIFF
--- a/app/queries/patient_summary_query.rb
+++ b/app/queries/patient_summary_query.rb
@@ -1,6 +1,6 @@
 class PatientSummaryQuery
   FILTERS = {
-    "only_less_than_year_overdue" => "< 365 days overdue",
+    "only_less_than_year_overdue" => "<365 days overdue",
     "phone_number" => "Has phone number",
     "no_phone_number" => "No phone number",
     "high_risk" => "High risk only"


### PR DESCRIPTION
**Story card:** [ch1749](https://app.clubhouse.io/simpledotorg/story/1749/overview-copy-fix)

## Because

There should be no space between `<` and `365` in the filter label

## This addresses

**No space between symbol and number**

![image](https://user-images.githubusercontent.com/16785131/97481135-bd4a0e00-192a-11eb-957d-527bad9df9aa.png)
