### PR TITLE
Fix state name in FacilitySeeder

### DIFF
--- a/lib/seed/facility_seeder.rb
+++ b/lib/seed/facility_seeder.rb
@@ -131,7 +131,7 @@ module Seed
             facility_group_id: facility_group_id,
             facility_size: size,
             facility_type: type,
-            state: state,
+            state: state.name,
             zone: blocks.sample
           }
           facility_attrs << FactoryBot.build(:facility, :seed, attrs)

--- a/lib/seed/facility_seeder.rb
+++ b/lib/seed/facility_seeder.rb
@@ -66,8 +66,9 @@ module Seed
       puts "Creating #{number_of_facility_groups} FacilityGroups..."
 
       # Create state Regions
-      states = number_of_states.times.map {
-        FactoryBot.build(:region, :state, id: nil, parent_path: Region.root.path)
+      state_names = Seed::FakeNames.instance.states.sample(number_of_states)
+      states = number_of_states.times.each_with_index.map { |i|
+        FactoryBot.build(:region, :state, id: nil, name: state_names[i], parent_path: Region.root.path)
       }
       state_results = Region.import(states, returning: [:path])
 

--- a/lib/seed/fake_names.rb
+++ b/lib/seed/fake_names.rb
@@ -2,7 +2,7 @@ module Seed
   class FakeNames
     include Singleton
 
-    attr_reader :blocks, :districts
+    attr_reader :blocks, :districts, :states
 
     def initialize
       @csv = CSV.read(Rails.root.join("db/fake_names.csv").to_s, headers: true).by_col!

--- a/spec/lib/seed/facility_seeder_spec.rb
+++ b/spec/lib/seed/facility_seeder_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Seed::FacilitySeeder do
     Region.facility_regions.each do |region|
       expect(region.name).to eq(region.source.name)
       expect(region.district_region).to_not be_nil
+      expect(region.state_region).to_not be_nil
+      expect(Seed::FakeNames.instance.states).to include(region.state_region.name)
       district = region.district_region
       block = region.block_region
       expect(district).to eq(region.source.facility_group.region)


### PR DESCRIPTION
**Story card:** -

## Because

The `FacilitySeeder` creates facilities with state names like ` #<Region:0x00007fb2c8ea8af8>`.

## This addresses

Fix state names.
