### PR TITLE
Access tree: Style updates

### DIFF
--- a/app/assets/stylesheets/partials/admin/_access_tree.scss
+++ b/app/assets/stylesheets/partials/admin/_access_tree.scss
@@ -74,9 +74,13 @@
     }
 
     .access-item {
-      height: 44px;
       display: flex;
       align-items: center;
+      padding: 8px 0;
+
+      @include media-breakpoint-down(sm) {
+        padding: 16px 0;
+      }
 
       .access-item__dropdown {
         display: flex;
@@ -104,6 +108,13 @@
         &:hover {
           background-color: $grey-light;
           @include transition(0.2s);
+        }
+
+        @include media-breakpoint-down(sm) {
+          height: 28px;
+          width: 28px;
+          margin: 0 4px 0 16px;
+          font-size: 28px;
         }
       }
 
@@ -150,11 +161,19 @@
       }
 
       .spacer {
-        padding-left: 20px;
+        padding-left: 24px;
+
+        @include media-breakpoint-down(sm) {
+          padding-left: 36px;
+        }
       }
 
       .form-check {
         margin-left: 10px;
+
+        @include media-breakpoint-down(sm) {
+          font-size: 18px;
+        }
 
         label {
           position: relative;

--- a/app/assets/stylesheets/partials/admin/_access_tree.scss
+++ b/app/assets/stylesheets/partials/admin/_access_tree.scss
@@ -48,8 +48,11 @@
 
     .form-check {
       margin: 10px;
+      cursor: pointer;
 
       label {
+        position: relative;
+        top: 1px;
         font-weight: 100;
       }
     }
@@ -76,11 +79,17 @@
       align-items: center;
 
       .access-item__dropdown {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 20px;
+        width: 20px;
+        margin-left: 14px;
+        margin-right: -4px;
         padding: 8px;
+        border-radius: 2px;
         font-size: 20px;
         cursor: pointer;
-        margin-left: 3px;
-        margin-right: -10px;
 
         i {
           transform: rotate(0deg);
@@ -90,6 +99,11 @@
 
         &.hidden {
           visibility: hidden;
+        }
+
+        &:hover {
+          background-color: $grey-light;
+          @include transition(0.2s);
         }
       }
 
@@ -131,7 +145,6 @@
       &:not(.facility) {
         .access-item__padding {
           flex: auto;
-          cursor: pointer;
           height: 100%;
         }
       }
@@ -144,6 +157,8 @@
         margin-left: 10px;
 
         label {
+          position: relative;
+          top: 1px;
           font-weight: 100;
         }
 
@@ -169,6 +184,7 @@
     &.show {
       .form-check-label {
         font-weight: normal;
+        cursor: pointer;
       }
     }
   }
@@ -189,5 +205,9 @@
     text-align: center;
     font-size: 16px;
     color: #6c737a;
+  }
+
+  .form-check-input, .form-check-label {
+    cursor: pointer;
   }
 }

--- a/app/assets/stylesheets/partials/admin/_access_tree.scss
+++ b/app/assets/stylesheets/partials/admin/_access_tree.scss
@@ -171,14 +171,11 @@
       .form-check {
         margin-left: 10px;
 
-        @include media-breakpoint-down(sm) {
-          font-size: 18px;
-        }
-
         label {
           position: relative;
           top: 1px;
           font-weight: 100;
+          margin-left: 4px;
         }
 
         &.show {

--- a/app/assets/stylesheets/partials/admin/_access_tree.scss
+++ b/app/assets/stylesheets/partials/admin/_access_tree.scss
@@ -120,10 +120,6 @@
         }
       }
 
-      &:not(.collapsed):not(.facility) {
-        background: #fff8e0;
-      }
-
       &.organization {
         div {
           label {
@@ -132,16 +128,7 @@
         }
       }
 
-      &:not(.collapsed):not(.facility) {
-        background: #fff8e0;
-      }
-
       &:not(.facility) {
-        &:hover {
-          background: var(--light);
-          @include transition(0.1s);
-        }
-
         .access-item__padding {
           flex: auto;
           cursor: pointer;

--- a/app/assets/stylesheets/partials/admin/_access_tree.scss
+++ b/app/assets/stylesheets/partials/admin/_access_tree.scss
@@ -37,7 +37,7 @@
   #select-all-facilities {
     height: 100%;
     display: flex;
-    padding: 5px 0 5px 0;
+    padding: 5px 0 5px 7px;
     justify-content: space-between;
     align-items: center;
 

--- a/app/assets/stylesheets/partials/admin/_access_tree.scss
+++ b/app/assets/stylesheets/partials/admin/_access_tree.scss
@@ -169,13 +169,21 @@
       }
 
       .form-check {
-        margin-left: 10px;
+        margin-left: 8px;
+
+        @include media-breakpoint-down(sm) {
+          font-size: 16px;
+        }
 
         label {
           position: relative;
           top: 1px;
           font-weight: 100;
           margin-left: 4px;
+
+          @include media-breakpoint-down(sm) {
+            position: unset;
+          }
         }
 
         &.show {

--- a/app/assets/stylesheets/partials/admin/_access_tree.scss
+++ b/app/assets/stylesheets/partials/admin/_access_tree.scss
@@ -161,7 +161,7 @@
       }
 
       .spacer {
-        padding-left: 24px;
+        padding-left: 25px;
 
         @include media-breakpoint-down(sm) {
           padding-left: 36px;

--- a/app/components/reports/region_tree_component.html.erb
+++ b/app/components/reports/region_tree_component.html.erb
@@ -8,7 +8,7 @@
 
       <% if parent.child_region_type %>
       <div class="access-item__dropdown">
-        <i class="fas fa-caret-down light"></i>
+        <i class="fas fa-caret-down c-grey-dark"></i>
       </div>
       <% end %>
 

--- a/app/views/email_authentications/invitations/_facility_access_tree.html.erb
+++ b/app/views/email_authentications/invitations/_facility_access_tree.html.erb
@@ -7,7 +7,7 @@
         <% end %>
 
         <div class="access-item__dropdown hidden">
-          <i class="fas fa-caret-down light"></i>
+          <i class="fas fa-caret-down c-grey-dark"></i>
         </div>
 
         <div class="form-check <%= "show" if page.eql?(:show) %>">

--- a/app/views/email_authentications/invitations/_facility_group_access_tree.html.erb
+++ b/app/views/email_authentications/invitations/_facility_group_access_tree.html.erb
@@ -7,7 +7,7 @@
         <% end %>
 
         <div class="access-item__dropdown">
-          <i class="fas fa-caret-down light"></i>
+          <i class="fas fa-caret-down c-grey-dark"></i>
         </div>
 
         <div class="form-check <%= "show" if page.eql?(:show) %>">

--- a/app/views/email_authentications/invitations/_organization_access_tree.html.erb
+++ b/app/views/email_authentications/invitations/_organization_access_tree.html.erb
@@ -4,7 +4,7 @@
       <div class="access-item organization collapsed">
 
         <div class="access-item__dropdown">
-          <i class="fas fa-caret-down light"></i>
+          <i class="fas fa-caret-down c-grey-dark"></i>
         </div>
 
         <div class="form-check <%= "show" if page.eql?(:show) %>">


### PR DESCRIPTION
**Story card:** [ch2365](https://app.clubhouse.io/simpledotorg/story/2365/access-tree-style-updates)

## Because

The access tree component could use a bit of UI polish to make the UI more accessible and intuitive.

## This addresses

* Removed background color change on row hover
* Removed background color yellow highlight when row is opened
* Added `20px` target box to dropdown arrow
* Added background color change on dropdown arrow hover
* Updated dropdown arrow and row title spacing and placement
* Made checkbox element in facility access tree show pointer cursor on hover

**Reports index page**
![image](https://user-images.githubusercontent.com/16785131/105398061-ddb6fb00-5bef-11eb-8f13-60b0552c57ae.png)
![image](https://user-images.githubusercontent.com/16785131/105398044-d7288380-5bef-11eb-8204-2a31140894d3.png)

**Invite new admin page**
![image](https://user-images.githubusercontent.com/16785131/105382373-00401880-5bde-11eb-82c8-335102f735e5.png)
![image](https://user-images.githubusercontent.com/16785131/105382398-07672680-5bde-11eb-9316-f75beebc6dba.png)