### PR TITLE
Update ET demo URL in manifest

### DIFF
--- a/public/manifest/demo.json
+++ b/public/manifest/demo.json
@@ -14,7 +14,7 @@
     },
     {
       "country_code": "ET",
-      "endpoint": "https://api-demo.et.simple.org/api/",
+      "endpoint": "https://simple-demo.et.simple.org/api/",
       "display_name": "Ethiopia",
       "isd_code": "251"
     }

--- a/public/manifest/demo.json
+++ b/public/manifest/demo.json
@@ -14,7 +14,7 @@
     },
     {
       "country_code": "ET",
-      "endpoint": "https://simple-demo.et.simple.org/api/",
+      "endpoint": "https://simple-demo.moh.gov.et/api/",
       "display_name": "Ethiopia",
       "isd_code": "251"
     }


### PR DESCRIPTION
**Story card:** [ch2122](https://app.clubhouse.io/simpledotorg/story/2122/update-ethiopia-production-domain)

Updates ET Demo URL in manifest.

`api-demo.et.simple.org -> simple-demo.moh.gov.et`

DNS for the new subdomain has already been configured. This PR goes hand in hand with https://github.com/simpledotorg/deployment/pull/302