### PR TITLE
Persist params for missed visits section

### DIFF
--- a/app/views/layouts/my_facilities.html.erb
+++ b/app/views/layouts/my_facilities.html.erb
@@ -13,7 +13,7 @@
         <%= link_to(my_facilities_blood_pressure_control_path(preserve_query_params(request.query_parameters, ["zone", "size"])), class: "sub-nav-link #{active_action?("blood_pressure_control")}") do %>
           BP control
         <% end %>
-        <%= link_to(my_facilities_missed_visits_path(preserve_query_params(request.query_parameters, ["zone", "size"])), class: "sub-nav-link #{active_action?("missed_visits")}") do %>
+        <%= link_to(my_facilities_missed_visits_path(preserve_query_params(request.query_parameters, ["zone", "size", "period"])), class: "sub-nav-link #{active_action?("missed_visits")}") do %>
           Missed visits
         <% end %>
         <%= link_to(my_facilities_registrations_path(preserve_query_params(request.query_parameters, ["zone", "size", "period"])), class: "sub-nav-link #{active_action?("registrations")}") do %>


### PR DESCRIPTION
**Story card:** [ch1779](https://app.clubhouse.io/simpledotorg/story/1779/persist-params-for-missed-visits-section)

## Because

The "period" param should persist when user navigates between "Missed visits" and "Registrations" sections in "Home".

## This addresses

Adds "period" as a param to persist for "Missed visits"
