### PR TITLE
Add changelog script

### DIFF
--- a/bin/changelog
+++ b/bin/changelog
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+
+last_release = ARGV[0]
+diff = `git log #{last_release}..HEAD --oneline --decorate=no`
+pretty_changelog = diff.strip.split("\n")
+  .map { |line| line.match(/\s(.*)/)&.captures&.last }
+  .reject { |line| line =~ /^Merge/ } # remove merge commits
+  .compact
+  .map { |line| "• #{line}" }
+  .join("\n")
+
+puts pretty_changelog

--- a/bin/changelog
+++ b/bin/changelog
@@ -1,12 +1,16 @@
 #!/usr/bin/env ruby
 
 last_release = ARGV[0]
-diff = `git log #{last_release}..HEAD --oneline --decorate=no`
-pretty_changelog = diff.strip.split("\n")
+if last_release.nil? || last_release == "-h" || last_release == "--help"
+  abort "You must provide a git ref to compare HEAD to for the changelog. \nFor example: bin/changelog release-2021-01-21"
+end
+
+git_log = `git log #{last_release}..HEAD --oneline --decorate=no`
+changelog = git_log.strip.split("\n")
   .map { |line| line.match(/\s(.*)/)&.captures&.last }
   .reject { |line| line =~ /^Merge/ } # remove merge commits
   .compact
   .map { |line| "• #{line}" }
   .join("\n")
 
-puts pretty_changelog
+puts changelog

--- a/bin/changelog
+++ b/bin/changelog
@@ -2,7 +2,11 @@
 
 last_release = ARGV[0]
 if last_release.nil? || last_release == "-h" || last_release == "--help"
-  abort "You must provide a git ref to compare HEAD to for the changelog. \nFor example: bin/changelog release-2021-01-21"
+  docs = <<~EOL
+    You must provide a git ref to compare HEAD to for the changelog. For example, if the last release was tagged
+    release-2020-12-01 and you want changes since then, run `bin/changelog release-2020-12-01`.
+  EOL
+  abort docs
 end
 
 git_log = `git log #{last_release}..HEAD --oneline --decorate=no`

--- a/bin/release
+++ b/bin/release
@@ -17,18 +17,7 @@ end
 `git fetch --tags`
 last_release = `git describe --tags --abbrev=0 --match "release-*"`.strip
 
-changelog = `git log #{last_release}..HEAD --oneline --decorate=no`
-  .strip
-  .split("\n")
-  .map { |line| line.match(/\s(.*)/)&.captures&.last }
-  .reject { |line| line =~ /^Merge/ } # remove merge commits
-  .compact
-  .map { |line| "• #{line}" }
-  .join("\n")
-
-puts "CHANGELOG"
-puts "---------"
-puts changelog
+changelog = `bin/changelog #{last_release}`
 
 # ------------------
 # New release tag
@@ -43,6 +32,10 @@ if last_release.start_with?("release-#{today}")
 else
   release_tag = "release-#{today}-1"
 end
+
+puts "CHANGELOG for #{release_tag}"
+puts "---------"
+puts changelog
 
 # ------------------
 # Push release tag

--- a/spec/lib/seed/patient_seeder_spec.rb
+++ b/spec/lib/seed/patient_seeder_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Seed::PatientSeeder do
     user = create(:user)
     facility = user.facility
 
-    result, patient_results = Seed::PatientSeeder.call(facility, user, config: Seed::Config.new, logger: logger)
+    _result, patient_results = Seed::PatientSeeder.call(facility, user, config: Seed::Config.new, logger: logger)
     patient_results.each do |(id, _recorded_at)|
       patient = Patient.find(id)
       expect(patient.registration_facility).to eq(facility)


### PR DESCRIPTION
I often end up needing the changing after releasing, often because I lose the output in a sea of terminal output.

This extracts the changeling bit to its own script and calls it from `bin/release`.