### PR TITLE
Bug: Center-align updated text

### DIFF
--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -297,7 +297,7 @@ span.percent {
 .updated-date {
   margin-top: 12px;
   padding: 0;
-  text-align: right;
+  text-align: center;
   font-size: 14px;
   color: rgba(0,0,0,0.6);
   letter-spacing: 1px;


### PR DESCRIPTION
**Story card:** [ch1891](https://app.clubhouse.io/simpledotorg/story/1891/updated-text-should-be-center-aligned)

## Because

The last updated text in the progress tab should be center-aligned, not right aligned.

## This addresses

* Center aligns last updated text
