### PR TITLE
Removed 'Registrations' tab from sub-menu

### DIFF
--- a/app/views/layouts/my_facilities.html.erb
+++ b/app/views/layouts/my_facilities.html.erb
@@ -19,9 +19,6 @@
         <%= link_to(my_facilities_missed_visits_path(preserve_query_params(request.query_parameters, ["zone", "size", "period", "facility_group"])), class: "sub-nav-link #{active_action?("missed_visits")}") do %>
           Missed visits
         <% end %>
-        <%= link_to(my_facilities_registrations_path(preserve_query_params(request.query_parameters, ["zone", "size", "period", "facility_group"])), class: "sub-nav-link #{active_action?("registrations")}") do %>
-          Registrations
-        <% end %>
         <% if current_admin.feature_enabled?(:drug_stocks) %>
           <%= link_to(my_facilities_drug_stocks_path(preserve_query_params(request.query_parameters, ["zone", "size"])), class: "sub-nav-link #{active_controller?("my_facilities/drug_stocks")}") do %>
             Drug stock


### PR DESCRIPTION
**Story card:** [ch2472](https://app.clubhouse.io/simpledotorg/story/2472/remove-registrations-tab-from-sub-menu)

## Because

The "Registrations" link in the "Home" page sub-menu shouldn't exist because the "Registrations" view no longer exists.

## This addresses

* Removes the "Registrations" link
