### PR TITLE
My Facilities Improvements: Remove new "Registrations" tables

### DIFF
--- a/app/controllers/my_facilities_controller.rb
+++ b/app/controllers/my_facilities_controller.rb
@@ -70,6 +70,7 @@ class MyFacilitiesController < AdminController
   def bp_not_controlled
     unless current_admin.feature_enabled?(:my_facilities_improvements)
       redirect_to my_facilities_overview_path(request.query_parameters)
+      return
     end
 
     @facilities = filter_facilities
@@ -87,7 +88,6 @@ class MyFacilitiesController < AdminController
 
     if current_admin.feature_enabled?(:my_facilities_improvements)
       redirect_to my_facilities_overview_path(request.query_parameters)
-      return
     else
       registrations_query = RegistrationsQuery.new(facilities: @facilities,
                                                    period: @selected_period,

--- a/app/controllers/my_facilities_controller.rb
+++ b/app/controllers/my_facilities_controller.rb
@@ -88,7 +88,6 @@ class MyFacilitiesController < AdminController
 
     if current_admin.feature_enabled?(:my_facilities_improvements)
       redirect_to my_facilities_overview_path(request.query_parameters)
-      return
     else
       registrations_query = RegistrationsQuery.new(facilities: @facilities,
                                                    period: @selected_period,

--- a/app/controllers/my_facilities_controller.rb
+++ b/app/controllers/my_facilities_controller.rb
@@ -70,7 +70,6 @@ class MyFacilitiesController < AdminController
   def bp_not_controlled
     unless current_admin.feature_enabled?(:my_facilities_improvements)
       redirect_to my_facilities_overview_path(request.query_parameters)
-      return
     end
 
     @facilities = filter_facilities

--- a/app/controllers/my_facilities_controller.rb
+++ b/app/controllers/my_facilities_controller.rb
@@ -88,7 +88,7 @@ class MyFacilitiesController < AdminController
 
     if current_admin.feature_enabled?(:my_facilities_improvements)
       redirect_to my_facilities_overview_path(request.query_parameters)
-      && return
+      return
     else
       registrations_query = RegistrationsQuery.new(facilities: @facilities,
                                                    period: @selected_period,

--- a/app/controllers/my_facilities_controller.rb
+++ b/app/controllers/my_facilities_controller.rb
@@ -87,17 +87,8 @@ class MyFacilitiesController < AdminController
     @facilities = filter_facilities
 
     if current_admin.feature_enabled?(:my_facilities_improvements)
-      @data_for_facility = {}
-      @scores_for_facility = {}
-
-      @facilities.each do |facility|
-        @data_for_facility[facility.name] = Reports::RegionService.new(region: facility, period: @period).call
-        @scores_for_facility[facility.name] = Reports::PerformanceScore.new(region: facility,
-                                                                            reports_result: @data_for_facility[facility.name],
-                                                                            period: @period)
-      end
-
-      @facilities_by_size = @facilities.group_by { |facility| facility.facility_size }
+      redirect_to my_facilities_overview_path(request.query_parameters)
+      return
     else
       registrations_query = RegistrationsQuery.new(facilities: @facilities,
                                                    period: @selected_period,

--- a/app/controllers/my_facilities_controller.rb
+++ b/app/controllers/my_facilities_controller.rb
@@ -88,6 +88,7 @@ class MyFacilitiesController < AdminController
 
     if current_admin.feature_enabled?(:my_facilities_improvements)
       redirect_to my_facilities_overview_path(request.query_parameters)
+      && return
     else
       registrations_query = RegistrationsQuery.new(facilities: @facilities,
                                                    period: @selected_period,

--- a/app/views/layouts/my_facilities.html.erb
+++ b/app/views/layouts/my_facilities.html.erb
@@ -21,8 +21,10 @@
         <%= link_to(my_facilities_missed_visits_path(preserve_query_params(request.query_parameters, ["zone", "size", "period", "facility_group"])), class: "sub-nav-link #{active_action?("missed_visits")}") do %>
           Missed visits
         <% end %>
-        <%= link_to(my_facilities_registrations_path(preserve_query_params(request.query_parameters, ["zone", "size", "period", "facility_group"])), class: "sub-nav-link #{active_action?("registrations")}") do %>
-          Registrations
+        <% unless current_admin.feature_enabled?(:my_facilities_improvements) %>
+          <%= link_to(my_facilities_registrations_path(preserve_query_params(request.query_parameters, ["zone", "size", "period", "facility_group"])), class: "sub-nav-link #{active_action?("registrations")}") do %>
+            Registrations
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/app/views/my_facilities/registrations.html.erb
+++ b/app/views/my_facilities/registrations.html.erb
@@ -1,5 +1,3 @@
-<% if current_admin.feature_enabled?(:my_facilities_improvements) %>
-  <%= render "registrations_details_v2" %>
-<% else %>
+<% unless current_admin.feature_enabled?(:my_facilities_improvements) %>
   <%= render "registrations_details_v1" %>
 <% end %>

--- a/app/views/my_facilities/registrations.html.erb
+++ b/app/views/my_facilities/registrations.html.erb
@@ -1,3 +1,1 @@
-<% unless current_admin.feature_enabled?(:my_facilities_improvements) %>
-  <%= render "registrations_details_v1" %>
-<% end %>
+<%= render "registrations_details_v1" %>


### PR DESCRIPTION
**Story card:** [ch2423](https://app.clubhouse.io/simpledotorg/story/2423/remove-registrations-page)

## Because

The new "Registrations" table displays rates that rely on "OPD load" — and the definition of OPD load is still being determined by leadership.

## This addresses

* Hides the "Registrations" page for users with access to the `:my_facilities_improvements` feature flag
* Redirects users with access to the `:my_facilities_improvements` feature flag to the "Home" overview page
* Updates registration controller and view to show old "Registration" tables for users without access to feature flag
