### PR TITLE
Add locales for address pin in Ethiopia

### DIFF
--- a/config/locales/en_ET.yml
+++ b/config/locales/en_ET.yml
@@ -11,6 +11,7 @@ en_ET:
         district: "Zone *"
         state: "Region *"
         country: "Country *"
+        pin: "Postal Code"
       address:
         street_address: "House and street number"
         village_or_colony: "Kebele"
@@ -18,6 +19,7 @@ en_ET:
         district: "Zone"
         state: "Region *"
         country: "Country *"
+        pin: "Postal Code"
     submit:
       facility:
         create: "Save facility"


### PR DESCRIPTION
**Story card:** [ch2048](https://app.clubhouse.io/simpledotorg/story/2048/change-pin-to-postal-code) 😎 

## Because

"Pin" or "Pin code" isn't recognized in Ethiopia.

## This addresses

Replace "Pin" with "Postal code" in Ethiopia.

## Screenshots

### Ethiopia
![Screen Shot 2020-12-08 at 4 14 39 PM](https://user-images.githubusercontent.com/4241399/101474012-8aa32480-3970-11eb-9280-ec97788c4dd6.png)

### India
![Screen Shot 2020-12-08 at 4 14 21 PM](https://user-images.githubusercontent.com/4241399/101474027-8ecf4200-3970-11eb-958b-af038aff4dfc.png)

