### PR TITLE
Remove unassociated facilities

### DIFF
--- a/app/controllers/admin/facility_groups_controller.rb
+++ b/app/controllers/admin/facility_groups_controller.rb
@@ -74,8 +74,7 @@ class Admin::FacilityGroupsController < AdminController
       :state,
       :description,
       :protocol_id,
-      :enable_diabetes_management,
-      facility_ids: []
+      :enable_diabetes_management
     )
   end
 

--- a/app/controllers/admin/facility_groups_controller.rb
+++ b/app/controllers/admin/facility_groups_controller.rb
@@ -77,8 +77,4 @@ class Admin::FacilityGroupsController < AdminController
       :enable_diabetes_management
     )
   end
-
-  def enable_diabetes_management
-    params[:enable_diabetes_management]
-  end
 end

--- a/app/views/admin/facility_groups/_form.html.erb
+++ b/app/views/admin/facility_groups/_form.html.erb
@@ -26,28 +26,20 @@
                         disabled: action_name == "edit" ? true : false %>
       <% end %>
 
-      <label>Associated Facilities</label>
-      <% if facility_group.facilities.present? %>
-        <ul class="pl-3">
-          <% facility_group.facilities.each do |facility| %>
-            <li>
-              <%= link_to facility.name, admin_facility_group_facility_path(facility_group, facility), target: :_blank %>
-            </li>
-          <% end %>
-        </ul>
-      <% end %>
+      <%= form.select(:protocol_id, protocols.order(:name).map { |protocol| [protocol.name, protocol.id] }) %>
 
-      <div class="mt-5 mb-5">
-        <h3>Diabetes enabled?</h3>
-        <div class="alert alert-primary mt-3" role="alert">
+      <div class="form-group">
+        <label class="mb-0">Diabetes enabled?</label>
+        <small class="form-text text-muted mt-0 mb-3">
           <% is_diabetes_enabled = facility_group.diabetes_enabled? %>
 
           <% if is_diabetes_enabled && facility_group.facilities.present? %>
             Diabetes management is already enabled for all facilities in this group.
           <% else %>
-            This will enable Diabetes management for all associated facilities in this group.
+            This will enable diabetes management for all associated facilities in this group.
           <% end %>
-        </div>
+        </small>
+
         <%= form.check_box :enable_diabetes_management,
             {id: :facility_group_enable_diabetes_management,
                 checked: is_diabetes_enabled,
@@ -55,8 +47,6 @@
                 onclick: "confirmDisableDM(this)"},
             true, false %>
       </div>
-
-      <%= form.select(:protocol_id, protocols.order(:name).map { |protocol| [protocol.name, protocol.id] }) %>
 
       <%= form.primary("Save facility group") %>
     <% end %>

--- a/app/views/admin/facility_groups/_form.html.erb
+++ b/app/views/admin/facility_groups/_form.html.erb
@@ -26,18 +26,19 @@
                         disabled: action_name == "edit" ? true : false %>
       <% end %>
 
-      <% if facility_group.facilities.present? %>
-        <%= form.collection_check_boxes :facility_ids, facility_group.facilities, :id, :name, label: "Associated facilities", checked_value: 1 %>
-      <% end %>
-
-      <% if Facility.where(facility_group: nil).present? %>
-        <%= form.collection_check_boxes :facility_ids, Facility.where(facility_group: nil), :id, :name, label: "Unassociated facilities", checked: true %>
-      <% else %>
-        <% if facility_group.new_record? %>
-          <div class="row">
-            <div class="col-md-9 mb-3 text-warning">All existing facilities belong to a facility group.</div>
-          </div>
+      <label>Associated Facilities</label>
+      <%= content_tag(:ul, class: "") do %>
+        <% facility_group.facilities.each do |facility| %>
+          <li>
+            <%= link_to facility.name, admin_facility_group_facility_path(facility_group, facility), target: :_blank %>
+          </li>
         <% end %>
+      <% end if facility_group.facilities.present? %>
+
+      <% if facility_group.new_record? %>
+        <div class="row">
+          <div class="col-md-9 mb-3 text-warning">All existing facilities belong to a facility group.</div>
+        </div>
       <% end %>
 
       <div class="mt-5 mb-5">

--- a/app/views/admin/facility_groups/_form.html.erb
+++ b/app/views/admin/facility_groups/_form.html.erb
@@ -27,19 +27,13 @@
       <% end %>
 
       <label>Associated Facilities</label>
-      <%= content_tag(:ul, class: "") do %>
+      <%= content_tag(:ul, class: "pl-3") do %>
         <% facility_group.facilities.each do |facility| %>
           <li>
             <%= link_to facility.name, admin_facility_group_facility_path(facility_group, facility), target: :_blank %>
           </li>
         <% end %>
       <% end if facility_group.facilities.present? %>
-
-      <% if facility_group.new_record? %>
-        <div class="row">
-          <div class="col-md-9 mb-3 text-warning">All existing facilities belong to a facility group.</div>
-        </div>
-      <% end %>
 
       <div class="mt-5 mb-5">
         <h3>Diabetes enabled?</h3>

--- a/app/views/admin/facility_groups/_form.html.erb
+++ b/app/views/admin/facility_groups/_form.html.erb
@@ -27,13 +27,15 @@
       <% end %>
 
       <label>Associated Facilities</label>
-      <%= content_tag(:ul, class: "pl-3") do %>
-        <% facility_group.facilities.each do |facility| %>
-          <li>
-            <%= link_to facility.name, admin_facility_group_facility_path(facility_group, facility), target: :_blank %>
-          </li>
-        <% end %>
-      <% end if facility_group.facilities.present? %>
+      <% if facility_group.facilities.present? %>
+        <ul class="pl-3">
+          <% facility_group.facilities.each do |facility| %>
+            <li>
+              <%= link_to facility.name, admin_facility_group_facility_path(facility_group, facility), target: :_blank %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
 
       <div class="mt-5 mb-5">
         <h3>Diabetes enabled?</h3>

--- a/app/views/admin/facility_groups/_form.html.erb
+++ b/app/views/admin/facility_groups/_form.html.erb
@@ -43,9 +43,9 @@
         <%= form.check_box :enable_diabetes_management,
             {id: :facility_group_enable_diabetes_management,
                 checked: is_diabetes_enabled,
-                disabled: is_diabetes_enabled && facility_group.facilities.present?,
                 onclick: "confirmDisableDM(this)"},
-            true, false %>
+            true,
+            false %>
       </div>
 
       <%= form.primary("Save facility group") %>

--- a/db/data/20201112075313_remove_unassociated_facilities_from_production.rb
+++ b/db/data/20201112075313_remove_unassociated_facilities_from_production.rb
@@ -1,7 +1,6 @@
 class RemoveUnassociatedFacilitiesFromProduction < ActiveRecord::Migration[5.2]
   def up
-    return if SIMPLE_SERVER_ENV != "production"
-    return if ENV["DEFAULT_COUNTRY"] != "IN"
+    return if CountryConfig.current[:abbreviation] != "IN"
 
     facilities_to_purge = Facility.where(facility_group_id: nil)
     Rails.logger.info "Purging facilities that are unassociated: #{facilities_to_purge.pluck(:id).join(", ")}."

--- a/db/data/20201112075313_remove_unassociated_facilities_from_production.rb
+++ b/db/data/20201112075313_remove_unassociated_facilities_from_production.rb
@@ -3,7 +3,9 @@ class RemoveUnassociatedFacilitiesFromProduction < ActiveRecord::Migration[5.2]
     return if SIMPLE_SERVER_ENV != "production"
     return if ENV["DEFAULT_COUNTRY"] != "IN"
 
-    Facility.where(facility_group_id: nil).delete_all
+    facilities_to_purge = Facility.where(facility_group_id: nil)
+    Rails.logger.info "Purging facilities that are unassociated: #{facilities_to_purge.pluck(:id).join(", ")}."
+    facilities_to_purge.discard_all
   end
 
   def down

--- a/db/data/20201112075313_remove_unassociated_facilities_from_production.rb
+++ b/db/data/20201112075313_remove_unassociated_facilities_from_production.rb
@@ -7,6 +7,6 @@ class RemoveUnassociatedFacilitiesFromProduction < ActiveRecord::Migration[5.2]
   end
 
   def down
-    raise ActiveRecord::IrreversibleMigration
+    Rails.logger.info "This data migration cannot be reversed. Skipping."
   end
 end

--- a/db/data/20201112075313_remove_unassociated_facilities_from_production.rb
+++ b/db/data/20201112075313_remove_unassociated_facilities_from_production.rb
@@ -1,0 +1,12 @@
+class RemoveUnassociatedFacilitiesFromProduction < ActiveRecord::Migration[5.2]
+  def up
+    return if SIMPLE_SERVER_ENV != "production"
+    return if ENV["DEFAULT_COUNTRY"] != "IN"
+
+    Facility.where(facility_group_id: nil).delete_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20201103111216)
+DataMigrate::Data.define(version: 20201112075313)

--- a/spec/features/admin/facilities/index_spec.rb
+++ b/spec/features/admin/facilities/index_spec.rb
@@ -54,34 +54,12 @@ RSpec.feature "Facility page functionality", type: :feature do
             org_name: "IHMI",
             name: "testfacilitygroup",
             description: "testDescription",
-            unassociated_facility: unassociated_facility.name,
             protocol_name: protocol_01.name
           )
 
           expect(page).to have_content("Bathinda")
           expect(page).to have_content("Testfacilitygroup")
           facility_page.is_edit_button_present_for_facilitygroup("Testfacilitygroup")
-        end
-
-        it "admin should be able to edit facility group info " do
-          facility_page.click_add_facility_group_button
-          facility_group.add_new_facility_group(
-            org_name: "IHMI",
-            name: "testfacilitygroup",
-            description: "testDescription",
-            unassociated_facility: unassociated_facility.name,
-            protocol_name: protocol_01.name
-          )
-          facility_page.click_edit_button_present_for_facilitygroup("Testfacilitygroup")
-
-          # deselecting previously selected facility
-          facility_group.select_unassociated_facility(unassociated_facility.name)
-
-          # select new unassigned facility
-          facility_group.select_unassociated_facility(unassociated_facility02.name)
-          facility_group.click_on_update_facility_group_button
-
-          expect(page).to have_content(unassociated_facility02.name)
         end
       end
 
@@ -114,7 +92,6 @@ RSpec.feature "Facility page functionality", type: :feature do
             org_name: "IHMI",
             name: "testfacilitygroup",
             description: "testDescription",
-            unassociated_facility: unassociated_facility.name,
             protocol_name: protocol_01.name,
             state: "Punjab"
           )
@@ -122,28 +99,6 @@ RSpec.feature "Facility page functionality", type: :feature do
           expect(page).to have_content("Bathinda")
           expect(page).to have_content("Testfacilitygroup")
           facility_page.is_edit_button_present_for_facilitygroup("Testfacilitygroup")
-        end
-
-        it "admin should be able to edit facility group info " do
-          facility_page.click_add_facility_group_button
-          facility_group.add_new_facility_group(
-            org_name: "IHMI",
-            name: "testfacilitygroup",
-            description: "testDescription",
-            unassociated_facility: unassociated_facility.name,
-            protocol_name: protocol_01.name,
-            state: "Punjab"
-          )
-          facility_page.click_edit_button_present_for_facilitygroup("Testfacilitygroup")
-
-          # deselecting previously selected facility
-          facility_group.select_unassociated_facility(unassociated_facility.name)
-
-          # select new unassigned facility
-          facility_group.select_unassociated_facility(unassociated_facility02.name)
-          facility_group.click_on_update_facility_group_button
-
-          expect(page).to have_content(unassociated_facility02.name)
         end
       end
 

--- a/spec/pages/admin/facility_groups/new.rb
+++ b/spec/pages/admin/facility_groups/new.rb
@@ -30,11 +30,10 @@ module AdminPage
         click(CREATE_FACILITY_GROUP_BUTTON)
       end
 
-      def add_new_facility_group(org_name:, name:, description:, unassociated_facility:, protocol_name:, state: nil)
+      def add_new_facility_group(org_name:, name:, description:, protocol_name:, state: nil)
         select_organisation_name_dropdown(org_name)
         type(FACILITY_NAME, name)
         select_state_dropdown(state) if state
-        select_unassociated_facility(unassociated_facility)
         select_protocol_name_dropdown(protocol_name)
         click(CREATE_FACILITY_GROUP_BUTTON)
       end


### PR DESCRIPTION
**Story card:** [ch1905](https://app.clubhouse.io/simpledotorg/story/1905/remove-non-essential-data-from-ihci-production)

## Because

We have a bunch of unassociated facilities that are unused. They were originally associated but disassociated later because of bad name or something else. This feature is not useful anymore since previously facilities used to be created before FGs, this is not the case anymore and now this data will only adds more entropy to our move towards Regions.

## This addresses

Remove unassociated facilities from India:production and remove the feature on the view layer as well, just show the list of associated facilities.

![Screenshot 2020-11-12 at 4 49 19 PM](https://user-images.githubusercontent.com/50663/98933700-042d2b80-2507-11eb-9eec-6264e1f64736.png)