### PR TITLE
LTFU exclusions performance fixes

### DIFF
--- a/app/jobs/region_cache_warmer_job.rb
+++ b/app/jobs/region_cache_warmer_job.rb
@@ -1,0 +1,16 @@
+class RegionCacheWarmerJob
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default
+
+  def perform(region_id, period_attributes)
+    region = Region.find(region_id)
+    period = Period.new(period_attributes)
+
+    Reports::RegionService.call(region: region, period: period)
+    Statsd.instance.increment("region_cache_warmer.#{region.region_type}.cache")
+
+    Reports::RegionService.call(region: region, period: period, with_exclusions: true)
+    Statsd.instance.increment("region_cache_warmer.with_exclusions.#{region.region_type}.cache")
+  end
+end

--- a/app/jobs/region_cache_warmer_job.rb
+++ b/app/jobs/region_cache_warmer_job.rb
@@ -17,7 +17,6 @@ class RegionCacheWarmerJob
       Statsd.instance.increment("region_cache_warmer.with_exclusions.#{region.region_type}.cache")
     end
     notify "finished region caching for region #{region_id}"
-
   end
 
   private

--- a/app/jobs/region_cache_warmer_job.rb
+++ b/app/jobs/region_cache_warmer_job.rb
@@ -6,11 +6,29 @@ class RegionCacheWarmerJob
   def perform(region_id, period_attributes)
     region = Region.find(region_id)
     period = Period.new(period_attributes)
+    RequestStore.store[:force_cache] = true
 
-    Reports::RegionService.call(region: region, period: period)
-    Statsd.instance.increment("region_cache_warmer.#{region.region_type}.cache")
+    notify "starting region caching for region #{region_id}"
+    Statsd.instance.time("region_cache_warmer.#{region_id}") do
+      Reports::RegionService.call(region: region, period: period)
+      Statsd.instance.increment("region_cache_warmer.#{region.region_type}.cache")
 
-    Reports::RegionService.call(region: region, period: period, with_exclusions: true)
-    Statsd.instance.increment("region_cache_warmer.with_exclusions.#{region.region_type}.cache")
+      Reports::RegionService.call(region: region, period: period, with_exclusions: true)
+      Statsd.instance.increment("region_cache_warmer.with_exclusions.#{region.region_type}.cache")
+    end
+    notify "finished region caching for region #{region_id}"
+
+  end
+
+  private
+
+  def notify(msg, extra = {})
+    data = {
+      logger: {
+        name: self.class.name
+      },
+      class: self.class.name
+    }.merge(extra).merge(msg: msg)
+    Rails.logger.info data
   end
 end

--- a/app/models/concerns/patient_reportable.rb
+++ b/app/models/concerns/patient_reportable.rb
@@ -3,19 +3,25 @@ module PatientReportable
   LTFU_TIME = 12.months
 
   included do
+    delegate :sanitize_sql, to: ActiveRecord::Base
+
     scope :with_diabetes, -> { joins(:medical_history).merge(MedicalHistory.diabetes_yes).distinct }
     scope :with_hypertension, -> { joins(:medical_history).merge(MedicalHistory.hypertension_yes).distinct }
     scope :excluding_dead, -> { where.not(status: :dead) }
 
     scope :ltfu_as_of, ->(date) do
-      joins("LEFT OUTER JOIN latest_blood_pressures_per_patient_per_months ON patients.id = latest_blood_pressures_per_patient_per_months.patient_id")
-        .where("NOT (bp_recorded_at > ? AND bp_recorded_at < ?) OR bp_recorded_at IS NULL", date - LTFU_TIME, date)
-        .where("recorded_at < ?", date - LTFU_TIME)
+      joins("LEFT OUTER JOIN latest_blood_pressures_per_patient_per_months
+             ON patients.id = latest_blood_pressures_per_patient_per_months.patient_id
+             AND #{sanitize_sql(["bp_recorded_at > ? AND bp_recorded_at < ?", date - LTFU_TIME, date])}")
+        .where("bp_recorded_at IS NULL AND patients.recorded_at < ?", date - LTFU_TIME)
+        .distinct(:patient_id)
     end
 
     scope :not_ltfu_as_of, ->(date) do
-      joins("LEFT OUTER JOIN latest_blood_pressures_per_patient_per_months ON patients.id = latest_blood_pressures_per_patient_per_months.patient_id")
+      joins("LEFT OUTER JOIN latest_blood_pressures_per_patient_per_months
+             ON patients.id = latest_blood_pressures_per_patient_per_months.patient_id")
         .where("bp_recorded_at > ? AND bp_recorded_at < ? OR patients.recorded_at >= ?", date - LTFU_TIME, date, date - LTFU_TIME)
+        .distinct(:patient_id)
     end
 
     scope :for_reports, ->(with_exclusions: false, exclude_ltfu_as_of: nil) do

--- a/app/services/control_rate_service.rb
+++ b/app/services/control_rate_service.rb
@@ -48,7 +48,7 @@ class ControlRateService
     results.assigned_patients = assigned_patients_counts
     results.earliest_registration_period = registration_counts.keys.first
     results.full_data_range.each do |(period, count)|
-      results.ltfu_patients[period] = ltfu_patients(period).count
+      results.ltfu_patients[period] = ltfu_patients(period)
     end
     results.fill_in_nil_registrations
     results.count_cumulative_registrations
@@ -90,10 +90,13 @@ class ControlRateService
   end
 
   def ltfu_patients(period)
+    return 0 unless with_exclusions
+
     Patient
       .for_reports(with_exclusions: with_exclusions)
-      .where(assigned_facility: facilities)
+      .where(assigned_facility: facilities.pluck(:id))
       .ltfu_as_of(period.start_date)
+      .count
   end
 
   def quarterly_report?

--- a/app/services/reports/region_cache_warmer.rb
+++ b/app/services/reports/region_cache_warmer.rb
@@ -4,36 +4,24 @@ module Reports
       new.call
     end
 
-    BATCH_SIZE = 1000
-
     def initialize(period: RegionService.default_period)
       @period = period
-      @original_force_cache = RequestStore.store[:force_cache]
-      RequestStore.store[:force_cache] = true
-      notify "start"
+      notify "queueing region reports cache warming"
     end
 
-    attr_reader :original_force_cache
     attr_reader :period
-    attr_reader :notifier
 
     def call
-      duration = Benchmark.ms {
-        if Flipper.enabled?(:disable_region_cache_warmer)
-          notify "disabled via flipper - exiting"
-          return
-        end
+      if Flipper.enabled?(:disable_region_cache_warmer)
+        notify "disabled via flipper - exiting"
+        return
+      end
 
-        notify "starting region caching"
-        Statsd.instance.time("region_cache_warmer") do
-          Region.where.not(region_type: ["root", "organization"]).pluck(:id).each do |region_id|
-            RegionCacheWarmerJob.perform_async(region_id, period.attributes)
-          end
-        end
-      }
-      notify "finished", duration: duration
-    ensure
-      RequestStore.store[:force_cache] = original_force_cache
+      Region.where.not(region_type: ["root", "organization"]).pluck(:id).each do |region_id|
+        RegionCacheWarmerJob.perform_async(region_id, period.attributes)
+      end
+
+      notify "queued region reports cache warming"
     end
 
     private

--- a/spec/jobs/region_cache_warmer_job_spec.rb
+++ b/spec/jobs/region_cache_warmer_job_spec.rb
@@ -3,42 +3,46 @@ require "rails_helper"
 RSpec.describe RegionCacheWarmerJob, type: :job do
   include ActiveJob::TestHelper
 
-  let!(:facility) { create(:facility) }
-  let!(:region) { facility.region }
-  let!(:period) { Period.month(Time.current.beginning_of_month) }
-
-  let!(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
-  let!(:cache) { Rails.cache }
-
   before do
+    memory_store = ActiveSupport::Cache.lookup_store(:memory_store)
+
     allow(Rails).to receive(:cache).and_return(memory_store)
     Rails.cache.clear
   end
 
   it "queues the job on the default queue" do
+    facility = create(:facility)
+    period = Period.month(Time.current.beginning_of_month)
+
     expect {
-      RegionCacheWarmerJob.perform_async(region.id, period.attributes)
+      RegionCacheWarmerJob.perform_async(facility.region.id, period.attributes)
     }.to change(Sidekiq::Queues["default"], :size).by(1)
     RegionCacheWarmerJob.clear
   end
 
   it "calls RegionService for the region and period" do
-    expect(Reports::RegionService).to receive(:call).with(region: region, period: period)
-    expect(Reports::RegionService).to receive(:call).with(region: region, period: period, with_exclusions: true)
+    facility = create(:facility)
+    period = Period.month(Time.current.beginning_of_month)
 
-    described_class.perform_async(region.id, period.attributes)
+    expect(Reports::RegionService).to receive(:call).with(region: facility.region, period: period)
+    expect(Reports::RegionService).to receive(:call).with(region: facility.region, period: period, with_exclusions: true)
+
+    described_class.perform_async(facility.region.id, period.attributes)
     described_class.drain
   end
 
   it "refreshes the cache" do
-    described_class.perform_async(region.id, period.attributes)
+    facility = create(:facility)
+    period = Period.month(Time.current.beginning_of_month)
+
+    described_class.perform_async(facility.region.id, period.attributes)
     described_class.drain
-    initial_registrations = Reports::RegionService.new(region: region, period: period).call[:cumulative_registrations]
+    initial_registrations = Reports::RegionService.new(region: facility.region, period: period).call[:cumulative_registrations]
 
     create(:patient, assigned_facility: facility, recorded_at: 1.month.ago)
-    described_class.perform_async(region.id, period.attributes)
+    described_class.perform_async(facility.region.id, period.attributes)
     described_class.drain
-    final_registrations = Reports::RegionService.new(region: region, period: period).call[:cumulative_registrations]
+    final_registrations = Reports::RegionService.new(region: facility.region, period: period).call[:cumulative_registrations]
 
     expect(final_registrations).not_to eq(initial_registrations)
   end

--- a/spec/jobs/region_cache_warmer_job_spec.rb
+++ b/spec/jobs/region_cache_warmer_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RegionCacheWarmerJob, type: :job do
     Rails.cache.clear
   end
 
-  it "queues the job on the low queue" do
+  it "queues the job on the default queue" do
     expect {
       RegionCacheWarmerJob.perform_async(region.id, period.attributes)
     }.to change(Sidekiq::Queues["default"], :size).by(1)

--- a/spec/jobs/region_cache_warmer_job_spec.rb
+++ b/spec/jobs/region_cache_warmer_job_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe RegionCacheWarmerJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let!(:facility) { create(:facility).region }
+  let!(:region) { facility.region }
+  let!(:period) { Period.month(Time.current) }
+
+  it "queues the job on the low queue" do
+    expect {
+      RegionCacheWarmerJob.perform_async(region.id, period.attributes)
+    }.to change(Sidekiq::Queues["default"], :size).by(1)
+    RegionCacheWarmerJob.clear
+  end
+
+  it "calls RegionService for the region and period" do
+    expect(Reports::RegionService).to receive(:call).with(region: region, period: period)
+    expect(Reports::RegionService).to receive(:call).with(region: region, period: period, with_exclusions: true)
+
+    described_class.perform_async(region.id, period.attributes)
+    described_class.drain
+  end
+end

--- a/spec/jobs/region_cache_warmer_job_spec.rb
+++ b/spec/jobs/region_cache_warmer_job_spec.rb
@@ -3,9 +3,17 @@ require "rails_helper"
 RSpec.describe RegionCacheWarmerJob, type: :job do
   include ActiveJob::TestHelper
 
-  let!(:facility) { create(:facility).region }
+  let!(:facility) { create(:facility) }
   let!(:region) { facility.region }
-  let!(:period) { Period.month(Time.current) }
+  let!(:period) { Period.month(Time.current.beginning_of_month) }
+
+  let!(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+  let!(:cache) { Rails.cache }
+
+  before do
+    allow(Rails).to receive(:cache).and_return(memory_store)
+    Rails.cache.clear
+  end
 
   it "queues the job on the low queue" do
     expect {
@@ -20,5 +28,18 @@ RSpec.describe RegionCacheWarmerJob, type: :job do
 
     described_class.perform_async(region.id, period.attributes)
     described_class.drain
+  end
+
+  it "refreshes the cache" do
+    described_class.perform_async(region.id, period.attributes)
+    described_class.drain
+    initial_registrations = Reports::RegionService.new(region: region, period: period).call[:cumulative_registrations]
+
+    create(:patient, assigned_facility: facility, recorded_at: 1.month.ago)
+    described_class.perform_async(region.id, period.attributes)
+    described_class.drain
+    final_registrations = Reports::RegionService.new(region: region, period: period).call[:cumulative_registrations]
+
+    expect(final_registrations).not_to eq(initial_registrations)
   end
 end

--- a/spec/services/reports/region_cache_warmer_spec.rb
+++ b/spec/services/reports/region_cache_warmer_spec.rb
@@ -35,14 +35,4 @@ RSpec.describe Reports::RegionCacheWarmer, type: :model do
     _facilities = FactoryBot.create_list(:facility, 2, facility_group: facility_group_1)
     Reports::RegionCacheWarmer.call
   end
-
-  it "warms the cache for all regions" do
-    _facilities = FactoryBot.create_list(:facility, 5, block: "Block 1", facility_group: facility_group_1)
-    # we don't cache the Root or Organization regions
-    regions_to_cache = Region.count - 2
-    expect(Reports::RegionService).not_to receive(:call).with(hash_including(region: Region.root))
-    expect(Reports::RegionService).not_to receive(:call).with(hash_including(region: Region.organization_regions.first))
-    expect(Reports::RegionService).to receive(:call).with(hash_including(region: instance_of(Region))).exactly(2 * regions_to_cache).times
-    Reports::RegionCacheWarmer.call
-  end
 end

--- a/spec/services/reports/region_cache_warmer_spec.rb
+++ b/spec/services/reports/region_cache_warmer_spec.rb
@@ -1,24 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Reports::RegionCacheWarmer, type: :model do
-  let(:organization) { create(:organization, name: "org-1") }
-  let(:user) { create(:admin, :manager, :with_access, resource: organization) }
-  let(:facility_group_1) { FactoryBot.create(:facility_group, name: "facility_group_1", organization: organization) }
-
-  let(:jan_2019) { Time.parse("January 1st, 2019") }
-  let(:jan_2020) { Time.parse("January 1st, 2020") }
-  let(:june_1) { Time.parse("June 1st, 2020") }
-  let(:july_1_2019) { Time.parse("July 1st, 2019") }
-  let(:july_2020) { Time.parse("July 1st, 2020") }
-
-  def refresh_views
-    ActiveRecord::Base.transaction do
-      LatestBloodPressuresPerPatientPerMonth.refresh
-      LatestBloodPressuresPerPatientPerQuarter.refresh
-      PatientRegistrationsPerDayPerFacility.refresh
-    end
-  end
-
   it "skips caching if disabled via Flipper" do
     Flipper.enable(:disable_region_cache_warmer)
     expect(Reports::RegionService).to receive(:new).never
@@ -26,7 +8,15 @@ RSpec.describe Reports::RegionCacheWarmer, type: :model do
   end
 
   it "completes successfully" do
-    _facilities = FactoryBot.create_list(:facility, 2, facility_group: facility_group_1)
+    create_list(:patient, 2)
     Reports::RegionCacheWarmer.call
+  end
+
+  it "queues a job on the default queue for every region" do
+    create(:patient)
+    reporting_regions = Region.where.not(region_type: ["root", "organization"])
+    expect {
+      Reports::RegionCacheWarmer.call
+    }.to change(Sidekiq::Queues["default"], :size).by(reporting_regions.count)
   end
 end

--- a/spec/services/reports/region_cache_warmer_spec.rb
+++ b/spec/services/reports/region_cache_warmer_spec.rb
@@ -25,12 +25,6 @@ RSpec.describe Reports::RegionCacheWarmer, type: :model do
     Reports::RegionCacheWarmer.call
   end
 
-  it "sets force_cache to true on creation" do
-    expect(RequestStore.store[:force_cache]).to be_nil
-    Reports::RegionCacheWarmer.new
-    expect(RequestStore.store[:force_cache]).to be true
-  end
-
   it "completes successfully" do
     _facilities = FactoryBot.create_list(:facility, 2, facility_group: facility_group_1)
     Reports::RegionCacheWarmer.call


### PR DESCRIPTION
**Story card:** [ch1966](https://app.clubhouse.io/simpledotorg/epic/1866/denominator-exclusions)

## Because

The LTFU queries add a lot of overhead to the cache warmer, we noticed cache warmer with the exclusions query to be taking around [9 hours on the perf environment](https://app.datadoghq.com/logs?cols=host%2Cservice%2Cenv&event=AQAAAXekqrP-6Ey9ogAAAABBWGVrcXJiMkFBQWp5M09xbE9ISFFnQUQ&from_ts=1612791824109&index=&live=true&messageDisplay=inline&query=finished&stream_sort=desc&to_ts=1613396624109)

## This addresses

This makes some improvements to the LTFU query which improves it's worst case performance by ~50%. This also parallelizes the cache warmer to run a separate job per region. 

The jobs take roughly ~4-5 mins combined to finish when running on a prod sized data set (~6k regions tested on perf).
