### PR TITLE
Disable patient list downloads for state and block

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -130,7 +130,7 @@ class Reports::RegionsController < AdminController
   def download_filename
     time = Time.current.to_s(:number)
     region_name = @region.name.tr(" ", "-")
-    "#{@region.source.class.to_s.underscore}-#{@period.adjective.downcase}-cohort-report_#{region_name}_#{time}.csv"
+    "#{@region.region_type.to_s.underscore}-#{@period.adjective.downcase}-cohort-report_#{region_name}_#{time}.csv"
   end
 
   def set_facility_keys

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -172,7 +172,7 @@ class Reports::RegionsController < AdminController
         if region_reports_enabled?
           current_admin.accessible_district_regions(:view_reports).find_by!(slug: report_params[:id])
         else
-          current_admin.accessible_facility_groups(:view_reports).find_by!(slug: report_params[:id])
+          current_admin.accessible_facility_groups(:view_reports).find_by!(slug: report_params[:id]).region
         end
       when "block"
         current_admin.accessible_block_regions(:view_reports).find_by!(slug: report_params[:id])
@@ -180,7 +180,7 @@ class Reports::RegionsController < AdminController
         if region_reports_enabled?
           current_admin.accessible_facility_regions(:view_reports).find_by!(slug: report_params[:id])
         else
-          current_admin.accessible_facilities(:view_reports).find_by!(slug: report_params[:id])
+          current_admin.accessible_facilities(:view_reports).find_by!(slug: report_params[:id]).region
         end
       else
         raise ActiveRecord::RecordNotFound, "unknown report_scope #{report_scope}"

--- a/app/jobs/patient_list_download_job.rb
+++ b/app/jobs/patient_list_download_job.rb
@@ -25,6 +25,6 @@ class PatientListDownloadJob < ApplicationJob
     exporter = with_medication_history ? PatientsWithHistoryExporter : PatientsExporter
     patients_csv = exporter.csv(patients)
 
-    PatientListDownloadMailer.patient_list(recipient_email, model_type, model_name, patients_csv).deliver_later
+    PatientListDownloadMailer.patient_list(recipient_email, model_type, model_name, patients_csv).deliver_now
   end
 end

--- a/app/models/facility_district.rb
+++ b/app/models/facility_district.rb
@@ -69,8 +69,14 @@ class FacilityDistrict
     updated_at.utc.to_s(:usec)
   end
 
+  # For regions compatibility
   def source
     self
+  end
+
+  # For regions compatibility
+  def region_type
+    "facility_district"
   end
 
   # For regions compatibility

--- a/app/views/reports/regions/_downloads.html.erb
+++ b/app/views/reports/regions/_downloads.html.erb
@@ -19,14 +19,16 @@
       Monthly cohort report
     <% end %>
 
-    <% if @region.facilities.to_set.subset?(current_admin.accessible_facilities(:view_pii).to_set) %>
-      <%= link_to(reports_patient_list_path(@region, report_scope: params[:report_scope]), class: "dropdown-item") do %>
-        <i class="far fa-file w-16px ta-center mr-4px c-grey-medium"></i>
-        Patient list 
-      <% end %>
-      <%= link_to(reports_patient_list_path(@region, report_scope: params[:report_scope], medication_history: true), class: "dropdown-item") do %>
-        <i class="far fa-file w-16px ta-center mr-4px c-grey-medium"></i>
-        Patient list with med. history
+    <% unless @region.region_type.in?(["state", "block"]) %>
+      <% if @region.facilities.to_set.subset?(current_admin.accessible_facilities(:view_pii).to_set) %>
+        <%= link_to(reports_patient_list_path(@region, report_scope: params[:report_scope]), class: "dropdown-item") do %>
+          <i class="far fa-file w-16px ta-center mr-4px c-grey-medium"></i>
+          Patient list
+        <% end %>
+        <%= link_to(reports_patient_list_path(@region, report_scope: params[:report_scope], medication_history: true), class: "dropdown-item") do %>
+          <i class="far fa-file w-16px ta-center mr-4px c-grey-medium"></i>
+          Patient list with med. history
+        <% end %>
       <% end %>
     <% end %>
 
@@ -44,7 +46,7 @@
 
     <%= link_to(reports_graphics_path(@region, report_scope: params[:report_scope], quarter: previous_quarter, year: previous_quarter_year, format: "png"), class: "dropdown-item") do %>
       <i class="far fa-image w-16px ta-center mr-4px c-grey-medium"></i>
-      Download as an image 
+      Download as an image
     <% end %>
 
     <div class="dropdown-divider"></div>

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -441,7 +441,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
       end
       expect(response).to be_successful
       expect(response.body).to include("#{facility_group.name} Quarterly Cohort Report")
-      expect(response.headers["Content-Disposition"]).to include('filename="facility_group-quarterly-cohort-report_')
+      expect(response.headers["Content-Disposition"]).to include('filename="district-quarterly-cohort-report_')
     end
 
     it "retrieves cohort data for a facility district" do


### PR DESCRIPTION
These require further work and refactoring

**Story card:** [ch2424](https://app.clubhouse.io/simpledotorg/story/2424/disable-patient-line-list-downloads-for-state-reports)

The patient list downloads assume legacy models (facility and facility group), and need some cleanup to work with Regions. Until we get that done, we need to disable patient list downloads for State and Blocks.