### PR TITLE
Enable block level sync per user

### DIFF
--- a/lib/tasks/enable_block_level_sync.rake
+++ b/lib/tasks/enable_block_level_sync.rake
@@ -8,7 +8,7 @@ task enable_block_level_sync: :environment do |_t, args|
     if user
       enable_block_level_sync(user)
     else
-      Rails.logger.info "User #{user_id} not found" unless user
+      Rails.logger.info "User #{user_id} not found"
     end
   end
 end

--- a/lib/tasks/enable_block_level_sync.rake
+++ b/lib/tasks/enable_block_level_sync.rake
@@ -1,17 +1,27 @@
 desc "Enable block level sync for users"
 task enable_block_level_sync: :environment do |_t, args|
   # bundle exec enable_block_level_sync[user_id_1,user_id_2,...]
-
   user_ids = args.extras
-  Rails.logger.info user_ids.map { |user_id|
+
+  user_ids.each do |user_id|
     user = User.find_by(id: user_id)
-    next "User with id #{user_id} not found" unless user
-
-    ActiveRecord::Base.transaction do
-      Flipper.enable(:region_level_sync, user)
-      user.facility_group.facilities.update_all(updated_at: Time.current)
+    if user
+      enable_block_level_sync(user)
+    else
+      Rails.logger.info "User #{user_id} not found" unless user
     end
+  end
+end
 
-    "Block level sync enabled for #{user_id}"
-  }
+def enable_block_level_sync(user)
+  ActiveRecord::Base.transaction do
+    if user.phone_number_authentication
+      user.facility_group.facilities.update_all(updated_at: Time.current)
+      Flipper.enable(:region_level_sync, user)
+
+      Rails.logger.info "Block level sync enabled for #{user.id}"
+    else
+      Rails.logger.info "User #{user.id} does not have a phone number authentication"
+    end
+  end
 end

--- a/lib/tasks/enable_block_level_sync.rake
+++ b/lib/tasks/enable_block_level_sync.rake
@@ -7,8 +7,10 @@ task enable_block_level_sync: :environment do |_t, args|
     user = User.find_by(id: user_id)
     next "User with id #{user_id} not found" unless user
 
-    Flipper.enable(:region_level_sync, user)
-    user.facility_group.facilities.update_all(updated_at: Time.current)
+    ActiveRecord::Base.transaction do
+      Flipper.enable(:region_level_sync, user)
+      user.facility_group.facilities.update_all(updated_at: Time.current)
+    end
 
     "Block level sync enabled for #{user_id}"
   }

--- a/lib/tasks/enable_block_level_sync.rake
+++ b/lib/tasks/enable_block_level_sync.rake
@@ -1,0 +1,14 @@
+desc "Enable block level sync for users"
+task enable_block_level_sync: :environment do |_t, args|
+  # bundle exec enable_block_level_sync[user_id_1,user_id_2,...]
+
+  user_ids = args.extras
+  puts user_ids.map { |user_id|
+    user = User.find_by(id: user_id)
+    next "User with id #{user_id} not found" unless user
+
+    Flipper.enable(:region_level_sync, user)
+    user.facility_group.facilities.update_all(updated_at: Time.current)
+    "Block level sync enabled for #{user_id}"
+  }
+end

--- a/lib/tasks/enable_block_level_sync.rake
+++ b/lib/tasks/enable_block_level_sync.rake
@@ -3,7 +3,7 @@ task enable_block_level_sync: :environment do |_t, args|
   # bundle exec enable_block_level_sync[user_id_1,user_id_2,...]
 
   user_ids = args.extras
-  puts user_ids.map { |user_id|
+  Rails.logger.info user_ids.map { |user_id|
     user = User.find_by(id: user_id)
     next "User with id #{user_id} not found" unless user
 

--- a/lib/tasks/enable_block_level_sync.rake
+++ b/lib/tasks/enable_block_level_sync.rake
@@ -9,6 +9,7 @@ task enable_block_level_sync: :environment do |_t, args|
 
     Flipper.enable(:region_level_sync, user)
     user.facility_group.facilities.update_all(updated_at: Time.current)
+
     "Block level sync enabled for #{user_id}"
   }
 end


### PR DESCRIPTION
**Story card:** -

## Because

When we enable block level sync for a user, we need to make sure the facilities are touched in order to trigger a resync. [Slack ref](https://simpledotorg.slack.com/archives/C018TPYH3J9/p1605886730074600)

## This addresses

This adds a quick script to make enabling block level sync for users easy.
