### PR TITLE
Dont override slug generation for factory created facilities

### DIFF
--- a/spec/factories/facilities.rb
+++ b/spec/factories/facilities.rb
@@ -16,10 +16,6 @@ FactoryBot.define do
     enable_teleconsultation { true }
     monthly_estimated_opd_load { 300 }
 
-    sequence :slug do |n|
-      "#{name.to_s.parameterize.underscore}_#{n}"
-    end
-
     trait :seed do
       name { "#{facility_type} #{village_or_colony}" }
       street_address { Faker::Address.street_address }

--- a/spec/factories/facility_groups.rb
+++ b/spec/factories/facility_groups.rb
@@ -9,9 +9,5 @@ FactoryBot.define do
     description { Faker::Company.catch_phrase }
     organization { org }
     protocol
-
-    sequence :slug do |n|
-      "#{name.to_s.parameterize.underscore}_#{n}"
-    end
   end
 end

--- a/spec/models/facility_group_spec.rb
+++ b/spec/models/facility_group_spec.rb
@@ -25,12 +25,31 @@ RSpec.describe FacilityGroup, type: :model do
     end
   end
 
-  describe "Validations" do
+  context "Validations" do
     it { should validate_presence_of(:name) }
   end
 
-  describe "Behavior" do
+  context "Behavior" do
     it_behaves_like "a record that is deletable"
+  end
+
+  context "slugs" do
+    it "generates slug on creation and avoids conflicts via appending a UUID" do
+      fg_1 = create(:facility_group, name: "New York")
+      expect(fg_1.slug).to eq("new-york")
+      fg_2 = create(:facility_group, name: "New York")
+      uuid_regex = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+      expect(fg_2.slug).to match(/^new-york-#{uuid_regex}$/)
+    end
+
+    it "does not change the slug when renamed" do
+      facility_group = create(:facility_group, name: "old_name")
+      original_slug = facility_group.slug
+      facility_group.name = "new name"
+      facility_group.valid?
+      facility_group.save!
+      expect(facility_group.slug).to eq(original_slug)
+    end
   end
 
   describe "Attribute sanitization" do

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -15,13 +15,23 @@ RSpec.describe Facility, type: :model do
     it { should have_many(:assigned_patients).class_name("Patient").with_foreign_key("assigned_facility_id") }
     it { should have_many(:assigned_hypertension_patients).class_name("Patient").with_foreign_key("assigned_facility_id") }
 
-    it "does not change the slug when renamed" do
-      facility = create(:facility, name: "old_name")
-      original_slug = facility.slug
-      facility.name = "new name"
-      facility.valid?
-      facility.save!
-      expect(facility.slug).to eq(original_slug)
+    context "slugs" do
+      it "generates slug on creation and avoids conflicts via appending a UUID" do
+        facility_1 = create(:facility, name: "New York General")
+        expect(facility_1.slug).to eq("new-york-general")
+        facility_2 = create(:facility, name: "New York General")
+        uuid_regex = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+        expect(facility_2.slug).to match(/^new-york-general-#{uuid_regex}$/)
+      end
+
+      it "does not change the slug when renamed" do
+        facility = create(:facility, name: "old_name")
+        original_slug = facility.slug
+        facility.name = "new name"
+        facility.valid?
+        facility.save!
+        expect(facility.slug).to eq(original_slug)
+      end
     end
 
     context "patients" do


### PR DESCRIPTION
This overrides what FriendlyId would do by default, which is not
something we want to mess with in our test data. Doing the slug generation via the factory also obscures the
default behavior of FriendlyId where it appends a UUID for unique slugs.

**Story card:** [ch1869](https://app.clubhouse.io/simpledotorg/story/1869/improve-our-slug-generation)
