### PR TITLE
Allow the discard appointment task to accept a dry_run argument

### DIFF
--- a/lib/tasks/data_fixes.rake
+++ b/lib/tasks/data_fixes.rake
@@ -21,13 +21,8 @@ namespace :data_fixes do
 
   desc "Clean up invalid scheduled appointments (multiple scheduled appointments for a patient)"
   task :discard_invalid_scheduled_appointments, [:dry_run] => :environment do |_t, args|
-
     dry_run =
-      if args.dry_run == "true"
-        true
-      else
-        false
-      end
+      args.dry_run == "true"
 
     puts "This is a dry run" if dry_run
 

--- a/lib/tasks/data_fixes.rake
+++ b/lib/tasks/data_fixes.rake
@@ -20,15 +20,21 @@ namespace :data_fixes do
   end
 
   desc "Clean up invalid scheduled appointments (multiple scheduled appointments for a patient)"
-  task discard_invalid_scheduled_appointments: :environment do
-    patients_ids = Appointment
-      .where(status: "scheduled")
-      .group(:patient_id).count
-      .select { |_k, v| v > 1 }
-      .keys
+  task :discard_invalid_scheduled_appointments, [:dry_run] => :environment do |_t, args|
+
+    dry_run =
+      if args.dry_run == "true"
+        true
+      else
+        false
+      end
+
+    puts "This is a dry run" if dry_run
+
+    patients_ids = Appointment.where(status: "scheduled").group(:patient_id).count.select { |_k, v| v > 1 }.keys
 
     Patient.with_discarded.where(id: patients_ids).each do |patient|
-      DiscardInvalidAppointments.call(patient: patient, dry_run: true)
+      DiscardInvalidAppointments.call(patient: patient, dry_run: dry_run)
     end
   end
 end


### PR DESCRIPTION
**Story card:** <none>
## Because

The task wasn't taking an arg, and was hardcoded to always dry run
