### PR TITLE
2531: add registered hypertension counts to my facilities views

### DIFF
--- a/app/views/my_facilities/bp_controlled.html.erb
+++ b/app/views/my_facilities/bp_controlled.html.erb
@@ -76,16 +76,16 @@
               </tr>
             </thead>
             <tbody>
-              <% facility_size_six_month_rate_change = facility_size_six_month_rate_change(@stats_by_size[size], "controlled_patients_rate") %>
+              <% facility_size_six_month_rate_change = facility_size_six_month_rate_change(@stats_by_size[size][:periods], "controlled_patients_rate") %>
               <tr class="row-total" data-row="<%= size %>" data-trend-color="<% if facility_size_six_month_rate_change > 0 %>green<% elsif facility_size_six_month_rate_change < 0 %>red<% else %>grey<% end %>">
                 <td class="type-title">
                   All <%= Facility.localized_facility_size(size) %>s
                 </td>
                 <td>
-                  <%= number_or_zero_with_delimiter(@stats_by_size[size][@period]["adjusted_registrations"]) %>
+                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:periods][@period][:cumulative_registrations]) %>
                 </td>
                 <td>
-                  <%= number_or_zero_with_delimiter(@stats_by_size[size][@period]["cumulative_registrations"]) %>
+                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:total_registered_hypertensive_patients]) %>
                 </td>
                 <td>
                   <div class="w-90px h-20px">
@@ -99,7 +99,7 @@
                 >
                   <%= number_to_percentage_with_symbol(facility_size_six_month_rate_change, precision: 0) %>
                 </td>
-                <% @stats_by_size[size].each_pair do |period, data| %>
+                <% @stats_by_size[size][:periods].each_pair do |period, data| %>
                   <% controlled_patients_rate = data["controlled_patients_rate"] %>
                   <td
                     class="type-percent"
@@ -125,10 +125,10 @@
                     <% end %>
                   </td>
                   <td>
-                    <%= number_or_zero_with_delimiter(facility_data["adjusted_registrations"].values.last) %>
+                    <%= number_or_zero_with_delimiter(facility_data["cumulative_registrations"].values.last) %>
                   </td>
                   <td>
-                    <%= number_or_zero_with_delimiter(facility_data["cumulative_registrations"].values.last) %>
+                    <%= number_or_zero_with_delimiter(facility.registered_hypertension_patients.count) %>
                   </td>
                   <td>
                     <div class="w-90px h-20px">

--- a/app/views/my_facilities/bp_not_controlled.html.erb
+++ b/app/views/my_facilities/bp_not_controlled.html.erb
@@ -76,16 +76,16 @@
               </tr>
             </thead>
             <tbody>
-              <% facility_size_six_month_rate_change = facility_size_six_month_rate_change(@stats_by_size[size], "uncontrolled_patients_rate") %>
+              <% facility_size_six_month_rate_change = facility_size_six_month_rate_change(@stats_by_size[size][:periods], "uncontrolled_patients_rate") %>
               <tr class="row-total" data-row="<%= size %>" data-trend-color="<% if facility_size_six_month_rate_change > 0 %>red<% elsif facility_size_six_month_rate_change < 0 %>green<% else %>grey<% end %>">
                 <td class="type-title">
                   All <%= Facility.localized_facility_size(size) %>s
                 </td>
                 <td>
-                  <%= number_or_zero_with_delimiter(@stats_by_size[size][@period]["adjusted_registrations"]) %>
+                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:periods][@period][:cumulative_registrations]) %>
                 </td>
                 <td>
-                  <%= number_or_zero_with_delimiter(@stats_by_size[size][@period]["cumulative_registrations"]) %>
+                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:total_registered_hypertensive_patients]) %>
                 </td>
                 <td>
                   <div class="w-90px h-20px">
@@ -99,7 +99,7 @@
                 >
                   <%= number_to_percentage_with_symbol(facility_size_six_month_rate_change, precision: 0) %>
                 </td>
-                <% @stats_by_size[size].each_pair do |period, data| %>
+                <% @stats_by_size[size][:periods].each_pair do |period, data| %>
                   <% uncontrolled_patients_rate = data["uncontrolled_patients_rate"] %>
                   <td
                     class="type-percent"
@@ -125,9 +125,10 @@
                     <% end %>
                   </td>
                   <td>
-                    <%= number_or_zero_with_delimiter(facility_data["adjusted_registrations"].values.last) %>                </td>
-                  <td>
                     <%= number_or_zero_with_delimiter(facility_data["cumulative_registrations"].values.last) %>
+                  </td>
+                  <td>
+                    <%= number_or_zero_with_delimiter(facility.registered_hypertension_patients.count) %>
                   </td>
                   <td>
                     <div class="w-90px h-20px">

--- a/app/views/my_facilities/missed_visits.html.erb
+++ b/app/views/my_facilities/missed_visits.html.erb
@@ -76,16 +76,16 @@
               </tr>
             </thead>
             <tbody>
-              <% facility_size_six_month_rate_change = facility_size_six_month_rate_change(@stats_by_size[size], "missed_visits_rate") %>
+              <% facility_size_six_month_rate_change = facility_size_six_month_rate_change(@stats_by_size[size][:periods], "missed_visits_rate") %>
               <tr class="row-total" data-row="<%= size %>" data-trend-color="<% if facility_size_six_month_rate_change > 0 %>red<% elsif facility_size_six_month_rate_change < 0 %>green<% else %>grey<% end %>">
                 <td class="type-title">
                   All <%= Facility.localized_facility_size(size) %>s
                 </td>
                 <td>
-                  <%= number_or_zero_with_delimiter(@stats_by_size[size][@period]["adjusted_registrations"]) %>
+                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:periods][@period][:cumulative_registrations]) %>
                 </td>
                 <td>
-                  <%= number_or_zero_with_delimiter(@stats_by_size[size][@period]["cumulative_registrations"]) %>
+                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:total_registered_hypertensive_patients]) %>
                 </td>
                 <td>
                   <div class="w-90px h-20px">
@@ -99,7 +99,7 @@
                 >
                   <%= number_to_percentage_with_symbol(facility_size_six_month_rate_change, precision: 0) %>
                 </td>
-                <% @stats_by_size[size].each_pair do |period, data| %>
+                <% @stats_by_size[size][:periods].each_pair do |period, data| %>
                   <% missed_visits_rate = data["missed_visits_rate"] %>
                   <td
                     class="type-percent"
@@ -125,10 +125,10 @@
                     <% end %>
                   </td>
                   <td>
-                    <%= number_or_zero_with_delimiter(facility_data["adjusted_registrations"].values.last) %>
+                    <%= number_or_zero_with_delimiter(facility_data["cumulative_registrations"].values.last) %>
                   </td>
                   <td>
-                    <%= number_or_zero_with_delimiter(facility_data["cumulative_registrations"].values.last) %>
+                    <%= number_or_zero_with_delimiter(facility.registered_hypertension_patients.count) %>
                   </td>
                   <td>
                     <div class="w-90px h-20px">

--- a/app/views/shared/_facility_size_overview.html.erb
+++ b/app/views/shared/_facility_size_overview.html.erb
@@ -7,10 +7,10 @@
         All <%= Facility.localized_facility_size(size) %>s
       </p>
       <p class="mb-4px fw-bold fs-24px">
-        <%= number_to_percentage(@stats_by_size[size][@period][rate_name] || 0, precision: 0) %>
+        <%= number_to_percentage(@stats_by_size[size][:periods][@period][rate_name] || 0, precision: 0) %>
       </p>
       <p class="mb-0 fs-14px c-grey-dark">
-        <% six_month_rate_change = facility_size_six_month_rate_change(@stats_by_size[size], rate_name) %>
+        <% six_month_rate_change = facility_size_six_month_rate_change(@stats_by_size[size][:periods], rate_name) %>
         6-month change, <span class="fw-bold <% if six_month_rate_change > 0 %><%= positive_number_color %><% elsif six_month_rate_change < 0 %><%= negative_number_color %><% else %>c-grey-dark<% end %>"><%= number_to_percentage(six_month_rate_change, precision: 0) %></span>
       </p>
     </div>

--- a/spec/services/facility_stats_service_spec.rb
+++ b/spec/services/facility_stats_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe FacilityStatsService do
     it "sets data for the past six periods" do
       stats_by_size = FacilityStatsService.call(facilities: facilities_data([small_facility]), period: period,
                                                 rate_numerator: :controlled_patients)
-      small = stats_by_size[:small]
+      small = stats_by_size[:small][:periods]
       periods = (1..5).inject([period]) { |periods|
         periods << periods.last.previous
       }
@@ -90,19 +90,19 @@ RSpec.describe FacilityStatsService do
                                                 period: period, rate_numerator: :controlled_patients)
 
       # all numbers except cumulative_registrations appear in data 3 months after they're recorded
-      small = stats_by_size[:small]
+      small = stats_by_size[:small][:periods]
       expect(small.map { |_, v| v[:controlled_patients] }).to eq [0, 0, 0, 2, 0, 0]
       expect(small.map { |_, v| v[:adjusted_registrations] }).to eq [0, 0, 0, 3, 3, 3]
       expect(small.map { |_, v| v[:cumulative_registrations] }).to eq [3, 3, 3, 3, 3, 3]
       expect(small.map { |_, v| v[:controlled_patients_rate] }).to eq [0, 0, 0, 67, 0, 0]
 
-      medium = stats_by_size[:medium]
+      medium = stats_by_size[:medium][:periods]
       expect(medium.map { |_, v| v[:controlled_patients] }).to eq [0, 0, 0, 0, 1, 0]
       expect(medium.map { |_, v| v[:adjusted_registrations] }).to eq [0, 0, 0, 0, 2, 2]
       expect(medium.map { |_, v| v[:cumulative_registrations] }).to eq [0, 2, 2, 2, 2, 2]
       expect(medium.map { |_, v| v[:controlled_patients_rate] }).to eq [0, 0, 0, 0, 50, 0]
 
-      large = stats_by_size[:large]
+      large = stats_by_size[:large][:periods]
       expect(large.map { |_, v| v[:controlled_patients] }).to eq [0, 0, 0, 0, 0, 1]
       expect(large.map { |_, v| v[:adjusted_registrations] }).to eq [0, 0, 0, 0, 0, 3]
       expect(large.map { |_, v| v[:cumulative_registrations] }).to eq [0, 0, 3, 3, 3, 3]
@@ -112,7 +112,7 @@ RSpec.describe FacilityStatsService do
     it "processes data for controlled_patients" do
       stats_by_size = FacilityStatsService.call(facilities: facilities_data([small_facility]),
                                                 period: period, rate_numerator: :controlled_patients)
-      period_keys = stats_by_size[:small].values.map(&:keys).flatten.uniq
+      period_keys = stats_by_size[:small][:periods].values.map(&:keys).flatten.uniq
       controlled_patient_keys = ["controlled_patients", "controlled_patients_rate"]
       expect(period_keys & controlled_patient_keys).to match_array(controlled_patient_keys)
     end
@@ -120,7 +120,7 @@ RSpec.describe FacilityStatsService do
     it "processes data for uncontrolled_patients" do
       stats_by_size = FacilityStatsService.call(facilities: facilities_data([small_facility]),
                                                 period: period, rate_numerator: :uncontrolled_patients)
-      period_keys = stats_by_size[:small].values.map(&:keys).flatten.uniq
+      period_keys = stats_by_size[:small][:periods].values.map(&:keys).flatten.uniq
       uncontrolled_patient_keys = ["uncontrolled_patients", "uncontrolled_patients_rate"]
       expect(period_keys & uncontrolled_patient_keys).to match_array(uncontrolled_patient_keys)
     end
@@ -128,7 +128,7 @@ RSpec.describe FacilityStatsService do
     it "processes data for missed_visits" do
       stats_by_size = FacilityStatsService.call(facilities: facilities_data([small_facility]),
                                                 period: period, rate_numerator: :missed_visits)
-      period_keys = stats_by_size[:small].values.map(&:keys).flatten.uniq
+      period_keys = stats_by_size[:small][:periods].values.map(&:keys).flatten.uniq
       missed_visits_keys = ["missed_visits", "missed_visits_rate"]
       expect(period_keys & missed_visits_keys).to match_array(missed_visits_keys)
     end
@@ -136,11 +136,29 @@ RSpec.describe FacilityStatsService do
     it "handles invalid rate_numerator by setting values to zero" do
       stats_by_size = FacilityStatsService.call(facilities: facilities_data([small_facility]),
                                                 period: period, rate_numerator: :womp)
-      stat_keys = stats_by_size[:small].values.first.keys
-      stat_values = stats_by_size[:small].values.first.values
+      stat_keys = stats_by_size[:small][:periods].values.first.keys
+      stat_values = stats_by_size[:small][:periods].values.first.values
       expected_keys = ["womp", "adjusted_registrations", "cumulative_registrations", "womp_rate"]
       expect(stat_keys).to match_array(expected_keys)
       expect(stat_values).to match_array([0, 0, 0, 0])
+    end
+
+    it "sets total_registered_hypertensive_patients for each size" do
+      small_facility
+      month = december - 4.months
+      medium_facility1 = create(:facility, name: "medium_1", facility_size: "medium")
+      medium_facility2 = create(:facility, name: "medium_2", facility_size: "medium")
+      create_list(:patient, 2, :hypertension, full_name: "medium_uncontrolled", registration_user: user,
+                                              registration_facility: medium_facility1, recorded_at: month)
+      create_list(:patient, 1, :without_hypertension, full_name: "medium_controlled", registration_user: user,
+                                                      registration_facility: medium_facility2, recorded_at: month)
+      facilities = [small_facility, medium_facility1, medium_facility2]
+      refresh_views
+      facilities_reports = facilities_data(facilities)
+      stats_by_size = FacilityStatsService.call(facilities: facilities_reports,
+                                                period: period, rate_numerator: :controlled_patients)
+      expect(stats_by_size[:small][:total_registered_hypertensive_patients]).to eq 0
+      expect(stats_by_size[:medium][:total_registered_hypertensive_patients]).to eq 2
     end
   end
 end


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/2531

## Because

The data in the my facilities views is incorrect. 

## This addresses

This changes the views in my facilities to use registered hypertensive patients per region/facility. 
