### PR TITLE
Cache the regions tree for Reports index

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -13,9 +13,9 @@ class Reports::RegionsController < AdminController
   def index
     if current_admin.feature_enabled?(:region_reports)
       accessible_facility_regions = authorize { current_admin.accessible_facility_regions(:view_reports) }
-      regions_cache_key = "#{current_admin.cache_key}/regions/index"
-      regions_cache_version = accessible_facility_regions.cache_key
-      @accessible_regions = cache.fetch(regions_cache_key, version: regions_cache_version, expires_in: 7.days) {
+      cache_key = "#{current_admin.cache_key}/regions/index"
+      cache_version = accessible_facility_regions.cache_key
+      @accessible_regions = cache.fetch(cache_key, version: cache_version, expires_in: 7.days) {
         accessible_facility_regions.each_with_object({}) { |facility, result|
           ancestors = Hash[facility.ancestors.map { |facility| [facility.region_type, facility] }]
           org, district, block = ancestors.values_at("organization", "district", "block")

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -8,17 +8,22 @@ class Reports::RegionsController < AdminController
   before_action :set_per_page, only: [:details]
   before_action :find_region, except: [:index]
   around_action :set_time_zone
+  delegate :cache, to: Rails
 
   def index
     if current_admin.feature_enabled?(:region_reports)
       accessible_facility_regions = authorize { current_admin.accessible_facility_regions(:view_reports) }
-      @accessible_regions = accessible_facility_regions.each_with_object({}) { |facility, result|
-        ancestors = Hash[facility.ancestors.map { |facility| [facility.region_type, facility] }]
-        org, district, block = ancestors.values_at("organization", "district", "block")
-        result[org] ||= {}
-        result[org][district] ||= {}
-        result[org][district][block] ||= []
-        result[org][district][block] << facility
+      regions_cache_key = "#{current_admin.cache_key}/regions/index"
+      regions_cache_version = accessible_facility_regions.cache_key
+      @accessible_regions = cache.fetch(regions_cache_key, version: regions_cache_version, expires_in: 7.days) {
+        accessible_facility_regions.each_with_object({}) { |facility, result|
+          ancestors = Hash[facility.ancestors.map { |facility| [facility.region_type, facility] }]
+          org, district, block = ancestors.values_at("organization", "district", "block")
+          result[org] ||= {}
+          result[org][district] ||= {}
+          result[org][district][block] ||= []
+          result[org][district][block] << facility
+        }
       }
     else
       @organizations = authorize {

--- a/app/models/user_access.rb
+++ b/app/models/user_access.rb
@@ -77,6 +77,7 @@ class UserAccess
 
   def accessible_block_regions(action)
     facility_group_ids = accessible_facility_groups(action).pluck("facility_groups.id")
+    facility_group_ids.uniq!
     paths = Region.district_regions.where(source_id: facility_group_ids, source_type: "FacilityGroup").pluck(:path)
     globs = paths.map { |path| " '#{path}.*' " }.join(",")
     Region.block_regions.where("path ? ARRAY[#{globs}]::lquery[]")

--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -10,7 +10,7 @@
 # This is needed for recyclable cache keys.
 Rails.application.config.active_record.cache_versioning = true
 
-# We need to configure this at the AR level as well, the top level setting above 
+# We need to configure this at the AR level as well, the top level setting above
 # isn't getting set into ActiveRecord
 ActiveRecord::Base.cache_versioning = true
 

--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -10,6 +10,10 @@
 # This is needed for recyclable cache keys.
 Rails.application.config.active_record.cache_versioning = true
 
+# We need to configure this at the AR level as well, the top level setting above 
+# isn't getting set into ActiveRecord
+ActiveRecord::Base.cache_versioning = true
+
 # Use AES-256-GCM authenticated encryption for encrypted cookies.
 # Also, embed cookie expiry in signed or encrypted cookies for increased security.
 #


### PR DESCRIPTION
The main index tree of regions is pretty slow for users who have access to many regions. This is fairly straightforward to cache here for each admin.

**Story card:** [ch1992](https://app.clubhouse.io/simpledotorg/story/1992/performance-testing-of-region-based-reports)
