### PR TITLE
Cohort reports copy fix

### DIFF
--- a/app/views/reports/regions/cohort.html.erb
+++ b/app/views/reports/regions/cohort.html.erb
@@ -44,7 +44,7 @@
                     data-toggle="tooltip"
                     data-placement="top"
                     data-trigger="hover focus click"
-                    title="<%= number_with_delimiter(cohort["no_bp"]) %> <%= "person".pluralize(cohort["no_bp"]) %> didn't have a BP taken"
+                    title="<%= number_with_delimiter(cohort["no_bp"]) %> <%= "patient".pluralize(cohort["no_bp"]) %> didn't have a BP taken"
                     style="width: <%= no_bp_percent %>;"
                   >
                     <%= (cohort["no_bp"] > 0 && no_bp_percent == 0) ? "< 1" : no_bp_percent %>
@@ -54,7 +54,7 @@
                     data-toggle="tooltip"
                     data-placement="top"
                     data-trigger="hover focus click"
-                    title="<%= number_with_delimiter(cohort["uncontrolled"]) %> <%= "person".pluralize(cohort["uncontrolled"]) %> visited with BP not controlled"
+                    title="<%= number_with_delimiter(cohort["uncontrolled"]) %> <%= "patient".pluralize(cohort["uncontrolled"]) %> visited with BP not controlled"
                     style="width: <%= uncontrolled_percent %>;"
                   >
                     <%= (cohort["uncontrolled"] > 1 && uncontrolled_percent == 0) ? "< 1" : uncontrolled_percent %>
@@ -64,7 +64,7 @@
                     data-toggle="tooltip"
                     data-placement="top"
                     data-trigger="hover focus click"
-                    title="<%= number_with_delimiter(cohort["controlled"]) %> <%= "person".pluralize(cohort["controlled"]) %> visited with BP controlled"
+                    title="<%= number_with_delimiter(cohort["controlled"]) %> <%= "patient".pluralize(cohort["controlled"]) %> visited with BP controlled"
                     style="width: <%= controlled_percent %>;"
                   >
                     <%= (cohort["controlled"] > 0 && controlled_percent == 0) ? "< 1" : controlled_percent %>


### PR DESCRIPTION
**Story card:** [ch1826](https://app.clubhouse.io/simpledotorg/story/1826/fix-cohort-report-tooltip-copy)

## Because

We refer to our users as patients, not 'people'. Cohort reports tooltip is now using 'patients'.

## This addresses

**Replaced 'person' with 'patient'**
![image](https://user-images.githubusercontent.com/16785131/102630817-9fbb4880-4112-11eb-817a-5cd535e7cca8.png)
