### PR TITLE
Access tree: Make dropdown arrow click target

### DIFF
--- a/app/assets/javascripts/common/admins.js
+++ b/app/assets/javascripts/common/admins.js
@@ -4,6 +4,7 @@
 const ACCESS_LIST_INPUT_SELECTOR = "input.access-input"
 const ACCESS_LEVEL_ID = "access-level"
 const ACCESS_LEVEL_POWER_USER = "power_user"
+const ACCESS_LIST_CLICK_ELEMENT = "access-item__dropdown"
 
 AdminAccess = function (accessDivId) {
   this.facilityAccess = document.getElementById(accessDivId)
@@ -40,7 +41,7 @@ AdminAccess.prototype = {
 
   resourceRowCollapseListener: function () {
     const collapsibleItems = [
-      document.getElementsByClassName("access-item")
+      document.getElementsByClassName(ACCESS_LIST_CLICK_ELEMENT)
     ].map(htmlCollection => Array.from(htmlCollection)).flat()
 
     for (const item of collapsibleItems) {


### PR DESCRIPTION
**Story card:** [ch2351](https://app.clubhouse.io/simpledotorg/story/2351/facility-access-tree-navigation)

## Because

Clicking the checkbox or the entire row shouldn't open the row—only clicking the dropdown arrow should.

## This addresses

Makes the click target the dropdown arrow instead of the entire row
