### PR TITLE
Monitor sidekiq on datadog

### DIFF
--- a/config/initializers/00_datadog.rb
+++ b/config/initializers/00_datadog.rb
@@ -10,7 +10,8 @@ Datadog.configure do |c|
   c.tracer.enabled = SEND_DATA_TO_DD_AGENT
   c.version = SimpleServer.git_ref(short: true)
   c.use :rails, analytics_enabled: true
-  c.use :rack, headers: {request: ["X-USER-ID", "X-FACILITY-ID", "X-SYNC-REGION-ID"], response: ["Content-Type", "X-Request-ID"]}
+  c.use :rack, headers: {request: %w[X-USER-ID X-FACILITY-ID X-SYNC-REGION-ID], response: %w[Content-Type X-Request-ID]}
+  c.use :sidekiq, analytics_enabled: true
 end
 
 require "statsd"


### PR DESCRIPTION
**Story card:** [ch2176](https://app.clubhouse.io/simpledotorg/story/2176/server-housekeeping)

## Because

Datadog doesn't trace Sidekiq by default

## This addresses

Add default DD analytics for sidekiq.

## Test on Sandbox
![Screenshot 2020-12-31 at 5 59 16 PM](https://user-images.githubusercontent.com/50663/103410575-f6ecfe80-4b91-11eb-8062-766e122eab62.png)
![Screenshot 2020-12-31 at 5 59 11 PM](https://user-images.githubusercontent.com/50663/103410577-f81e2b80-4b91-11eb-82a5-39eb30c85f43.png)

