### PR TITLE
My Facilities Improvements: Sort in ascending alphabetical order

### DIFF
--- a/app/assets/javascripts/common/analytics.js
+++ b/app/assets/javascripts/common/analytics.js
@@ -1,5 +1,5 @@
 window.addEventListener("DOMContentLoaded", function() {
   $('.analytics-table').each(function(index) {
-    new Tablesort(this, { descending: true })
+    new Tablesort(this);
   })
 });

--- a/app/views/my_facilities/_bp_controlled_details_v2.html.erb
+++ b/app/views/my_facilities/_bp_controlled_details_v2.html.erb
@@ -42,7 +42,7 @@
           </colgroup>
           <thead>
             <tr data-sort-method="thead" class="sorts">
-              <th class="row-label sort-label sort-label-small">
+              <th class="row-label sort-label sort-label-small" data-sort-default>
                 Facilities
               </th>
               <th class="row-label sort-label sort-label-small" data-sort-method="number">

--- a/app/views/my_facilities/_missed_visits_details_v2.html.erb
+++ b/app/views/my_facilities/_missed_visits_details_v2.html.erb
@@ -42,7 +42,7 @@
           </colgroup>
           <thead>
             <tr data-sort-method="thead" class="sorts">
-              <th class="row-label sort-label sort-label-small">
+              <th class="row-label sort-label sort-label-small" data-sort-default>
                 Facilities
               </th>
               <th class="row-label sort-label sort-label-small" data-sort-method="number">

--- a/app/views/my_facilities/_registrations_details_v2.html.erb
+++ b/app/views/my_facilities/_registrations_details_v2.html.erb
@@ -42,7 +42,7 @@
           </colgroup>
           <thead>
             <tr data-sort-method="thead" class="sorts">
-              <th class="row-label sort-label sort-label-small">
+              <th class="row-label sort-label sort-label-small" data-sort-default>
                 Facilities
               </th>
               <th class="row-label sort-label sort-label-small" data-sort-method="number">

--- a/app/views/my_facilities/bp_not_controlled.html.erb
+++ b/app/views/my_facilities/bp_not_controlled.html.erb
@@ -42,7 +42,7 @@
           </colgroup>
           <thead>
             <tr data-sort-method="thead" class="sorts">
-              <th class="row-label sort-label sort-label-small">
+              <th class="row-label sort-label sort-label-small" data-sort-default>
                 Facilities
               </th>
               <th class="row-label sort-label sort-label-small" data-sort-method="number">


### PR DESCRIPTION
**Story card:** [ch2354](https://app.clubhouse.io/simpledotorg/story/2354/order-facilities-alphabetically)

## Because

All Dashboard tables should be intentionally sorted. 'Home' tables should be sorted alphabetically.

## This addresses

* Sorts all Dashboard tables in ascending order
* Sorts all 'Home' tables in ascending alphabetical order by 'Facility' name
