### PR TITLE
Revert sync performance PRs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ gem "kaminari"
 gem "lodash-rails"
 gem "lograge"
 gem "ougai"
-gem "oj"
 gem "parallel", require: false
 gem "passenger"
 gem "pg", ">= 0.18", "< 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -608,7 +608,6 @@ DEPENDENCIES
   memery
   memory_profiler
   mock_redis
-  oj
   ougai
   parallel
   parallel_tests

--- a/app/controllers/api/v3/blood_sugars_controller.rb
+++ b/app/controllers/api/v3/blood_sugars_controller.rb
@@ -12,7 +12,7 @@ class Api::V3::BloodSugarsController < Api::V3::SyncController
 
   private
 
-  def model_sync_scope
+  def region_records
     super.for_v3
   end
 

--- a/app/controllers/api/v3/patients_controller.rb
+++ b/app/controllers/api/v3/patients_controller.rb
@@ -13,19 +13,22 @@ class Api::V3::PatientsController < Api::V3::SyncController
     {request_user_id: current_user.id, request_facility_id: current_facility.id}
   end
 
+  def region_records
+    super
+      .includes(:address, :phone_numbers, :business_identifiers)
+  end
+
   def current_facility_records
-    model_sync_scope
-      .where(id: current_facility.prioritized_patients.pluck(:id))
+    region_records
+      .where(registration_facility: current_facility)
       .updated_on_server_since(current_facility_processed_since, limit)
   end
 
   def other_facility_records
     other_facilities_limit = limit - current_facility_records.count
-    other_patient_records =
-      current_sync_region.syncable_patients.pluck(:id) - current_facility.prioritized_patients.pluck(:id)
 
-    model_sync_scope
-      .where(id: other_patient_records)
+    region_records
+      .where.not(registration_facility: current_facility)
       .updated_on_server_since(other_facilities_processed_since, other_facilities_limit)
   end
 

--- a/app/controllers/api/v3/sync_controller.rb
+++ b/app/controllers/api/v3/sync_controller.rb
@@ -11,14 +11,12 @@ class Api::V3::SyncController < APIController
   end
 
   def __sync_to_user__(response_key)
-    records = records_to_sync
-
-    AuditLog.create_logs_async(current_user, records, "fetch", Time.current) unless disable_audit_logs?
+    AuditLog.create_logs_async(current_user, records_to_sync, "fetch", Time.current) unless disable_audit_logs?
     render(
-      json: Oj.dump({
-        response_key => records.map { |record| transform_to_response(record) },
+      json: {
+        response_key => records_to_sync.map { |record| transform_to_response(record) },
         "process_token" => encode_process_token(response_process_token)
-      }, mode: :compat),
+      },
       status: :ok
     )
   end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -40,7 +40,9 @@ class Appointment < ApplicationRecord
   validates :device_created_at, presence: true
   validates :device_updated_at, presence: true
 
-  scope :for_sync, -> { with_discarded }
+  scope :syncable_to_region, ->(region) {
+    with_discarded.where(patient: Patient.syncable_to_region(region))
+  }
 
   def self.all_overdue
     where(status: "scheduled")

--- a/app/models/blood_pressure.rb
+++ b/app/models/blood_pressure.rb
@@ -32,7 +32,9 @@ class BloodPressure < ApplicationRecord
       .where(arel_table[:diastolic].lt(THRESHOLDS[:hypertensive][:diastolic]))
   }
 
-  scope :for_sync, -> { with_discarded }
+  scope :syncable_to_region, ->(region) {
+    with_discarded.where(patient: Patient.syncable_to_region(region))
+  }
 
   def critical?
     systolic >= THRESHOLDS[:critical][:systolic] || diastolic >= THRESHOLDS[:critical][:diastolic]

--- a/app/models/blood_sugar.rb
+++ b/app/models/blood_sugar.rb
@@ -30,7 +30,10 @@ class BloodSugar < ApplicationRecord
   V3_TYPES = %i[random post_prandial fasting].freeze
 
   scope :for_v3, -> { where(blood_sugar_type: V3_TYPES) }
-  scope :for_sync, -> { with_discarded }
+
+  scope :syncable_to_region, ->(region) {
+    with_discarded.where(patient: Patient.syncable_to_region(region))
+  }
 
   THRESHOLDS = {
     high: {random: 300,

--- a/app/models/encounter.rb
+++ b/app/models/encounter.rb
@@ -9,7 +9,9 @@ class Encounter < ApplicationRecord
   has_many :blood_pressures, through: :observations, source: :observable, source_type: "BloodPressure"
   has_many :blood_sugars, through: :observations, source: :observable, source_type: "BloodSugar"
 
-  scope :for_sync, -> { with_discarded }
+  scope :syncable_to_region, ->(region) {
+    with_discarded.where(patient: Patient.syncable_to_region(region))
+  }
 
   def self.generate_id(facility_id, patient_id, encountered_on)
     UUIDTools::UUID

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -215,10 +215,6 @@ class Facility < ApplicationRecord
     end
   end
 
-  def prioritized_patients
-    registered_patients.with_discarded
-  end
-
   def self.localized_facility_size(facility_size)
     return unless facility_size
     I18n.t("activerecord.facility.facility_size.#{facility_size}", default: facility_size.capitalize)

--- a/app/models/medical_history.rb
+++ b/app/models/medical_history.rb
@@ -29,7 +29,9 @@ class MedicalHistory < ApplicationRecord
   enum hypertension: MEDICAL_HISTORY_ANSWERS, _prefix: true
   enum diagnosed_with_hypertension: MEDICAL_HISTORY_ANSWERS, _prefix: true
 
-  scope :for_sync, -> { with_discarded }
+  scope :syncable_to_region, ->(region) {
+    with_discarded.where(patient: Patient.syncable_to_region(region))
+  }
 
   def indicates_hypertension_risk?
     prior_heart_attack_boolean || prior_stroke_boolean

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -56,8 +56,7 @@ class Patient < ApplicationRecord
 
   attribute :call_result, :string
 
-  scope :with_nested_sync_resources, -> { includes(:address, :phone_numbers, :business_identifiers) }
-  scope :for_sync, -> { with_discarded.with_nested_sync_resources }
+  scope :syncable_to_region, ->(region) { region.syncable_patients }
   scope :search_by_address, ->(term) { joins(:address).merge(Address.search_by_street_or_village(term)) }
   scope :with_diabetes, -> { joins(:medical_history).merge(MedicalHistory.diabetes_yes) }
   scope :with_hypertension, -> { joins(:medical_history).merge(MedicalHistory.hypertension_yes) }

--- a/app/models/prescription_drug.rb
+++ b/app/models/prescription_drug.rb
@@ -21,7 +21,9 @@ class PrescriptionDrug < ApplicationRecord
   validates :is_protocol_drug, inclusion: {in: [true, false]}
   validates :is_deleted, inclusion: {in: [true, false]}
 
-  scope :for_sync, -> { with_discarded }
+  scope :syncable_to_region, ->(region) {
+    with_discarded.where(patient: Patient.syncable_to_region(region))
+  }
 
   def self.prescribed_as_of(date)
     where("device_created_at <= ?", date.end_of_day)

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -96,10 +96,10 @@ class Region < ApplicationRecord
     case region_type
       when "block"
         registered_patients.with_discarded
-          .or(assigned_patients.with_discarded)
+          .union(assigned_patients.with_discarded)
           .union(appointed_patients.with_discarded)
       else
-        registered_patients.with_discarded
+        registered_patients
     end
   end
 

--- a/app/transformers/api/v3/facility_transformer.rb
+++ b/app/transformers/api/v3/facility_transformer.rb
@@ -7,9 +7,7 @@ class Api::V3::FacilityTransformer
           "enable_teleconsultation",
           "teleconsultation_phone_number",
           "teleconsultation_isd_code",
-          "teleconsultation_phone_numbers",
-          "organization_name",
-          "facility_group_name")
+          "teleconsultation_phone_numbers")
         .merge(config: {enable_diabetes_management: facility.enable_diabetes_management,
                         enable_teleconsultation: facility.enable_teleconsultation},
                protocol_id: facility.protocol.try(:id))

--- a/app/transformers/api/v3/patient_transformer.rb
+++ b/app/transformers/api/v3/patient_transformer.rb
@@ -59,10 +59,10 @@ class Api::V3::PatientTransformer
 
     def to_nested_response(patient)
       Api::V3::Transformer.to_response(patient)
-        .except("address_id",
-          "registration_user_id",
-          "test_data",
-          "deleted_by_user_id")
+        .except("address_id")
+        .except("registration_user_id")
+        .except("test_data")
+        .except("deleted_by_user_id")
         .merge(
           "address" => Api::V3::Transformer.to_response(patient.address),
           "phone_numbers" => patient.phone_numbers.map do |phone_number|

--- a/app/transformers/api/v3/transformer.rb
+++ b/app/transformers/api/v3/transformer.rb
@@ -1,33 +1,31 @@
 class Api::V3::Transformer
   class << self
-    def from_request(payload_attributes)
-      rename_attributes(payload_attributes, from_request_key_mapping)
+    def from_request(attributes_of_payload)
+      rename_attributes(attributes_of_payload, key_mapping)
     end
 
     def to_response(model)
-      rename_attributes(model.attributes, to_response_key_mapping).as_json
+      rename_attributes(model.attributes, inverted_key_mapping).as_json
     end
 
     def rename_attributes(attributes, mapping)
-      replace_keys(attributes.to_hash, mapping).with_indifferent_access
+      mapping = mapping.with_indifferent_access
+      attributes
+        .to_hash
+        .except(*mapping.values)
+        .transform_keys! { |key| mapping[key] || key }
+        .with_indifferent_access
     end
 
-    def replace_keys(hsh, mapping)
-      mapping.each do |k, v|
-        hsh[v] = hsh.delete(k)
-      end
-      hsh
-    end
-
-    def from_request_key_mapping
+    def key_mapping
       {
         "created_at" => "device_created_at",
         "updated_at" => "device_updated_at"
       }
     end
 
-    def to_response_key_mapping
-      from_request_key_mapping.invert
+    def inverted_key_mapping
+      key_mapping.invert
     end
   end
 end

--- a/db/migrate/20201224074852_add_old_sync_indexes_back.rb
+++ b/db/migrate/20201224074852_add_old_sync_indexes_back.rb
@@ -1,0 +1,11 @@
+class AddOldSyncIndexesBack < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :patients, :updated_at, algorithm: :concurrently
+    add_index :blood_pressures, :updated_at, algorithm: :concurrently
+    add_index :blood_sugars, :updated_at, algorithm: :concurrently
+    add_index :appointments, :updated_at, algorithm: :concurrently
+    add_index :prescription_drugs, :updated_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_18_062046) do
+ActiveRecord::Schema.define(version: 2020_12_24_074852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2020_12_18_062046) do
     t.index ["patient_id", "scheduled_date"], name: "index_appointments_on_patient_id_and_scheduled_date", order: { scheduled_date: :desc }
     t.index ["patient_id", "updated_at"], name: "index_appointments_on_patient_id_and_updated_at"
     t.index ["patient_id"], name: "index_appointments_on_patient_id"
+    t.index ["updated_at"], name: "index_appointments_on_updated_at"
     t.index ["user_id"], name: "index_appointments_on_user_id"
   end
 
@@ -89,6 +90,7 @@ ActiveRecord::Schema.define(version: 2020_12_18_062046) do
     t.index ["patient_id", "updated_at"], name: "index_blood_pressures_on_patient_id_and_updated_at"
     t.index ["patient_id"], name: "index_blood_pressures_on_patient_id"
     t.index ["recorded_at"], name: "index_blood_pressures_on_recorded_at"
+    t.index ["updated_at"], name: "index_blood_pressures_on_updated_at"
     t.index ["user_id"], name: "index_blood_pressures_on_user_id"
   end
 
@@ -109,6 +111,7 @@ ActiveRecord::Schema.define(version: 2020_12_18_062046) do
     t.index ["facility_id"], name: "index_blood_sugars_on_facility_id"
     t.index ["patient_id", "updated_at"], name: "index_blood_sugars_on_patient_id_and_updated_at"
     t.index ["patient_id"], name: "index_blood_sugars_on_patient_id"
+    t.index ["updated_at"], name: "index_blood_sugars_on_updated_at"
     t.index ["user_id"], name: "index_blood_sugars_on_user_id"
   end
 
@@ -406,6 +409,7 @@ ActiveRecord::Schema.define(version: 2020_12_18_062046) do
     t.index ["registration_facility_id"], name: "index_patients_on_registration_facility_id"
     t.index ["registration_user_id"], name: "index_patients_on_registration_user_id"
     t.index ["reminder_consent"], name: "index_patients_on_reminder_consent"
+    t.index ["updated_at"], name: "index_patients_on_updated_at"
   end
 
   create_table "phone_number_authentications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -446,6 +450,7 @@ ActiveRecord::Schema.define(version: 2020_12_18_062046) do
     t.index ["patient_id", "updated_at"], name: "index_prescription_drugs_on_patient_id_and_updated_at"
     t.index ["patient_id"], name: "index_prescription_drugs_on_patient_id"
     t.index ["teleconsultation_id"], name: "index_prescription_drugs_on_teleconsultation_id"
+    t.index ["updated_at"], name: "index_prescription_drugs_on_updated_at"
     t.index ["user_id"], name: "index_prescription_drugs_on_user_id"
   end
 

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -105,11 +105,28 @@ describe Appointment, type: :model do
       end
     end
 
-    describe ".for_sync" do
-      it "includes discarded appointments" do
-        discarded_appointment = create(:appointment, deleted_at: Time.now)
+    describe ".syncable_to_region" do
+      it "returns all patients registered in the region" do
+        facility_group = create(:facility_group)
+        facility = create(:facility, facility_group: facility_group)
+        patient = create(:patient)
+        other_patient = create(:patient)
 
-        expect(described_class.for_sync).to include(discarded_appointment)
+        allow(Patient).to receive(:syncable_to_region).with(facility_group).and_return([patient])
+
+        appointments = [
+          create(:appointment, patient: patient, facility: facility),
+          create(:appointment, patient: patient, facility: facility).tap(&:discard),
+          create(:appointment, patient: patient)
+        ]
+
+        _other_appointments = [
+          create(:appointment, patient: other_patient, facility: facility),
+          create(:appointment, patient: other_patient, facility: facility).tap(&:discard),
+          create(:appointment, patient: other_patient)
+        ]
+
+        expect(Appointment.syncable_to_region(facility_group)).to contain_exactly(*appointments)
       end
     end
   end

--- a/spec/models/blood_pressure_spec.rb
+++ b/spec/models/blood_pressure_spec.rb
@@ -40,11 +40,28 @@ RSpec.describe BloodPressure, type: :model do
       end
     end
 
-    describe ".for_sync" do
-      it "includes discarded blood pressures" do
-        discarded_bp = create(:blood_pressure, deleted_at: Time.now)
+    describe ".syncable_to_region" do
+      it "returns all patients registered in the region" do
+        facility_group = create(:facility_group)
+        facility = create(:facility, facility_group: facility_group)
+        patient = create(:patient)
+        other_patient = create(:patient)
 
-        expect(described_class.for_sync).to include(discarded_bp)
+        allow(Patient).to receive(:syncable_to_region).with(facility_group).and_return([patient])
+
+        blood_pressures = [
+          create(:blood_pressure, patient: patient, facility: facility),
+          create(:blood_pressure, patient: patient, facility: facility).tap(&:discard),
+          create(:blood_pressure, patient: patient)
+        ]
+
+        _other_blood_pressures = [
+          create(:blood_pressure, patient: other_patient, facility: facility),
+          create(:blood_pressure, patient: other_patient, facility: facility).tap(&:discard),
+          create(:blood_pressure, patient: other_patient)
+        ]
+
+        expect(BloodPressure.syncable_to_region(facility_group)).to contain_exactly(*blood_pressures)
       end
     end
   end

--- a/spec/models/blood_sugar_spec.rb
+++ b/spec/models/blood_sugar_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe BloodSugar, type: :model do
     end
   end
 
-  describe "Scopes" do
+  describe "scopes" do
     let!(:fasting) { create(:blood_sugar, blood_sugar_type: :fasting) }
     let!(:random) { create(:blood_sugar, blood_sugar_type: :random) }
     let!(:post_prandial) { create(:blood_sugar, blood_sugar_type: :post_prandial) }
@@ -50,11 +50,28 @@ RSpec.describe BloodSugar, type: :model do
       end
     end
 
-    describe ".for_sync" do
-      it "includes discarded blood sugars" do
-        discarded_blood_sugar = create(:blood_sugar, deleted_at: Time.now)
+    describe ".syncable_to_region" do
+      it "returns all patients registered in the region" do
+        facility_group = create(:facility_group)
+        facility = create(:facility, facility_group: facility_group)
+        patient = create(:patient)
+        other_patient = create(:patient)
 
-        expect(described_class.for_sync).to include(discarded_blood_sugar)
+        allow(Patient).to receive(:syncable_to_region).with(facility_group).and_return([patient])
+
+        blood_sugars = [
+          create(:blood_sugar, patient: patient, facility: facility),
+          create(:blood_sugar, patient: patient, facility: facility).tap(&:discard),
+          create(:blood_sugar, patient: patient)
+        ]
+
+        _other_blood_sugars = [
+          create(:blood_sugar, patient: other_patient, facility: facility),
+          create(:blood_sugar, patient: other_patient, facility: facility).tap(&:discard),
+          create(:blood_sugar, patient: other_patient)
+        ]
+
+        expect(BloodSugar.syncable_to_region(facility_group)).to contain_exactly(*blood_sugars)
       end
     end
   end

--- a/spec/models/encounter_spec.rb
+++ b/spec/models/encounter_spec.rb
@@ -34,11 +34,28 @@ describe Encounter, type: :model do
   end
 
   describe "Scopes" do
-    describe ".for_sync" do
-      it "includes discarded encounters" do
-        discarded_encounter = create(:encounter, deleted_at: Time.now)
+    describe ".syncable_to_region" do
+      it "returns all patients registered in the region" do
+        facility_group = create(:facility_group)
+        facility = create(:facility, facility_group: facility_group)
+        patient = create(:patient)
+        other_patient = create(:patient)
 
-        expect(described_class.for_sync).to include(discarded_encounter)
+        allow(Patient).to receive(:syncable_to_region).with(facility_group).and_return([patient])
+
+        encounters = [
+          create(:encounter, patient: patient, facility: facility),
+          create(:encounter, patient: patient, facility: facility).tap(&:discard),
+          create(:encounter, patient: patient)
+        ]
+
+        _other_encounters = [
+          create(:encounter, patient: other_patient, facility: facility),
+          create(:encounter, patient: other_patient, facility: facility).tap(&:discard),
+          create(:encounter, patient: other_patient)
+        ]
+
+        expect(Encounter.syncable_to_region(facility_group)).to contain_exactly(*encounters)
       end
     end
   end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -313,19 +313,27 @@ describe Patient, type: :model do
       end
     end
 
-    describe ".for_sync" do
-      it "includes discarded patients" do
-        discarded_patient = create(:patient, deleted_at: Time.now)
+    describe ".syncable_to_region" do
+      it "returns all patients registered in the region" do
+        facility_group = create(:facility_group)
+        other_facility_group = create(:facility_group)
 
-        expect(described_class.for_sync).to include(discarded_patient)
-      end
+        facility = create(:facility, facility_group: facility_group)
+        other_facility = create(:facility, facility_group: other_facility_group)
 
-      it "includes nested sync resources" do
-        _discarded_patient = create(:patient, deleted_at: Time.now)
+        patients = [
+          create(:patient, registration_facility: facility),
+          create(:patient, registration_facility: facility).tap(&:discard),
+          create(:patient, registration_facility: facility, assigned_facility: other_facility)
+        ]
 
-        expect(described_class.for_sync.first.association(:address).loaded?).to eq true
-        expect(described_class.for_sync.first.association(:phone_numbers).loaded?).to eq true
-        expect(described_class.for_sync.first.association(:business_identifiers).loaded?).to eq true
+        _other_patients = [
+          create(:patient, registration_facility: other_facility),
+          create(:patient, registration_facility: other_facility).tap(&:discard),
+          create(:patient, registration_facility: other_facility, assigned_facility: facility)
+        ]
+
+        expect(Patient.syncable_to_region(facility_group)).to contain_exactly(*patients)
       end
     end
   end

--- a/spec/utils.rb
+++ b/spec/utils.rb
@@ -20,7 +20,7 @@ class Hash
 
   def with_payload_keys
     Api::V3::Transformer.rename_attributes(
-      self, Api::V3::Transformer.to_response_key_mapping
+      self, Api::V3::Transformer.inverted_key_mapping
     )
   end
 end


### PR DESCRIPTION
## Because

We're seeing FG sync performance degrade after shipping the "perf improvements",
![Screenshot 2020-12-24 at 1 15 26 PM](https://user-images.githubusercontent.com/50663/103071673-1a400880-45ea-11eb-8b57-68ca32308077.png)

## This addresses

Reverting these changes to unblock deploys.
