### PR TITLE
Allow Region backfill in other countries

### DIFF
--- a/app/services/region_backfill.rb
+++ b/app/services/region_backfill.rb
@@ -42,9 +42,6 @@ class RegionBackfill
 
   def create_regions
     current_country_name = CountryConfig.current[:name]
-    if current_country_name != "India" && !dry_run?
-      raise UnsupportedCountry, "#{self.class.name} not yet ready to run in write mode in #{current_country_name}"
-    end
     root_type = "root"
     org_type = "organization"
     state_type = "state"

--- a/spec/services/region_backfill_spec.rb
+++ b/spec/services/region_backfill_spec.rb
@@ -17,13 +17,6 @@ RSpec.describe RegionBackfill, type: :model do
   end
 
   context "write mode" do
-    it "fails in countries other than India for now" do
-      allow(CountryConfig).to receive(:current).and_return({name: "Bangladesh"})
-      expect {
-        RegionBackfill.call(dry_run: false)
-      }.to raise_error(RegionBackfill::UnsupportedCountry)
-    end
-
     it "backfills" do
       org = create(:organization, name: "Test Organization")
       facility_group_1 = create(:facility_group, :without_parent_region, name: "fg1", organization: org, state: "State 1")


### PR DESCRIPTION
**Story card:** [ch1940](https://app.clubhouse.io/simpledotorg/story/1940/create-regions-in-production)

## Because

We want to run Region backfill in other countries.

## This addresses

Removes the guard clause from Region backfill that restricts the script to India only.
