### PR TITLE
Create all necessary regions in seed process

### DIFF
--- a/app/models/facility_group.rb
+++ b/app/models/facility_group.rb
@@ -32,10 +32,11 @@ class FacilityGroup < ApplicationRecord
   # FacilityGroups don't actually have a state
   # This virtual attr exists simply to simulate the State -> FG/District hierarchy for Regions.
   attr_writer :state
-  validates :state, presence: true, if: -> { Flipper.enabled?(:regions_prep) }
+  validates :state, presence: true, if: -> { Flipper.enabled?(:regions_prep) }, unless: :generating_seed_data
 
   attr_accessor :new_block_names
   attr_accessor :remove_block_ids
+  attr_accessor :generating_seed_data
 
   after_create { |record| FacilityGroupRegionSync.new(record).after_create }
   after_update { |record| FacilityGroupRegionSync.new(record).after_update }

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -16,7 +16,9 @@ class Region < ApplicationRecord
   # To set a new path for a Region, assign the parent region via `reparent_to`, and the before_validation
   # callback will assign the new path.
   attr_accessor :reparent_to
+  attr_accessor :parent_path
   before_validation :initialize_path, if: :reparent_to
+  before_validation :_set_path_for_seeds, if: :parent_path
   before_discard :remove_path
 
   REGION_TYPES = %w[root organization state district block facility].freeze
@@ -80,8 +82,12 @@ class Region < ApplicationRecord
 
   private
 
+  def _set_path_for_seeds
+    self.path = "#{parent_path}.#{path_label}"
+  end
+
   def initialize_path
-    logger.info(class: self.class.name, msg: "got reparent_to: #{reparent_to.name}, going to initialize new path")
+    # logger.info(class: self.class.name, msg: "got reparent_to: #{reparent_to.name}, going to initialize new path")
     self.path = if reparent_to.path.present?
       "#{reparent_to.path}.#{path_label}"
     else

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,5 +42,5 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.log_level = :info
+  config.log_level = :debug
 end

--- a/lib/seed/facility_seeder.rb
+++ b/lib/seed/facility_seeder.rb
@@ -67,7 +67,7 @@ module Seed
 
       # Create state Regions
       states = number_of_states.times.map {
-        FactoryBot.build(:region, id: nil, region_type: :state, parent_path: Region.root.path)
+        FactoryBot.build(:region, :state, id: nil, parent_path: Region.root.path)
       }
       state_results = Region.import(states, returning: [:path])
 

--- a/lib/seed/facility_seeder.rb
+++ b/lib/seed/facility_seeder.rb
@@ -80,8 +80,7 @@ module Seed
           generating_seed_data: true,
           name: district_names[i],
           organization_id: organization.id,
-          state: nil
-        )
+          state: nil)
       }
       fg_result = FacilityGroup.import(facility_groups, returning: [:id, :name], on_duplicate_key_ignore: true)
 

--- a/lib/seed/facility_seeder.rb
+++ b/lib/seed/facility_seeder.rb
@@ -38,6 +38,10 @@ module Seed
       config.number_of_facility_groups
     end
 
+    def number_of_states
+      3
+    end
+
     def number_of_facilities_per_facility_group
       config.rand_or_max(1..config.max_number_of_facilities_per_facility_group)
     end
@@ -61,17 +65,59 @@ module Seed
       end
       puts "Creating #{number_of_facility_groups} FacilityGroups..."
 
+      # Create state Regions
+      states = number_of_states.times.map {
+        FactoryBot.build(:region, id: nil, region_type: :state, parent_path: Region.root.path)
+      }
+      state_results = Region.import(states, returning: [:path])
+
+      # Create FacilityGroups
       facility_groups = number_of_facility_groups.times.map {
-        FactoryBot.build(:facility_group, organization_id: organization.id, state: nil)
+        FactoryBot.build(:facility_group,
+          id: nil,
+          organization_id: organization.id,
+          state: nil,
+          create_parent_region: false,
+          generating_seed_data: true)
       }
       fg_result = FacilityGroup.import(facility_groups, returning: [:id, :name], on_duplicate_key_ignore: true)
 
+      # Create district Regions
+      district_regions = fg_result.results.map { |row|
+        facility_group_id, facility_group_name = *row
+        attrs = {
+          id: nil,
+          name: facility_group_name,
+          region_type: "district",
+          parent_path: state_results.results.sample,
+          source_id: facility_group_id,
+          source_type: "FacilityGroup"
+        }
+        FactoryBot.build(:region, attrs)
+      }
+      district_regions_results = Region.import(district_regions, returning: [:id, :name, :path])
+
+      # Create block Regions
+      block_regions = district_regions_results.results.map { |row|
+        id, name, path = *row
+        attrs = {
+          id: nil,
+          name: Seed::FakeNames.instance.blocks.sample,
+          parent_path: path,
+          region_type: "block"
+        }
+        FactoryBot.build(:region, attrs)
+      }
+      Region.import(block_regions, returning: [:id, :name, :path])
+
+      # Create Facilities
       facility_attrs = []
       fg_result.results.each do |row|
         facility_group_id, facility_group_name = *row
+        facility_group_region = Region.find_by!(source_id: facility_group_id)
         number_facilities = number_of_facilities_per_facility_group
-        state = Seed::FakeNames.instance.state
-        blocks = Seed::FakeNames.instance.blocks.sample(facilities_per_block)
+        state = facility_group_region.state_region
+        blocks = facility_group_region.block_regions.pluck(:name)
         number_facilities.times {
           size = weighted_facility_size_sample
           type = SIZES_TO_TYPE.fetch(size).sample
@@ -90,7 +136,21 @@ module Seed
         }
       end
 
-      Facility.import(facility_attrs, on_duplicate_key_ignore: true)
+      facility_results = Facility.import(facility_attrs, returning: [:id, :name, :zone], on_duplicate_key_ignore: true)
+      facility_regions = facility_results.results.map { |row|
+        id, name, block_name = *row
+        block = Region.find_by!(name: block_name)
+        attrs = {
+          id: nil,
+          name: name,
+          parent_path: block&.path,
+          region_type: "facility",
+          source_id: id,
+          source_type: "Facility"
+        }
+        FactoryBot.build(:region, attrs)
+      }
+      result = Region.import(facility_regions)
     end
   end
 end

--- a/lib/seed/facility_seeder.rb
+++ b/lib/seed/facility_seeder.rb
@@ -72,13 +72,16 @@ module Seed
       state_results = Region.import(states, returning: [:path])
 
       # Create FacilityGroups
-      facility_groups = number_of_facility_groups.times.map {
+      district_names = Seed::FakeNames.instance.districts.sample(number_of_facility_groups)
+      facility_groups = number_of_facility_groups.times.each_with_index.map { |i|
         FactoryBot.build(:facility_group,
           id: nil,
-          organization_id: organization.id,
-          state: nil,
           create_parent_region: false,
-          generating_seed_data: true)
+          generating_seed_data: true,
+          name: district_names[i],
+          organization_id: organization.id,
+          state: nil
+        )
       }
       fg_result = FacilityGroup.import(facility_groups, returning: [:id, :name], on_duplicate_key_ignore: true)
 

--- a/lib/seed/fake_names.rb
+++ b/lib/seed/fake_names.rb
@@ -2,7 +2,7 @@ module Seed
   class FakeNames
     include Singleton
 
-    attr_reader :blocks
+    attr_reader :blocks, :districts
 
     def initialize
       @csv = CSV.read(Rails.root.join("db/fake_names.csv").to_s, headers: true).by_col!

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -12,7 +12,7 @@ namespace :db do
   end
 
   desc "Clear patient data, regenerate patient seed data, and refresh materialized views"
-  task purge_and_refresh: [:purge_users_data, :seed_patients, :refresh_materialized_views]
+  task purge_and_reseed: [:purge_users_data, :seed_patients, :refresh_materialized_views]
 
   desc "Generate some fake data for a seed user roles"
   task seed_users_data: :environment do

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :region do
     id { SecureRandom.uuid }
     name { Faker::Company.name }
-    region_type { :organization }
+    region_type { "organization" }
 
     trait :block do
       region_type { :block }

--- a/spec/lib/seed/facility_seeder_spec.rb
+++ b/spec/lib/seed/facility_seeder_spec.rb
@@ -1,36 +1,62 @@
 require "rails_helper"
 
-RSpec.describe Seed::FacilitySeeder do
-  it "creates facility groups and facilities" do
-    expect {
-      Seed::FacilitySeeder.call(config: Seed::Config.new)
-    }.to change { FacilityGroup.count }.by(2)
-      .and change { Facility.count }.by(8)
-  end
-
-  it "generates a name based on the facility size" do
-    seeder = Seed::FacilitySeeder.new(config: Seed::Config.new)
-    expect(seeder).to receive(:weighted_facility_size_sample).and_return(:small).at_least(1).times
-    seeder.call
-    small_facility_names = Regexp.union(Seed::FacilitySeeder::SIZES_TO_TYPE[:small])
-    Facility.all.each do |facility|
-      expect(facility.name).to match(small_facility_names)
+[:enable, :disable].each do |toggle|
+  RSpec.describe Seed::FacilitySeeder, "with regions_prep #{toggle}d" do
+    before do
+      Flipper.public_send(toggle, :regions_prep)
     end
-  end
 
-  it "does not create more facility groups than the max when called multiple times" do
-    expect {
-      3.times { Seed::FacilitySeeder.call(config: Seed::Config.new) }
-    }.to change { FacilityGroup.count }.by(2)
-      .and change { Facility.count }.by_at_most(8)
-  end
+    it "creates facility groups and facilities" do
+      expect {
+        Seed::FacilitySeeder.call(config: Seed::Config.new)
+      }.to change { FacilityGroup.count }.by(2)
+        .and change { Facility.count }.by(8)
+    end
 
-  it "creates facilities within a facility group (ie district) that are all within the same state" do
-    seeder = Seed::FacilitySeeder.new(config: Seed::Config.new)
-    seeder.call
-    Facility.all.group_by { |f| f.facility_group_id }.each do |facility_group_id, facilities|
-      single_state = facilities.first.state
-      expect(facilities.map(&:state).uniq).to contain_exactly(single_state)
+    it "creates facility groups and facilities with regions" do
+      expect {
+        Seed::FacilitySeeder.call(config: Seed::Config.new)
+      }.to change { Region.district_regions.count }.by(2)
+        .and change { Region.facility_regions.count }.by(8)
+        .and change { FacilityGroup.count }.by(2)
+        .and change { Facility.count }.by(8)
+      expect(Region.block_regions.count).to be > 0
+      expect(Region.state_regions.count).to be > 0
+      # verify facility regions are linked up correctly
+      Region.facility_regions.each do |region|
+        expect(region.name).to eq(region.source.name)
+        expect(region.district_region).to_not be_nil
+        district = region.district_region
+        block = region.block_region
+        expect(district).to eq(region.source.facility_group.region)
+        expect(block.parent).to eq(district)
+      end
+    end
+
+    it "generates a name based on the facility size" do
+      seeder = Seed::FacilitySeeder.new(config: Seed::Config.new)
+      expect(seeder).to receive(:weighted_facility_size_sample).and_return(:small).at_least(1).times
+      seeder.call
+      small_facility_names = Regexp.union(Seed::FacilitySeeder::SIZES_TO_TYPE[:small])
+      Facility.all.each do |facility|
+        expect(facility.name).to match(small_facility_names)
+      end
+    end
+
+    it "does not create more facility groups than the max when called multiple times" do
+      expect {
+        3.times { Seed::FacilitySeeder.call(config: Seed::Config.new) }
+      }.to change { FacilityGroup.count }.by(2)
+        .and change { Facility.count }.by_at_most(8)
+    end
+
+    it "creates facilities within a facility group (ie district) that are all within the same state" do
+      seeder = Seed::FacilitySeeder.new(config: Seed::Config.new)
+      seeder.call
+      Facility.all.group_by { |f| f.facility_group_id }.each do |facility_group_id, facilities|
+        single_state = facilities.first.state
+        expect(facilities.map(&:state).uniq).to contain_exactly(single_state)
+      end
     end
   end
 end


### PR DESCRIPTION
Creating Regions in our FacilitySeeder so that things will be valid in non-prod envs.

I'm keeping this all inside the FacilitySeeder for now, because we really need this to stay fast and drive it via ActiveRecord Import. Also, the logic will get cleaner and simpler once the legacy fields are removed (`zone` and `state` fields).

