### PR TITLE
Revert sequences in seed data

### DIFF
--- a/spec/factories/facilities.rb
+++ b/spec/factories/facilities.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     end
 
     trait :seed do
-      sequence(:name) { |n| "#{facility_type} #{village_or_colony} #{n}" }
+      name { "#{facility_type} #{village_or_colony}" }
       street_address { Faker::Address.street_address }
       village_or_colony { Seed::FakeNames.instance.village }
       district { Faker::Address.district }

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :region do
     id { SecureRandom.uuid }
-    sequence(:name) { |n| "#{Faker::Company.name} #{n}" }
+    name { Faker::Company.name }
     region_type { "organization" }
 
     trait :block do

--- a/spec/lib/seed/patient_seeder_spec.rb
+++ b/spec/lib/seed/patient_seeder_spec.rb
@@ -28,6 +28,6 @@ RSpec.describe Seed::PatientSeeder do
     end
     expect(facility.assigned_patients.count).to eq(4)
     expect(facility.assigned_patients.with_hypertension.count).to eq(4)
-    expect(facility.assigned_patients.with_hypertension.where(status: 0).count).to be > 3
+    expect(facility.assigned_patients.with_hypertension.where(status: 0).count).to be >= 3
   end
 end


### PR DESCRIPTION
These create really strange looking facilities in seed data, which
defeats the purpose of nice seed data =).

If we have spec failures we should let those bubble up so we can tackle
the root cause.
