### PR TITLE
Comma-separate "Registrations" numbers

### DIFF
--- a/app/views/my_facilities/registrations.html.erb
+++ b/app/views/my_facilities/registrations.html.erb
@@ -106,7 +106,9 @@
         <tr class="row-total" data-sort-method="none">
           <td class="type-title">All</td>
           <% @display_periods.reverse.each do |period| %>
-            <td class="type-number" <% unless @selected_period == :day %>colspan="2"<% end %>><%= @total_registrations_by_period[period].to_i %></td>
+            <td class="type-number" <% unless @selected_period == :day %>colspan="2"<% end %>>
+              <%= number_or_dash_with_delimiter(@total_registrations_by_period[period].to_i) %>
+            </td>
           <% end %>
           <td class="type-number"><%= number_or_dash_with_delimiter(@total_registrations.values.sum) %></td>
         </tr>


### PR DESCRIPTION
**Story card:** [ch2083](https://app.clubhouse.io/simpledotorg/story/2083/comma-separated-numbers-in-my-facilities-registrations)

## Because

The "All" numbers aren't comma-formatted.

## This addresses

Uses `number_or_dash_with_delimiter()` helper to comma-separate "All" numbers

![image](https://user-images.githubusercontent.com/16785131/101963704-f84f8a80-3bd4-11eb-98a2-bca12e5932cc.png)