### PR TITLE
Add UTs to State list in India

### DIFF
--- a/config/data/canonical_states.yml
+++ b/config/data/canonical_states.yml
@@ -1,16 +1,23 @@
 India:
+  - Andaman and Nicobar Islands
   - Andhra Pradesh
   - Arunachal Pradesh
   - Assam
   - Bihar
+  - Chandigarh
   - Chhattisgarh
+  - Dadra and Nagar Haveli and Daman and Diu
+  - Delhi
   - Goa
   - Gujarat
   - Haryana
   - Himachal Pradesh
+  - Jammu and Kashmir
   - Jharkhand
   - Karnataka
   - Kerala
+  - Ladakh
+  - Lakshadweep
   - Madhya Pradesh
   - Maharashtra
   - Manipur
@@ -18,6 +25,7 @@ India:
   - Mizoram
   - Nagaland
   - Odisha
+  - Puducherry
   - Punjab
   - Rajasthan
   - Sikkim


### PR DESCRIPTION
**Story card:** [ch2121](https://app.clubhouse.io/simpledotorg/story/2121)

## Because

Missed adding Union Territories to State list in India

## This addresses

Adds them.
