### PR TITLE
Dont send notifications if the appointment is missing

### DIFF
--- a/app/jobs/appointment_notification/worker.rb
+++ b/app/jobs/appointment_notification/worker.rb
@@ -7,7 +7,11 @@ class AppointmentNotification::Worker
   DEFAULT_LOCALE = :en
 
   def perform(appointment_id, communication_type, locale = nil)
-    appointment = Appointment.find(appointment_id)
+    appointment = Appointment.find_by(id: appointment_id)
+    unless appointment
+      logger.warn "Appointment #{appointment_id} not found, skipping notification"
+      return
+    end
 
     return if appointment.previously_communicated_via?(communication_type)
 

--- a/spec/jobs/appointment_notification/worker_spec.rb
+++ b/spec/jobs/appointment_notification/worker_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 require "sidekiq/testing"
 
 RSpec.describe AppointmentNotification::Worker, type: :job do
-  let!(:facility_name) { "Simple Facility" }
-  let!(:appointment_scheduled_date) { Date.new(2018, 1, 1) }
-  let!(:appointment) do
+  let(:facility_name) { "Simple Facility" }
+  let(:appointment_scheduled_date) { Date.new(2018, 1, 1) }
+  let(:appointment) do
     create(:appointment,
       facility: create(:facility, name: facility_name),
       scheduled_date: appointment_scheduled_date)
@@ -48,6 +48,13 @@ RSpec.describe AppointmentNotification::Worker, type: :job do
         described_class.perform_async(appointment.id, communication_type, locale)
         described_class.drain
       }.to change { Communication.count }.by(1)
+    end
+
+    it "does not send if Appointment is missing" do
+      expect {
+        described_class.perform_async("12345", communication_type, locale)
+        described_class.drain
+      }.not_to change { Communication.count }
     end
 
     it "does not send if Communication already sent" do


### PR DESCRIPTION
**Story card:** [ch2463](https://app.clubhouse.io/simpledotorg/story/2463/known-sidekiq-failures)

Quick bug fix for this older sentry issue. I'm guessing this is a race condition between job submission and the appointment worker picking up the record.