### PR TITLE
PatientSummary breaks for discarded patients

### DIFF
--- a/spec/models/patient_summary_spec.rb
+++ b/spec/models/patient_summary_spec.rb
@@ -210,4 +210,16 @@ describe PatientSummary, type: :model do
       expect(PatientSummary.overdue.map(&:id)).not_to include(upcoming_appointment.patient_id)
     end
   end
+
+  describe "PatientSummary for a discarded patient" do
+    let!(:patient) { create(:patient) }
+
+    it "shouldn't return a PatientSummary for a discarded patient" do
+      patient.discard
+
+      create(:appointment, scheduled_date: 31.days.ago, status: :scheduled, patient: patient)
+
+      expect(PatientSummary.find_by(id: patient.id)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
**Story card:** [ch2246](https://app.clubhouse.io/simpledotorg/story/2246/patientsummary-breaks-for-discarded-patients-who-have-undiscarded-appointments)

## Because

PatientSummary breaks for discarded patients who have undiscarded appointments
This happened because:

- User A discarded a patient
- User B created an appointment for the same patient _after_ the patient + their data was discarded

## This addresses

This is a failing spec for the issue, doesn't have a fix yet

PatientSummary should exclude discarded patients. 
Separately, new records for discarded patients should get discarded automatically.
