### PR TITLE
Region breadcrumbs and show 'children data'

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -24,7 +24,7 @@ class Reports::RegionsController < AdminController
     @new_registrations = @last_registration_value - (@data[:cumulative_registrations].values[-2] || 0)
     @adjusted_registration_date = @data[:adjusted_registrations].keys[-4]
 
-    if @region.district_region?
+    if @region.district_region? || @region.block_region?
       @data_for_facility = @region.facilities.each_with_object({}) { |facility, hsh|
         hsh[facility.name] = Reports::RegionService.new(region: facility,
                                                         period: @period).call

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -24,16 +24,10 @@ class Reports::RegionsController < AdminController
     @new_registrations = @last_registration_value - (@data[:cumulative_registrations].values[-2] || 0)
     @adjusted_registration_date = @data[:adjusted_registrations].keys[-4]
 
-    if @region.district_region? || @region.block_region?
-      @data_for_facility = @region.facilities.each_with_object({}) { |facility, hsh|
-        hsh[facility.name] = Reports::RegionService.new(region: facility,
-                                                        period: @period).call
-      }
-    end
-    if current_admin.feature_enabled?(:region_reports) && @region.district_region? && @region.respond_to?(:block_regions)
-      @block_data = @region.block_regions.each_with_object({}) { |region, hsh|
-        hsh[region.name] = Reports::RegionService.new(region: region,
-                                                      period: @period).call
+    if @region.respond_to?(:children)
+      @children_data = @region.children.each_with_object({}) { |child, hsh|
+        hsh[child.name] = Reports::RegionService.new(region: child,
+                                                     period: @period).call
       }
     end
   end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -148,6 +148,10 @@ class Facility < ApplicationRecord
     [self]
   end
 
+  def child_region_type
+    nil
+  end
+
   def recent_blood_pressures
     blood_pressures.includes(:patient, :user).order(Arel.sql("DATE(recorded_at) DESC, recorded_at ASC"))
   end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -198,15 +198,7 @@ class Facility < ApplicationRecord
     registered_patients.none? && blood_pressures.none? && blood_sugars.none? && appointments.none?
   end
 
-  # For regions compatibility
-  def facility_region?
-    true
-  end
-
-  # For regions compatibility
-  def district_region?
-    false
-  end
+  delegate :district_region?, :block_region?, :facility_region?, to: :region
 
   def valid_block
     unless facility_group.region.block_regions.pluck(:name).include?(block)

--- a/app/models/facility_district.rb
+++ b/app/models/facility_district.rb
@@ -13,6 +13,10 @@ class FacilityDistrict
     scope.where(district: name)
   end
 
+  def child_region_type
+    "facility"
+  end
+
   alias_method :children, :facilities
 
   def organization

--- a/app/models/facility_district.rb
+++ b/app/models/facility_district.rb
@@ -13,6 +13,8 @@ class FacilityDistrict
     scope.where(district: name)
   end
 
+  alias_method :children, :facilities
+
   def organization
     facility_group_ids = facilities.pluck(:facility_group_id).uniq
     organization_ids = FacilityGroup.where(id: facility_group_ids).pluck(:organization_id).uniq

--- a/app/models/facility_group.rb
+++ b/app/models/facility_group.rb
@@ -94,15 +94,7 @@ class FacilityGroup < ApplicationRecord
     registered_patients.with_discarded
   end
 
-  # For regions compatibility
-  def facility_region?
-    false
-  end
-
-  # For regions compatibility
-  def district_region?
-    true
-  end
+  delegate :district_region?, :block_region?, :facility_region?, to: :region
 
   private
 

--- a/app/models/facility_group.rb
+++ b/app/models/facility_group.rb
@@ -60,6 +60,16 @@ class FacilityGroup < ApplicationRecord
     Region.state_regions.create!(name: state, reparent_to: organization.region)
   end
 
+  # For Regions compatibility
+  delegate :district_region?, :block_region?, :facility_region?, to: :region
+
+  def child_region_type
+    "facility"
+  end
+
+  # A FacilityGroup's children are Facilities for reporting purposes
+  alias_method :children, :facilities
+
   def registered_hypertension_patients
     Patient.with_hypertension.where(registration_facility: facilities)
   end
@@ -93,8 +103,6 @@ class FacilityGroup < ApplicationRecord
   def syncable_patients
     registered_patients.with_discarded
   end
-
-  delegate :district_region?, :block_region?, :facility_region?, to: :region
 
   private
 

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -34,6 +34,11 @@ class Region < ApplicationRecord
     undef_method "#{type}_regions?"
   end
 
+  def child_region_type
+    index = REGION_TYPES.find_index { |type| type == region_type }
+    REGION_TYPES[index + 1]
+  end
+
   def organization
     organization_region.source
   end

--- a/app/views/reports/regions/_block_tables.html.erb
+++ b/app/views/reports/regions/_block_tables.html.erb
@@ -1,5 +1,6 @@
 <h3 class="mt-48px mb-8px fs-28px c-black">
-  Blocks in <%= @region.name %>
+  <%= region_type.capitalize.pluralize %> in <%= @region.name %>
+  <% denominator = "<strong>Denominator:</strong> All hypertensive patients assigned to a #{region_type} in #{@region.name} registered before the last 3 months" %>
 </h3>
 <p class="mb-24px fs-16px c-grey-dark c-print-black">
   <span class="fw-bold">Total:</span> <%= @region.facilities.length %> facilities
@@ -22,7 +23,7 @@
           <thead>
             <tr class="sorts" data-sort-method="thead">
               <th class="row-label sort-label sort-label-small ta-left">
-                Facility
+                <%= region_type.capitalize %>
               </th>
               <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number" data-sort-default>
                 % of patients with BP controlled
@@ -67,8 +68,7 @@
           <strong>Numerator:</strong> Patients with BP &lt;140/90 at their most recent visit in the last 3 months
         </p>
         <p class="mb-0px fs-14px c-grey-dark c-print-black ">
-          <strong>Denominator:</strong> All hypertensive patients assigned to a facility in <%= @region.name %> registered before
-          the last 3 months
+          <%= denominator %>
         </p>
       </div>
     </div>
@@ -90,7 +90,7 @@
           <thead>
             <tr class="sorts" data-sort-method="thead">
               <th class="row-label sort-label sort-label-small ta-left">
-                Facility
+                <%= region_type.capitalize %>
               </th>
               <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number" data-sort-default>
                 % of patients with BP not controlled
@@ -135,8 +135,7 @@
           <strong>Numerator:</strong> Patients with BP &ge;140/90 at their most recent visit in the last 3 months
         </p>
         <p class="mb-0px fs-14px c-grey-dark c-print-black ">
-          <strong>Denominator:</strong> All hypertensive patients assigned to a facility in <%= @region.name %> registered before
-          the last 3 months
+          <%= denominator %>
         </p>
       </div>
     </div>
@@ -158,7 +157,7 @@
           <thead>
             <tr class="sorts" data-sort-method="thead">
               <th class="row-label sort-label sort-label-small ta-left">
-                Facility
+                <%= region_type.capitalize %>
               </th>
               <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number" data-sort-default>
                 % of patients with no visit in >3 months
@@ -203,8 +202,7 @@
           <strong>Numerator:</strong> Patients with no visit in >3 months
         </p>
         <p class="mb-0px fs-14px c-grey-dark c-print-black ">
-          <strong>Denominator:</strong> All hypertensive patients assigned to a facility in <%= @region.name %> registered before
-          the last 3 months
+          <%= denominator %>
         </p>
       </div>
     </div>
@@ -226,7 +224,7 @@
           <thead>
             <tr class="sorts" data-sort-method="thead">
               <th class="row-label sort-label sort-label-small ta-left">
-                Facility
+                <%= region_type.capitalize %>
               </th>
               <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number" data-sort-default>
                 Patients registered in <%= @period.to_s %>
@@ -268,8 +266,7 @@
       </div>
       <div class="mb-2 pt-12px">
         <p class="us-none fs-14px c-transparent">
-          <strong>Denominator:</strong> All hypertensive patients assigned to a facility in <%= @region.name %> registered before
-          the last 3 months
+          <%= denominator %>
         </p>
       </div>
     </div>

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -1,6 +1,6 @@
 <h3 class="mt-48px mb-8px fs-28px c-black">
   <%= region_type.capitalize.pluralize %> in <%= @region.name %>
-  <% denominator = "<strong>Denominator:</strong> All hypertensive patients assigned to a #{region_type} in #{@region.name} registered before the last 3 months" %>
+  <% denominator = "<strong>Denominator:</strong> All hypertensive patients assigned to a #{region_type} in #{@region.name} registered before the last 3 months".html_safe %>
 </h3>
 <p class="mb-24px fs-16px c-grey-dark c-print-black">
   <span class="fw-bold">Total:</span> <%= @region.facilities.length %> facilities

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -2,17 +2,28 @@
 
 <div class="dashboard">
   <nav class="breadcrumb mb-0px">
-    <%= link_to 'All reports', dashboard_districts_path %>
-    <% if @region.respond_to?(:facility_group) %>
-      <i class="fas fa-chevron-right"></i>
-      <%= link_to @region.facility_group.name, reports_region_path(@region.facility_group.slug, report_scope: "district") %>
+    <%= link_to "All reports", dashboard_districts_path %>
+
+    <% if current_admin.feature_enabled?(:region_reports) %>
+      <% @region.ancestors.where(region_type: %w[district block facility]).order(:path).each do |region| %>
+        <i class="fas fa-chevron-right"></i>
+        <%= link_to region.name, reports_region_path(region.slug, report_scope: region.region_type) %>
+      <% end %>
+    <% else %>
+      <% if @region.respond_to?(:facility_group) %>
+        <i class="fas fa-chevron-right"></i>
+        <%= link_to @region.facility_group.name, reports_region_path(@region.facility_group.slug, report_scope: "district") %>
+      <% end %>
     <% end %>
+
     <i class="fas fa-chevron-right"></i>
     <%= @region.name %>
   </nav>
+
   <p class="mb-12px fs-xxlarge fw-bold">
     <%= @region.name %>
   </p>
+
   <p class="d-none fw-bold d-print-block">
     <%= @period %> Report — <% if params[:action] == "show" %>Overview<% elsif params[:action] == "details" %>Details<% elsif params[:action] == "cohort" %>Cohort Reports<% end %>
   </p>

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -4,7 +4,8 @@
   <nav class="breadcrumb mb-0px">
     <%= link_to "All reports", dashboard_districts_path %>
 
-    <% if current_admin.feature_enabled?(:region_reports) %>
+    <% # we can get rid of this check when FacilityDistrict goes away %>
+    <% if @region.respond_to?(:ancestors) %>
       <% @region.ancestors.where(region_type: %w[district block facility]).order(:path).each do |region| %>
         <i class="fas fa-chevron-right"></i>
         <%= link_to region.name, reports_region_path(region.slug, report_scope: region.region_type) %>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -297,12 +297,8 @@
 
 <%= render "visit_details_card" %>
 
-<% if current_admin.feature_enabled?(:region_reports) && @region.district_region? && @region.respond_to?(:block_regions) %>
-  <%= render "block_tables", data: @block_data, region_type: "block" %>
-<% end %>
-
-<% if @region.district_region? || @region.block_region? %>
-  <%= render "facility_tables" %>
+<% if @region.child_region_type.in?(["block", "facility"]) %>
+  <%= render "child_data_tables", data: @children_data, region_type: @region.child_region_type %>
 <% end %>
 
 <div id="data-json" style="display: none;">

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -1,4 +1,5 @@
 <%= render "header" %>
+
 <div class="d-lg-flex flex-lg-wrap">
   <div class="d-lg-flex w-lg-50 pr-lg-2">
     <div id="bp-controlled" data-period="<%= @period.to_s %>" class="mt-8px mx-0px mb-16px bg-white br-4px bs-small d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black w-print-16cm">

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -300,7 +300,7 @@
   <%= render "block_tables", data: @block_data, region_type: "block" %>
 <% end %>
 
-<% if @region.district_region? %>
+<% if @region.district_region? || @region.block_region? %>
   <%= render "facility_tables" %>
 <% end %>
 

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -178,7 +178,6 @@ RSpec.describe Reports::RegionsController, type: :controller do
       other_fg = create(:facility_group, name: "other facility group", organization: organization)
       other_fg.facilities << build(:facility, name: "other facility")
       user = create(:admin, :viewer_reports_only, :with_access, resource: other_fg)
-      pp user.accessible_facility_groups(:view_reports)
 
       sign_in(user.email_authentication)
       get :show, params: {id: other_fg.slug, report_scope: "district"}

--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -8,6 +8,12 @@ Dir[Rails.root.join("spec/pages/**/*.rb")].sort.each { |f| require f }
 RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :feature
 
+  config.around(:example) do |example|
+    Rails.cache.clear
+    example.run
+    Rails.cache.clear
+  end
+
   Capybara.default_max_wait_time = 5
 
   Webdrivers::Chromedriver.update

--- a/spec/initializers/rate_limiter_spec.rb
+++ b/spec/initializers/rate_limiter_spec.rb
@@ -8,6 +8,12 @@ describe "RateLimiter", type: :controller do
     Rails.application
   end
 
+  around(:example) do |example|
+    Rails.cache.clear
+    example.run
+    Rails.cache.clear
+  end
+
   describe "throttle authentication APIs" do
     context "admin logins by IP address" do
       let(:limit) { 5 }

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe Region, type: :model do
       expect(region_3.block_region?).to be_truthy
       expect(region_4.facility_region?).to be_truthy
     end
+
+    it "can determine child region type" do
+      state = Region.new(name: "New York", region_type: "state")
+      expect(state.child_region_type).to eq("district")
+      district = Region.new(region_type: "district")
+      expect(district.child_region_type).to eq("block")
+      district = Region.new(region_type: "facility")
+      expect(district.child_region_type).to be_nil
+    end
   end
 
   context "facilities" do

--- a/spec/services/refresh_materialized_views_spec.rb
+++ b/spec/services/refresh_materialized_views_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.describe RefreshMaterializedViews do
+  around(:example) do |example|
+    Rails.cache.clear
+    example.run
+    Rails.cache.clear
+  end
+
   it "returns nil if no time set" do
     expect(RefreshMaterializedViews.last_updated_at).to be_nil
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,6 @@ RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
   config.before(:each) do
-    Rails.cache.clear
     RequestStore.clear!
   end
 


### PR DESCRIPTION
Ads [ch1988 - region breadcrumbs](https://app.clubhouse.io/simpledotorg/story/1988/add-region-breadcrumbs) and also cleans up how we are showing 'children data' for a region, which makes it easier to show the tables for the correct things. So a District will show its blocks in the tables, and a Block will show its facilities.

This is done by asking the model itself what its children records are, so that things will work correctly regardless of the `region_reports` feature flag.