### PR TITLE
Facility Performance Registration Rate Fix

### DIFF
--- a/app/models/reports/performance_score.rb
+++ b/app/models/reports/performance_score.rb
@@ -7,7 +7,6 @@ module Reports
     CONTROL_SCORE_WEIGHT = 0.5
     VISITS_SCORE_WEIGHT = 0.3
     REGISTRATIONS_SCORE_WEIGHT = 0.2
-    TARGET_REGISTRATIONS_RATE = 0.1
 
     def initialize(region:, reports_result:, period:)
       @region = region
@@ -65,20 +64,16 @@ module Reports
     end
 
     def registrations_rate
-      # If the target is zero, return 100% if any registrations occurred
-      if target_registrations <= 0
+      # If opd load is 0, return 100% if any registrations occurred
+      if (@region.opd_load || 0) <= 0
         return registrations > 0 ? 100 : 0
       end
 
-      registrations / target_registrations.to_f * 100.0
+      registrations / @region.opd_load.to_f * 100.0
     end
 
     def registrations
       @reports_result.registrations_for(@period) || 0
-    end
-
-    def target_registrations
-      TARGET_REGISTRATIONS_RATE * (@region.opd_load || 0)
     end
   end
 end

--- a/spec/models/reports/performance_score_spec.rb
+++ b/spec/models/reports/performance_score_spec.rb
@@ -167,21 +167,18 @@ describe Reports::PerformanceScore, type: :model do
   end
 
   describe "#registrations_rate" do
-    it "returns registrations rate based on registrations / target registrations" do
+    it "returns registrations rate based on registrations / opd load" do
       allow(perf_score).to receive(:registrations).and_return(30)
-      allow(perf_score).to receive(:target_registrations).and_return(60)
-      expect(perf_score.registrations_rate).to eq(50)
+      expect(perf_score.registrations_rate).to eq(10)
     end
 
-    it "returns 100 if target is 0 and any registrations happen" do
+    it "returns 100 if opd load is 0 and any registrations happen" do
       allow(perf_score).to receive(:registrations).and_return(10)
-      allow(perf_score).to receive(:target_registrations).and_return(0)
       expect(perf_score.registrations_rate).to eq(100)
     end
 
-    it "returns 0 if target is 0 and no registrations happen" do
+    it "returns 0 if opd load is 0 and no registrations happen" do
       allow(perf_score).to receive(:registrations).and_return(0)
-      allow(perf_score).to receive(:target_registrations).and_return(0)
       expect(perf_score.registrations_rate).to eq(0)
     end
   end
@@ -195,18 +192,6 @@ describe Reports::PerformanceScore, type: :model do
     it "returns 0 when registrations count is nil" do
       allow(reports_result).to receive(:registrations_for).with(period).and_return(nil)
       expect(perf_score.registrations).to eq(0)
-    end
-  end
-
-  describe "#target_registrations" do
-    it "returns the target based on the estimated OPD load" do
-      allow(facility).to receive(:monthly_estimated_opd_load).and_return(1000)
-      expect(perf_score.target_registrations).to eq(100)
-    end
-
-    it "functions when opd_load is 0" do
-      allow(facility).to receive(:monthly_estimated_opd_load).and_return(0)
-      expect(perf_score.target_registrations).to eq(0)
     end
   end
 end

--- a/spec/models/reports/performance_score_spec.rb
+++ b/spec/models/reports/performance_score_spec.rb
@@ -173,11 +173,13 @@ describe Reports::PerformanceScore, type: :model do
     end
 
     it "returns 100 if opd load is 0 and any registrations happen" do
+      allow(facility).to receive(:monthly_estimated_opd_load).and_return(0)
       allow(perf_score).to receive(:registrations).and_return(10)
       expect(perf_score.registrations_rate).to eq(100)
     end
 
     it "returns 0 if opd load is 0 and no registrations happen" do
+      allow(facility).to receive(:monthly_estimated_opd_load).and_return(0)
       allow(perf_score).to receive(:registrations).and_return(0)
       expect(perf_score.registrations_rate).to eq(0)
     end


### PR DESCRIPTION
**Story card:** [ch2128](https://app.clubhouse.io/simpledotorg/story/2128/fix-facility-performance-registration)

## Because

The `registration_rate` calculation in `PerformanceScore` should return `(monthly_registrations / est_opd_load) * 100`. If `est_opd_load == 0, return 100`

## This addresses

Updates `PerformanceScore` class and tests