### PR TITLE
Resize performance boxes

### DIFF
--- a/config/deploy/india/performance/feature.rb
+++ b/config/deploy/india/performance/feature.rb
@@ -1,1 +1,1 @@
-server "65.0.55.38", user: "deploy", roles: %w[web app db cron]
+server "13.232.178.205", user: "deploy", roles: %w[web app db cron]

--- a/config/deploy/india/performance/primary.rb
+++ b/config/deploy/india/performance/primary.rb
@@ -1,1 +1,1 @@
-server "13.233.31.62", user: "deploy", roles: %w[web app db cron]
+server "13.233.237.184", user: "deploy", roles: %w[web app db cron]


### PR DESCRIPTION
**Story card:** - 

## Because

The performance boxes are a `t2.large`. Bump them up to test how block level sync would work on prod boxes (which we will bump to `t2.xlarge` soon as well).