### PR TITLE
Hide inactive facilities card if there are no inactive facilities

### DIFF
--- a/app/views/shared/my_facilities/_inactive_facilities.html.erb
+++ b/app/views/shared/my_facilities/_inactive_facilities.html.erb
@@ -1,51 +1,53 @@
-<div class="card mt-4">
-  <h2>
-    Inactive facilities
-  </h2>
-  <p>
-    Facilities where &lt;10 patients had any BPs recorded in the last 7 days
-  </p>
-  <section id="facilities-inactive">
-    <table class="table table-compact table-hover table-responsive-md analytics-table">
-      <colgroup>
-        <col>
-        <col style="width: 7em;" class="table-divider">
-        <col style="width: 7em;" class="table-divider">
-      </colgroup>
-      <thead>
-        <tr>
-          <th></th>
-          <th
-            class="row-label sort-label"
-            data-sort-default data-sort-method="number"
-            data-sort-column-key="week"
-          >
-            Patients in<br>last 7 days
-          </th>
-          <th
-            class="row-label sort-label"
-            data-sort-method="number"
-            data-sort-column-key="month"
-          >
-            Patients in<br> last 30 days
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @inactive_facilities.sort_by(&:name).each do |facility| %>
+<% if @inactive_facilities.any? %>
+  <div class="card mt-4">
+    <h2>
+      Inactive facilities
+    </h2>
+    <p>
+      Facilities where &lt;10 patients had any BPs recorded in the last 7 days
+    </p>
+    <section id="facilities-inactive">
+      <table class="table table-compact table-hover table-responsive-md analytics-table">
+        <colgroup>
+          <col>
+          <col style="width: 7em;" class="table-divider">
+          <col style="width: 7em;" class="table-divider">
+        </colgroup>
+        <thead>
           <tr>
-            <td>
-              <%= link_to facility.name, reports_region_facility_path(facility) %>
-            </td>
-            <td class="text-right" data-sort-column-key="week">
-              <%= number_with_delimiter(@inactive_facilities_bp_counts[:last_week][facility.id].to_i) %>
-            </td>
-            <td class="text-right" data-sort-column-key="month">
-              <%= number_with_delimiter(@inactive_facilities_bp_counts[:last_month][facility.id].to_i) %>
-            </td>
+            <th></th>
+            <th
+              class="row-label sort-label"
+              data-sort-default data-sort-method="number"
+              data-sort-column-key="week"
+            >
+              Patients in<br>last 7 days
+            </th>
+            <th
+              class="row-label sort-label"
+              data-sort-method="number"
+              data-sort-column-key="month"
+            >
+              Patients in<br> last 30 days
+            </th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </section>
-</div>
+        </thead>
+        <tbody>
+          <% @inactive_facilities.sort_by(&:name).each do |facility| %>
+            <tr>
+              <td>
+                <%= link_to facility.name, reports_region_facility_path(facility) %>
+              </td>
+              <td class="text-right" data-sort-column-key="week">
+                <%= number_with_delimiter(@inactive_facilities_bp_counts[:last_week][facility.id].to_i) %>
+              </td>
+              <td class="text-right" data-sort-column-key="month">
+                <%= number_with_delimiter(@inactive_facilities_bp_counts[:last_month][facility.id].to_i) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </section>
+  </div>
+<% end %>


### PR DESCRIPTION
**Story card:** [ch1733](https://app.clubhouse.io/simpledotorg/story/1733/dashboard-home-inactive-facilites-card-shouldn-t-show-up-if-empty)

Hide the "Inactive Facilities" card completely if there are no inactive facilities. This is better than the current behavior of rendering a card with a heading and subheading, and no table.

### Before
<img width="1139" alt="Screen Shot 2020-12-21 at 11 05 51 PM" src="https://user-images.githubusercontent.com/4241399/102805336-15f4cf00-43e1-11eb-8432-0eb4f869e4e8.png">

### After
<img width="1168" alt="Screen Shot 2020-12-21 at 11 05 35 PM" src="https://user-images.githubusercontent.com/4241399/102805368-24db8180-43e1-11eb-9277-2c7789e45dae.png">
