### PR TITLE
Semaphore tweaks

### DIFF
--- a/.semaphore/bangladesh_production_deployment.yml
+++ b/.semaphore/bangladesh_production_deployment.yml
@@ -12,7 +12,7 @@ blocks:
             - yarn install
             - bundle install --deployment --path vendor/bundle
             - cache store
-            - 'bundle exec cap bangladesh:production deploy'
+            - 'BRANCH=$SEMAPHORE_GIT_BRANCH bundle exec cap bangladesh:production deploy'
       secrets:
         - name: semaphore-deploy-key
       prologue:

--- a/.semaphore/india_production_deployment.yml
+++ b/.semaphore/india_production_deployment.yml
@@ -12,7 +12,7 @@ blocks:
             - yarn install
             - bundle install --deployment --path vendor/bundle
             - cache store
-            - 'bundle exec cap india:production deploy'
+            - 'BRANCH=$SEMAPHORE_GIT_BRANCH bundle exec cap india:production deploy'
       secrets:
         - name: semaphore-deploy-key
       prologue:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,6 +4,9 @@ agent:
   machine:
     type: e1-standard-2
     os_image: ubuntu1804
+auto_cancel:
+  running:
+    when: "true"
 blocks:
   - name: Tests
     task:


### PR DESCRIPTION
**Story card:** [ch2174](https://app.clubhouse.io/simpledotorg/story/2174/semaphore-tweaks)

* Auto-cancel running and queued builds on a branch when a new commit is pushed
* Production deployment button should push current build, not latest master

![Screen Shot 2020-12-29 at 1 58 03 PM](https://user-images.githubusercontent.com/4241399/103270417-e09e4180-49dd-11eb-80cc-4fd055d6b8b8.png)
