### PR TITLE
Fix some issues around regions preparatory work

### DIFF
--- a/app/assets/javascripts/common/facility_group_block_fields.js
+++ b/app/assets/javascripts/common/facility_group_block_fields.js
@@ -1,5 +1,4 @@
 FacilityGroupBlockFields = function() {
-
   this.newBlockRow = (name) => {
     let template = $("template#block-row").html()
     let $template = $(template);
@@ -26,7 +25,7 @@ FacilityGroupBlockFields = function() {
   }
 
   this.isBlockAdded = (name) => {
-    return this.addedBlocks().map(block => block.toLowerCase()).includes(name.toLowerCase())
+    return this.addedBlocks().map(block => block.toLowerCase().trim()).includes(name.toLowerCase().trim())
   }
 
   this.addBlock = (name) => {

--- a/app/jobs/import_facilities_job.rb
+++ b/app/jobs/import_facilities_job.rb
@@ -12,6 +12,10 @@ class ImportFacilitiesJob < ApplicationJob
       import_facilities << import_facility
     end
 
-    Facility.import!(import_facilities, validate: true)
+    ActiveRecord::Base.transaction do
+      Facility.import!(import_facilities, validate: true)
+      # import! can't run callbacks, so we manually ensure that we create regions
+      import_facilities.each(&:make_region) if Flipper.enabled?(:regions_prep)
+    end
   end
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -127,7 +127,7 @@ class Facility < ApplicationRecord
     facility_group.region.block_regions.find_by(name: block)
   end
 
-  private :make_region, :update_region
+  private :update_region
   # ----------------
 
   def hypertension_follow_ups_by_period(*args)

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -71,7 +71,8 @@ class Facility < ApplicationRecord
   validates :name, presence: true
   validates :district, presence: true
   validates :slug, presence: true
-  validates :state, presence: true
+  # this validation (and the field) should go away from facility after regions become first-class
+  validates :state, presence: true, if: -> { facility_group.present? }
   validates :country, presence: true
   validates :zone, presence: true, on: :create
   validates :pin, numericality: true, allow_blank: true
@@ -88,7 +89,7 @@ class Facility < ApplicationRecord
       message: "must be added to enable teleconsultation"
     }
   validates :enable_diabetes_management, inclusion: {in: [true, false]}
-  validate :valid_block, if: -> { Flipper.enabled?(:regions_prep) }
+  validate :valid_block, if: -> { Flipper.enabled?(:regions_prep) && facility_group.present? }
 
   delegate :protocol, to: :facility_group, allow_nil: true
   delegate :organization, :organization_id, to: :facility_group, allow_nil: true

--- a/spec/jobs/import_facilities_job_spec.rb
+++ b/spec/jobs/import_facilities_job_spec.rb
@@ -5,11 +5,12 @@ RSpec.describe ImportFacilitiesJob, type: :job do
 
   describe "#perform_later" do
     let(:organization) { create(:organization, name: "OrgOne") }
-    let!(:facility_group_2) { create(:facility_group, name: "FGTwo", organization_id: organization.id) }
+    let(:facility_group) { create(:facility_group, name: "FGTwo", organization_id: organization.id) }
+    let(:block) { create(:region, :block, name: "Block1", reparent_to: facility_group.region) }
     let(:facilities) do
       [
-        attributes_for(:facility, organization_name: "OrgOne", facility_group_name: "FGTwo").except(:id),
-        attributes_for(:facility, organization_name: "OrgOne", facility_group_name: "FGTwo").except(:id)
+        attributes_for(:facility, organization_name: organization.name, facility_group_name: facility_group.name).except(:id),
+        attributes_for(:facility, organization_name: organization.name, facility_group_name: facility_group.name).except(:id)
       ]
     end
     let(:job) { ImportFacilitiesJob.perform_later(facilities) }
@@ -28,6 +29,35 @@ RSpec.describe ImportFacilitiesJob, type: :job do
       expect {
         perform_enqueued_jobs { job }
       }.to change(Facility, :count).by(2)
+    end
+
+    context "regions" do
+      before { enable_flag(:regions_prep) }
+      let!(:organization) { create(:organization, name: "OrgOne") }
+      let!(:facility_group) { create(:facility_group, name: "FGTwo", organization_id: organization.id) }
+      let!(:block) { create(:region, :block, name: "Block1", reparent_to: facility_group.region) }
+      let!(:facilities) do
+        [
+          attributes_for(:facility, block: block.name, organization_name: organization.name, facility_group_name: facility_group.name).except(:id),
+          attributes_for(:facility, block: block.name, organization_name: organization.name, facility_group_name: facility_group.name).except(:id)
+        ]
+      end
+
+      it "creates regions after importing facilities" do
+        expect {
+          perform_enqueued_jobs { job }
+        }.to change(Region.facility_regions, :count).by(2)
+      end
+
+      it "does not import facilities if creating regions fails" do
+        allow_any_instance_of(Facility).to receive(:make_region).and_raise(ActiveRecord::RecordInvalid)
+
+        expect {
+          perform_enqueued_jobs { job }
+        }.to raise_error(ActiveRecord::RecordInvalid)
+
+        expect(Facility.count).to eq(0)
+      end
     end
   end
 end

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -226,7 +226,10 @@ RSpec.describe Facility, type: :model do
   describe "Validations" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:district) }
-    it { is_expected.to validate_presence_of(:state) }
+    context "validate state presence only if facility_group exists" do
+      let(:subject) { Facility.new(facility_group: create(:facility_group)) }
+      it { is_expected.to validate_presence_of(:state) }
+    end
     it { is_expected.to validate_presence_of(:country) }
     it { is_expected.to validate_numericality_of(:pin) }
 


### PR DESCRIPTION
## Because

We enabled the flag on SBX and tested all the work around these [PRs](https://github.com/simpledotorg/simple-server/pulls?q=is%3Apr+is%3Aclosed+label%3A%22block+level+sync%22) and found a few issues.

## This addresses

- [x] Bulk upload facility was not creating regions for facilities
- [x] State presence validation (on Facility) runs even if FG doesn't exist during bulk upload (this causes confusing error messages)
- [x] Valid block validation (on Facility) runs even if FG doesn't exist
- [x] Dedupe block creation in the UI by trimming the names to reduce erroneous names
