### PR TITLE
Compress line list CSVs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ gem "roo", "~> 2.8.0"
 gem "rspec-rails", "~> 3.7"
 gem "rswag", "~> 1.6.0"
 gem "ruby-progressbar", require: false
+gem "rubyzip"
 gem "sassc-rails"
 gem "scenic"
 gem "sentry-raven"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -637,6 +637,7 @@ DEPENDENCIES
   rspec-sidekiq
   rswag (~> 1.6.0)
   ruby-progressbar
+  rubyzip
   sassc-rails
   scenic
   sentry-raven

--- a/app/mailers/patient_list_download_mailer.rb
+++ b/app/mailers/patient_list_download_mailer.rb
@@ -18,10 +18,10 @@ class PatientListDownloadMailer < ApplicationMailer
   end
 
   def compress_file(file_name, file_data)
-    output_buffer = Zip::OutputStream.write_buffer do |zip|
+    output_buffer = Zip::OutputStream.write_buffer { |zip|
       zip.put_next_entry(file_name)
       zip.write file_data
-    end
+    }
 
     output_buffer.string
   end

--- a/app/mailers/patient_list_download_mailer.rb
+++ b/app/mailers/patient_list_download_mailer.rb
@@ -6,11 +6,23 @@ class PatientListDownloadMailer < ApplicationMailer
     subject = I18n.t("patient_list_email.subject", model_type: @model_type, model_name: @model_name)
 
     file_name = "patient-list_#{model_type}_#{@model_name.strip}_#{I18n.l(Date.current)}.csv"
-    attachments[file_name] = {
-      mime_type: "text/csv",
-      content: patients_csv
+    zip_file_name = "#{file_name}.zip"
+    zip_file = compress_file(file_name, patients_csv)
+
+    attachments[zip_file_name] = {
+      mime_type: "application/zip",
+      content: zip_file
     }
 
     mail(to: recipient_email, subject: subject)
+  end
+
+  def compress_file(file_name, file_data)
+    output_buffer = Zip::OutputStream.write_buffer do |zip|
+      zip.put_next_entry(file_name)
+      zip.write file_data
+    end
+
+    output_buffer.string
   end
 end

--- a/app/mailers/patient_list_download_mailer.rb
+++ b/app/mailers/patient_list_download_mailer.rb
@@ -4,25 +4,23 @@ class PatientListDownloadMailer < ApplicationMailer
     @model_name = model_name
 
     subject = I18n.t("patient_list_email.subject", model_type: @model_type, model_name: @model_name)
+    file_name = "patient-list_#{model_type}_#{@model_name.strip}_#{I18n.l(Date.current)}"
 
-    file_name = "patient-list_#{model_type}_#{@model_name.strip}_#{I18n.l(Date.current)}.csv"
-    zip_file_name = "#{file_name}.zip"
-    zip_file = compress_file(file_name, patients_csv)
+    csv_file_name = "#{file_name}.csv"
+    zip_archive_name = "#{file_name}.zip"
 
-    attachments[zip_file_name] = {
+    attachments[zip_archive_name] = {
       mime_type: "application/zip",
-      content: zip_file
+      content: compress_file(csv_file_name, patients_csv)
     }
 
     mail(to: recipient_email, subject: subject)
   end
 
   def compress_file(file_name, file_data)
-    output_buffer = Zip::OutputStream.write_buffer { |zip|
+    Zip::OutputStream.write_buffer { |zip|
       zip.put_next_entry(file_name)
       zip.write file_data
-    }
-
-    output_buffer.string
+    }.string
   end
 end

--- a/spec/mailers/patient_list_download_mailer_spec.rb
+++ b/spec/mailers/patient_list_download_mailer_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe PatientListDownloadMailer, type: :mailer do
     it "sends a compresses the csv into a valid zip file and sends as attachment" do
       attachment = mail.attachments.first
       expect(attachment.content_type).to eq "application/zip"
-      expect(attachment.filename).to eq "patient-list_facility_group_Bhandara_#{Date.current}.csv.zip"
+      expect(attachment.filename).to eq "patient-list_facility_group_Bhandara_#{I18n.l(Date.current)}.csv.zip"
 
       Zip::InputStream.open(StringIO.new(attachment.body.raw_source)) do |io|
         entry = io.get_next_entry
 
-        expect(entry.name).to eq "patient-list_facility_group_Bhandara_#{Date.current}.csv"
+        expect(entry.name).to eq "patient-list_facility_group_Bhandara_#{I18n.l(Date.current)}.csv"
         expect(io.read).to eq csv_content
       end
     end

--- a/spec/mailers/patient_list_download_mailer_spec.rb
+++ b/spec/mailers/patient_list_download_mailer_spec.rb
@@ -3,19 +3,28 @@ require "rails_helper"
 RSpec.describe PatientListDownloadMailer, type: :mailer do
   describe "#patient_list" do
     let(:csv_content) { "This is a test csv" }
+    let!(:recipient_email) { "test@simple.org" }
     let!(:mail) {
       described_class.patient_list(
-        "test@simple.org",
+        recipient_email,
         "facility_group",
         "Bhandara",
         csv_content
       )
     }
 
-    it "sends a compresses the csv into a valid zip file and sends as attachment" do
+    it "sends an email to the recipient" do
+      expect(mail.to.first).to eq recipient_email
+    end
+
+    it "sends a zip archive in the attachment" do
       attachment = mail.attachments.first
       expect(attachment.content_type).to eq "application/zip"
       expect(attachment.filename).to eq "patient-list_facility_group_Bhandara_#{I18n.l(Date.current)}.csv.zip"
+    end
+
+    it "compresses the csv in a valid zip archive as attachment" do
+      attachment = mail.attachments.first
 
       Zip::InputStream.open(StringIO.new(attachment.body.raw_source)) do |io|
         entry = io.get_next_entry

--- a/spec/mailers/patient_list_download_mailer_spec.rb
+++ b/spec/mailers/patient_list_download_mailer_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe PatientListDownloadMailer, type: :mailer do
+  describe "#patient_list" do
+    let(:csv_content) { "This is a test csv" }
+    let!(:mail) {
+      described_class.patient_list(
+        "test@simple.org",
+        "facility_group",
+        "Bhandara",
+        csv_content
+      )
+    }
+
+    it "sends a compresses the csv into a valid zip file and sends as attachment" do
+      attachment = mail.attachments.first
+      expect(attachment.content_type).to eq "application/zip"
+      expect(attachment.filename).to eq "patient-list_facility_group_Bhandara_#{Date.current}.csv.zip"
+
+      Zip::InputStream.open(StringIO.new(attachment.body.raw_source)) do |io|
+        entry = io.get_next_entry
+
+        expect(entry.name).to eq "patient-list_facility_group_Bhandara_#{Date.current}.csv"
+        expect(io.read).to eq csv_content
+      end
+    end
+  end
+end

--- a/spec/mailers/patient_list_download_mailer_spec.rb
+++ b/spec/mailers/patient_list_download_mailer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PatientListDownloadMailer, type: :mailer do
     it "sends a zip archive in the attachment" do
       attachment = mail.attachments.first
       expect(attachment.content_type).to eq "application/zip"
-      expect(attachment.filename).to eq "patient-list_facility_group_Bhandara_#{I18n.l(Date.current)}.csv.zip"
+      expect(attachment.filename).to eq "patient-list_facility_group_Bhandara_#{I18n.l(Date.current)}.zip"
     end
 
     it "compresses the csv in a valid zip archive as attachment" do


### PR DESCRIPTION
**Story card:** [ch2202](https://app.clubhouse.io/simpledotorg/story/2202/improve-line-list-download-performance)

## Because

While investigating the line list performance issues, we found that our line list attachments are exceeding the size limit on sendgrid's SMTP API. The size limit is 20 MB, which most of our medical history line lists are larger than.

## This addresses

This compresses the line lists as zip archives before attaching them. The zipped files are well under the limit (~5MB is the current worst case), so we shouldn't hit the limit soon again. `.zip` files can be opened natively on Windows 10 (doesn't need any specialised software like WinZip) and MacOS (using the native archive utility), so this shouldn't have much impact on the user experience.
