### PR TITLE
Include facility breakdown in facilitydistrict cohort report downlodas

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -66,7 +66,7 @@ class Reports::RegionsController < AdminController
 
     respond_to do |format|
       format.csv do
-        if @region.is_a?(FacilityGroup)
+        if @region.is_a?(FacilityGroup) || @region.is_a?(FacilityDistrict)
           set_facility_keys
           send_data render_to_string("facility_group_cohort.csv.erb"), filename: download_filename
         else


### PR DESCRIPTION
**Story card:** [ch1947](https://app.clubhouse.io/simpledotorg/story/1947/facility-district-reports-cohort-download-bug)

## Because

Per-facility breakdown was missing from the Bathinda and Mansa cohort report downloads.

## This addresses

Treats `FacilityDistrict` like a `District` for downloads, which adds back the per-facility breakdowns for Bathinda and Mansa cohort reports.
