### PR TITLE
Fix child tables reports

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -46,10 +46,10 @@ class Reports::RegionsController < AdminController
     @adjusted_registration_date = @data[:adjusted_registrations].keys[-4]
 
     @children = @region.reportable_children(region_reports_enabled: region_reports_enabled?)
-    @children_data = @children.each_with_object({}) { |child, hsh|
-      hsh[child.name] = Reports::RegionService.new(region: child,
-                                                   period: @period,
-                                                   with_exclusions: report_with_exclusions?).call
+    @children_data = @children.map { |child|
+      Reports::RegionService.new(region: child,
+                                 period: @period,
+                                 with_exclusions: report_with_exclusions?).call
     }
   end
 

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -44,19 +44,19 @@
                 <%= number_with_delimiter(@data.last_value(:controlled_patients)) %>
               </td>
             </tr>
-            <% data.values.map(&:region).each do |region| %>
-              <% next if data[region.name].dig("controlled_patients_rate", @period).nil? %>
+            <% data.each do |result| %>
+              <% next if result.dig("controlled_patients_rate", @period).nil? %>
               <tr>
                 <td class="ta-left">
-                  <%= link_to(reports_region_path(region, report_scope: region_type))do %>
-                    <%= region.name %>
+                  <%= link_to(reports_region_path(result.region, report_scope: region_type))do %>
+                    <%= result.region.name %>
                   <% end %>
                 </td>
                 <td class="ta-left">
-                  <%= number_to_percentage(data[region.name]["controlled_patients_rate"].values.last, precision: 0) %>
+                  <%= number_to_percentage(result["controlled_patients_rate"].values.last, precision: 0) %>
                 </td>
                 <td class="ta-left">
-                  <%= number_with_delimiter(data[region.name]["controlled_patients"].values.last) %>
+                  <%= number_with_delimiter(result["controlled_patients"].values.last) %>
                 </td>
               </tr>
             <% end %>
@@ -112,19 +112,19 @@
                 <%= number_with_delimiter(@data.last_value(:uncontrolled_patients)) %>
               </td>
             </tr>
-            <% data.values.map(&:region).each do |region| %>
-              <% next if data[region.name].dig("uncontrolled_patients_rate", @period).nil? %>
+            <% data.each do |result| %>
+              <% next if result.dig("uncontrolled_patients_rate", @period).nil? %>
               <tr>
                 <td class="ta-left">
-                  <%= link_to(reports_region_path(region, report_scope: region_type))do %>
-                    <%= region.name %>
+                  <%= link_to(reports_region_path(result.region, report_scope: region_type))do %>
+                    <%= result.region.name %>
                   <% end %>
                 </td>
                 <td class="ta-left">
-                  <%= number_to_percentage(data[region.name]["uncontrolled_patients_rate"].values.last, precision: 0) %>
+                  <%= number_to_percentage(result["uncontrolled_patients_rate"].values.last, precision: 0) %>
                 </td>
                 <td class="ta-left">
-                  <%= number_with_delimiter(data[region.name]["uncontrolled_patients"].values.last) %>
+                  <%= number_with_delimiter(result["uncontrolled_patients"].values.last) %>
                 </td>
               </tr>
             <% end %>
@@ -180,19 +180,19 @@
                 <%= number_with_delimiter(@data.last_value(:missed_visits)) %>
               </td>
             </tr>
-            <% data.values.map(&:region).each do |region| %>
-              <% next if data[region.name].dig("missed_visits_rate", @period).nil? %>
+            <% data.each do |result| %>
+              <% next if result.dig("missed_visits_rate", @period).nil? %>
               <tr>
                 <td class="ta-left">
-                  <%= link_to(reports_region_path(region, report_scope: region_type))do %>
-                    <%= region.name %>
+                  <%= link_to(reports_region_path(result.region, report_scope: region_type))do %>
+                    <%= result.region.name %>
                   <% end %>
                 </td>
                 <td class="ta-left">
-                  <%= data[region.name]["missed_visits_rate"].values.last %>%
+                  <%= result["missed_visits_rate"].values.last %>%
                 </td>
                 <td class="ta-left">
-                  <%= data[region.name]["missed_visits"].values.last %>
+                  <%= result["missed_visits"].values.last %>
                 </td>
               </tr>
             <% end %>
@@ -248,19 +248,19 @@
                 <%= number_with_delimiter(@data.last_value(:cumulative_registrations)) %>
               </td>
             </tr>
-            <% data.values.map(&:region).each do |region| %>
-              <% next if data[region.name].dig("registrations", @period).nil? %>
+            <% data.each do |result| %>
+              <% next if result.dig("registrations", @period).nil? %>
               <tr>
                 <td class="ta-left">
-                  <%= link_to(reports_region_path(region, report_scope: region_type))do %>
-                    <%= region.name %>
+                  <%= link_to(reports_region_path(result.region, report_scope: region_type))do %>
+                    <%= result.region.name %>
                   <% end %>
                 </td>
                 <td class="ta-left">
-                  <%= number_with_delimiter(data[region.name]["registrations"].values.last || 0) %>
+                  <%= number_with_delimiter(result["registrations"].values.last || 0) %>
                 </td>
                 <td class="ta-left">
-                  <%= number_with_delimiter(data[region.name]["cumulative_registrations"].values.last) %>
+                  <%= number_with_delimiter(result["cumulative_registrations"].values.last) %>
                 </td>
               </tr>
             <% end %>

--- a/config/deploy/india/performance/primary.rb
+++ b/config/deploy/india/performance/primary.rb
@@ -1,1 +1,1 @@
-server "13.235.104.119", user: "deploy", roles: %w[web app db cron sidekiq]
+server "13.232.211.91", user: "deploy", roles: %w[web app db cron sidekiq]


### PR DESCRIPTION
**Story card:** [ch2503](https://app.clubhouse.io/simpledotorg/story/2503)

## Because

We found that reports for a district were breaking in IHCI. [Sentry reference](https://sentry.io/organizations/resolve-to-save-lives/issues/2190893958/?referrer=slack)

## This addresses
This happens because some facilities in the district have a different name from their regions. Specifically, these facilities have spaces in the name which were created before we added `auto_squish` to any models.

This breaks the reports because:
- The cache warmer caches `RegionService` [by facility](https://github.com/simpledotorg/simple-server/blob/7a0167ef36c77595d779390b77bff3f7b4eedf15/app/services/reports/region_cache_warmer.rb#L76), but the controller fetches reports by regions.
- A facility and it's region have the [same cache key](https://github.com/simpledotorg/simple-server/blob/7a0167ef36c77595d779390b77bff3f7b4eedf15/app/models/facility.rb#L104).
- When we request a `Result` object for a facility's region, we actually get the result object for the facility.
- The view however tries to iterate over regions and does not find any data if the names of the facility and it's region are different.

This skips putting results into a hash by the region's name and then looking them up in the view. This ensures that we display whatever results are fetched (from DB or cached) as is.