### PR TITLE
Abort if git errors out in bin/release

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -55,7 +55,7 @@ puts "Creating release #{release_tag}. Continue? (y/N):"
 exit unless gets.chomp.downcase == "y"
 
 system(%Q{git tag -a #{release_tag} -m "#{changelog.shellescape}"}) || abort("Error creating git tag #{release_tag}")
-system("git push origin refs/tags/#{release_tag}") || abort("Error pushing tags to origin")
+system("git push origin refs/tags/#{release_tag}") || abort("Error pushing git tags to origin")
 
 # ------------------
 # Conclusion

--- a/bin/release
+++ b/bin/release
@@ -54,8 +54,8 @@ puts changelog
 puts "Creating release #{release_tag}. Continue? (y/N):"
 exit unless gets.chomp.downcase == "y"
 
-`git tag -a #{release_tag} -m "#{changelog.shellescape}"`
-`git push origin refs/tags/#{release_tag}`
+system(%Q{git tag -a #{release_tag} -m "#{changelog.shellescape}"}) || abort("Error creating git tag #{release_tag}")
+system("git push origin refs/tags/#{release_tag}") || abort("Error pushing tags to origin")
 
 # ------------------
 # Conclusion


### PR DESCRIPTION
Saw this happen locally when I accidentally duplicated an existing tag name.

The script should abort and not continue.

(no story)