### PR TITLE
Ensure we don't get negative missed visits

### DIFF
--- a/app/models/reports/result.rb
+++ b/app/models/reports/result.rb
@@ -149,7 +149,8 @@ module Reports
         controlled = controlled_patients_for(period)
         uncontrolled = uncontrolled_patients_for(period)
         visited_without_bp_taken = visited_without_bp_taken_for(period)
-        hsh[period] = registrations - visited_without_bp_taken - controlled - uncontrolled
+        missed_visits = registrations - visited_without_bp_taken - controlled - uncontrolled
+        hsh[period] = missed_visits.try(:floor) || 0
       }
     end
 


### PR DESCRIPTION
This could happen if the patient counts aren't up to the minute
accurate, on the first days of the month for example

**Story card:** [ch2485](https://app.clubhouse.io/simpledotorg/story/2485/set-floor-on-reports-numerators)

