### PR TITLE
Ensure we dont create unnecessary orgs in User seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,44 +1,4 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
-
-require_relative "../lib/tasks/scripts/create_admin_user"
+# Our Seed process is entirely managed via the Seed objects to keep things fast and
+# testable.
 
 Seed::Runner.call
-
-# TODO move over this protocal drug data to new seed lib
-# protocol_data = {
-#   name: "Simple Hypertension Protocol",
-#   follow_up_days: 30
-# }
-
-# protocol_drugs_data = [
-#   {
-#     name: "Amlodipine",
-#     dosage: "5 mg"
-#   },
-#   {
-#     name: "Amlodipine",
-#     dosage: "10 mg"
-#   },
-#   {
-#     name: "Telmisartan",
-#     dosage: "40 mg"
-#   },
-#   {
-#     name: "Telmisartan",
-#     dosage: "80 mg"
-#   },
-#   {
-#     name: "Chlorthalidone",
-#     dosage: "12.5 mg"
-#   },
-#   {
-#     name: "Chlorthalidone",
-#     dosage: "25 mg"
-#   }
-# ]

--- a/lib/seed/user_seeder.rb
+++ b/lib/seed/user_seeder.rb
@@ -36,17 +36,20 @@ module Seed
 
     def create_dashboard_admins
       unless EmailAuthentication.exists?(email: "admin@simple.org")
-        FactoryBot.create(:admin, :power_user, full_name: "Admin User", email: "admin@simple.org", password: config.admin_password)
+        FactoryBot.create(:admin, :power_user, full_name: "Admin User", email: "admin@simple.org",
+                                               password: config.admin_password, organization: organization)
       end
 
       unless EmailAuthentication.exists?(email: "power_user@simple.org")
-        FactoryBot.create(:admin, :power_user, full_name: "Power User", email: "power_user@simple.org", password: config.admin_password)
+        FactoryBot.create(:admin, :power_user, full_name: "Power User", email: "power_user@simple.org",
+                                               password: config.admin_password, organization: organization)
       end
 
       cvho = User.find_by_email("cvho@simple.org")
       unless cvho && cvho.accesses.where(resource_type: "FacilityGroup").count == DISTRICTS_MANAGED_BY_CVHO
         districts = *FacilityGroup.take(DISTRICTS_MANAGED_BY_CVHO)
-        user = cvho || FactoryBot.create(:admin, :manager, full_name: "CVHO", email: "cvho@simple.org", password: config.admin_password)
+        user = cvho || FactoryBot.create(:admin, :manager, full_name: "CVHO", email: "cvho@simple.org",
+                                                           password: config.admin_password, organization: organization)
         districts.each do |district|
           user.accesses.create! resource: district
         end
@@ -55,7 +58,8 @@ module Seed
       sts = User.find_by_email("sts@simple.org")
       unless sts && sts.accesses.where(resource_type: "FacilityGroup").count == DISTRICTS_FOR_STS
         districts = *FacilityGroup.order("name desc").take(DISTRICTS_FOR_STS)
-        user = sts || FactoryBot.create(:admin, :viewer_all, full_name: "STS", email: "sts@simple.org", password: config.admin_password)
+        user = sts || FactoryBot.create(:admin, :viewer_all, full_name: "STS", email: "sts@simple.org",
+                                                             password: config.admin_password, organization: organization)
         districts.each do |district|
           user.accesses.create! resource: district
         end
@@ -64,7 +68,8 @@ module Seed
       district_official = User.find_by_email("district_official@simple.org")
       unless district_official && district_official.accesses.where(resource_type: "FacilityGroup").count == DISTRICTS_FOR_DISTRICT_OFFICIAL
         districts = *FacilityGroup.take(DISTRICTS_FOR_DISTRICT_OFFICIAL)
-        user = district_official || FactoryBot.create(:admin, :viewer_reports_only, full_name: "District Official", email: "district_official@simple.org", password: config.admin_password)
+        user = district_official || FactoryBot.create(:admin, :viewer_reports_only, full_name: "District Official", email: "district_official@simple.org",
+                                                                                    password: config.admin_password, organization: organization)
         districts.each do |district|
           user.accesses.create! resource: district
         end
@@ -73,7 +78,8 @@ module Seed
       medical_officer = User.find_by_email("medical_officer@simple.org")
       unless medical_officer && medical_officer.accesses.where(resource_type: "Facility").count == FACILITIES_FOR_MED_OFFICER
         facilities = *Facility.take(FACILITIES_FOR_MED_OFFICER)
-        user = medical_officer || FactoryBot.create(:admin, :viewer_all, full_name: "Medical Officer", email: "medical_officer@simple.org", password: config.admin_password)
+        user = medical_officer || FactoryBot.create(:admin, :viewer_all, full_name: "Medical Officer", email: "medical_officer@simple.org",
+                                                                         password: config.admin_password, organization: organization)
         facilities.each do |facility|
           user.accesses.create! resource: facility
         end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -68,7 +68,6 @@ FactoryBot.define do
     device_updated_at { Time.current }
     sync_approval_status { User.sync_approval_statuses[:denied] }
     email_authentications { build_list(:email_authentication, 1, email: email, password: password) }
-    # organization
     role { "power user" }
     access_level { :power_user }
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     end
 
     full_name { Faker::Name.name }
-    organization
     device_created_at { Time.current }
     device_updated_at { Time.current }
     teleconsultation_phone_number { Faker::PhoneNumber.phone_number }
@@ -69,7 +68,7 @@ FactoryBot.define do
     device_updated_at { Time.current }
     sync_approval_status { User.sync_approval_statuses[:denied] }
     email_authentications { build_list(:email_authentication, 1, email: email, password: password) }
-    organization
+    # organization
     role { "power user" }
     access_level { :power_user }
 

--- a/spec/lib/seed/runner_spec.rb
+++ b/spec/lib/seed/runner_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Seed::Runner do
       .and change { BloodPressure.count }.by(expected_bps)
       .and change { Encounter.count }.by(expected_bps)
       .and change { Observation.count }.by(expected_bps)
+      .and change { Organization.count }.by(1)
     Patient.all.each do |patient|
       expect(patient).to be_valid
       expect(patient.medical_history).to be_valid

--- a/spec/lib/seed/user_seeder_spec.rb
+++ b/spec/lib/seed/user_seeder_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe Seed::UserSeeder do
   let(:config) { Seed::Config.new }
   let(:expected_admins) { 6 }
 
+  it "does not create unnecessary orgs" do
+    expect {
+      Seed::UserSeeder.call(config: config)
+    }.to change { Organization.count }.by(1)
+  end
+
   it "creates standard admin users" do
     create_list(:facility_group, 2)
     Seed::UserSeeder.call(config: config)

--- a/spec/lib/seed/user_seeder_spec.rb
+++ b/spec/lib/seed/user_seeder_spec.rb
@@ -4,10 +4,13 @@ RSpec.describe Seed::UserSeeder do
   let(:config) { Seed::Config.new }
   let(:expected_admins) { 6 }
 
-  it "does not create unnecessary orgs" do
+  it "associates Users with the one seed org" do
     expect {
       Seed::UserSeeder.call(config: config)
     }.to change { Organization.count }.by(1)
+    User.all.each do |user|
+      expect(user.organization).to eq(Seed.seed_org)
+    end
   end
 
   it "creates standard admin users" do


### PR DESCRIPTION
**Story card:** [ch2543](https://app.clubhouse.io/simpledotorg/story/2543/create-protocols-and-protocol-drugs)

Adding some more specs around a bug @harimohanraj89 found in https://github.com/simpledotorg/simple-server/pull/2045.

I _think_ the user#organization association can go away completely, since we now can determine org relationship via user_access....but we probably want to make sure all these users are still associated with the one seed org until that happens.