### PR TITLE
Fix rendering issues with progress tabs

### DIFF
--- a/app/views/api/v3/analytics/user_analytics/_gender_filter.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_gender_filter.html.erb
@@ -1,23 +1,26 @@
 <form>
   <select class="card-dropdown <%= data_table_name %>" onchange='filterDataByGender("<%= data_table_name %>")'>
     <% if is_diabetes_enabled %>
-      <option value="all"><%= t("analytics.all_hypertension_and_diabetes") %></option>
+      <option value="all"><%= raw t("analytics.all_hypertension_and_diabetes") %></option>
     <% end %>
 
-    <% hypertension_option_text = is_diabetes_enabled ? t('analytics.hypertension').to_s + ": "  : "" %>
+    <% hypertension_option_text = is_diabetes_enabled ? raw(t('analytics.hypertension')).to_s + ": "  : "" %>
 
-    <option value="hypertension:all"><%= hypertension_option_text + t('analytics.genders.all') %></option>
+    <option value="hypertension:all"><%= hypertension_option_text + raw(t('analytics.genders.all')) %></option>
     <% Patient::GENDERS.each do |gender| %>
       <option value="hypertension:<%= gender %>">
-        <%= hypertension_option_text + t('analytics.genders.' + gender.to_s) %>
+        <%= hypertension_option_text + raw(t('analytics.genders.' + gender.to_s)) %>
       </option>
     <% end %>
 
     <% if is_diabetes_enabled %>
-      <option value="diabetes:all"><%= t('analytics.diabetes').to_s + ": " + t('analytics.genders.all') %></option>
+      <option value="diabetes:all">
+        <%= raw(t('analytics.diabetes')).to_s + ": " + raw(t('analytics.genders.all')) %>
+      </option>
+
       <% Patient::GENDERS.each do |gender| %>
         <option value="diabetes:<%= gender %>">
-          <%= t('analytics.diabetes').to_s + ": " + t('analytics.genders.' + gender.to_s) %>
+          <%= raw(t('analytics.diabetes')).to_s + ": " + raw(t('analytics.genders.' + gender.to_s)) %>
         </option>
       <% end %>
     <% end %>

--- a/app/views/api/v3/analytics/user_analytics/_gender_filter.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_gender_filter.html.erb
@@ -4,23 +4,29 @@
       <option value="all"><%= raw t("analytics.all_hypertension_and_diabetes") %></option>
     <% end %>
 
-    <% hypertension_option_text = is_diabetes_enabled ? raw(t('analytics.hypertension')).to_s + ": "  : "" %>
+    <% hypertension_option_text = is_diabetes_enabled ? "#{raw(t("analytics.hypertension"))}: " : "" %>
 
-    <option value="hypertension:all"><%= hypertension_option_text + raw(t('analytics.genders.all')) %></option>
+    <option value="hypertension:all"><%= hypertension_option_text + raw(t("analytics.genders.all")) %></option>
     <% Patient::GENDERS.each do |gender| %>
       <option value="hypertension:<%= gender %>">
-        <%= hypertension_option_text + raw(t('analytics.genders.' + gender.to_s)) %>
+        <%= hypertension_option_text + raw(t("analytics.genders." + gender.to_s)) %>
       </option>
     <% end %>
 
     <% if is_diabetes_enabled %>
       <option value="diabetes:all">
-        <%= raw(t('analytics.diabetes')).to_s + ": " + raw(t('analytics.genders.all')) %>
+        <%= raw [
+            t("analytics.diabetes"),
+            t("analytics.genders.all")
+        ].join(": ") %>
       </option>
 
       <% Patient::GENDERS.each do |gender| %>
         <option value="diabetes:<%= gender %>">
-          <%= raw(t('analytics.diabetes')).to_s + ": " + raw(t('analytics.genders.' + gender.to_s)) %>
+          <%= raw [
+              t("analytics.diabetes"),
+              t("analytics.genders." + gender.to_s)
+          ].join(": ") %>
         </option>
       <% end %>
     <% end %>

--- a/app/views/api/v3/analytics/user_analytics/_monthly_gender_table.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_monthly_gender_table.html.erb
@@ -3,7 +3,7 @@
   <!-- the "all" table for both HTN & DM across genders -->
   <table class="progress-table <%= data_table_name %> all">
     <tr class="total">
-      <td class="row-label"><%= t("analytics.all_time") %></td>
+      <td class="row-label"><%= raw t("analytics.all_time") %></td>
       <td>
         <%= user_analytics.all_time_htn_or_dm_count(stat) %>
       </td>
@@ -22,7 +22,7 @@
   <!-- the "all genders" table -->
   <table class="progress-table <%= data_table_name %> diabetes:all" style="display: none">
     <tr class="total">
-      <td class="row-label"><%= t("analytics.all_time") %></td>
+      <td class="row-label"><%= raw t("analytics.all_time") %></td>
       <td>
         <%= user_analytics.all_time_dm_count(stat) %>
       </td>
@@ -42,7 +42,7 @@
   <!-- gender-wise tables -->
   <table class="progress-table <%= data_table_name %> diabetes:<%= gender %>" style="display: none">
     <tr class="total">
-      <td class="row-label"><%= t("analytics.all_time") %></td>
+      <td class="row-label"><%= raw t("analytics.all_time") %></td>
       <td>
         <%= user_analytics.all_time_dm_stats_by_gender(stat, gender) %>
       </td>
@@ -64,7 +64,7 @@
        style="<%= user_analytics.diabetes_enabled? ? 'display: none' : '' %>">
 
   <tr class="total">
-    <td class="row-label"><%= t("analytics.all_time") %></td>
+    <td class="row-label"><%= raw t("analytics.all_time") %></td>
     <td>
       <%= user_analytics.all_time_htn_count(stat) %>
     </td>
@@ -83,7 +83,7 @@
   <!-- gender-wise tables -->
   <table class="progress-table <%= data_table_name %> hypertension:<%= gender %>" style="display: none">
     <tr class="total">
-      <td class="row-label"><%= t("analytics.all_time") %></td>
+      <td class="row-label"><%= raw t("analytics.all_time") %></td>
       <td>
         <%= user_analytics.all_time_htn_stats_by_gender(stat, gender) %>
       </td>

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -6,7 +6,7 @@
   <meta name="MobileOptimized" content="320">
   <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,shrink-to-fit=no"/>
   <meta name="apple-mobile-web-app-capable" content="yes"/>
-  <title><%= t("analytics.page_title") %></title>
+  <title><%= raw t("analytics.page_title") %></title>
 
   <%= inline_stylesheet("user_analytics.css") %>
 </head>
@@ -17,7 +17,7 @@
 
   <p class="updated-date">
     <span>
-      <%= t("analytics.updated", time: @user_analytics.last_updated_at) %>
+      <%= raw t("analytics.updated", time: @user_analytics.last_updated_at) %>
     </span>
   </p>
 
@@ -44,7 +44,7 @@
       <div class="day count-empty" style="display: none">
         <h3 class="stat-day"></h3>
         <%= inline_svg('icon_sync_cloud.svg') %>
-        <p><%= t("analytics.tap_sync") %></p>
+        <p><%= raw t("analytics.tap_sync") %></p>
       </div>
 
       <% @user_analytics.daily_period_list.each do |day_date| %>
@@ -55,19 +55,19 @@
 
           <div class="counts">
             <div class="count count-1">
-              <strong><%= t("analytics.registered") %></strong>
+              <strong><%= raw t("analytics.registered") %></strong>
               <div class="big-number">
                 <%= @user_analytics.daily_stats_by_date(:registrations, day_date) %>
               </div>
-              <%= t("analytics.patient", count: @user_analytics.daily_stats_by_date(:registrations, day_date)) %>
+              <%= raw t("analytics.patient", count: @user_analytics.daily_stats_by_date(:registrations, day_date)) %>
             </div>
 
             <div class="count count-2">
-              <strong><%= t("analytics.follow_up") %></strong>
+              <strong><%= raw t("analytics.follow_up") %></strong>
               <div class="big-number">
                 <%= @user_analytics.daily_stats_by_date(:follow_ups, day_date) %>
               </div>
-              <%= t("analytics.patient", count: @user_analytics.daily_stats_by_date(:follow_ups, day_date)) %>
+              <%= raw t("analytics.patient", count: @user_analytics.daily_stats_by_date(:follow_ups, day_date)) %>
             </div>
           </div>
         </div>
@@ -78,7 +78,7 @@
   <!-- monthly registered patients view -->
   <div class="card">
     <a href="#"  onclick="openWindow('progress-help-registered', 'progress-start'); return false" class="info"><span>?</span></a>
-    <h3><%= t("analytics.registered_patients") %></h3>
+    <h3><%= raw t("analytics.registered_patients") %></h3>
 
     <% registrations_table_name = 'registrations' %>
 
@@ -95,7 +95,7 @@
   <!-- monthly follow-up patients view -->
   <div class="card">
     <a href="#"  onclick="openWindow('progress-help-followup', 'progress-start'); return false" class="info"><span>?</span></a>
-    <h3><%= t("analytics.follow_up_patients") %></h3>
+    <h3><%= raw t("analytics.follow_up_patients") %></h3>
 
     <% follow_ups_table_name = 'follow_ups' %>
 
@@ -112,9 +112,9 @@
   <!-- monthly hypertension control view -->
   <div class="card">
     <a href="#"  onclick="openWindow('progress-help-controlled', 'progress-start'); return false" class="info"><span>?</span></a>
-    <h3><%= t("analytics.hypertension_controlled") %></h3>
+    <h3><%= raw t("analytics.hypertension_controlled") %></h3>
     <p class="desc">
-      <%= t("analytics.hypertension_controlled_desc") %>
+      <%= raw t("analytics.hypertension_control_desc") %>
     </p>
 
     <p class="desc control-desc">
@@ -136,7 +136,7 @@
             </tr>
         </tbody>
     </table>
-    <p class="center" style="margin: 12px 0 0 0; text-align: center;"><%= t("analytics.last_12_months") %></p>
+    <p class="center" style="margin: 12px 0 0 0; text-align: center;"><%= raw t("analytics.last_12_months") %></p>
   </div>
 
   <div class="card">
@@ -146,7 +146,7 @@
   <!-- all trophies view -->
   <% if @user_analytics.achievements? %>
     <div class="trophies">
-      <h4><%= t("analytics.achievements") %></h4>
+      <h4><%= raw t("analytics.achievements") %></h4>
       <% @user_analytics.unlocked_trophies.sort.each do |trophy| %>
         <div class="trophy trophy-<%= trophy %>">
           <%= inline_svg('ribbon.svg') %>
@@ -154,7 +154,7 @@
           <span>
               <%= number_to_human(trophy, :format => '%n%u', :units => { thousand: 'K', million: 'M' }) %>
             </span>
-          <div><%= trophy %> <%= t("analytics.follow_up") %><br><%= t("analytics.hypertension_patients") %></div>
+          <div><%= trophy %> <%= raw t("analytics.follow_up") %><br><%= raw t("analytics.hypertension_patients") %></div>
         </div>
       <% end %>
 
@@ -164,17 +164,17 @@
         <span>
             <%= inline_svg('icon_lock.svg') %>
           </span>
-        <div><%= @user_analytics.locked_trophy %> <%= t("analytics.follow_up") %><br><%= t("analytics.hypertension_patients") %></div>
+        <div><%= @user_analytics.locked_trophy %> <%= raw t("analytics.follow_up") %><br><%= raw t("analytics.hypertension_patients") %></div>
       </div>
     </div>
   <% end %>
 
   <!-- footer -->
   <footer>
-    <h4 style="padding-top: 60px;"><%= t("analytics.notes") %></h4>
-    <p><%= t("analytics.footer_note_1", facility_name: @current_facility.name) %></p>
-    <h4 style="padding-top: 60px;"><%= t("analytics.thank_you") %></h4>
-    <p><%= t("analytics.thank_you_note") %></p>
+    <h4 style="padding-top: 60px;"><%= raw t("analytics.notes") %></h4>
+    <p><%= raw t("analytics.footer_note_1", facility_name: @current_facility.name) %></p>
+    <h4 style="padding-top: 60px;"><%= raw t("analytics.thank_you") %></h4>
+    <p><%= raw t("analytics.thank_you_note") %></p>
     <div style="height: 100px;"></div>
   </footer>
   </div>
@@ -186,12 +186,12 @@
             <%= inline_svg('icon_back.svg') %>
         </a>
 
-        <h2 style="padding-top: 80px; padding-left: 8px;"><%= t("analytics.definition") %></h2>
+        <h2 style="padding-top: 80px; padding-left: 8px;"><%= raw t("analytics.definition") %></h2>
 
         <div class="card">
-            <h3 style="margin-bottom: 1em;"><%= t("analytics.registered_patients") %></h3>
+            <h3 style="margin-bottom: 1em;"><%= raw t("analytics.registered_patients") %></h3>
             <p class="desc" style="margin-bottom: 1em;">
-              <%= t("analytics.registered_patients_desc") %>
+              <%= raw t("analytics.registered_patients_desc") %>
             </p>
         </div>
     </div>
@@ -203,12 +203,12 @@
             <%= inline_svg('icon_back.svg') %>
         </a>
 
-        <h2 style="padding-top: 80px; padding-left: 8px;"><%= t("analytics.definition") %></h2>
+        <h2 style="padding-top: 80px; padding-left: 8px;"><%= raw t("analytics.definition") %></h2>
 
         <div class="card">
-            <h3 style="margin-bottom: 1em;"><%= t("analytics.follow_up_patients") %></h3>
+            <h3 style="margin-bottom: 1em;"><%= raw t("analytics.follow_up_patients") %></h3>
             <p class="desc" style="margin-bottom: 1em;">
-              <%= t("analytics.follow_up_patients_desc") %>
+              <%= raw t("analytics.follow_up_patients_desc") %>
             </p>
         </div>
     </div>
@@ -220,17 +220,17 @@
             <%= inline_svg('icon_back.svg') %>
         </a>
 
-        <h2 style="padding-top: 80px; padding-left: 8px;"><%= t("analytics.definition") %></h2>
+        <h2 style="padding-top: 80px; padding-left: 8px;"><%= raw t("analytics.definition") %></h2>
 
         <div class="card">
-            <h3 style="margin-bottom: 1em;"><%= t("analytics.hypertension_controlled") %></h3>
+            <h3 style="margin-bottom: 1em;"><%= raw t("analytics.hypertension_controlled") %></h3>
             <p class="desc" style="margin-bottom: 1em;">
-                <b><%= t("analytics.numerator") %></b><br>
-              <%= t("analytics.hypertension_controlled_numerator") %>
+                <b><%= raw t("analytics.numerator") %></b><br>
+              <%= raw t("analytics.hypertension_controlled_numerator") %>
             </p>
             <p class="desc">
-                <b><%= t("analytics.denominator") %></b><br>
-              <%= t("analytics.hypertension_controlled_denominator") %>
+                <b><%= raw t("analytics.denominator") %></b><br>
+              <%= raw t("analytics.hypertension_controlled_denominator") %>
             </p>
         </div>
     </div>
@@ -242,22 +242,26 @@
             <%= inline_svg('icon_back.svg') %>
         </a>
 
-        <h2 style="padding-top: 80px; padding-left: 8px;"><%= t("analytics.hypertension_cohort_report") %></h2>
-        <p class="left"><%= t("analytics.hypertension_cohort_report_desc") %></p>
+        <h2 style="padding-top: 80px; padding-left: 8px;"><%= raw t("analytics.hypertension_cohort_report") %></h2>
+        <p class="left"><%= raw t("analytics.hypertension_cohort_report_desc") %></p>
         <div class="key">
-            <p class="left" style="color: #007A31;"><span class="key-color green"></span> <%= t("analytics.patients_with_controlled_bp") %></p>
-            <p class="left" style="color: #FF3355;"><span class="key-color red"></span> <%= t("analytics.patients_with_uncontrolled_bp") %></p>
-            <p class="left" style="color: #6C737A;"><span class="key-color grey"></span> <%= t("analytics.patients_with_no_bp_measure") %></p>
+            <p class="left" style="color: #007A31;"><span class="key-color green"></span> <%= raw t("analytics.patients_with_controlled_bp") %></p>
+            <p class="left" style="color: #FF3355;"><span class="key-color red"></span> <%= raw t("analytics.patients_with_uncontrolled_bp") %></p>
+            <p class="left" style="color: #6C737A;"><span class="key-color grey"></span> <%= raw t("analytics.patients_with_no_bp_measure") %></p>
         </div>
 
         <% @user_analytics.statistics.dig(:cohorts).each do |cohort| %>
           <div class="card cohort">
-              <h6><%= cohort[:registered] %> <%= t("analytics.patient", count: cohort[:registered]) %> <%= t("analytics.registered_in") %> <%= cohort[:patients_registered] %></h6>
-              <div style="font-size: 16px; margin: 8px 0 12px 0;">  <%= t("analytics.result_from_last_visit_in") %> <%= cohort[:results_in] %></div>
+              <h6>
+                <%= cohort[:registered] %> <%= raw t("analytics.patient", count: cohort[:registered]) %>&nbsp;
+                <%= raw t("analytics.registered_in") %> <%= cohort[:patients_registered] %>
+              </h6>
+
+              <div style="font-size: 16px; margin: 8px 0 12px 0;">  <%= raw t("analytics.result_from_last_visit_in") %> <%= cohort[:results_in] %></div>
               <table class="cohort-bars">
                   <tr>
                     <% if cohort[:registered].zero? %>
-                      <td class="cohort-none"> <%= t("analytics.no_patients") %></td>
+                      <td class="cohort-none"> <%= raw t("analytics.no_patients") %></td>
                     <% else %>
                       <td class="cohort-nobp" style="width: <%= @user_analytics.cohort_no_bp(cohort) %>;">
                         <%= @user_analytics.cohort_no_bp(cohort) %>
@@ -274,11 +278,11 @@
           </div>
         <% end %>
 
-        <h3 style="padding-top: 40px; padding-left: 8px;"> <%= t("analytics.notes") %></h3>
+        <h3 style="padding-top: 40px; padding-left: 8px;"> <%= raw t("analytics.notes") %></h3>
         <ul class="footnotes">
-            <li><strong> <%= t("analytics.numerator") %>:</strong> <%= t("analytics.cohort_report_footnote_1") %></li>
-            <li><strong> <%= t("analytics.denominator") %>:</strong> <%= t("analytics.cohort_report_footnote_2") %></li>
-            <li><%= t("analytics.cohort_report_footnote_3") %></li>
+            <li><strong> <%= raw t("analytics.numerator") %>:</strong> <%= raw t("analytics.cohort_report_footnote_1") %></li>
+            <li><strong> <%= raw t("analytics.denominator") %>:</strong> <%= raw t("analytics.cohort_report_footnote_2") %></li>
+            <li><%= raw t("analytics.cohort_report_footnote_3") %></li>
         </ul>
     </div>
 </div>


### PR DESCRIPTION
**Story card:** [ch2137](https://app.clubhouse.io/simpledotorg/story/2137/typos-in-progress-tab)

## Because

Some of the progress tab translations were spilling un-escaped HTML because we weren't rendering them safely.

## This addresses

There's mainly [three](https://guides.rubyonrails.org/i18n.html#using-safe-html-translations) ways to solve the problem of rendering HTML from locale files,

1. Put `_html` in front of the keys,
```yaml
hello_html: <b>hello!</b>
```
2. Put an `html` key nested under, 
```yaml
title:
  html: <b>title!</b>
```
3. Render the translations `raw`
```ruby
<%= raw t('welcome') %>
```

I've chosen 3. because it's the least invasive in terms of the translation files being modified. Since those files are auto-generated, it's better to not manually fiddle with them too much. Also, since the input is fairly static and since `raw` is a wrapper over `html_safe` we needn't worry about XSS attacks.

I've made ~most~all of the `t()` calls wrap around `raw` in case we need to add HTML in other places in the future (in addition to the ones that were actually breaking).