### PR TITLE
Create regions when importing source models

### DIFF
--- a/app/jobs/import_facilities_job.rb
+++ b/app/jobs/import_facilities_job.rb
@@ -12,10 +12,6 @@ class ImportFacilitiesJob < ApplicationJob
       import_facilities << import_facility
     end
 
-    ActiveRecord::Base.transaction do
-      Facility.import!(import_facilities, validate: true)
-      # import! can't run callbacks, so we manually ensure that we create regions
-      import_facilities.each(&:make_region) if Flipper.enabled?(:regions_prep)
-    end
+    Facility.import_with_regions(import_facilities, validate: true)
   end
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -131,11 +131,13 @@ class Facility < ApplicationRecord
   # the gem to bulk import cannot run callbacks, so we manually ensure that we create regions
   def self.import_with_regions(facilities, *args)
     Facility.transaction do
-      Facility.import(facilities, *args)
+      imported_facilities = Facility.import(facilities, *args)
 
       if Flipper.enabled?(:regions_prep)
         facilities.each { |facility| facility.make_region }
       end
+
+      imported_facilities
     end
   end
 

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -131,12 +131,10 @@ class Facility < ApplicationRecord
   # the gem to bulk import cannot run callbacks, so we manually ensure that we create regions
   def self.import_with_regions(facilities, *args)
     Facility.transaction do
-      imported_facilities = Facility.import(facilities, *args)
+      Facility.import(facilities, *args)
 
       if Flipper.enabled?(:regions_prep)
-        imported_facilities.each do |facility|
-          facility.make_region
-        end
+        facilities.each { |facility| facility.make_region }
       end
     end
   end

--- a/app/models/facility_group.rb
+++ b/app/models/facility_group.rb
@@ -43,11 +43,13 @@ class FacilityGroup < ApplicationRecord
   # the gem to bulk import cannot run callbacks, so we manually ensure that we create regions
   def self.import_with_regions(facility_groups, *args)
     Facility.transaction do
-      FacilityGroup.import(facility_groups, *args)
+      imported_facility_groups = FacilityGroup.import(facility_groups, *args)
 
       if Flipper.enabled?(:regions_prep)
         facility_groups.each { |facility_group| FacilityGroupRegionSync.new(facility_group).after_create }
       end
+
+      imported_facility_groups
     end
   end
 

--- a/app/models/facility_group.rb
+++ b/app/models/facility_group.rb
@@ -43,12 +43,10 @@ class FacilityGroup < ApplicationRecord
   # the gem to bulk import cannot run callbacks, so we manually ensure that we create regions
   def self.import_with_regions(facility_groups, *args)
     Facility.transaction do
-      imported_facility_groups = FacilityGroup.import(facility_groups, *args)
+      FacilityGroup.import(facility_groups, *args)
 
       if Flipper.enabled?(:regions_prep)
-        imported_facility_groups.each do |facility_group|
-          FacilityGroupRegionSync.new(facility_group).after_create
-        end
+        facility_groups.each { |facility_group| FacilityGroupRegionSync.new(facility_group).after_create }
       end
     end
   end

--- a/lib/seed/facility_seeder.rb
+++ b/lib/seed/facility_seeder.rb
@@ -64,7 +64,7 @@ module Seed
       facility_groups = number_of_facility_groups.times.map {
         FactoryBot.build(:facility_group, organization_id: organization.id, state: nil)
       }
-      fg_result = FacilityGroup.import(facility_groups, returning: [:id, :name], on_duplicate_key_ignore: true)
+      fg_result = FacilityGroup.import_with_regions(facility_groups, returning: [:id, :name], on_duplicate_key_ignore: true)
 
       facility_attrs = []
       fg_result.results.each do |row|
@@ -90,7 +90,7 @@ module Seed
         }
       end
 
-      Facility.import(facility_attrs, on_duplicate_key_ignore: true)
+      Facility.import_with_regions(facility_attrs, on_duplicate_key_ignore: true)
     end
   end
 end


### PR DESCRIPTION
**Story card:** TBD
## Because

Importing using the `activerecord-import` gem bypasses most of the callbacks that Rails supports, since it runs in it's own codepath and uses a separate bulk query. This means it cannot reliably guarantee creating regions on its own.

This is problematic because the new seed script never created any regions for source models.

## This addresses

Add a `Facility#import_with_regions` and `FacilityGroup#import_with_regions`.
