### PR TITLE
Don't allow releasing if there are changes from remote

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -18,7 +18,7 @@ unless changes_from_remote.match?(/nothing to commit, working tree clean/)
   puts "--"
   puts changes_from_remote
   puts "--"
-  puts "Please fetch the latest to make sure you are deploying from the latest changes"
+  puts "Please fetch and merge the latest into #{current_branch} to make sure you are deploying the latest changes."
   abort
 end
 

--- a/bin/release
+++ b/bin/release
@@ -11,6 +11,17 @@ unless current_branch == MAIN_BRANCH
   abort unless gets.chomp.downcase == "y"
 end
 
+changes_from_remote = `git remote update && git status`.chomp
+unless changes_from_remote.match?(/nothing to commit, working tree clean/)
+  puts
+  puts "Your local git repo has differences from whats on GitHub:"
+  puts "--"
+  puts changes_from_remote
+  puts "--"
+  puts "Please fetch the latest to make sure you are deploying from the latest changes"
+  abort
+end
+
 # ------------------
 # Changelog
 # ------------------


### PR DESCRIPTION
We want to fail fast if the local branch someone is trying to release
from is out of date from what is actually on GitHub.

(no story)