### PR TITLE
Show region type and parent type in subtitle

### DIFF
--- a/app/assets/javascripts/common/regions_search.js
+++ b/app/assets/javascripts/common/regions_search.js
@@ -9,7 +9,7 @@ RegionsSearch = function () {
 
     let link = $html.find("a")
     link.prepend(highlightedName)
-    $html.find(".ancestors").append(result["ancestors"])
+    $html.find(".subtitle").append(result["subtitle"])
     link.attr("href", result["link"])
     return $html
   }

--- a/app/controllers/regions_search_controller.rb
+++ b/app/controllers/regions_search_controller.rb
@@ -16,9 +16,11 @@ class RegionsSearchController < AdminController
     @query = params.permit(:query)[:query] || ""
     regex = /.*#{Regexp.escape(@query)}.*/i
     results = search(regions, regex)
+
     json = results.sort_by(&:name).map { |region|
+      subtitle = "#{region.region_type.humanize} in #{region.parent.name} #{region.parent.region_type.humanize}"
       {
-        ancestors: region.cached_ancestors.reject { |r| r.region_type.in?(["root", "organization"]) }.map { |r| r.name }.join(" > "),
+        ancestors: subtitle,
         id: region.id,
         name: region.name,
         slug: region.slug,

--- a/app/controllers/regions_search_controller.rb
+++ b/app/controllers/regions_search_controller.rb
@@ -20,11 +20,11 @@ class RegionsSearchController < AdminController
     json = results.sort_by(&:name).map { |region|
       subtitle = "#{region.region_type.humanize} in #{region.parent.name} #{region.parent.region_type.humanize}"
       {
-        ancestors: subtitle,
         id: region.id,
+        link: reports_region_url(region, report_scope: region.region_type),
         name: region.name,
         slug: region.slug,
-        link: reports_region_url(region, report_scope: region.region_type)
+        subtitle: subtitle
       }
     }
     render json: json

--- a/app/views/reports/regions/_search.html.erb
+++ b/app/views/reports/regions/_search.html.erb
@@ -33,7 +33,7 @@
         data-id=""
         data-name=""
         data-link="">
-      <p class="ancestors mb-0px fs-14px lh-18px c-grey-dark"></p>
+      <p class="subtitle mb-0px fs-14px lh-18px c-grey-dark"></p>
     </a>
   </div>
 </template>

--- a/spec/exporters/patients_with_history_exporter_spec.rb
+++ b/spec/exporters/patients_with_history_exporter_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe PatientsWithHistoryExporter, type: :model do
       patient.id,
       patient.latest_bp_passport&.shortcode,
       patient.full_name,
-      patient.current_age,
+      patient.current_age.to_i,
       patient.gender.capitalize,
       "Died",
       patient.phone_numbers.last&.number,


### PR DESCRIPTION
**Story card:** [ch2511](https://app.clubhouse.io/simpledotorg/story/2511/update-reports-search-bar-results-subtitle)

Updating search results to be more clear about what the region types are.

## Screenshots

<img width="762" alt="image" src="https://user-images.githubusercontent.com/69/107278891-f90d6d00-6a1b-11eb-8d9f-7ff5b17cb026.png">

<img width="720" alt="image" src="https://user-images.githubusercontent.com/69/107278954-0b87a680-6a1c-11eb-9e88-9a8094b0e2b3.png">

