### PR TITLE
Drain audit_log_queue from prod sidekiq

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,3 +6,4 @@
   - [high, 3]
   - [default, 2]
   - [low, 1]
+  - [audit_log_queue, 1]


### PR DESCRIPTION
**Story card:** -

## Because

Since we cleaned up various sidekiq queues in https://github.com/simpledotorg/simple-server/pull/1936, some dangling jobs were left in those queues in prod since sidekiq stopped processing them.
![image](https://user-images.githubusercontent.com/16774200/106445751-6c0b6680-64a5-11eb-86ae-cef6b26d570e.png)


## This addresses

This adds `audit_log_queue` back to sidekiq so it gets drained out. We will revert this once we deploy to prod and the queue has drained.