### PR TITLE
Run the sidekiq tracer job every 2 minutes

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -49,7 +49,7 @@ every :monday, at: local("6:00 am"), roles: [:cron] do
   end
 end
 
-every 5.minutes, roles: [:cron] do
+every 2.minutes, roles: [:cron] do
   runner "TracerJob.perform_later(Time.current.iso8601)"
 end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -49,7 +49,7 @@ every :monday, at: local("6:00 am"), roles: [:cron] do
   end
 end
 
-every 13.minutes, roles: [:cron] do
+every 5.minutes, roles: [:cron] do
   runner "TracerJob.perform_later(Time.current.iso8601)"
 end
 


### PR DESCRIPTION
## Because

It's cheap enough to run this job every 5 minutes and a health check generally should probably run a bit more frequently. This gives us room to make more flexible monitors.

## This addresses

Run tracer job every 2 minutes.