### PR TITLE
Add a Sidekiq tracer job to ensure background jobs are working

### DIFF
--- a/app/jobs/tracer_job.rb
+++ b/app/jobs/tracer_job.rb
@@ -1,0 +1,9 @@
+class TracerJob < ApplicationJob
+  queue_as :default
+  self.queue_adapter = :sidekiq
+
+  def perform(submitted_at)
+    Rails.logger.info msg: "tracer job completed successfully, was submitted at #{submitted_at}",
+                      submitted_at: submitted_at
+  end
+end

--- a/app/jobs/tracer_job.rb
+++ b/app/jobs/tracer_job.rb
@@ -3,7 +3,8 @@ class TracerJob < ApplicationJob
   self.queue_adapter = :sidekiq
 
   def perform(submitted_at)
-    Rails.logger.info msg: "tracer job completed successfully, was submitted at #{submitted_at}",
+    Rails.logger.info class: self.class.name,
+                      msg: "tracer job completed successfully, was submitted at #{submitted_at}",
                       submitted_at: submitted_at
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -49,7 +49,10 @@ every :monday, at: local("6:00 am"), roles: [:cron] do
   end
 end
 
+every 13.minutes, roles: [:cron] do
+  runner "TracerJob.perform_later(Time.current.iso8601)"
+end
+
 every 30.minutes, roles: [:cron] do
   runner "RegionsIntegrityCheck.sweep"
-  runner "TracerJob.perform_later(Time.current.iso8601)"
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -51,4 +51,5 @@ end
 
 every 30.minutes, roles: [:cron] do
   runner "RegionsIntegrityCheck.sweep"
+  runner "TracerJob.perform_later(Time.current.iso8601)"
 end


### PR DESCRIPTION
This will get scheduled on a regular basis and just ack that are Sidekiq
machinery is working.

**Story card:** [ch2201](https://app.clubhouse.io/simpledotorg/story/2201/run-a-regular-tracer-job-for-sidekiq-to-ensure-background-jobs-are-working)
