### PR TITLE
Make sure we find correct model via the region slug

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -119,7 +119,12 @@ class Reports::RegionsController < AdminController
     current_admin.region_access(memoized: true).accessible_region?(region, action)
   end
 
+  def region_reports_enabled?
+    current_admin.feature_enabled?(:region_reports)
+  end
+
   helper_method :accessible_region?
+  helper_method :region_reports_enabled?
 
   def download_filename
     time = Time.current.to_s(:number)
@@ -208,9 +213,5 @@ class Reports::RegionsController < AdminController
   def percentage(numerator, denominator)
     return 0 if denominator == 0 || numerator == 0
     ((numerator.to_f / denominator) * 100).round(2)
-  end
-
-  def region_reports_enabled?
-    current_admin.feature_enabled?(:region_reports)
   end
 end

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -12,7 +12,7 @@ class Reports::RegionsController < AdminController
   delegate :cache, to: Rails
 
   def index
-    if current_admin.feature_enabled?(:region_reports)
+    if region_reports_enabled?
       accessible_facility_regions = authorize { current_admin.accessible_facility_regions(:view_reports) }
 
       cache_key = "#{current_admin.cache_key}/regions/index"
@@ -61,7 +61,7 @@ class Reports::RegionsController < AdminController
                                                        prev_periods: 6,
                                                        include_current_period: true)
 
-    region_source = current_admin.feature_enabled?(:region_reports) ? @region.source : @region
+    region_source = region_reports_enabled? ? @region.source : @region
     if region_source.respond_to?(:recent_blood_pressures)
       @recent_blood_pressures = paginate(region_source.recent_blood_pressures)
     end
@@ -163,11 +163,19 @@ class Reports::RegionsController < AdminController
         scope = current_admin.accessible_facilities(:view_reports)
         FacilityDistrict.new(name: report_params[:id], scope: scope)
       when "district"
-        current_admin.accessible_district_regions(:view_reports).find_by!(slug: report_params[:id])
+        if region_reports_enabled?
+          current_admin.accessible_district_regions(:view_reports).find_by!(slug: report_params[:id])
+        else
+          current_admin.accessible_facility_groups(:view_reports).find_by!(slug: report_params[:id])
+        end
       when "block"
         current_admin.accessible_block_regions(:view_reports).find_by!(slug: report_params[:id])
       when "facility"
-        current_admin.accessible_facility_regions(:view_reports).find_by!(slug: report_params[:id])
+        if region_reports_enabled?
+          current_admin.accessible_facility_regions(:view_reports).find_by!(slug: report_params[:id])
+        else
+          current_admin.accessible_facilities(:view_reports).find_by!(slug: report_params[:id])
+        end
       else
         raise ActiveRecord::RecordNotFound, "unknown report_scope #{report_scope}"
       end
@@ -200,5 +208,9 @@ class Reports::RegionsController < AdminController
   def percentage(numerator, denominator)
     return 0 if denominator == 0 || numerator == 0
     ((numerator.to_f / denominator) * 100).round(2)
+  end
+
+  def region_reports_enabled?
+    current_admin.feature_enabled?(:region_reports)
   end
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -136,6 +136,11 @@ class Facility < ApplicationRecord
     facility_group.region.block_regions.find_by(name: block)
   end
 
+  # Remove me after region_reports is mainline
+  def source
+    self
+  end
+
   private :update_region
   # ----------------
 
@@ -230,8 +235,4 @@ class Facility < ApplicationRecord
     I18n.t("activerecord.facility.facility_size.#{facility_size}", default: facility_size.capitalize)
   end
 
-  # Remove me after region_reports is mainline
-  def source
-    self
-  end
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -234,5 +234,4 @@ class Facility < ApplicationRecord
     return unless facility_size
     I18n.t("activerecord.facility.facility_size.#{facility_size}", default: facility_size.capitalize)
   end
-
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -229,4 +229,9 @@ class Facility < ApplicationRecord
     return unless facility_size
     I18n.t("activerecord.facility.facility_size.#{facility_size}", default: facility_size.capitalize)
   end
+
+  # Remove me after region_reports is mainline
+  def source
+    self
+  end
 end

--- a/app/models/facility_group.rb
+++ b/app/models/facility_group.rb
@@ -106,6 +106,11 @@ class FacilityGroup < ApplicationRecord
 
   private
 
+  # Remove me after region_reports is mainline
+  def source
+    self
+  end
+
   def set_diabetes_management(value)
     facilities.each { |f| f.update!(enable_diabetes_management: value) }
   end

--- a/app/models/facility_group.rb
+++ b/app/models/facility_group.rb
@@ -104,12 +104,11 @@ class FacilityGroup < ApplicationRecord
     registered_patients.with_discarded
   end
 
-  private
-
-  # Remove me after region_reports is mainline
   def source
     self
   end
+
+  private
 
   def set_diabetes_management(value)
     facilities.each { |f| f.update!(enable_diabetes_management: value) }

--- a/app/views/reports/regions/index.html.erb
+++ b/app/views/reports/regions/index.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-sm-5 col-lg-7">
 
-    <% if current_admin.feature_enabled?(:region_reports) %>
+    <% if region_reports_enabled? %>
       <%= form_tag regions_search_url(format: :json), id: "search-form", method: :get do %>
         <div class="mo-search">
           <%= render "search" %>

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -192,6 +192,21 @@ RSpec.describe Reports::RegionsController, type: :controller do
       expect(response).to be_redirect
     end
 
+    it "finds a facility group if it has different slug compared to the region" do
+      other_fg = create(:facility_group, name: "other facility group", organization: organization)
+      region = other_fg.region
+      slug = region.slug
+      region.update!(slug: "#{slug}-district")
+      expect(region.slug).to_not eq(other_fg.slug)
+
+      other_fg.facilities << build(:facility, name: "other facility")
+      user = create(:admin, :viewer_reports_only, :with_access, resource: other_fg)
+
+      sign_in(user.email_authentication)
+      get :show, params: {id: other_fg.slug, report_scope: "district"}
+      expect(response).to be_successful
+    end
+
     it "renders successfully if report viewer has access to region" do
       other_fg = create(:facility_group, name: "other facility group", organization: organization)
       other_fg.facilities << build(:facility, name: "other facility")


### PR DESCRIPTION
Story:  [ch2397](https://app.clubhouse.io/simpledotorg/story/2397/some-districts-aren-t-loading-for-users-with-region-reports-turned-off)

We need to make sure we find FacilityGroups and Facilities if region_reports is
disabled, and find Regions if region_reports is enabled. Otherwise slug
mismatches can result in records not being found, which ends up
returning authorization errors to users.

We also need to duck type source in some of the source models to make
sure the download links still work correctly.

This will all be resolved once all users are in the world of region
reports, and are list views _only_ show Regions and never FGs or
Facilities...so the links will have the correct slugs.
