### PR TITLE
Safe navigate while enabling block-sync for users without FG

### DIFF
--- a/lib/tasks/scripts/block_level_sync.rb
+++ b/lib/tasks/scripts/block_level_sync.rb
@@ -67,10 +67,15 @@ class BlockLevelSync
   private
 
   def touch_facilities(user)
-    user
-      .facility_group
-      .facilities
-      .update_all(updated_at: Time.current)
+    begin
+      user
+        .facility_group
+        .facilities
+        .update_all(updated_at: Time.current)
+    rescue Module::DelegationError # skip for users who don't have an associated FG
+      return
+    end
+
   end
 
   # this filters out admin users since there's no easy way to filter them out during percentage ramp-up

--- a/lib/tasks/scripts/block_level_sync.rb
+++ b/lib/tasks/scripts/block_level_sync.rb
@@ -67,15 +67,12 @@ class BlockLevelSync
   private
 
   def touch_facilities(user)
-    begin
-      user
-        .facility_group
-        .facilities
-        .update_all(updated_at: Time.current)
-    rescue Module::DelegationError # skip for users who don't have an associated FG
-      return
-    end
-
+    user
+      .facility_group
+      .facilities
+      .update_all(updated_at: Time.current)
+  rescue Module::DelegationError # skip for users who don't have an associated FG
+    nil
   end
 
   # this filters out admin users since there's no easy way to filter them out during percentage ramp-up


### PR DESCRIPTION
**Story card:** (tiny fix)

Skip over users when calling `User#facility_group` results in an error.