### PR TITLE
Fix sync metrics logging

### DIFF
--- a/app/controllers/api/v3/protocols_controller.rb
+++ b/app/controllers/api/v3/protocols_controller.rb
@@ -38,6 +38,10 @@ class Api::V3::ProtocolsController < Api::V3::SyncController
     }
   end
 
+  def block_level_sync?
+    current_user&.block_level_sync?
+  end
+
   def force_resync?
     resync_token_modified?
   end

--- a/app/controllers/api/v3/sync_controller.rb
+++ b/app/controllers/api/v3/sync_controller.rb
@@ -39,6 +39,7 @@ class Api::V3::SyncController < APIController
   end
 
   def log_block_level_sync_metrics(response_key)
+    return unless current_facility
     Rails.logger.tagged("Block Sync") do
       if resync_token_modified?
         Rails.logger.info msg: "Resync token modified", resource: response_key


### PR DESCRIPTION
**Story card:** [ch2467](https://app.clubhouse.io/simpledotorg/story/2467)

## Because

We ran into some errors on [facilities sync](https://simpledotorg.slack.com/archives/CFHMC60P5/p1611896726114700) and [protocols sync](https://simpledotorg.slack.com/archives/CFHMC60P5/p1611896727114800).

## This addresses

For facilities sync: The logging breaks when users from a soft deleted facility try to sync. This adds a check in the logging function.

For protocols sync: The logging function calls `block_level_sync?`, which may not be available for public requests. This adds a `block_level_sync?` method to protocols controller similar to facilities controller, which does a safe navigate on `current_user`.
