### PR TITLE
Fix duplicate patient scopes

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -58,8 +58,8 @@ class Patient < ApplicationRecord
 
   scope :syncable_to_region, ->(region) { region.syncable_patients }
   scope :search_by_address, ->(term) { joins(:address).merge(Address.search_by_street_or_village(term)) }
-  scope :with_diabetes, -> { joins(:medical_history).merge(MedicalHistory.diabetes_yes) }
-  scope :with_hypertension, -> { joins(:medical_history).merge(MedicalHistory.hypertension_yes) }
+  scope :with_diabetes, -> { joins(:medical_history).merge(MedicalHistory.diabetes_yes).distinct }
+  scope :with_hypertension, -> { joins(:medical_history).merge(MedicalHistory.hypertension_yes).distinct }
   scope :follow_ups_by_period, ->(period, at_region: nil, current: true, last: nil) {
     follow_ups_with(Encounter, period, at_region: at_region, current: current, time_column: "encountered_on", last: last)
   }

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -90,8 +90,16 @@ describe Patient, type: :model do
 
     describe ".with_hypertension" do
       it "only includes patients with diagnosis of hypertension" do
-        htn_patients = create_list(:patient, 2)
-        _non_htn_patient = create(:patient, :without_hypertension)
+        htn_patients = [
+          create(:patient),
+          create(:patient).tap { |patient| create(:medical_history, :hypertension_yes, patient: patient) }
+        ]
+
+        _non_htn_patients = [
+          create(:patient, :without_hypertension),
+          create(:patient).tap { |patient| patient.medical_history.discard },
+          create(:patient).tap { |patient| patient.medical_history.destroy }
+        ]
 
         expect(Patient.with_hypertension).to match_array(htn_patients)
       end


### PR DESCRIPTION
**Story card:** [ch1182](https://app.clubhouse.io/simpledotorg/story/1182/number-of-total-registered-patients-is-different-in-facility-view-and-district-view)

## Because

The `with_hypertension` and `with_diabetes` scopes return duplicate patient records if a patient has, for whatever reason, more than one medical history record.

## This addresses

Teaching the scopes to de-dupe patients. We don't make attempts to correct the data or enforce correct data because:

> Has-One relationships are always tough :thinking:
> 
> On one hand, we could enforce clean data, but how? A validation? That doesn't protect against concurrent processes writing two medical histories for the same patient.
> 
> So, a supporting unique index on medical_history.patient_id? That makes it hard to do things like soft-delete medical histories, right?
> 
> So instead of cleaning up the data, I feel like we should just be robust to these kinds of data issues, and slap the necessary distinct clause on the problematic patient scopes. It makes sense conceptually to do so.
