### PR TITLE
Add Teleconsultation to purge controller

### DIFF
--- a/lib/tasks/scripts/purge_users_data.rb
+++ b/lib/tasks/scripts/purge_users_data.rb
@@ -17,7 +17,8 @@ module PurgeUsersData
       PatientBusinessIdentifier,
       PatientPhoneNumber,
       Patient,
-      Address]
+      Address,
+      Teleconsultation]
 
     ActiveRecord::Base.transaction do
       models.each do |model|


### PR DESCRIPTION
**Story card:** -

## Because

We are not purging teleconsultations via the purge controller for QA

## This addresses

Adds `Teleconsultation` to `PurgeUsersData`.
