### PR TITLE
Stop handling retroactive data entry as a special case

### DIFF
--- a/app/controllers/api/v3/blood_pressures_controller.rb
+++ b/app/controllers/api/v3/blood_pressures_controller.rb
@@ -1,6 +1,5 @@
 class Api::V3::BloodPressuresController < Api::V3::SyncController
   include Api::V3::SyncEncounterObservation
-  include Api::V3::RetroactiveDataEntry
 
   def sync_from_user
     __sync_from_user__(blood_pressures_params)
@@ -18,7 +17,6 @@ class Api::V3::BloodPressuresController < Api::V3::SyncController
     if validator.check_invalid?
       {errors_hash: validator.errors_hash}
     else
-      set_patient_recorded_at(bp_params)
       transformed_params = Api::V3::BloodPressureTransformer.from_request(bp_params)
       {record: merge_encounter_observation(:blood_pressures, transformed_params)}
     end

--- a/app/controllers/api/v3/blood_sugars_controller.rb
+++ b/app/controllers/api/v3/blood_sugars_controller.rb
@@ -1,6 +1,5 @@
 class Api::V3::BloodSugarsController < Api::V3::SyncController
   include Api::V3::SyncEncounterObservation
-  include Api::V3::RetroactiveDataEntry
 
   def sync_from_user
     __sync_from_user__(blood_sugars_params)
@@ -26,7 +25,6 @@ class Api::V3::BloodSugarsController < Api::V3::SyncController
     if validator.check_invalid?
       {errors_hash: validator.errors_hash}
     else
-      set_patient_recorded_at(blood_sugar_params)
       transformed_params = Api::V3::Transformer.from_request(blood_sugar_params)
       {record: merge_encounter_observation(:blood_sugars, transformed_params)}
     end

--- a/app/controllers/api/v4/blood_sugars_controller.rb
+++ b/app/controllers/api/v4/blood_sugars_controller.rb
@@ -1,6 +1,5 @@
 class Api::V4::BloodSugarsController < Api::V4::SyncController
   include Api::V3::SyncEncounterObservation
-  include Api::V3::RetroactiveDataEntry
 
   def sync_from_user
     __sync_from_user__(blood_sugars_params)
@@ -22,7 +21,6 @@ class Api::V4::BloodSugarsController < Api::V4::SyncController
     if validator.check_invalid?
       {errors_hash: validator.errors_hash}
     else
-      set_patient_recorded_at(blood_sugar_params)
       transformed_params = Api::V4::Transformer.from_request(blood_sugar_params)
       {record: merge_encounter_observation(:blood_sugars, transformed_params)}
     end


### PR DESCRIPTION
**Story card:** TBA

## Because

This should not be necessary anymore since most users would've updated.

## This addresses

Remove the `RetroactiveDataEntry` concern entirely as it was meant to be transitional. 
