### PR TITLE
Fix the path for generated state regions

### DIFF
--- a/lib/seed/facility_seeder.rb
+++ b/lib/seed/facility_seeder.rb
@@ -68,7 +68,7 @@ module Seed
       # Create state Regions
       state_names = Seed::FakeNames.instance.states.sample(number_of_states)
       states = number_of_states.times.each_with_index.map { |i|
-        FactoryBot.build(:region, :state, id: nil, name: state_names[i], parent_path: Region.root.path)
+        FactoryBot.build(:region, :state, id: nil, name: state_names[i], parent_path: organization.region.path)
       }
       state_results = Region.import(states, returning: [:path])
 

--- a/spec/lib/seed/facility_seeder_spec.rb
+++ b/spec/lib/seed/facility_seeder_spec.rb
@@ -17,11 +17,18 @@ RSpec.describe Seed::FacilitySeeder do
       .and change { Facility.count }.by_at_least(7)
     expect(Region.block_regions.count).to be > 0
     expect(Region.state_regions.count).to be > 0
+    Region.district_regions.each do |region|
+      expect(region.name).to eq(region.source.name)
+      expect(region.district_region).to_not be_nil
+      expect(region.state_region).to_not be_nil
+      expect(region.organization_region).to_not be_nil
+    end
     # verify facility regions are linked up correctly
     Region.facility_regions.each do |region|
       expect(region.name).to eq(region.source.name)
       expect(region.district_region).to_not be_nil
       expect(region.state_region).to_not be_nil
+      expect(region.organization_region).to_not be_nil
       expect(Seed::FakeNames.instance.states).to include(region.state_region.name)
       district = region.district_region
       block = region.block_region


### PR DESCRIPTION
This was breaking everything in region reports because none of the
descendant regions had the proper paths, as they were all missing their
organization.

**Story card:** no story, just a hot fix