### PR TITLE
My Facilities Improvements: Set fixed column widths

### DIFF
--- a/app/views/my_facilities/_bp_controlled_details_v2.html.erb
+++ b/app/views/my_facilities/_bp_controlled_details_v2.html.erb
@@ -22,36 +22,36 @@
         </p>
         <table class="mt-3 mt-lg-4 table table-compact table-responsive-md table-hover analytics-table">
           <colgroup>
-            <col>
-            <col>
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
+            <col style="width: 12%;">
+            <col style="width: 10%;">
+            <col style="width: 10%;">
+            <col class="table-divider" style="width: 5%;">
+            <col style="width: 5%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
           </colgroup>
           <thead>
             <tr data-sort-method="thead" class="sorts">
-              <th class="row-label sort-label sort-label-small" style="width: 160px;">
+              <th class="row-label sort-label sort-label-small">
                 Facilities
               </th>
-              <th class="row-label sort-label sort-label-small" data-sort-method="number" style="width: 120px;">
+              <th class="row-label sort-label sort-label-small" data-sort-method="number">
                 Total assigned<br>patients
               </th>
-              <th class="row-label sort-label sort-label-small" data-sort-method="number" style="width: 120px;">
+              <th class="row-label sort-label sort-label-small" data-sort-method="number">
                 Total registered<br>patients
               </th>
-              <th class="row-label sort-label sort-label-small" colspan="2" style="width: 80px;">
+              <th class="row-label sort-label sort-label-small" colspan="2">
                 6-month change
               </th>
               <% (@start_period..@period).each do |period| %>

--- a/app/views/my_facilities/_missed_visits_details_v2.html.erb
+++ b/app/views/my_facilities/_missed_visits_details_v2.html.erb
@@ -22,36 +22,36 @@
         </p>
         <table class="mt-3 mt-lg-4 table table-compact table-responsive-md table-hover analytics-table">
           <colgroup>
-            <col>
-            <col>
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
+            <col style="width: 12%;">
+            <col style="width: 10%;">
+            <col style="width: 10%;">
+            <col class="table-divider" style="width: 5%;">
+            <col style="width: 5%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
           </colgroup>
           <thead>
             <tr data-sort-method="thead" class="sorts">
-              <th class="row-label sort-label sort-label-small" style="width: 160px;">
+              <th class="row-label sort-label sort-label-small">
                 Facilities
               </th>
-              <th class="row-label sort-label sort-label-small" data-sort-method="number" style="width: 120px;">
+              <th class="row-label sort-label sort-label-small" data-sort-method="number">
                 Total assigned<br>patients
               </th>
-              <th class="row-label sort-label sort-label-small" data-sort-method="number" style="width: 120px;">
+              <th class="row-label sort-label sort-label-small" data-sort-method="number">
                 Total registered<br>patients
               </th>
-              <th class="row-label sort-label sort-label-small" colspan="2" style="width: 80px;">
+              <th class="row-label sort-label sort-label-small" colspan="2">
                 6-month change
               </th>
               <% (@start_period..@period).each do |period| %>

--- a/app/views/my_facilities/_registrations_details_v2.html.erb
+++ b/app/views/my_facilities/_registrations_details_v2.html.erb
@@ -22,36 +22,36 @@
         </p>
         <table class="mt-3 mt-lg-4 table table-compact table-responsive-md table-hover analytics-table">
           <colgroup>
-            <col>
-            <col>
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
+            <col style="width: 12%;">
+            <col style="width: 10%;">
+            <col style="width: 10%;">
+            <col class="table-divider" style="width: 5%;">
+            <col style="width: 5%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
           </colgroup>
           <thead>
             <tr data-sort-method="thead" class="sorts">
-              <th class="row-label sort-label sort-label-small" style="width: 160px;">
+              <th class="row-label sort-label sort-label-small">
                 Facilities
               </th>
-              <th class="row-label sort-label sort-label-small" data-sort-method="number" style="width: 120px;">
+              <th class="row-label sort-label sort-label-small" data-sort-method="number">
                 Total assigned<br>patients
               </th>
-              <th class="row-label sort-label sort-label-small" data-sort-method="number" style="width: 120px;">
+              <th class="row-label sort-label sort-label-small" data-sort-method="number">
                 Total registered<br>patients
               </th>
-              <th class="row-label sort-label sort-label-small" colspan="2" style="width: 80px;">
+              <th class="row-label sort-label sort-label-small" colspan="2">
                 6-month change
               </th>
               <% (@start_period..@period).each do |period| %>

--- a/app/views/my_facilities/bp_not_controlled.html.erb
+++ b/app/views/my_facilities/bp_not_controlled.html.erb
@@ -22,36 +22,36 @@
         </p>
         <table class="mt-3 mt-lg-4 table table-compact table-responsive-md table-hover analytics-table">
           <colgroup>
-            <col>
-            <col>
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
-            <col class="table-divider">
-            <col>
+            <col style="width: 12%;">
+            <col style="width: 10%;">
+            <col style="width: 10%;">
+            <col class="table-divider" style="width: 5%;">
+            <col style="width: 5%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
+            <col class="table-divider" style="width: 4%;">
+            <col style="width: 4%;">
           </colgroup>
           <thead>
             <tr data-sort-method="thead" class="sorts">
-              <th class="row-label sort-label sort-label-small" style="width: 160px;">
+              <th class="row-label sort-label sort-label-small">
                 Facilities
               </th>
-              <th class="row-label sort-label sort-label-small" data-sort-method="number" style="width: 120px;">
+              <th class="row-label sort-label sort-label-small" data-sort-method="number">
                 Total assigned<br>patients
               </th>
-              <th class="row-label sort-label sort-label-small" data-sort-method="number" style="width: 120px;">
+              <th class="row-label sort-label sort-label-small" data-sort-method="number">
                 Total registered<br>patients
               </th>
-              <th class="row-label sort-label sort-label-small" colspan="2" style="width: 80px;">
+              <th class="row-label sort-label sort-label-small" colspan="2">
                 6-month change
               </th>
               <% (@start_period..@period).each do |period| %>


### PR DESCRIPTION
**Story card:** [ch2244](https://github.com/simpledotorg/simple-server/pull/1959)

## Because

The old way of setting column widths (in the `th`) was not working and was causing tables to have varying column widths based on the table content.

## This addresses

This PR removes widths set in headers and adds widths to columns for a more consistent table view
