### PR TITLE
Remove progress tab note for facilities too

### DIFF
--- a/app/views/reports/regions/details.html.erb
+++ b/app/views/reports/regions/details.html.erb
@@ -302,9 +302,6 @@
     </div>
     <div class="mt-20px">
       <p class="mb-8px fs-14px c-grey-dark c-print-black">
-        Facility rows display the same data as the "Progress" tab in the Simple app with "Hypertension: All" selected
-      </p>
-      <p class="mb-8px fs-14px c-grey-dark c-print-black">
         <strong>1. Cumulative registrations:</strong> Total hypertensive patients registered at facilities in <%= @region.name %>
       </p>
       <p class="mb-8px fs-14px c-grey-dark c-print-black">


### PR DESCRIPTION
Followup to #1426 

Remove Progress Tab footnote from district activity table as well.

[Slack](https://simpledotorg.slack.com/archives/CFKD42741/p1604055437152600?thread_ts=1604008725.130700&cid=CFKD42741)