### PR TITLE
ActiveJob / ActionMailer should use sidekiq by default

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,6 +67,7 @@ Rails.application.configure do
   config.active_job.queue_adapter = :sidekiq
   # config.active_job.queue_name_prefix = "simple-server_#{Rails.env}"
   config.action_mailer.perform_caching = false
+  config.action_mailer.deliver_later_queue_name = "default"
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   end
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
-  config.active_job.queue_adapter = :inline
+  config.active_job.queue_adapter = :sidekiq
   # config.active_job.queue_name_prefix = "simple-server_#{Rails.env}"
   config.action_mailer.perform_caching = false
 

--- a/config/sidekiq-heroku.yml
+++ b/config/sidekiq-heroku.yml
@@ -1,6 +1,5 @@
 :concurrency: 2
 :queues:
-  - default
-  - mailers
-  - [low, 1]
   - [high, 3]
+  - [default, 2]
+  - [low, 1]

--- a/config/sidekiq-heroku.yml
+++ b/config/sidekiq-heroku.yml
@@ -1,5 +1,6 @@
 :concurrency: 2
 :queues:
   - default
+  - mailers
   - [low, 1]
   - [high, 3]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,7 +3,6 @@
 :logfile: ./log/sidekiq.log
 
 :queues:
-  - default
-  - mailers
-  - [low, 1]
   - [high, 3]
+  - [default, 2]
+  - [low, 1]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,5 +4,6 @@
 
 :queues:
   - default
+  - mailers
   - [low, 1]
   - [high, 3]


### PR DESCRIPTION
**Story card:** [ch2202](https://app.clubhouse.io/simpledotorg/story/2202/improve-line-list-download-performance)
## Because

We don't run mailers as proper sidekiq jobs because our default active job adapter is `:inline`

## This addresses

Change the adapter to be `:sidekiq`
