### PR TITLE
Rename region family methods to be more explicit

### DIFF
--- a/app/controllers/admin/facility_groups_controller.rb
+++ b/app/controllers/admin/facility_groups_controller.rb
@@ -72,7 +72,7 @@ class Admin::FacilityGroupsController < AdminController
 
   def set_blocks
     district_region = Region.find_by(source: @facility_group)
-    @blocks = district_region&.blocks&.order(:name) || []
+    @blocks = district_region&.block_regions&.order(:name) || []
   end
 
   def wrap_in_transaction

--- a/app/models/facility_group.rb
+++ b/app/models/facility_group.rb
@@ -97,8 +97,8 @@ class FacilityGroup < ApplicationRecord
   end
 
   def state_region
-    Region.state.find_by_name(state) || Region.create(name: state,
-                                                      region_type: Region.region_types[:state],
-                                                      reparent_to: organization.region)
+    Region.state_regions.find_by_name(state) || Region.create(name: state,
+                                                              region_type: Region.region_types[:state],
+                                                              reparent_to: organization.region)
   end
 end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -22,7 +22,6 @@ class Region < ApplicationRecord
   REGION_TYPES = %w[root organization state district block facility].freeze
   enum region_type: REGION_TYPES.zip(REGION_TYPES).to_h, _suffix: "regions"
 
-  # Override the auto-generated root method (via enum) to return the one, single root Region
   def self.root
     Region.find_by(region_type: :root)
   end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -20,7 +20,7 @@ class Region < ApplicationRecord
   before_discard :remove_path
 
   REGION_TYPES = %w[root organization state district block facility].freeze
-  enum region_type: REGION_TYPES.zip(REGION_TYPES).to_h
+  enum region_type: REGION_TYPES.zip(REGION_TYPES).to_h, _suffix: "regions"
 
   # Override the auto-generated root method (via enum) to return the one, single root Region
   def self.root
@@ -58,7 +58,8 @@ class Region < ApplicationRecord
   REGION_TYPES.reject { |t| t == "root" }.map do |region_type|
     # Generates belongs_to type of methods to fetch a region's ancestor
     # e.g. facility.organization
-    define_method(region_type) do
+    ancestor_method = "#{region_type}_region"
+    define_method(ancestor_method) do
       if self_and_descendant_types(region_type).include?(self.region_type)
         self_and_ancestors.find_by(region_type: region_type)
       else
@@ -68,7 +69,8 @@ class Region < ApplicationRecord
 
     # Generates has_many type of methods to fetch a region's descendants
     # e.g. organization.facilities
-    define_method(region_type.pluralize) do
+    descendant_method = "#{region_type}_regions"
+    define_method(descendant_method) do
       if ancestor_types(region_type).include?(self.region_type)
         descendants.where(region_type: region_type)
       else

--- a/spec/models/facility_group_spec.rb
+++ b/spec/models/facility_group_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe FacilityGroup, type: :model do
         end
 
         it "creates the state region if it doesn't exist" do
-          expect(facility_group.region.state.name).to eq "Punjab"
+          expect(facility_group.region.state_region.name).to eq "Punjab"
         end
       end
 
@@ -175,7 +175,7 @@ RSpec.describe FacilityGroup, type: :model do
 
         it "updates the state region" do
           facility_group.update(state: "Maharashtra")
-          expect(facility_group.region.state.name).to eq "Maharashtra"
+          expect(facility_group.region.state_region.name).to eq "Maharashtra"
           expect(facility_group.region.path).to eq "india.ihci.maharashtra.fg"
         end
       end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -73,74 +73,74 @@ RSpec.describe Region, type: :model do
       # TODO: Stop using backfill script to generate test data
       RegionBackfill.call(dry_run: false)
       root_region = Region.root
-      org_region = Region.organization.first
-      state_region = Region.state.first
-      district_region = Region.district.first
-      block_region = Region.block.first
-      facility_region = Region.facility.first
+      org_region = Region.organization_regions.first
+      state_region = Region.state_regions.first
+      district_region = Region.district_regions.first
+      block_region = Region.block_regions.first
+      facility_region = Region.facility_regions.first
 
       expect(root_region.root).to eq root_region
-      expect(root_region.organizations).to contain_exactly org_region
-      expect(root_region.states).to contain_exactly state_region
-      expect(root_region.districts).to contain_exactly district_region
-      expect(root_region.blocks).to contain_exactly block_region
-      expect(root_region.facilities).to contain_exactly facility_region
+      expect(root_region.organization_regions).to contain_exactly org_region
+      expect(root_region.state_regions).to contain_exactly state_region
+      expect(root_region.district_regions).to contain_exactly district_region
+      expect(root_region.block_regions).to contain_exactly block_region
+      expect(root_region.facility_regions).to contain_exactly facility_region
       expect { root_region.roots }.to raise_error NoMethodError
 
       expect(org_region.root).to eq root_region
-      expect(org_region.organization).to eq org_region
-      expect(org_region.states).to contain_exactly state_region
-      expect(org_region.districts).to contain_exactly district_region
-      expect(org_region.blocks).to contain_exactly block_region
-      expect(org_region.facilities).to contain_exactly facility_region
+      expect(org_region.organization_region).to eq org_region
+      expect(org_region.state_regions).to contain_exactly state_region
+      expect(org_region.district_regions).to contain_exactly district_region
+      expect(org_region.block_regions).to contain_exactly block_region
+      expect(org_region.facility_regions).to contain_exactly facility_region
       expect { org_region.roots }.to raise_error NoMethodError
-      expect { org_region.organizations }.to raise_error NoMethodError
+      expect { org_region.organization_regions }.to raise_error NoMethodError
 
       expect(state_region.root).to eq root_region
-      expect(state_region.organization).to eq org_region
-      expect(state_region.state).to eq state_region
-      expect(state_region.districts).to contain_exactly district_region
-      expect(state_region.blocks).to contain_exactly block_region
-      expect(state_region.facilities).to contain_exactly facility_region
+      expect(state_region.organization_region).to eq org_region
+      expect(state_region.state_region).to eq state_region
+      expect(state_region.district_regions).to contain_exactly district_region
+      expect(state_region.block_regions).to contain_exactly block_region
+      expect(state_region.facility_regions).to contain_exactly facility_region
       expect { state_region.roots }.to raise_error NoMethodError
-      expect { state_region.organizations }.to raise_error NoMethodError
-      expect { state_region.states }.to raise_error NoMethodError
+      expect { state_region.organization_regions }.to raise_error NoMethodError
+      expect { state_region.state_regions }.to raise_error NoMethodError
 
       expect(district_region.root).to eq root_region
-      expect(district_region.organization).to eq org_region
-      expect(district_region.state).to eq state_region
-      expect(district_region.district).to eq district_region
-      expect(district_region.blocks).to contain_exactly block_region
-      expect(district_region.facilities).to contain_exactly facility_region
+      expect(district_region.organization_region).to eq org_region
+      expect(district_region.state_region).to eq state_region
+      expect(district_region.district_region).to eq district_region
+      expect(district_region.block_regions).to contain_exactly block_region
+      expect(district_region.facility_regions).to contain_exactly facility_region
       expect { district_region.roots }.to raise_error NoMethodError
-      expect { district_region.organizations }.to raise_error NoMethodError
-      expect { district_region.states }.to raise_error NoMethodError
-      expect { district_region.districts }.to raise_error NoMethodError
+      expect { district_region.organization_regions }.to raise_error NoMethodError
+      expect { district_region.state_regions }.to raise_error NoMethodError
+      expect { district_region.district_regions }.to raise_error NoMethodError
 
       expect(block_region.root).to eq root_region
-      expect(block_region.organization).to eq org_region
-      expect(block_region.state).to eq state_region
-      expect(block_region.district).to eq district_region
-      expect(block_region.block).to eq block_region
-      expect(block_region.facilities).to contain_exactly facility_region
+      expect(block_region.organization_region).to eq org_region
+      expect(block_region.state_region).to eq state_region
+      expect(block_region.district_region).to eq district_region
+      expect(block_region.block_region).to eq block_region
+      expect(block_region.facility_regions).to contain_exactly facility_region
       expect { block_region.roots }.to raise_error NoMethodError
-      expect { block_region.organizations }.to raise_error NoMethodError
-      expect { block_region.states }.to raise_error NoMethodError
-      expect { block_region.districts }.to raise_error NoMethodError
-      expect { block_region.blocks }.to raise_error NoMethodError
+      expect { block_region.organization_regions }.to raise_error NoMethodError
+      expect { block_region.state_regions }.to raise_error NoMethodError
+      expect { block_region.district_regions }.to raise_error NoMethodError
+      expect { block_region.block_regions }.to raise_error NoMethodError
 
       expect(facility_region.root).to eq root_region
-      expect(facility_region.organization).to eq org_region
-      expect(facility_region.state).to eq state_region
-      expect(facility_region.district).to eq district_region
-      expect(facility_region.block).to eq block_region
-      expect(facility_region.facility).to eq facility_region
+      expect(facility_region.organization_region).to eq org_region
+      expect(facility_region.state_region).to eq state_region
+      expect(facility_region.district_region).to eq district_region
+      expect(facility_region.block_region).to eq block_region
+      expect(facility_region.facility_region).to eq facility_region
       expect { facility_region.roots }.to raise_error NoMethodError
-      expect { facility_region.organizations }.to raise_error NoMethodError
-      expect { facility_region.states }.to raise_error NoMethodError
-      expect { facility_region.districts }.to raise_error NoMethodError
-      expect { facility_region.blocks }.to raise_error NoMethodError
-      expect { facility_region.facilities }.to raise_error NoMethodError
+      expect { facility_region.organization_regions }.to raise_error NoMethodError
+      expect { facility_region.state_regions }.to raise_error NoMethodError
+      expect { facility_region.district_regions }.to raise_error NoMethodError
+      expect { facility_region.block_regions }.to raise_error NoMethodError
+      expect { facility_region.facility_regions }.to raise_error NoMethodError
     end
   end
 end

--- a/spec/services/manage_district_region_service_spec.rb
+++ b/spec/services/manage_district_region_service_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe ManageDistrictRegionService, type: :model do
 
     described_class.update_blocks(district_region: facility_group.region, new_blocks: new_blocks)
 
-    expect(facility_group.region.blocks.pluck(:name)).to match_array new_blocks
-    expect(facility_group.region.blocks.pluck(:path)).to contain_exactly("india.ihci.punjab.fg.block_1", "india.ihci.punjab.fg.block_2")
+    expect(facility_group.region.block_regions.pluck(:name)).to match_array new_blocks
+    expect(facility_group.region.block_regions.pluck(:path)).to contain_exactly("india.ihci.punjab.fg.block_1", "india.ihci.punjab.fg.block_2")
   end
 
   it "deletes blocks from remove_blocks" do
@@ -23,8 +23,8 @@ RSpec.describe ManageDistrictRegionService, type: :model do
 
     described_class.update_blocks(district_region: facility_group.region, new_blocks: new_blocks)
 
-    block = facility_group.region.blocks.first
+    block = facility_group.region.block_regions.first
     described_class.update_blocks(district_region: facility_group.region, remove_blocks: [block.id])
-    expect(facility_group.region.blocks).not_to include block
+    expect(facility_group.region.block_regions).not_to include block
   end
 end

--- a/spec/services/region_backfill_spec.rb
+++ b/spec/services/region_backfill_spec.rb
@@ -52,20 +52,20 @@ RSpec.describe RegionBackfill, type: :model do
       expect(org.children.map(&:name)).to contain_exactly("State 1", "State 2")
       expect(org.root).to eq(root)
 
-      states = Region.state
+      states = Region.state_regions
       expect(states.count).to eq(2)
       expect(states.pluck(:slug)).to contain_exactly("state-1", "state-2")
       expect(states.pluck(:name)).to contain_exactly("State 1", "State 2")
 
-      block_regions = Region.block
+      block_regions = Region.block_regions
       expect(block_regions.size).to eq(4)
       expect(block_regions.map(&:name)).to contain_exactly("Block XYZ", "Block 123", "Block ZZZ", "Block ABC")
 
-      facility_regions = Region.facility
+      facility_regions = Region.facility_regions
       expect(facility_regions.size).to eq(6)
 
-      expect(org.facilities.map(&:source)).to contain_exactly(*facilities)
-      expect(org.facilities.pluck(:region_type).uniq).to contain_exactly("facility")
+      expect(org.facility_regions.map(&:source)).to contain_exactly(*facilities)
+      expect(org.facility_regions.pluck(:region_type).uniq).to contain_exactly("facility")
     end
 
     it "works when there is are blocks and facilities that have the same name and slug" do
@@ -81,16 +81,16 @@ RSpec.describe RegionBackfill, type: :model do
 
       RegionBackfill.call(dry_run: false)
 
-      expect(Region.root.facilities.map(&:source)).to contain_exactly(queens, new_york, manhatten, east_village, other_new_york)
-      blocks = Region.root.blocks
+      expect(Region.root.facility_regions.map(&:source)).to contain_exactly(queens, new_york, manhatten, east_village, other_new_york)
+      blocks = Region.root.block_regions
       expect(blocks.size).to eq(3)
       expect(blocks.map(&:name)).to contain_exactly("New York", "Other Block", "New York")
       blocks.each do |block|
         next unless block.name == "New York"
         expect(block.slug).to match(/new-york/)
       end
-      expect(queens.region.block).to eq(manhatten.region.block)
-      expect(queens.region.block).to_not eq(east_village.region.block)
+      expect(queens.region.block_region).to eq(manhatten.region.block_region)
+      expect(queens.region.block_region).to_not eq(east_village.region.block_region)
     end
 
     it "establishes associations from facility / facility group back to regions" do
@@ -134,11 +134,11 @@ RSpec.describe RegionBackfill, type: :model do
       end
 
       expect(Region.where(region_type: "root").count).to eq 1
-      expect(Region.organization.count).to eq 1
-      expect(Region.state.count).to eq 2
-      expect(Region.district.count).to eq 4
-      expect(Region.block.count).to eq 5
-      expect(Region.facility.count).to eq 6
+      expect(Region.organization_regions.count).to eq 1
+      expect(Region.state_regions.count).to eq 2
+      expect(Region.district_regions.count).to eq 4
+      expect(Region.block_regions.count).to eq 5
+      expect(Region.facility_regions.count).to eq 6
       expect(Region.count).to eq 19
     end
   end


### PR DESCRIPTION
Because we sitll have source models like Facility and FacilityGroup, we
should name the methods that can move up or down the region tree very
explicitly ...other wise its very confusing if you see calls like the following:


```
  region.facilities
  region.districts
  region.facility_groups
```

Does that return actual Facilities, or Regions of type facility?

This changes the ancestor methods to have a _region suffix and the
descendant methods to a have a _regions suffix. It also gives the scopes
provided by the enum a _regions suffix for consistency.

This came up in the context or region reports /cc #1477 

[ch132](https://app.clubhouse.io/simpledotorg/story/132/block-level-reports)