### PR TITLE
Find or create parent regions in specs

### DIFF
--- a/spec/factories/facilities.rb
+++ b/spec/factories/facilities.rb
@@ -37,9 +37,10 @@ FactoryBot.define do
       create_parent_region { Flipper.enabled?(:regions_prep) }
     end
 
-    before(:create) do |f, options|
+    before(:create) do |facility, options|
       if options.create_parent_region
-        create(:region, :block, name: f.zone, reparent_to: f.facility_group.region)
+        facility.facility_group.region.block_regions.find_by(name: facility.zone) ||
+          create(:region, :block, name: facility.zone, reparent_to: facility.facility_group.region)
       end
     end
 

--- a/spec/factories/facility_groups.rb
+++ b/spec/factories/facility_groups.rb
@@ -16,9 +16,10 @@ FactoryBot.define do
       create_parent_region { Flipper.enabled?(:regions_prep) }
     end
 
-    before(:create) do |fg, options|
+    before(:create) do |facility_group, options|
       if options.create_parent_region
-        create(:region, :state, name: fg.state, reparent_to: fg.organization.region)
+        facility_group.organization.region.state_regions.find_by(name: facility_group.state) ||
+          create(:region, :state, name: facility_group.state, reparent_to: facility_group.organization.region)
       end
     end
 


### PR DESCRIPTION
## Because

Keeping Region model and actual Source model is quite tricky in this intermediate transitional stage of Regions. Our factories (for source models) can currently create parent regions (block, state) automatically behind-the-scenes to help keep the Region model and its Source model in sync (during tests), but since Region cannot allow a uniqueness validation on `name`, we cannot guarantee our tests creating duplicating blocks or states within the same Organization or District.

for eg.,
```ruby
fg = create(:facility_group)
# creates a region: "Blck A" with a unique path: "blck_a"
f1 = create(:facility, block: "Blck A", facility_group: fg) 
# creates a "duplicate" region: "Blck A" with a unique path: "blck_a_block"
f2 = create(:facility, block: f1.block, facility_group: fg) 
```

## This addresses

Find or create parent regions in the factories for `Facility` and `FacilityGroup` so that we don't accidentally end up with dupes.

**Side-note:**

One way to deal with this problem is to create blocks and states inline all throughout the codebase, but we've chosen to have them be _always available_ through the factories because:

1. lot of boilerplate
2. not straightforward to migrate (some specs don't create FGs explicitly, some FGs, don't create Orgs explicitly)