### PR TITLE
Change cache key to just have period type

### DIFF
--- a/app/services/control_rate_service.rb
+++ b/app/services/control_rate_service.rb
@@ -109,7 +109,7 @@ class ControlRateService
   end
 
   def cache_key
-    "#{self.class}/#{region.cache_key}/#{@periods.end.cache_key}"
+    "#{self.class}/#{region.cache_key}/#{@periods.end.type}"
   end
 
   def cache_version

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -31,7 +31,7 @@ every :day, at: local("01:00 am"), roles: [:cron] do
   runner "MarkPatientMobileNumbers.call"
 end
 
-every :day, at: local("02:00 am"), roles: [:cron] do
+every :day, at: local("04:00 am"), roles: [:cron] do
   runner "Reports::RegionCacheWarmer.call"
 end
 

--- a/spec/services/control_rate_service_spec.rb
+++ b/spec/services/control_rate_service_spec.rb
@@ -298,14 +298,20 @@ RSpec.describe ControlRateService, type: :model do
     end
 
     it "has a cache key that distinguishes based on period" do
+      region = facility_group_1.region
+
       month_periods = Period.month("September 1 2018")..Period.month("September 1 2020")
+      earlier_month_periods = Period.month("January 1 2018")..Period.month("January 1 2020")
       quarter_periods = Period.quarter(july_2018)..Period.quarter(july_2020)
       Timecop.freeze("October 1 2020") do
         service_1 = ControlRateService.new(facility_group_1, periods: month_periods)
-        expect(service_1.send(:cache_key)).to match(/month\/Sep-2020/)
+        expect(service_1.send(:cache_key)).to match(/regions\/district\/#{region.id}\/month/)
 
-        service_2 = ControlRateService.new(facility_group_1, periods: quarter_periods)
-        expect(service_2.send(:cache_key)).to match(/quarter\/Q3-2020/)
+        service_2 = ControlRateService.new(facility_group_1, periods: earlier_month_periods)
+        expect(service_2.send(:cache_key)).to match(/regions\/district\/#{region.id}\/month/)
+
+        service_3 = ControlRateService.new(facility_group_1, periods: quarter_periods)
+        expect(service_3.send(:cache_key)).to match(/regions\/district\/#{region.id}\/quarter/)
       end
     end
 


### PR DESCRIPTION
since we are storing all the data we don't need the actual period, just
the period type to distinguise between month and quarter

[ch231](https://app.clubhouse.io/simpledotorg/story/2321/elasticache-in-production-seems-slower-in-aws-prod-than-it-should-be)
