### PR TITLE
Add Patient -> Teleconsultations association

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -30,6 +30,7 @@ class Patient < ApplicationRecord
   has_many :users, -> { distinct }, through: :blood_pressures
   has_many :appointments
   has_one :medical_history
+  has_many :teleconsultations
 
   has_many :encounters
   has_many :observations, through: :encounters

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -20,6 +20,7 @@ describe Patient, type: :model do
     it { is_expected.to have_many(:facilities).through(:blood_pressures) }
     it { is_expected.to have_many(:users).through(:blood_pressures) }
     it { is_expected.to have_many(:appointments) }
+    it { is_expected.to have_many(:teleconsultations) }
 
     it { is_expected.to have_many(:encounters) }
     it { is_expected.to have_many(:observations).through(:encounters) }


### PR DESCRIPTION
**Story card:** [ch1795](https://app.clubhouse.io/simpledotorg/story/1795/add-association-b-w-teleconsultation-and-patient)

## Because

We have the teleconsultations -> patient association set up, but not the inverse.