### PR TITLE
Help: New "Med refills" card

### DIFF
--- a/config/locales/api/help/en.html
+++ b/config/locales/api/help/en.html
@@ -357,6 +357,22 @@
               Done!
             </li>
           </ol>
+          <div class="video-small">
+            <a href="https://www.youtube.com/watch?v=8EmUUGzLz3w">
+              How to refill a patient's medicines
+              <span>
+                English
+              </span>
+            </a>
+          </div>
+          <div class="video-small">
+            <a href="https://www.youtube.com/watch?v=zYGBczMmx9c">
+              हर मरीज़ जो अस्पताल में जाँच के लिए आएँ, उन्हें दवाई देकर सिम्पल ऐप में अप्डेट करने का तरीक़ा
+              <span>
+                Hindi
+              </span>
+            </a>
+          </div>
         </div>
         <hr>
         <div class="card card-tip">

--- a/config/locales/api/help/en.html
+++ b/config/locales/api/help/en.html
@@ -339,6 +339,25 @@
                 <li class="num">Done. The patient visit is saved.</li>
             </ol>
         </div>
+        <div class="card">
+          <h3>
+            Medicine refills
+          </h3>
+          <p>
+            If you are refilling a patient’s current medicines:
+          </p>
+          <ol>
+            <li class="num">
+              On the patient's summary screen, press "+ Medicines"
+            </li>
+            <li class="num">
+              Press "Refill medicines"
+            </li>
+            <li class="num">
+              Done!
+            </li>
+          </ol>
+        </div>
         <hr>
         <div class="card card-tip">
             %{help_tip_svg}

--- a/config/locales/api/help/en.html
+++ b/config/locales/api/help/en.html
@@ -348,10 +348,10 @@
           </p>
           <ol>
             <li class="num">
-              On the patient's summary screen, press "+ Medicines"
+              On the patient's summary screen, press <span class="code">+ Medicines</span>
             </li>
             <li class="num">
-              Press "Refill medicines"
+              Press <span class="code">Refill medicines</span>
             </li>
             <li class="num">
               Done!

--- a/config/locales/api/help/en.html
+++ b/config/locales/api/help/en.html
@@ -367,7 +367,7 @@
           </div>
           <div class="video-small">
             <a href="https://www.youtube.com/watch?v=zYGBczMmx9c">
-              हर मरीज़ जो अस्पताल में जाँच के लिए आएँ, उन्हें दवाई देकर सिम्पल ऐप में अप्डेट करने का तरीक़ा
+              How to refill a patient's medicines
               <span>
                 Hindi
               </span>


### PR DESCRIPTION
**Story card:** [ch1948](https://app.clubhouse.io/simpledotorg/story/1948/update-help-section)

## Because

The "Help" section should include details on how to refill a patient's medications.

## This addresses

![image](https://user-images.githubusercontent.com/16785131/100767033-4a1f3600-33c7-11eb-97b7-a57efd5ae6c7.png)

* Added new "Medicine refills card"
* Added links to English and Hindi walkthrough videos