### PR TITLE
Stop the parser warnings in dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ group :development, :test do
   gem "rails-controller-testing"
   gem "rb-readline"
   gem "shoulda-matchers", "~> 4.1.2"
-  gem "standard"
+  gem "standard", require: false
 end
 
 group :development do


### PR DESCRIPTION
We are getting constant parser warnings in dev mode due to standard
loading rubocop, which loads a parser gem, which will always complain
about our minor ruby version being behind the latest.

See https://github.com/whitequark/parser#compatibility-with-ruby-mri for
more details on this. I believe if we kept our ruby versions up to date
we would avoid this issue entirely, but that is a bigger infra level
change.

So the quick fix is to never require standard in dev mode in our normal
bundle...so the warning should only happen for explicit `standardrb`
calls.
