### PR TITLE
Discard Organizations

### DIFF
--- a/app/models/encounter.rb
+++ b/app/models/encounter.rb
@@ -5,7 +5,7 @@ class Encounter < ApplicationRecord
   belongs_to :patient, optional: true
   belongs_to :facility
 
-  has_many :observations
+  has_many :observations, dependent: :destroy
   has_many :blood_pressures, through: :observations, source: :observable, source_type: "BloodPressure"
   has_many :blood_sugars, through: :observations, source: :observable, source_type: "BloodSugar"
 

--- a/app/models/encounter.rb
+++ b/app/models/encounter.rb
@@ -5,7 +5,7 @@ class Encounter < ApplicationRecord
   belongs_to :patient, optional: true
   belongs_to :facility
 
-  has_many :observations, dependent: :destroy
+  has_many :observations
   has_many :blood_pressures, through: :observations, source: :observable, source_type: "BloodPressure"
   has_many :blood_sugars, through: :observations, source: :observable, source_type: "BloodSugar"
 

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -242,4 +242,12 @@ class Facility < ApplicationRecord
   def discardable?
     registered_patients.none? && blood_pressures.none? && blood_sugars.none? && appointments.none?
   end
+
+  def discard_data
+    registered_patients.each do |patient|
+      patient.discard_data
+    end
+
+    discard
+  end
 end

--- a/app/models/facility_group.rb
+++ b/app/models/facility_group.rb
@@ -101,4 +101,12 @@ class FacilityGroup < ApplicationRecord
                                                       region_type: Region.region_types[:state],
                                                       reparent_to: organization.region)
   end
+
+  def discard_data
+    facilities.each do |facility|
+      facility.discard_data
+    end
+
+    discard
+  end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -42,4 +42,12 @@ class Organization < ApplicationRecord
   def discardable?
     facility_groups.none? && users.none? && appointments.none?
   end
+
+  def discard_data
+    facility_groups.each do |facility_group|
+      facility_group.discard_data
+    end
+
+    discard
+  end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -48,6 +48,8 @@ class Organization < ApplicationRecord
       facility_group.discard_data
     end
 
+    protocols&.discard_all
+
     discard
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -18,21 +18,23 @@ class Patient < ApplicationRecord
   ANONYMIZED_DATA_FIELDS = %w[id created_at registration_date registration_facility_name user_id age gender]
   DELETED_REASONS = %w[duplicate unknown accidental_registration].freeze
 
+  belongs_to :address, optional: true
   has_many :phone_numbers, class_name: "PatientPhoneNumber"
   has_many :business_identifiers, class_name: "PatientBusinessIdentifier"
   has_many :passport_authentications, through: :business_identifiers
-  has_many :blood_pressures, inverse_of: :patient, dependent: :destroy
-  has_many :blood_sugars,  dependent: :destroy
-  has_many :prescription_drugs,  dependent: :destroy
-  has_many :encounters, dependent: :destroy
-  has_many :observations, through: :encounters
-  has_many :appointments, dependent: :destroy
-  has_many :teleconsultations,  dependent: :destroy
+
+  has_many :blood_pressures, inverse_of: :patient
+  has_many :blood_sugars
+  has_many :prescription_drugs
   has_many :facilities, -> { distinct }, through: :blood_pressures
   has_many :users, -> { distinct }, through: :blood_pressures
-  has_one :medical_history,  dependent: :destroy
+  has_many :appointments
+  has_one :medical_history
+  has_many :teleconsultations
 
-  belongs_to :address, optional: true, dependent: :destroy
+  has_many :encounters
+  has_many :observations, through: :encounters
+
   belongs_to :registration_facility, class_name: "Facility", optional: true
   belongs_to :assigned_facility, class_name: "Facility", optional: true
   belongs_to :registration_user, class_name: "User"

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -18,23 +18,21 @@ class Patient < ApplicationRecord
   ANONYMIZED_DATA_FIELDS = %w[id created_at registration_date registration_facility_name user_id age gender]
   DELETED_REASONS = %w[duplicate unknown accidental_registration].freeze
 
-  belongs_to :address, optional: true
   has_many :phone_numbers, class_name: "PatientPhoneNumber"
   has_many :business_identifiers, class_name: "PatientBusinessIdentifier"
   has_many :passport_authentications, through: :business_identifiers
-
-  has_many :blood_pressures, inverse_of: :patient
-  has_many :blood_sugars
-  has_many :prescription_drugs
+  has_many :blood_pressures, inverse_of: :patient, dependent: :destroy
+  has_many :blood_sugars,  dependent: :destroy
+  has_many :prescription_drugs,  dependent: :destroy
+  has_many :encounters, dependent: :destroy
+  has_many :observations, through: :encounters
+  has_many :appointments, dependent: :destroy
+  has_many :teleconsultations,  dependent: :destroy
   has_many :facilities, -> { distinct }, through: :blood_pressures
   has_many :users, -> { distinct }, through: :blood_pressures
-  has_many :appointments
-  has_one :medical_history
-  has_many :teleconsultations
+  has_one :medical_history,  dependent: :destroy
 
-  has_many :encounters
-  has_many :observations, through: :encounters
-
+  belongs_to :address, optional: true, dependent: :destroy
   belongs_to :registration_facility, class_name: "Facility", optional: true
   belongs_to :assigned_facility, class_name: "Facility", optional: true
   belongs_to :registration_user, class_name: "User"
@@ -238,7 +236,10 @@ class Patient < ApplicationRecord
     encounters.discard_all
     medical_history&.discard
     phone_numbers.discard_all
+    business_identifiers.discard_all
+    passport_authentications.discard_all
     prescription_drugs.discard_all
+    teleconsultations.discard_all
     discard
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -233,12 +233,11 @@ class Patient < ApplicationRecord
     appointments.discard_all
     blood_pressures.discard_all
     blood_sugars.discard_all
-    business_identifiers.discard_all
+    business_identifiers.each { |bid| bid.discard_data }
     encounters.discard_all
     medical_history&.discard
     observations.discard_all
     phone_numbers.discard_all
-    passport_authentications.discard_all
     prescription_drugs.discard_all
     teleconsultations.discard_all
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -234,14 +234,14 @@ class Patient < ApplicationRecord
     blood_pressures.discard_all
     blood_sugars.discard_all
     business_identifiers.discard_all
-    observations.discard_all
     encounters.discard_all
     medical_history&.discard
+    observations.discard_all
     phone_numbers.discard_all
-    business_identifiers.discard_all
     passport_authentications.discard_all
     prescription_drugs.discard_all
     teleconsultations.discard_all
+
     discard
   end
 end

--- a/app/models/patient_business_identifier.rb
+++ b/app/models/patient_business_identifier.rb
@@ -35,4 +35,9 @@ class PatientBusinessIdentifier < ApplicationRecord
       identifier
     end
   end
+
+  def discard_data
+    passport_authentication.discard
+    discard
+  end
 end


### PR DESCRIPTION
**Story card:** [ch1905](https://app.clubhouse.io/simpledotorg/story/1905/remove-non-essential-data-from-ihci-production)

## Because

We need to be able to say: _discard an organization_ which will discard the entire tree.

## This addresses

The discard [gem](https://github.com/jhawthorn/discard#why-not-paranoia-or-acts_as_paranoid) philosophy recommends explicit discard scopes, hence adding an explicit `discard_data` method to discard the entire relevant tree.
