### PR TITLE
Overdue: Subtitle fix

### DIFF
--- a/app/views/layouts/overdue.html.erb
+++ b/app/views/layouts/overdue.html.erb
@@ -3,7 +3,7 @@
     Overdue patients
   </h1>
   <p>
-    Patients that are overdue for a follow-up visit. If you select a facility, you can download a patient list.
+    Patients that are overdue for a follow-up visit<% if current_admin.accessible_facilities(:manage_overdue_list) %>. If you select a facility, you can download a patient list.<% end %>
   </p>
   <% if current_admin.accessible_facilities(:manage_overdue_list) %>
     <%= render('shared/paginate_and_filter_by_facility',


### PR DESCRIPTION
**Story card:** [ch1778](https://app.clubhouse.io/simpledotorg/story/1778/overdue-subtitle-fix)

## Because

User should only be instructed to download overdue patient list within subtitle **if** user has overdue manage access.

## This addresses

**1. Only shows 'download' section of subtitle to users that have overdue manage access**
