### PR TITLE
User does not need to belong to an Organization

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -5,7 +5,6 @@ class Organization < ApplicationRecord
   has_many :facility_groups, dependent: :destroy
   has_many :facilities, through: :facility_groups
   has_many :appointments, through: :facilities
-  has_many :users
   has_many :protocols, through: :facility_groups
 
   validates :name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,6 @@ class User < ApplicationRecord
     {can_teleconsult: CAPABILITY_VALUES[can_teleconsult?]}
   end
 
-  belongs_to :organization, optional: true
   has_many :user_authentications
   has_many :blood_pressures
   has_many :patients, -> { distinct }, through: :blood_pressures

--- a/db/migrate/20201112102515_remove_organization_from_user.rb
+++ b/db/migrate/20201112102515_remove_organization_from_user.rb
@@ -1,0 +1,5 @@
+class RemoveOrganizationFromUser < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :organization_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_03_092409) do
+ActiveRecord::Schema.define(version: 2020_11_12_102515) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+  enable_extension "tsm_system_rows"
 
   create_table "accesses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "user_id", null: false
@@ -541,14 +542,12 @@ ActiveRecord::Schema.define(version: 2020_11_03_092409) do
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
     t.string "role"
-    t.uuid "organization_id"
     t.string "access_level"
     t.string "teleconsultation_phone_number"
     t.string "teleconsultation_isd_code"
     t.index "to_tsvector('simple'::regconfig, COALESCE((full_name)::text, ''::text))", name: "index_gin_users_on_full_name", using: :gin
     t.index ["access_level"], name: "index_users_on_access_level"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
-    t.index ["organization_id"], name: "index_users_on_organization_id"
     t.index ["teleconsultation_phone_number"], name: "index_users_on_teleconsultation_phone_number"
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -69,7 +69,6 @@ FactoryBot.define do
     device_updated_at { Time.current }
     sync_approval_status { User.sync_approval_statuses[:denied] }
     email_authentications { build_list(:email_authentication, 1, email: email, password: password) }
-    organization
     role { "power user" }
     access_level { :power_user }
 


### PR DESCRIPTION
## Because

Dashboard users have access to an Organization through `Access` now.
App users don't need to be associated to an Organization anyway, since they are linked via a Facility.

## This addresses

Remove `organization_id` from `users` table and related changes.
