### PR TITLE
Reports: Add search bar

### DIFF
--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -1,7 +1,12 @@
 <% period_selector = local_assigns.fetch(:period_selector, true) %>
 
 <div class="dashboard">
-  <nav class="breadcrumb mb-0px">
+  <%= form_tag regions_search_url(format: :json), id: "search-form", method: :get do %>
+    <div class="mo-search">
+      <%= render "search" %>
+    </div>
+  <% end %>
+  <nav class="breadcrumb mt-24px mb-0px pb-8px">
     <%= link_to "All reports", dashboard_districts_path %>
 
     <% # we can get rid of this check when FacilityDistrict goes away %>

--- a/app/views/reports/regions/_search.html.erb
+++ b/app/views/reports/regions/_search.html.erb
@@ -10,7 +10,7 @@
                          id: :search_query,
                          class: "typeahead-input form-control",
                          hide_label: true,
-                         placeholder: "Search for a region or facility",
+                         placeholder: "Search for a region or facility report",
                          autocomplete: "off" %>
     <div class="typeahead-dropdown regions"></div>
   </div>
@@ -37,3 +37,4 @@
     </a>
   </div>
 </template>
+<%= render "search_script" %>

--- a/app/views/reports/regions/_search_script.html.erb
+++ b/app/views/reports/regions/_search_script.html.erb
@@ -1,0 +1,15 @@
+<script>
+  const search = new RegionsSearch().search;
+  const form = $("#search-form");
+
+  form.on("submit", function(event) {
+    input = $(event.target).find(".typeahead-input");
+    search(input);
+    return false;
+  });
+
+  form.on("keyup", function(event) {
+    search(event.target);
+    return false;
+  });
+</script>

--- a/app/views/reports/regions/index.html.erb
+++ b/app/views/reports/regions/index.html.erb
@@ -21,24 +21,10 @@
             </div>
           <% end %>
         </div>
-
         <script>
-          const search = new RegionsSearch().search;
-          const form = $("#search-form")
-          form.on("submit", function(event) {
-            input = $(event.target).find(".typeahead-input")
-            search(input);
-            return false;
-          })
-          form.on("keyup", function(event) {
-            search(event.target);
-            return false;
-          })
-
-          const async = false
-          new AdminAccess("facility-access").initialize(async)
+          const async = false;
+          new AdminAccess("facility-access").initialize(async);
         </script>
-
       <% else %>
         <% @organizations.each do |organization| %>
         <section>


### PR DESCRIPTION
**Story card:** [ch2409](https://app.clubhouse.io/simpledotorg/story/2409/add-search-bar-to-reports-pages)

## Because

Adding reports search bar to Reports pages for faster navigation between reports.

## This addresses

* Creates partial for search `<script>`
* Appends search script partial into search partial
* Adds search partial to reports pages

**Mobile view**
![image](https://user-images.githubusercontent.com/16785131/105520864-36969a00-5ca9-11eb-9b9f-c50cf55fc4ea.png)

**Desktop view**
![image](https://user-images.githubusercontent.com/16785131/105520827-2c749b80-5ca9-11eb-8634-14a0ee194a1a.png)