### PR TITLE
Pause hard-deletes and remove PATH delete tasks

### DIFF
--- a/lib/tasks/hard_delete.rake
+++ b/lib/tasks/hard_delete.rake
@@ -1,32 +1,10 @@
 require "tasks/scripts/delete_organization_data"
 
 namespace :hard_delete do
-  desc "Delete PATH and associated data"
-  task :path_data, [:dry_run] => :environment do |_t, args|
-    # This is a temporary rake task to delete PATH specifically since
-    # an earlier cleanup cleared only the Org and FGs. This deletes
-    # the associated data only.
-    dry_run =
-      if args.dry_run == "false"
-        false
-      else
-        args.dry_run || args.dry_run.nil?
-      end
-
-    if !SimpleServer.env.production? || CountryConfig.current[:name] != "India"
-      abort "Can run only in India production"
-    end
-
-    puts "Dry run: #{dry_run}"
-    puts "This will delete all facilities belonging to PATH and associated data"
-    puts "Are you sure you want to proceed? (y/n): "
-    abort unless $stdin.gets.chomp.downcase == "y"
-
-    DeleteOrganizationData.delete_path_data("7e896fa8-5e8f-4902-b814-b58d12332d0f", dry_run: dry_run)
-  end
-
   desc "Delete an org and associated data"
   task :organization, [:organization_id, :dry_run] => :environment do |_t, args|
+    abort "This script is currently disabled, to enable it, raise a PR and make necessary code changes."
+
     # hard_delete:organization[<org_id>] for a dry run
     # hard_delete:organization[<org_id>,false] otherwise
     dry_run =
@@ -46,6 +24,6 @@ namespace :hard_delete do
     puts "Are you sure you want to proceed? (y/n): "
     abort unless $stdin.gets.chomp.downcase == "y"
 
-    DeleteOrganizationData.call(organization_id: organization.id, dry_run: dry_run)
+    DeleteOrganizationData.call(organization: organization, dry_run: dry_run)
   end
 end

--- a/lib/tasks/scripts/delete_organization_data.rb
+++ b/lib/tasks/scripts/delete_organization_data.rb
@@ -1,5 +1,8 @@
 class DeleteOrganizationData
   include Memery
+
+  class ScriptDisabled < RuntimeError; end
+
   DISABLE = true
 
   def initialize(organization:, dry_run: true)
@@ -13,7 +16,7 @@ class DeleteOrganizationData
 
   def call
     if DISABLE
-      raise RuntimeError, "This script is currently disabled, to enable it, raise a PR and make necessary code changes."
+      raise ScriptDisabled, "This script is currently disabled, to enable it, raise a PR and make necessary code changes."
     end
 
     ActiveRecord::Base.transaction do

--- a/spec/tasks/scripts/delete_organization_data_spec.rb
+++ b/spec/tasks/scripts/delete_organization_data_spec.rb
@@ -2,170 +2,102 @@ require "rails_helper"
 require "tasks/scripts/delete_organization_data"
 
 RSpec.describe DeleteOrganizationData do
-  describe ".delete_path_data" do
-    let!(:path_organization_id) { "7e896fa8-5e8f-4902-b814-b58d12332d0f" }
-    let!(:organization) { create(:organization, id: path_organization_id) }
-    let!(:facility_group) { create(:facility_group, organization: organization) }
-    let!(:facilities) { create_list(:facility, 2, facility_group: facility_group, facility_type: "Standalone") }
-    let!(:soft_deleted_facilities) { create_list(:facility, 2, facility_group: nil, facility_type: "Standalone", deleted_at: Time.current) }
-
-    let!(:patients) { facilities.map { |facility| create_list(:patient, 2, registration_facility: facility) }.flatten }
-    let!(:medical_histories) { patients.map(&:medical_history) }
-    let!(:prescription_drugs) { patients.map(&:prescription_drugs).flatten }
-    let!(:patient_phone_numbers) { patients.map(&:phone_numbers).flatten }
-    let!(:blood_pressures) { patients.map { |patient| create_list(:blood_pressure, 2, :with_encounter, patient: patient, facility: facilities.second) }.flatten }
-    let!(:blood_sugars) { patients.map { |patient| create_list(:blood_sugar, 2, :with_encounter, patient: patient, facility: facilities.first) }.flatten }
-    let!(:encounters) { [*blood_pressures.map(&:encounter), *blood_sugars.map(&:encounter)] }
-    let!(:observations) { [*blood_pressures.map(&:observation), *blood_sugars.map(&:observation)] }
-    let!(:appointments) { patients.map { |patient| create_list(:appointment, 2, patient: patient, facility: facilities.first) }.flatten }
-    let!(:app_users) { create_list(:user, 2, :with_phone_number_authentication, registration_facility: facilities.first) }
-    let!(:dashboard_users) { create_list(:admin, 2, organization: organization) }
-
-    before do
-      allow(SimpleServer).to receive_message_chain(:env, :production?).and_return(true)
-      allow(CountryConfig).to receive(:current).and_return({name: "India"})
-      allow_any_instance_of(described_class).to receive(:log)
-
-      # Accidentally delete PATH and its FGs. womp womp.
-      facility_group.destroy
-      organization.destroy
-    end
-
-    it "deletes PATH and associated data" do
-      described_class.delete_path_data(path_organization_id, dry_run: false)
-
-      facilities.each { |facility| expect { facility.reload }.to raise_error ActiveRecord::RecordNotFound }
-      soft_deleted_facilities.each { |facility| expect { facility.reload }.to raise_error ActiveRecord::RecordNotFound }
-
-      patients.each { |patient| expect { patient.reload }.to raise_error ActiveRecord::RecordNotFound }
-      appointments.each { |appointment| expect { appointment.reload }.to raise_error ActiveRecord::RecordNotFound }
-      blood_pressures.each { |blood_pressure| expect { blood_pressure.reload }.to raise_error ActiveRecord::RecordNotFound }
-      blood_sugars.each { |blood_sugar| expect { blood_sugar.reload }.to raise_error ActiveRecord::RecordNotFound }
-      encounters.each { |encounter| expect { encounter.reload }.to raise_error ActiveRecord::RecordNotFound }
-      observations.each { |observation| expect { observation.reload }.to raise_error ActiveRecord::RecordNotFound }
-      medical_histories.each { |medical_history| expect { medical_history.reload }.to raise_error ActiveRecord::RecordNotFound }
-      prescription_drugs.each { |prescription_drug| expect { prescription_drug.reload }.to raise_error ActiveRecord::RecordNotFound }
-      patient_phone_numbers.each { |patient_phone_number| expect { patient_phone_number.reload }.to raise_error ActiveRecord::RecordNotFound }
-
-      app_users.each { |app_user| expect { app_user.reload }.to raise_error ActiveRecord::RecordNotFound }
-      dashboard_users.each { |dashboard_user| expect { dashboard_user.reload }.to raise_error ActiveRecord::RecordNotFound }
-    end
-
-    it "does not delete things from other orgs" do
-      other_organizations = create_list(:organization, 2)
-      other_facility_groups = other_organizations.map { |org| create_list(:facility_group, 2, organization: org) }.flatten
-      other_facilities = other_facility_groups.map { |fg| create_list(:facility, 2, facility_group: fg) }.flatten
-      other_soft_deleted_facilities = create_list(:facility, 2, facility_group: nil, deleted_at: Time.current)
-      other_patients = other_facilities.map { |facility| create_list(:patient, 2, registration_facility: facility) }.flatten
-      other_medical_histories = other_patients.map(&:medical_history)
-      other_prescription_drugs = other_patients.map(&:prescription_drugs).flatten
-      other_patient_phone_numbers = other_patients.map(&:phone_numbers).flatten
-      other_blood_pressures = other_patients.map { |patient| create_list(:blood_pressure, 2, :with_encounter, patient: patient, facility: other_facilities.second) }.flatten
-      other_blood_sugars = other_patients.map { |patient| create_list(:blood_sugar, 2, :with_encounter, patient: patient, facility: other_facilities.first) }.flatten
-      other_encounters = [*other_blood_pressures.map(&:encounter), *other_blood_sugars.map(&:encounter)]
-      other_observations = [*other_blood_pressures.map(&:observation), *other_blood_sugars.map(&:observation)]
-      other_appointments = other_patients.map { |patient| create_list(:appointment, 2, patient: patient, facility: other_facilities.first) }.flatten
-
-      other_app_users = create_list(:user, 2, :with_phone_number_authentication, registration_facility: other_facilities.first)
-      other_dashboard_users = create_list(:admin, 2, organization: other_organizations.first)
-
-      described_class.delete_path_data(path_organization_id, dry_run: false)
-      other_organizations.map { |org| expect(org.reload).to eq org }
-      other_facility_groups.map { |fg| expect(fg.reload).to eq fg }
-      other_facilities.each { |facility| expect(facility.reload).to eq facility }
-      other_soft_deleted_facilities.each { |facility| expect(facility.reload).to eq facility }
-
-      other_patients.each { |patient| expect(patient.reload).to eq patient }
-      other_appointments.each { |appointment| expect(appointment.reload).to eq appointment }
-      other_blood_pressures.each { |blood_pressure| expect(blood_pressure.reload).to eq blood_pressure }
-      other_blood_sugars.each { |blood_sugar| expect(blood_sugar.reload).to eq blood_sugar }
-      other_encounters.each { |encounter| expect(encounter.reload).to eq encounter }
-      other_observations.each { |observation| expect(observation.reload).to eq observation }
-      other_medical_histories.each { |medical_history| expect(medical_history.reload).to eq medical_history }
-      other_prescription_drugs.each { |prescription_drug| expect(prescription_drug.reload).to eq prescription_drug }
-      other_patient_phone_numbers.each { |patient_phone_number| expect(patient_phone_number.reload).to eq patient_phone_number }
-
-      other_app_users.each { |app_user| expect(app_user.reload).to eq app_user }
-      other_dashboard_users.each { |dashboard_user| expect(dashboard_user.reload).to eq dashboard_user }
-    end
-  end
-
   describe ".call" do
-    let!(:organization) { create(:organization) }
-    let!(:facility_group) { create(:facility_group, organization: organization) }
-    let!(:facilities) { create_list(:facility, 2, facility_group: facility_group) }
-    let!(:soft_deleted_facilities) { create_list(:facility, 2, facility_group: facility_group, facility_type: "Standalone", deleted_at: Time.current) }
+    context "disabled" do
+      before do
+        stub_const("DeleteOrganizationData::DISABLE", true)
+      end
 
-    let!(:patients) { facilities.map { |facility| create_list(:patient, 2, registration_facility: facility) }.flatten }
-    let!(:medical_histories) { patients.map(&:medical_history) }
-    let!(:prescription_drugs) { patients.map(&:prescription_drugs).flatten }
-    let!(:patient_phone_numbers) { patients.map(&:phone_numbers).flatten }
-    let!(:blood_pressures) { patients.map { |patient| create_list(:blood_pressure, 2, :with_encounter, patient: patient, facility: facilities.second) }.flatten }
-    let!(:blood_sugars) { patients.map { |patient| create_list(:blood_sugar, 2, :with_encounter, patient: patient, facility: facilities.first) }.flatten }
-    let!(:encounters) { [*blood_pressures.map(&:encounter), *blood_sugars.map(&:encounter)] }
-    let!(:observations) { [*blood_pressures.map(&:observation), *blood_sugars.map(&:observation)] }
-    let!(:appointments) { patients.map { |patient| create_list(:appointment, 2, patient: patient, facility: facilities.first) }.flatten }
-    let!(:app_users) { create_list(:user, 2, :with_phone_number_authentication, registration_facility: facilities.first) }
-    let!(:dashboard_users) { create_list(:admin, 2, organization: organization) }
+      let!(:organization) { create(:organization) }
 
-    before { allow_any_instance_of(described_class).to receive(:log) }
-
-    it "deletes an org and associated data" do
-      described_class.call(organization_id: organization.id, dry_run: false)
-
-      facilities.each { |facility| expect { facility.reload }.to raise_error ActiveRecord::RecordNotFound }
-      soft_deleted_facilities.each { |facility| expect { facility.reload }.to raise_error ActiveRecord::RecordNotFound }
-
-      patients.each { |patient| expect { patient.reload }.to raise_error ActiveRecord::RecordNotFound }
-      appointments.each { |appointment| expect { appointment.reload }.to raise_error ActiveRecord::RecordNotFound }
-      blood_pressures.each { |blood_pressure| expect { blood_pressure.reload }.to raise_error ActiveRecord::RecordNotFound }
-      blood_sugars.each { |blood_sugar| expect { blood_sugar.reload }.to raise_error ActiveRecord::RecordNotFound }
-      encounters.each { |encounter| expect { encounter.reload }.to raise_error ActiveRecord::RecordNotFound }
-      observations.each { |observation| expect { observation.reload }.to raise_error ActiveRecord::RecordNotFound }
-      medical_histories.each { |medical_history| expect { medical_history.reload }.to raise_error ActiveRecord::RecordNotFound }
-      prescription_drugs.each { |prescription_drug| expect { prescription_drug.reload }.to raise_error ActiveRecord::RecordNotFound }
-      patient_phone_numbers.each { |patient_phone_number| expect { patient_phone_number.reload }.to raise_error ActiveRecord::RecordNotFound }
-
-      app_users.each { |app_user| expect { app_user.reload }.to raise_error ActiveRecord::RecordNotFound }
-      dashboard_users.each { |dashboard_user| expect { dashboard_user.reload }.to raise_error ActiveRecord::RecordNotFound }
+      it "halts execution" do
+        expect {
+          described_class.call(organization: organization, dry_run: false)
+        }.to raise_error(RuntimeError, "This script is currently disabled, to enable it, raise a PR and make necessary code changes.")
+      end
     end
 
-    it "does not delete things from other orgs" do
-      other_organizations = create_list(:organization, 2)
-      other_facility_groups = other_organizations.map { |org| create_list(:facility_group, 2, organization: org) }.flatten
-      other_facilities = other_facility_groups.map { |fg| create_list(:facility, 2, facility_group: fg) }.flatten
-      other_soft_deleted_facilities = create_list(:facility, 2, facility_group: nil, deleted_at: Time.current)
-      other_patients = other_facilities.map { |facility| create_list(:patient, 2, registration_facility: facility) }.flatten
-      other_medical_histories = other_patients.map(&:medical_history)
-      other_prescription_drugs = other_patients.map(&:prescription_drugs).flatten
-      other_patient_phone_numbers = other_patients.map(&:phone_numbers).flatten
-      other_blood_pressures = other_patients.map { |patient| create_list(:blood_pressure, 2, :with_encounter, patient: patient, facility: other_facilities.second) }.flatten
-      other_blood_sugars = other_patients.map { |patient| create_list(:blood_sugar, 2, :with_encounter, patient: patient, facility: other_facilities.first) }.flatten
-      other_encounters = [*other_blood_pressures.map(&:encounter), *other_blood_sugars.map(&:encounter)]
-      other_observations = [*other_blood_pressures.map(&:observation), *other_blood_sugars.map(&:observation)]
-      other_appointments = other_patients.map { |patient| create_list(:appointment, 2, patient: patient, facility: other_facilities.first) }.flatten
+    context "enabled" do
+      before do
+        stub_const("DeleteOrganizationData::DISABLE", false)
+      end
 
-      other_app_users = create_list(:user, 2, :with_phone_number_authentication, registration_facility: other_facilities.first)
-      other_dashboard_users = create_list(:admin, 2, organization: other_organizations.first)
+      let!(:organization) { create(:organization) }
+      let!(:facility_group) { create(:facility_group, organization: organization) }
+      let!(:facilities) { create_list(:facility, 2, facility_group: facility_group) }
+      let!(:soft_deleted_facilities) { create_list(:facility, 2, facility_group: facility_group, facility_type: "Standalone", deleted_at: Time.current) }
 
-      described_class.call(organization_id: organization.id, dry_run: false)
-      other_organizations.map { |org| expect(org.reload).to eq org }
-      other_facility_groups.map { |fg| expect(fg.reload).to eq fg }
-      other_facilities.each { |facility| expect(facility.reload).to eq facility }
-      other_soft_deleted_facilities.each { |facility| expect(facility.reload).to eq facility }
+      let!(:patients) { facilities.map { |facility| create_list(:patient, 2, registration_facility: facility) }.flatten }
+      let!(:medical_histories) { patients.map(&:medical_history) }
+      let!(:prescription_drugs) { patients.map(&:prescription_drugs).flatten }
+      let!(:patient_phone_numbers) { patients.map(&:phone_numbers).flatten }
+      let!(:blood_pressures) { patients.map { |patient| create_list(:blood_pressure, 2, :with_encounter, patient: patient, facility: facilities.second) }.flatten }
+      let!(:blood_sugars) { patients.map { |patient| create_list(:blood_sugar, 2, :with_encounter, patient: patient, facility: facilities.first) }.flatten }
+      let!(:encounters) { [*blood_pressures.map(&:encounter), *blood_sugars.map(&:encounter)] }
+      let!(:observations) { [*blood_pressures.map(&:observation), *blood_sugars.map(&:observation)] }
+      let!(:appointments) { patients.map { |patient| create_list(:appointment, 2, patient: patient, facility: facilities.first) }.flatten }
+      let!(:app_users) { create_list(:user, 2, :with_phone_number_authentication, registration_facility: facilities.first) }
+      let!(:dashboard_users) { create_list(:admin, 2, organization: organization) }
 
-      other_patients.each { |patient| expect(patient.reload).to eq patient }
-      other_appointments.each { |appointment| expect(appointment.reload).to eq appointment }
-      other_blood_pressures.each { |blood_pressure| expect(blood_pressure.reload).to eq blood_pressure }
-      other_blood_sugars.each { |blood_sugar| expect(blood_sugar.reload).to eq blood_sugar }
-      other_encounters.each { |encounter| expect(encounter.reload).to eq encounter }
-      other_observations.each { |observation| expect(observation.reload).to eq observation }
-      other_medical_histories.each { |medical_history| expect(medical_history.reload).to eq medical_history }
-      other_prescription_drugs.each { |prescription_drug| expect(prescription_drug.reload).to eq prescription_drug }
-      other_patient_phone_numbers.each { |patient_phone_number| expect(patient_phone_number.reload).to eq patient_phone_number }
+      before { allow_any_instance_of(described_class).to receive(:log) }
 
-      other_app_users.each { |app_user| expect(app_user.reload).to eq app_user }
-      other_dashboard_users.each { |dashboard_user| expect(dashboard_user.reload).to eq dashboard_user }
+      it "deletes an org and associated data" do
+        described_class.call(organization: organization, dry_run: false)
+
+        facilities.each { |facility| expect { facility.reload }.to raise_error ActiveRecord::RecordNotFound }
+        soft_deleted_facilities.each { |facility| expect { facility.reload }.to raise_error ActiveRecord::RecordNotFound }
+
+        patients.each { |patient| expect { patient.reload }.to raise_error ActiveRecord::RecordNotFound }
+        appointments.each { |appointment| expect { appointment.reload }.to raise_error ActiveRecord::RecordNotFound }
+        blood_pressures.each { |blood_pressure| expect { blood_pressure.reload }.to raise_error ActiveRecord::RecordNotFound }
+        blood_sugars.each { |blood_sugar| expect { blood_sugar.reload }.to raise_error ActiveRecord::RecordNotFound }
+        encounters.each { |encounter| expect { encounter.reload }.to raise_error ActiveRecord::RecordNotFound }
+        observations.each { |observation| expect { observation.reload }.to raise_error ActiveRecord::RecordNotFound }
+        medical_histories.each { |medical_history| expect { medical_history.reload }.to raise_error ActiveRecord::RecordNotFound }
+        prescription_drugs.each { |prescription_drug| expect { prescription_drug.reload }.to raise_error ActiveRecord::RecordNotFound }
+        patient_phone_numbers.each { |patient_phone_number| expect { patient_phone_number.reload }.to raise_error ActiveRecord::RecordNotFound }
+
+        app_users.each { |app_user| expect { app_user.reload }.to raise_error ActiveRecord::RecordNotFound }
+        dashboard_users.each { |dashboard_user| expect { dashboard_user.reload }.to raise_error ActiveRecord::RecordNotFound }
+      end
+
+      it "does not delete things from other orgs" do
+        other_organizations = create_list(:organization, 2)
+        other_facility_groups = other_organizations.map { |org| create_list(:facility_group, 2, organization: org) }.flatten
+        other_facilities = other_facility_groups.map { |fg| create_list(:facility, 2, facility_group: fg) }.flatten
+        other_soft_deleted_facilities = create_list(:facility, 2, facility_group: nil, deleted_at: Time.current)
+        other_patients = other_facilities.map { |facility| create_list(:patient, 2, registration_facility: facility) }.flatten
+        other_medical_histories = other_patients.map(&:medical_history)
+        other_prescription_drugs = other_patients.map(&:prescription_drugs).flatten
+        other_patient_phone_numbers = other_patients.map(&:phone_numbers).flatten
+        other_blood_pressures = other_patients.map { |patient| create_list(:blood_pressure, 2, :with_encounter, patient: patient, facility: other_facilities.second) }.flatten
+        other_blood_sugars = other_patients.map { |patient| create_list(:blood_sugar, 2, :with_encounter, patient: patient, facility: other_facilities.first) }.flatten
+        other_encounters = [*other_blood_pressures.map(&:encounter), *other_blood_sugars.map(&:encounter)]
+        other_observations = [*other_blood_pressures.map(&:observation), *other_blood_sugars.map(&:observation)]
+        other_appointments = other_patients.map { |patient| create_list(:appointment, 2, patient: patient, facility: other_facilities.first) }.flatten
+
+        other_app_users = create_list(:user, 2, :with_phone_number_authentication, registration_facility: other_facilities.first)
+        other_dashboard_users = create_list(:admin, 2, organization: other_organizations.first)
+
+        described_class.call(organization: organization, dry_run: false)
+        other_organizations.map { |org| expect(org.reload).to eq org }
+        other_facility_groups.map { |fg| expect(fg.reload).to eq fg }
+        other_facilities.each { |facility| expect(facility.reload).to eq facility }
+        other_soft_deleted_facilities.each { |facility| expect(facility.reload).to eq facility }
+
+        other_patients.each { |patient| expect(patient.reload).to eq patient }
+        other_appointments.each { |appointment| expect(appointment.reload).to eq appointment }
+        other_blood_pressures.each { |blood_pressure| expect(blood_pressure.reload).to eq blood_pressure }
+        other_blood_sugars.each { |blood_sugar| expect(blood_sugar.reload).to eq blood_sugar }
+        other_encounters.each { |encounter| expect(encounter.reload).to eq encounter }
+        other_observations.each { |observation| expect(observation.reload).to eq observation }
+        other_medical_histories.each { |medical_history| expect(medical_history.reload).to eq medical_history }
+        other_prescription_drugs.each { |prescription_drug| expect(prescription_drug.reload).to eq prescription_drug }
+        other_patient_phone_numbers.each { |patient_phone_number| expect(patient_phone_number.reload).to eq patient_phone_number }
+
+        other_app_users.each { |app_user| expect(app_user.reload).to eq app_user }
+        other_dashboard_users.each { |dashboard_user| expect(dashboard_user.reload).to eq dashboard_user }
+      end
     end
   end
 end


### PR DESCRIPTION
## Because

Just a clean-up task. This script is a little scary to have around, so let's make sure we disable for now and enable it back when we need it manually (i.e. for cleaning up Screening Data Wardha on production)

## This addresses

* Disallow running the `hard_delete` script, force people to make code-changes to use.
* Remove PATH delete tasks.
