### PR TITLE
Quick logging fix for RegionsIntegrityCheck

### DIFF
--- a/app/services/regions_integrity_check.rb
+++ b/app/services/regions_integrity_check.rb
@@ -17,6 +17,7 @@
 # Reporting –
 # It reports inconsistencies to Sentry and Logs to standard logger
 class RegionsIntegrityCheck
+  RegionsIntegrityCheck.sweep
   SENTRY_ERROR_TITLE = "Regions Integrity Failure"
 
   attr_reader :inconsistencies
@@ -206,11 +207,11 @@ class RegionsIntegrityCheck
     end
   end
 
-  def log(type, *args)
+  def log(type, args)
     Rails.logger.public_send(type, msg: args, class: self.class.name)
   end
 
-  def sentry(*args)
+  def sentry(args)
     Raven.capture_message(SENTRY_ERROR_TITLE, logger: "logger", extra: args, tags: {type: "regions"})
   end
 end

--- a/app/services/regions_integrity_check.rb
+++ b/app/services/regions_integrity_check.rb
@@ -17,7 +17,6 @@
 # Reporting –
 # It reports inconsistencies to Sentry and Logs to standard logger
 class RegionsIntegrityCheck
-  RegionsIntegrityCheck.sweep
   SENTRY_ERROR_TITLE = "Regions Integrity Failure"
 
   attr_reader :inconsistencies

--- a/spec/services/regions_integrity_check_spec.rb
+++ b/spec/services/regions_integrity_check_spec.rb
@@ -111,8 +111,8 @@ RSpec.describe RegionsIntegrityCheck, type: :model do
 
     it "tracks duplicate facilities" do
       duplicates = create_list(:region, 2, region_type: :facility, source: facility_1, reparent_to: block_1)
-                     .yield_self { |facilities| facilities << facility_1.region }
-                     .map(&:id)
+        .yield_self { |facilities| facilities << facility_1.region }
+        .map(&:id)
 
       swept = RegionsIntegrityCheck.sweep
 

--- a/spec/services/regions_integrity_check_spec.rb
+++ b/spec/services/regions_integrity_check_spec.rb
@@ -111,8 +111,8 @@ RSpec.describe RegionsIntegrityCheck, type: :model do
 
     it "tracks duplicate facilities" do
       duplicates = create_list(:region, 2, region_type: :facility, source: facility_1, reparent_to: block_1)
-        .yield_self { |facilities| facilities << facility_1.region }
-        .map(&:id)
+                     .yield_self { |facilities| facilities << facility_1.region }
+                     .map(&:id)
 
       swept = RegionsIntegrityCheck.sweep
 
@@ -127,10 +127,10 @@ RSpec.describe RegionsIntegrityCheck, type: :model do
 
       expected_log = {
         class: "RegionsIntegrityCheck",
-        msg: [{
+        msg: {
           resource: :blocks,
           result: {missing_regions: [["B2", facility_groups[1].id], ["B1", facility_groups[0].id]]}
-        }]
+        }
       }
 
       expect(Rails.logger).to receive(:error).with(expected_log)
@@ -153,15 +153,13 @@ RSpec.describe RegionsIntegrityCheck, type: :model do
       expected_msg = [
         "Regions Integrity Failure",
         {
-          extra: [
-            {
-              resource: :blocks,
-              result:
-                {
-                  missing_regions: [["B2", facility_groups[1].id], ["B1", facility_groups[0].id]]
-                }
-            }
-          ],
+          extra: {
+            resource: :blocks,
+            result:
+              {
+                missing_regions: [["B2", facility_groups[1].id], ["B1", facility_groups[0].id]]
+              }
+          },
           logger: "logger",
           tags: {type: "regions"}
         }


### PR DESCRIPTION
Quick fix to render the `RegionsIntegrityCheck` reporting clearly in logs/sentry.