### PR TITLE
LTFU: Reports registration updates

### DIFF
--- a/app/assets/javascripts/common/patient_breakdown_reports.js
+++ b/app/assets/javascripts/common/patient_breakdown_reports.js
@@ -11,7 +11,7 @@ PatientBreakdownReports = function () {
     return {
       ltfuPatients: jsonData.ltfu_patients,
       ltfuPatientsRate: jsonData.ltfu_patients_rate,
-      cumulativeRegistrations: jsonData.cumulative_registrations,
+      cumulativeAssignedPatients: jsonData.cumulative_assigned_patients,
       periodInfo: jsonData.period_info
     }
   }
@@ -102,13 +102,13 @@ PatientBreakdownReports = function () {
           label = mostRecentPeriod;
         }
         const period = data.periodInfo[label];
-        const cumulativeRegistrations = data.cumulativeRegistrations[label];
+        const cumulativeAssignedPatients = data.cumulativeAssignedPatients[label];
         const totalPatients = data.ltfuPatients[label];
 
         rateNode.innerHTML = rate;
         totalPatientsNode.innerHTML = reports.formatNumberWithCommas(totalPatients);
         periodStartNode.innerHTML = period.start_date;
-        registrationsNode.innerHTML = reports.formatNumberWithCommas(cumulativeRegistrations);
+        registrationsNode.innerHTML = reports.formatNumberWithCommas(cumulativeAssignedPatients);
         registrationsPeriodEndNode.innerHTML = period.start_date;
       }
     };
@@ -170,7 +170,7 @@ PatientBreakdownReports = function () {
         label: (tooltipItem, tooltipData) => {
           const label = tooltipData.labels[tooltipItem.index];
           let tooltipBody = [`Total: ${data[label]}`];
-          if (transferredPatients[label] == undefined) {
+          if (transferredPatients[label] !== undefined) {
             tooltipBody.push(`Transferred-out: ${transferredPatients[label]}`)
           }
           return tooltipBody;

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -31,9 +31,6 @@ class Reports::RegionsController < AdminController
 
   def show
     @data = Reports::RegionService.new(region: @region, period: @period, with_exclusions: report_with_exclusions?).call
-    @last_registration_value = @data[:cumulative_registrations].values&.last || 0
-    @new_registrations = @last_registration_value - (@data[:cumulative_registrations].values[-2] || 0)
-    @adjusted_registration_date = @data[:adjusted_registrations].keys[-4]
     @with_ltfu = with_ltfu?
 
     @children = @region.reportable_children

--- a/app/models/reports/result.rb
+++ b/app/models/reports/result.rb
@@ -21,6 +21,7 @@ module Reports
           controlled_patients_rate: Hash.new(0),
           controlled_patients_with_ltfu_rate: Hash.new(0),
           cumulative_registrations: Hash.new(0),
+          cumulative_assigned_patients: Hash.new(0),
           earliest_registration_period: nil,
           ltfu_patients: Hash.new(0),
           ltfu_patients_rate: Hash.new(0),
@@ -100,8 +101,9 @@ module Reports
 
     [:period_info, :earliest_registration_period,
       :registrations, :cumulative_registrations,
-      :assigned_patients, :ltfu_patients,
-      :adjusted_registrations, :adjusted_registrations_with_ltfu,
+      :assigned_patients, :cumulative_assigned_patients,
+      :ltfu_patients,
+      :adjusted_registrations_with_ltfu, :adjusted_registrations,
       :missed_visits, :missed_visits_rate,
       :controlled_patients, :controlled_patients_with_ltfu,
       :controlled_patients_rate, :controlled_patients_with_ltfu_rate,
@@ -146,6 +148,15 @@ module Reports
         adjusted_period = period.advance(months: -3)
         running_totals[period] = adjusted_registrations_with_ltfu[period] - ltfu_patients[adjusted_period]
       end
+    end
+
+    def count_cumulative_assigned_patients
+      self.cumulative_assigned_patients = full_data_range.each_with_object(Hash.new(0)) { |period, running_totals|
+        previous_registrations = running_totals[period.previous]
+        current_registrations = assigned_patients[period]
+        total = current_registrations + previous_registrations
+        running_totals[period] = total
+      }
     end
 
     def count_cumulative_registrations

--- a/app/models/reports/result.rb
+++ b/app/models/reports/result.rb
@@ -135,12 +135,7 @@ module Reports
         counts[period] = assigned_patients[adjusted_period]
       }
 
-      self.adjusted_registrations_with_ltfu = full_data_range.each_with_object(Hash.new(0)) { |period, running_totals|
-        previous_registrations = running_totals[period.previous]
-        current_registrations = adjusted_registration_counts[period]
-        total = current_registrations + previous_registrations
-        running_totals[period] = total
-      }
+      self.adjusted_registrations_with_ltfu = running_totals(adjusted_registration_counts)
     end
 
     def count_adjusted_registrations
@@ -151,21 +146,11 @@ module Reports
     end
 
     def count_cumulative_assigned_patients
-      self.cumulative_assigned_patients = full_data_range.each_with_object(Hash.new(0)) { |period, running_totals|
-        previous_registrations = running_totals[period.previous]
-        current_registrations = assigned_patients[period]
-        total = current_registrations + previous_registrations
-        running_totals[period] = total
-      }
+      self.cumulative_assigned_patients = running_totals(assigned_patients)
     end
 
     def count_cumulative_registrations
-      self.cumulative_registrations = full_data_range.each_with_object(Hash.new(0)) { |period, running_totals|
-        previous_registrations = running_totals[period.previous]
-        current_registrations = registrations[period]
-        total = current_registrations + previous_registrations
-        running_totals[period] = total
-      }
+      self.cumulative_registrations = running_totals(registrations)
     end
 
     # "Missed visits" is the remaining registered patients when we subtract out the other three groups.
@@ -245,6 +230,15 @@ module Reports
     def percentage(numerator, denominator)
       return 0 if denominator == 0 || numerator == 0
       ((numerator.to_f / denominator) * 100).round(PERCENTAGE_PRECISION)
+    end
+
+    def running_totals(periodwise_counts)
+      full_data_range.each_with_object(Hash.new(0)) { |period, running_totals|
+        previous_total = running_totals[period.previous]
+        current_count = periodwise_counts[period]
+        total = previous_total + current_count
+        running_totals[period] = total
+      }
     end
   end
 end

--- a/app/services/control_rate_service.rb
+++ b/app/services/control_rate_service.rb
@@ -46,7 +46,7 @@ class ControlRateService
   def fetch_all_data
     results.registrations = registration_counts
     results.assigned_patients = assigned_patients_counts
-    results.earliest_registration_period = registration_counts.keys.first
+    results.earliest_registration_period = registration_counts.keys.first, assigned_patients_counts.keys.first
     results.full_data_range.each do |(period, count)|
       results.ltfu_patients[period] = ltfu_patients(period).count
     end

--- a/app/services/control_rate_service.rb
+++ b/app/services/control_rate_service.rb
@@ -46,7 +46,7 @@ class ControlRateService
   def fetch_all_data
     results.registrations = registration_counts
     results.assigned_patients = assigned_patients_counts
-    results.earliest_registration_period = registration_counts.keys.first, assigned_patients_counts.keys.first
+    results.earliest_registration_period = [registration_counts.keys.first, assigned_patients_counts.keys.first].compact.min
     results.full_data_range.each do |(period, count)|
       results.ltfu_patients[period] = ltfu_patients(period).count
     end

--- a/app/services/control_rate_service.rb
+++ b/app/services/control_rate_service.rb
@@ -52,6 +52,7 @@ class ControlRateService
     end
     results.fill_in_nil_registrations
     results.count_cumulative_registrations
+    results.count_cumulative_assigned_patients
     results.count_adjusted_registrations_with_ltfu
 
     if with_exclusions

--- a/app/services/control_rate_service.rb
+++ b/app/services/control_rate_service.rb
@@ -75,7 +75,8 @@ class ControlRateService
     return @registration_counts if defined? @registration_counts
 
     @registration_counts =
-      region.assigned_patients
+      region.registered_patients
+        .with_hypertension
         .group_by_period(report_range.begin.type, :recorded_at, {format: group_date_formatter})
         .count
   end

--- a/app/services/facility_stats_service.rb
+++ b/app/services/facility_stats_service.rb
@@ -17,7 +17,6 @@ class FacilityStatsService
   def call
     facilities.values.each do |facility_data|
       add_facility_stats(facility_data)
-      add_registrations_count(facility_data.region.source)
     end
     calculate_percentages
     stats_by_size
@@ -35,6 +34,7 @@ class FacilityStatsService
       current_period[rate_numerator] += facility_data.dig(rate_numerator, period) || 0
       current_period[:adjusted_registrations] += facility_data[:adjusted_registrations][period]
       current_period[:cumulative_registrations] += facility_data[:cumulative_registrations][period]
+      current_period[:cumulative_assigned_patients] += facility_data[:cumulative_assigned_patients][period]
     end
   end
 
@@ -48,14 +48,9 @@ class FacilityStatsService
     end
   end
 
-  def add_registrations_count(facility)
-    hypertensive_count = facility.registered_hypertension_patients.count
-    stats_by_size[facility.facility_size][:total_registered_hypertensive_patients] += hypertensive_count
-  end
-
   def add_size_section(size)
     stats_by_size[size] = {
-      periods: size_data_template, total_registered_hypertensive_patients: 0
+      periods: size_data_template
     }
   end
 
@@ -65,6 +60,7 @@ class FacilityStatsService
         rate_numerator => 0,
         "adjusted_registrations" => 0,
         "cumulative_registrations" => 0,
+        "cumulative_assigned_patients" => 0,
         rate_name => 0
       }.with_indifferent_access
     end

--- a/app/views/my_facilities/bp_controlled.html.erb
+++ b/app/views/my_facilities/bp_controlled.html.erb
@@ -14,7 +14,13 @@
           <strong>What to look for:</strong> High percentages are good, and 70% or higher is ideal 
         </p>
         <p class="c-grey-dark c-print-black">
-          <strong>Numerator:</strong> <%= t("numerator_copy.bp_controlled") %>, <strong>Denominator:</strong> <%= t("denominator_copy") %>
+          <strong>Numerator:</strong> <%= t("bp_controlled_copy.numerator") %>
+          <strong>Denominator:</strong>
+          <% if current_admin.feature_enabled?(:report_with_exclusions) %>
+            <%= t("denominator_copy", region_name: "each facility") %>
+          <% else %>
+            <%= t("denominator_without_exclusions_copy", region_name: "each facility") %>
+          <% end %>
         </p>
       </div>
       <div class="d-flex fw-wrap mb-16px ph-16px">
@@ -82,10 +88,10 @@
                   All <%= Facility.localized_facility_size(size) %>s
                 </td>
                 <td>
-                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:periods][@period][:cumulative_registrations]) %>
+                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:periods][@period][:cumulative_assigned_patients]) %>
                 </td>
                 <td>
-                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:total_registered_hypertensive_patients]) %>
+                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:periods][@period][:cumulative_registrations]) %>
                 </td>
                 <td>
                   <div class="w-90px h-20px">
@@ -125,10 +131,10 @@
                     <% end %>
                   </td>
                   <td>
-                    <%= number_or_zero_with_delimiter(facility_data["cumulative_registrations"].values.last) %>
+                    <%= number_or_zero_with_delimiter(facility_data["cumulative_assigned_patients"].values.last) %>
                   </td>
                   <td>
-                    <%= number_or_zero_with_delimiter(facility.registered_hypertension_patients.count) %>
+                    <%= number_or_zero_with_delimiter(facility_data["cumulative_registrations"].values.last) %>
                   </td>
                   <td>
                     <div class="w-90px h-20px">

--- a/app/views/my_facilities/bp_not_controlled.html.erb
+++ b/app/views/my_facilities/bp_not_controlled.html.erb
@@ -14,7 +14,13 @@
           <strong>What to look for:</strong> Low percentages are good, and 10% or lower is ideal 
         </p>
         <p class="c-grey-dark c-print-black">
-          <strong>Numerator:</strong> <%= t("numerator_copy.bp_not_controlled") %>, <strong>Denominator:</strong> <%= t("denominator_copy") %>
+          <strong>Numerator:</strong> <%= t("bp_not_controlled_copy.numerator") %>
+          <strong>Denominator:</strong>
+          <% if current_admin.feature_enabled?(:report_with_exclusions) %>
+            <%= t("denominator_copy", region_name: "each facility") %>
+          <% else %>
+            <%= t("denominator_without_exclusions_copy", region_name: "each facility") %>
+          <% end %>
         </p>
       </div>
       <div class="d-flex fw-wrap mb-16px ph-16px">
@@ -82,10 +88,10 @@
                   All <%= Facility.localized_facility_size(size) %>s
                 </td>
                 <td>
-                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:periods][@period][:cumulative_registrations]) %>
+                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:periods][@period][:cumulative_assigned_patients]) %>
                 </td>
                 <td>
-                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:total_registered_hypertensive_patients]) %>
+                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:periods][@period][:cumulative_registrations]) %>
                 </td>
                 <td>
                   <div class="w-90px h-20px">
@@ -125,10 +131,10 @@
                     <% end %>
                   </td>
                   <td>
-                    <%= number_or_zero_with_delimiter(facility_data["cumulative_registrations"].values.last) %>
+                    <%= number_or_zero_with_delimiter(facility_data["cumulative_assigned_patients"].values.last) %>
                   </td>
                   <td>
-                    <%= number_or_zero_with_delimiter(facility.registered_hypertension_patients.count) %>
+                    <%= number_or_zero_with_delimiter(facility_data["cumulative_registrations"].values.last) %>
                   </td>
                   <td>
                     <div class="w-90px h-20px">

--- a/app/views/my_facilities/missed_visits.html.erb
+++ b/app/views/my_facilities/missed_visits.html.erb
@@ -14,7 +14,13 @@
           <strong>What to look for:</strong> Low percentages are good, and 20% or lower is ideal 
         </p>
         <p class="c-grey-dark c-print-black">
-          <strong>Numerator:</strong> <%= t("numerator_copy.missed_visits") %>, <strong>Denominator:</strong> <%= t("denominator_copy") %>
+          <strong>Numerator:</strong> <%= t("missed_visits_copy.numerator") %>
+          <strong>Denominator:</strong>
+          <% if current_admin.feature_enabled?(:report_with_exclusions) %>
+            <%= t("denominator_copy", region_name: "each facility") %>
+          <% else %>
+            <%= t("denominator_without_exclusions_copy", region_name: "each facility") %>
+          <% end %>
         </p>
       </div>
       <div class="d-flex fw-wrap mb-16px ph-16px">
@@ -82,10 +88,10 @@
                   All <%= Facility.localized_facility_size(size) %>s
                 </td>
                 <td>
-                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:periods][@period][:cumulative_registrations]) %>
+                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:periods][@period][:cumulative_assigned_patients]) %>
                 </td>
                 <td>
-                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:total_registered_hypertensive_patients]) %>
+                  <%= number_or_zero_with_delimiter(@stats_by_size[size][:periods][@period][:cumulative_registrations]) %>
                 </td>
                 <td>
                   <div class="w-90px h-20px">
@@ -125,10 +131,10 @@
                     <% end %>
                   </td>
                   <td>
-                    <%= number_or_zero_with_delimiter(facility_data["cumulative_registrations"].values.last) %>
+                    <%= number_or_zero_with_delimiter(facility_data["cumulative_assigned_patients"].values.last) %>
                   </td>
                   <td>
-                    <%= number_or_zero_with_delimiter(facility.registered_hypertension_patients.count) %>
+                    <%= number_or_zero_with_delimiter(facility_data["cumulative_registrations"].values.last) %>
                   </td>
                   <td>
                     <div class="w-90px h-20px">

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -47,8 +47,8 @@
               patients
             </th>
             <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-              Monthly registered<br>
-              patients
+              Patients registered<br>
+              in <%= @period.to_s %>
             </th>
           </tr>
         </thead>

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -43,11 +43,11 @@
               a missed visit
             </th>
             <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-              Total assigned<br>
+              Total registered<br>
               patients
             </th>
             <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-              Monthly assigned<br>
+              Monthly registered<br>
               patients
             </th>
           </tr>
@@ -191,10 +191,10 @@
         </div>
         <div class="pt-12px">
           <p class="mb-8px fs-14px c-grey-dark c-print-black ">
-            <strong>Numerator:</strong> <%= t("numerator_copy.bp_controlled") %>
+            <strong>Numerator:</strong> <%= t("bp_controlled_copy.numerator") %>
           </p>
           <p class="mb-0px fs-14px c-grey-dark c-print-black ">
-            <strong>Denominator:</strong> <%= t("denominator_copy") %>
+            <strong>Denominator:</strong> <%= t("denominator_without_exclusions_copy", region_name: @region.name) %>
           </p>
         </div>
       </div>
@@ -259,10 +259,10 @@
         </div>
         <div class="pt-12px">
           <p class="mb-8px fs-14px c-grey-dark c-print-black ">
-            <strong>Numerator:</strong> <%= t("numerator_copy.bp_not_controlled") %>
+            <strong>Numerator:</strong> <%= t("bp_not_controlled_copy.numerator") %>
           </p>
           <p class="mb-0px fs-14px c-grey-dark c-print-black ">
-            <strong>Denominator:</strong> <%= t("denominator_copy") %>
+            <strong>Denominator:</strong> <%= t("denominator_without_exclusions_copy", region_name: @region.name) %>
           </p>
         </div>
       </div>
@@ -327,10 +327,10 @@
         </div>
         <div class="pt-12px">
           <p class="mb-8px fs-14px c-grey-dark c-print-black ">
-            <strong>Numerator:</strong> <%= t("numerator_copy.missed_visits") %>
+            <strong>Numerator:</strong> <%= t("missed_visits_copy.numerator") %>
           </p>
           <p class="mb-0px fs-14px c-grey-dark c-print-black ">
-            <strong>Denominator:</strong> <%= t("denominator_copy") %>
+            <strong>Denominator:</strong> <%= t("denominator_without_exclusions_copy", region_name: @region.name) %>
           </p>
         </div>
       </div>
@@ -339,7 +339,7 @@
       <div class="card d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0">
         <div class="mb-2">
           <h3 class="c-black">
-            Monthly and cumulative patients
+            Monthly and cumulative registrations
           </h3>
         </div>
         <div class="table-responsive">
@@ -358,7 +358,7 @@
                   Patients registered in <%= @period.to_s %>
                 </th>
                 <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-                  Cumulative patients
+                  Total registered patients
                 </th>
               </tr>
             </thead>
@@ -395,7 +395,8 @@
         </div>
         <div class="mb-2 pt-12px">
           <p class="us-none fs-14px c-transparent">
-            <strong>Denominator:</strong> <%= t("denominator_copy") %>
+            <br>
+            <br>
           </p>
         </div>
       </div>

--- a/app/views/reports/regions/_details_footnotes.html.erb
+++ b/app/views/reports/regions/_details_footnotes.html.erb
@@ -31,17 +31,17 @@
     </p>
     <div class="pl-16px">
       <p class="mb-8px fs-14px c-grey-dark">
-        <%= t("total_registered_patients_copy", region_name: @region.name) %>
+        <%= t("registered_patients_copy.total_registered_patients", region_name: @region.name) %>
       </p>
     </div>
   </div>
   <div class="mb-24px">
     <p class="mb-8px fs-16px fw-bold c-grey-dark">
-      New registered patients
+      Monthly registered patients
     </p>
     <div class="pl-16px">
       <p class="mb-0px fs-14px c-grey-dark">
-        <%= t("new_registered_patients_copy", region_name: @region.name) %>
+        <%= t("registered_patients_copy.monthly_registered_patients", region_name: @region.name) %>
       </p>
     </div>
   </div>

--- a/app/views/reports/regions/_overview_footnotes.html.erb
+++ b/app/views/reports/regions/_overview_footnotes.html.erb
@@ -74,21 +74,21 @@
   </div>
   <div class="mb-24px">
     <p class="mb-8px fs-16px fw-bold c-grey-dark">
-      Monthly assigned patients
+      Monthly registered patients
     </p>
     <div class="pl-16px">
       <p class="mb-0px fs-14px c-grey-dark">
-        <%= t("assigned_patients_copy.monthly_assigned_patients", region_name: @region.name) %>
+        <%= t("registered_patients_copy.monthly_registered_patients", region_name: @region.name) %>
       </p>
     </div>
   </div>
   <div class="mb-24px">
     <p class="mb-8px fs-16px fw-bold c-grey-dark">
-      Total assigned patients
+      Total registered patients
     </p>
     <div class="pl-16px">
       <p class="mb-0px fs-14px c-grey-dark">
-        <%= t("assigned_patients_copy.total_assigned_patients", region_name: @region.name) %>
+        <%= t("registered_patients_copy.total_registered_patients", region_name: @region.name) %>
       </p>
     </div>
   </div>

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -42,8 +42,8 @@
               </p>
               <p class="m-0px c-grey-dark c-print-black">
                 of
-                <span data-registrations="<%= number_with_delimiter(@chart_data[:ltfu_trend].last_value(:cumulative_registrations)) %>">
-                  <%= number_with_delimiter(@chart_data[:ltfu_trend].last_value(:cumulative_registrations)) %>
+                <span data-registrations="<%= number_with_delimiter(@chart_data[:ltfu_trend].last_value(:cumulative_assigned_patients)) %>">
+                  <%= number_with_delimiter(@chart_data[:ltfu_trend].last_value(:cumulative_assigned_patients)) %>
                 </span>
                 patients till
                 <span data-registrations-period-end="<%= @chart_data[:ltfu_trend].last_value(:period_info)["start_date"] %>">

--- a/app/views/reports/regions/_visit_details_card.html.erb
+++ b/app/views/reports/regions/_visit_details_card.html.erb
@@ -2,7 +2,7 @@
   <h3 class="mb-0px pl-20px">
     Visit details of all assigned hypertension patients
   </h3>
-  <% if @last_registration_value %>
+  <% if @data[:cumulative_assigned_patients].values&.last %>
     <div class="d-flex fd-column fd-lg-row">
       <div class="pl-lg-12px w-lg-50 h-lg-auto h-print-12cm">
         <canvas id="missedVisitDetails"></canvas>
@@ -267,13 +267,13 @@
         <% unless current_admin.feature_enabled?(:report_with_exclusions) %>
           <div class="d-flex fd-column align-baseline mt-20px pt-8px bt-1px bt-grey-light mb-8px mb-lg-16px">
             <p class="mb-8px fs-14px c-grey-dark c-print-black">
-              <strong>Visit but no BP taken numerator:</strong> <%= t("numerator_copy.visit_but_no_bp_taken") %>
+              <strong>Visit but no BP taken numerator:</strong> <%= t("visit_but_no_bp_taken_copy.numerator") %>
             </p>
             <p class="mb-8px fs-14px c-grey-dark c-print-black">
               <strong>All other numerators:</strong> Same numerators as cards above
             </p>
             <p class="mb-0px fs-14px c-grey-dark c-print-black">
-              <strong>Denominator:</strong> <%= t("denominator_copy") %>
+              <strong>Denominator:</strong> <%= t("denominator_without_exclusions_copy", region_name: @region.name) %>
             </p>
           </div>
         <% end %>

--- a/app/views/reports/regions/details.html.erb
+++ b/app/views/reports/regions/details.html.erb
@@ -18,7 +18,7 @@
             data-placement="right"
             data-trigger="hover click"
             data-html="true"
-            title="<p class='mb-4px'><strong>New registered patients:</strong> <%= t("new_registered_patients_copy", region_name: @region.name) %></p><p class='mb-0px'><strong>Follow-up patients:</strong> <%= t("follow_up_patients_copy", region_name: @region.name) %></p>"
+            title="<p class='mb-4px'><strong>Monthly registered patients:</strong> <%= t("registered_patients_copy.monthly_registered_patients", region_name: @region.name) %></p><p class='mb-0px'><strong>Follow-up patients:</strong> <%= t("follow_up_patients_copy", region_name: @region.name) %></p>"
           >
           </i>
         </span>
@@ -52,7 +52,7 @@
             <th></th>
             <% if current_admin.feature_enabled?(:report_with_exclusions) %>
               <th colspan="6">
-                New registered patients
+                Monthly registered patients
               </th>
               <th colspan="6">
                 Follow-up patients
@@ -195,7 +195,7 @@
             <th></th>
             <% if current_admin.feature_enabled?(:report_with_exclusions) %>
               <th colspan="6">
-                New registered patients
+                Monthly registered patients
               </th>
               <th colspan="6">
                 BP measures taken
@@ -290,7 +290,7 @@
             data-placement="right"
             data-trigger="hover click"
             data-html="true"
-            title="<p class='mb-4px'><strong>New registered patients:</strong> <%= t("new_registered_patients_copy", region_name: @region.name) %></p><p class='mb-0px'><strong>Follow-up patients:</strong> <%= t("follow_up_patients_copy", region_name: @region.name) %></p>"
+            title="<p class='mb-4px'><strong>Monthly registered patients:</strong> <%= t("registered_patients_copy.monthly_registered_patients", region_name: @region.name) %></p><p class='mb-0px'><strong>Follow-up patients:</strong> <%= t("follow_up_patients_copy", region_name: @region.name) %></p>"
           >
           </i>
         </span>
@@ -324,7 +324,7 @@
             <th></th>
             <% if current_admin.feature_enabled?(:report_with_exclusions) %>
               <th colspan="6">
-                New registered patients
+                Monthly registered patients
               </th>
               <th colspan="6">
                 Follow-up patients

--- a/app/views/reports/regions/details.html.erb
+++ b/app/views/reports/regions/details.html.erb
@@ -137,10 +137,10 @@
     <% unless current_admin.feature_enabled?(:report_with_exclusions) %>
       <div class="mt-20px">
         <p class="mb-8px fs-14px c-grey-dark c-print-black">
-          <strong>1. Cumulative registrations:</strong> <%= t("total_registered_patients_copy", region_name: @region.name) %>
+          <strong>1. Cumulative registrations:</strong> <%= t("registered_patients_copy.total_registered_patients", region_name: @region.name) %>
         </p>
         <p class="mb-8px fs-14px c-grey-dark c-print-black">
-          <strong>2. New registrations:</strong> <%= t("new_registered_patients_copy", region_name: @region.name) %>
+          <strong>2. New registrations:</strong> <%= t("registered_patients_copy.monthly_registered_patients", region_name: @region.name) %>
         </p>
         <p class="mb-0px fs-14px c-grey-dark c-print-black">
           <strong>3. Follow-up patients:</strong> <%= t("follow_up_patients_copy", region_name: @region.name) %>
@@ -262,10 +262,10 @@
     <% unless current_admin.feature_enabled?(:report_with_exclusions) %>
       <div class="mt-20px">
         <p class="mb-8px fs-14px c-grey-dark c-print-black">
-          <strong>1. Cumulative registrations:</strong> <%= t("total_registered_patients_copy", region_name: @region.name) %>
+          <strong>1. Cumulative registrations:</strong> <%= t("registered_patients_copy.total_registered_patients", region_name: @region.name) %>
         </p>
         <p class="mb-8px fs-14px c-grey-dark c-print-black">
-          <strong>2. New registrations:</strong> <%= t("new_registered_patients_copy", region_name: @region.name) %>
+          <strong>2. New registrations:</strong> <%= t("registered_patients_copy.monthly_registered_patients", region_name: @region.name) %>
         </p>
         <p class="mb-0px fs-14px c-grey-dark c-print-black">
           <strong>3. BP measures taken:</strong> <%= t("bp_measures_taken_copy", region_name: @region.name) %>
@@ -409,10 +409,10 @@
     <% unless current_admin.feature_enabled?(:report_with_exclusions) %>
       <div class="mt-20px">
         <p class="mb-8px fs-14px c-grey-dark c-print-black">
-          <strong>1. Cumulative registrations:</strong> <%= t("total_registered_patients_copy", region_name: @region.name) %>
+          <strong>1. Cumulative registrations:</strong> <%= t("registered_patients_copy.total_registered_patients", region_name: @region.name) %>
         </p>
         <p class="mb-8px fs-14px c-grey-dark c-print-black">
-          <strong>2. New registrations:</strong> <%= t("new_registered_patients_copy", region_name: @region.name) %>
+          <strong>2. New registrations:</strong> <%= t("registered_patients_copy.monthly_registered_patients", region_name: @region.name) %>
         </p>
         <p class="mb-0px fs-14px c-grey-dark c-print-black">
           <strong>3. Follow-up patients:</strong> <%= t("follow_up_patients_copy", region_name: @region.name) %>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -362,7 +362,7 @@
         <% if current_admin.feature_enabled?(:report_with_exclusions) %>
           <div class="d-flex flex-1 mb-8px">
             <h3 class="mb-0px mr-8px">
-              Assigned patients
+              Registrations
             </h3>
             <span class="p-relative t-1px">
               <i
@@ -371,13 +371,13 @@
                 data-placement="right"
                 data-trigger="hover click"
                 data-html="true"
-                title="<p class='mb-4px'><strong>Total assigned patients:</strong> <%= t("assigned_patients_copy.total_assigned_patients", region_name: @region.name) %></p><p class='mb-0px'><strong>Monthly assigned patients:</strong> <%= t("assigned_patients_copy.monthly_assigned_patients", region_name: @region.name) %>"
+                title="<p class='mb-4px'><strong>Total registered patients:</strong> <%= t("registered_patients_copy.total_registered_patients", region_name: @region.name) %></p><p class='mb-0px'><strong>Monthly registered patients:</strong> <%= t("registered_patients_copy.monthly_registered_patients", region_name: @region.name) %>"
               >
               </i>
             </span>
           </div>
           <p class="c-grey-dark">
-            <%= t("assigned_patients_copy.reports_card_subtitle", region_name: @region.name) %>
+            <%= t("registered_patients_copy.reports_card_subtitle", region_name: @region.name) %>
           </p>
         <% else %>
           <div class="mb-16px">
@@ -406,7 +406,7 @@
               <div>
                 <% if @data.last_value(:cumulative_registrations) %>
                   <p class="m-0px c-black">
-                    total patients<br>till
+                    total registrations<br>till
                     <span data-registrations-period-end="<%= @period.bp_control_range_end_date %>">
                       <%= @period.bp_control_range_end_date %>
                     </span>
@@ -429,8 +429,7 @@
               <div>
                 <% if @data.last_value(:registrations) %>
                   <p class="m-0px c-black">
-                    <%= "patient".pluralize(@data.last_value(:registrations)) %> registered<br>
-                    in
+                    new registrations<br>in
                     <span data-registrations-month-end="<%= @data.last_key(:registrations) %>">
                       <%= @data.last_key(:registrations) %>
                     </span>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -401,15 +401,15 @@
               </p>
               <div>
                 <% if @data.last_value(:cumulative_registrations) %>
-                  <p class="m-0px c-black">
-                    total registrations<br>till
+                  <p class="m-0px c-black c-print-black">
+                    total <%= "registrations".pluralize(@data.last_value(:cumulative_registrations)) %><br>till
                     <span data-registrations-period-end="<%= @period.bp_control_range_end_date %>">
                       <%= @period.bp_control_range_end_date %>
                     </span>
                   </p>
                 <% else %>
                   <p class="m-0px c-grey-medium c-print-black">
-                    No total assigned patients<br>
+                    No total registered patients<br>
                     data available
                   </p>
                 <% end %>
@@ -424,13 +424,17 @@
               </p>
               <div>
                 <% if @data.last_value(:registrations) %>
-                  <p class="m-0px c-black">
-                    new registrations<br>in
+                  <p class="m-0px c-black c-print-black">
+                    new <%= "registrations".pluralize(@data.last_value(:registrations)) %><br>in
                     <span data-registrations-month-end="<%= @data.last_key(:registrations) %>">
                       <%= @data.last_key(:registrations) %>
                     </span>
                   </p>
                 <% else %>
+                  <p class="m-0px c-grey-medium c-print-black">
+                    No monthly registered patients<br>
+                    data available
+                  </p>
                 <% end %>
               </div>
             </div>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -156,10 +156,10 @@
           <div class="px-20px pb-8px pb-lg-0">
             <div class="mb-2">
               <p class="mb-8px fs-14px c-grey-dark c-print-black">
-                <strong>Numerator:</strong> <%= t("numerator_copy.bp_controlled") %>
+                <strong>Numerator:</strong> <%= t("bp_controlled_copy.numerator") %>
               </p>
               <p class="fs-14px c-grey-dark c-print-black">
-                <strong>Denominator:</strong> <%= t("denominator_copy") %>
+                <strong>Denominator:</strong> <%= t("denominator_without_exclusions_copy", region_name: @region.name) %>
               </p>
             </div>
           </div>
@@ -255,10 +255,10 @@
           <div class="px-20px pb-8px pb-lg-0">
             <div class="mb-2">
               <p class="mb-8px fs-14px c-grey-dark c-print-black">
-                <strong>Numerator:</strong> <%= t("numerator_copy.bp_not_controlled") %>
+                <strong>Numerator:</strong> <%= t("bp_not_controlled_copy.numerator") %>
               </p>
               <p class="fs-14px c-grey-dark c-print-black">
-                <strong>Denominator:</strong> <%= t("denominator_copy") %>
+                <strong>Denominator:</strong> <%= t("denominator_without_exclusions_copy", region_name: @region.name) %>
               </p>
             </div>
           </div>
@@ -345,10 +345,10 @@
           <div class="px-20px pb-8px pb-lg-0">
             <div class="mb-2">
               <p class="mb-8px fs-14px c-grey-dark c-print-black">
-                <strong>Numerator:</strong> <%= t("numerator_copy.missed_visits") %>
+                <strong>Numerator:</strong> <%= t("missed_visits_copy.numerator") %>
               </p>
               <p class="fs-14px c-grey-dark c-print-black">
-                <strong>Denominator:</strong> <%= t("denominator_copy") %>
+                <strong>Denominator:</strong> <%= t("denominator_without_exclusions_copy", region_name: @region.name) %>
               </p>
             </div>
           </div>
@@ -382,11 +382,7 @@
         <% else %>
           <div class="mb-16px">
             <h3 class="mb-0px">
-              <% if @region.is_a?(Facility) %>
-                Monthly and cumulative patients
-              <% else %>
-                Monthly and cumulative registrations
-              <% end %>
+              Monthly and cumulative registrations
             </h3>
           </div>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,16 +46,16 @@ en:
     confidential: 'Please note that this information is confidential and should be kept private.'
     unrequested_html: 'If you did not request this or have questions, please immediately reply to <a href="mailto:help@simple.org">help@simple.org</a>'
   bp_controlled_copy:
-    reports_card_subtitle: "Hypertension patients with BP <140/90 at their last visit within the last 3 months"
-    numerator: "Patients with BP <140/90 at their last visit within the last 3 months."
+    reports_card_subtitle: "Hypertension patients with BP <140/90 at their last visit in the last 3 months"
+    numerator: "Patients with BP <140/90 at their last visit in the last 3 months."
   bp_not_controlled_copy:
-    reports_card_subtitle: "Hypertension patients with BP ≥140/90 at their last visit within the last 3 months"
-    numerator: "Patients with BP ≥140/90 at their last visit within the last 3 months."
+    reports_card_subtitle: "Hypertension patients with BP ≥140/90 at their last visit in the last 3 months"
+    numerator: "Patients with BP ≥140/90 at their last visit in the last 3 months."
   missed_visits_copy:
     reports_card_subtitle: "Hypertension patients with no visit in the last 3 months"
-    numerator: "Patients with no visit within the last 3 months."
+    numerator: "Patients with no visit in the last 3 months."
   visit_but_no_bp_taken_copy:
-    numerator: "Patients with no BP taken at their last visit within the last 3 months."
+    numerator: "Patients with no BP taken at their last visit in the last 3 months."
   lost_to_follow_up_copy:
     reports_card_subtitle: "Hypertension patients with no BP taken in the last 12 months"
     numerator: "Patients with no BP taken in the last 12 months."
@@ -71,7 +71,7 @@ en:
   ltfu_denominator_copy: "Hypertension patients assigned to %{region_name}. Dead patients are excluded."
   follow_up_patients_copy: "Hypertension patients with a BP measure taken during a month in %{region_name}."
   not_lost_to_follow_up_copy: "Hypertension patients with a BP taken in the last 12 months."
-  bp_measures_taken_copy: "All BP measures taken during a month by healthcare workers at %{region_name}."
+  bp_measures_taken_copy: "All BP measures taken in a month by healthcare workers at %{region_name}."
 
   admin:
     reset_otp_alert: 'Are you sure you want to reset the OTP? This will invalidate the previous OTP and a SMS will be sent to the user with the new OTP'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,15 +59,15 @@ en:
   lost_to_follow_up_copy:
     reports_card_subtitle: "Hypertension patients with no BP taken in the last 12 months"
     numerator: "Patients with no BP taken in the last 12 months."
+  registered_patients_copy:
+    reports_card_subtitle: "Monthly and total hypertension patient registrations in %{region_name}"
+    monthly_registered_patients: "Hypertension patients registered during a month in %{region_name}."
+    total_registered_patients: "Total hypertension patients registered in %{region_name}."
   assigned_patients_copy:
-    reports_card_subtitle: "Monthly and total registrations for patients assigned to %{region_name}"
-    monthly_assigned_patients: "Diabetic and hypertension patients registered in a month assigned to %{region_name}."
-    total_assigned_patients: "Diabetic and hypertension patients assigned to %{region_name}."
+    total_assigned_patients: "Hypertension patients assigned to %{region_name}."
   denominator_copy: "Hypertension patients assigned to %{region_name}, registered before the last 3 months. Dead patients are excluded."
   denominator_excluding_ltfu_copy: "Hypertension patients assigned to %{region_name}, registered before the last 3 months. Dead and lost to follow-up patients are excluded."
   ltfu_denominator_copy: "Hypertension patients assigned to %{region_name}. Dead patients are excluded."
-  total_registered_patients_copy: "All hypertension patients registered in %{region_name}."
-  new_registered_patients_copy: "Hypertension patients registered during a month in %{region_name}."
   follow_up_patients_copy: "Hypertension patients with a BP measure taken during a month in %{region_name}."
   not_lost_to_follow_up_copy: "Hypertension patients with a BP taken in the last 12 months."
   bp_measures_taken_copy: "All BP measures taken during a month by healthcare workers at %{region_name}."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,7 +60,7 @@ en:
     reports_card_subtitle: "Hypertension patients with no BP taken in the last 12 months"
     numerator: "Patients with no BP taken in the last 12 months."
   registered_patients_copy:
-    reports_card_subtitle: "Monthly and total hypertension patient registrations in %{region_name}"
+    reports_card_subtitle: "Monthly and total hypertension patients registered in %{region_name}"
     monthly_registered_patients: "Hypertension patients registered during a month in %{region_name}."
     total_registered_patients: "Total hypertension patients registered in %{region_name}."
   assigned_patients_copy:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
     total_registered_patients: "Total hypertension patients registered in %{region_name}."
   assigned_patients_copy:
     total_assigned_patients: "Hypertension patients assigned to %{region_name}."
+  denominator_without_exclusions_copy: "Hypertension patients assigned to %{region_name}, registered before the last 3 months."
   denominator_copy: "Hypertension patients assigned to %{region_name}, registered before the last 3 months. Dead patients are excluded."
   denominator_excluding_ltfu_copy: "Hypertension patients assigned to %{region_name}, registered before the last 3 months. Dead and lost to follow-up patients are excluded."
   ltfu_denominator_copy: "Hypertension patients assigned to %{region_name}. Dead patients are excluded."

--- a/spec/services/control_rate_service_spec.rb
+++ b/spec/services/control_rate_service_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ControlRateService, type: :model do
       create_list(:patient, 2, recorded_at: Time.current, registration_facility: facility, assigned_facility: facility, registration_user: user)
     end
     Timecop.freeze("May 30th 2018") do
-      create_list(:patient, 2, recorded_at: Time.current, registration_facility: facility,  assigned_facility: facility, registration_user: user)
+      create_list(:patient, 2, recorded_at: Time.current, registration_facility: facility, assigned_facility: facility, registration_user: user)
     end
     Timecop.freeze(june_1_2018) do
       create_list(:patient, 2, recorded_at: Time.current, registration_facility: facility, assigned_facility: facility, registration_user: user)
@@ -275,11 +275,11 @@ RSpec.describe ControlRateService, type: :model do
     facility = facilities.first
 
     controlled = create_list(:patient, 2, full_name: "controlled", recorded_at: jan_2019,
-                             registration_facility: facility, registration_user: user)
+                                          registration_facility: facility, registration_user: user)
     uncontrolled = create_list(:patient, 4, full_name: "uncontrolled", recorded_at: jan_2019,
-                               registration_facility: facility, registration_user: user)
+                                            registration_facility: facility, registration_user: user)
     patient_from_other_facility = create(:patient, full_name: "other facility", recorded_at: jan_2019,
-                                         registration_facility: facilities.last, registration_user: user)
+                                                   registration_facility: facilities.last, registration_user: user)
 
     Timecop.freeze(jan_2020) do
       controlled.map do |patient|

--- a/spec/services/control_rate_service_spec.rb
+++ b/spec/services/control_rate_service_spec.rb
@@ -25,24 +25,24 @@ RSpec.describe ControlRateService, type: :model do
   it "counts registrations and cumulative registrations" do
     facility = FactoryBot.create(:facility, facility_group: facility_group_1)
     Timecop.freeze("January 1st 2018") do
-      create_list(:patient, 2, recorded_at: Time.current, assigned_facility: facility, registration_user: user)
+      create_list(:patient, 2, recorded_at: Time.current, registration_facility: facility, assigned_facility: facility, registration_user: user)
     end
     Timecop.freeze("May 30th 2018") do
-      create_list(:patient, 2, recorded_at: Time.current, assigned_facility: facility, registration_user: user)
+      create_list(:patient, 2, recorded_at: Time.current, registration_facility: facility,  assigned_facility: facility, registration_user: user)
     end
     Timecop.freeze(june_1_2018) do
-      create_list(:patient, 2, recorded_at: Time.current, assigned_facility: facility, registration_user: user)
+      create_list(:patient, 2, recorded_at: Time.current, registration_facility: facility, assigned_facility: facility, registration_user: user)
     end
     Timecop.freeze("April 15th 2020") do
-      create_list(:patient, 2, recorded_at: Time.current, assigned_facility: facility, registration_user: user)
+      create_list(:patient, 2, recorded_at: Time.current, registration_facility: facility, assigned_facility: facility, registration_user: user)
     end
     Timecop.freeze("May 1 2020") do
-      create_list(:patient, 3, recorded_at: Time.current, assigned_facility: facility, registration_user: user)
-      create_list(:patient, 1, recorded_at: Time.current, assigned_facility: create(:facility), registration_user: user)
+      create_list(:patient, 3, recorded_at: Time.current, registration_facility: facility, assigned_facility: facility, registration_user: user)
+      create_list(:patient, 1, recorded_at: Time.current, registration_facility: facility, assigned_facility: create(:facility), registration_user: user)
     end
 
     Timecop.freeze(june_30_2020) do
-      create_list(:patient, 4, recorded_at: Time.current, assigned_facility: facility, registration_user: user)
+      create_list(:patient, 4, recorded_at: Time.current, registration_facility: facility, assigned_facility: facility, registration_user: user)
     end
 
     refresh_views
@@ -54,19 +54,27 @@ RSpec.describe ControlRateService, type: :model do
     may_period = Date.parse("May 1 2020").to_period
     june_period = Date.parse("June 1 2020").to_period
     expect(result[:registrations][june_1_2018.to_date.to_period]).to eq(2)
+    expect(result[:assigned_patients][june_1_2018.to_date.to_period]).to eq(2)
     expect(result[:cumulative_registrations][june_1_2018.to_date.to_period]).to eq(6)
+    expect(result[:cumulative_assigned_patients][june_1_2018.to_date.to_period]).to eq(6)
     expect(result[:registrations][april_period]).to eq(2)
+    expect(result[:assigned_patients][april_period]).to eq(2)
     expect(result[:cumulative_registrations][april_period]).to eq(8)
-    expect(result[:registrations][may_period]).to eq(3)
-    expect(result[:cumulative_registrations][may_period]).to eq(11)
+    expect(result[:cumulative_assigned_patients][april_period]).to eq(8)
+    expect(result[:registrations][may_period]).to eq(4)
+    expect(result[:assigned_patients][may_period]).to eq(3)
+    expect(result[:cumulative_registrations][may_period]).to eq(12)
+    expect(result[:cumulative_assigned_patients][may_period]).to eq(11)
     expect(result[:registrations][june_period]).to eq(4)
-    expect(result[:cumulative_registrations][june_period]).to eq(15)
+    expect(result[:assigned_patients][june_period]).to eq(4)
+    expect(result[:cumulative_registrations][june_period]).to eq(16)
+    expect(result[:cumulative_assigned_patients][june_period]).to eq(15)
   end
 
   it "does not include months without registration data" do
     facility = FactoryBot.create(:facility, facility_group: facility_group_1)
     Timecop.freeze("April 15th 2020") do
-      patients_with_controlled_bp = create_list(:patient, 2, recorded_at: 1.month.ago, assigned_facility: facility, registration_user: user)
+      patients_with_controlled_bp = create_list(:patient, 2, recorded_at: 1.month.ago, registration_facility: facility, registration_user: user)
       patients_with_controlled_bp.map do |patient|
         create(:blood_pressure, :under_control, facility: facility, patient: patient, recorded_at: Time.current, user: user)
         create(:blood_pressure, :under_control, facility: facility, patient: patient, recorded_at: Time.current, user: user)
@@ -91,10 +99,10 @@ RSpec.describe ControlRateService, type: :model do
     facility = facilities.first
     facility_2 = create(:facility)
 
-    controlled_in_jan_and_june = create_list(:patient, 2, full_name: "controlled", recorded_at: jan_2019, assigned_facility: facility, registration_user: user)
-    uncontrolled_in_jan = create_list(:patient, 2, full_name: "uncontrolled", recorded_at: jan_2019, assigned_facility: facility, registration_user: user)
-    controlled_just_for_june = create(:patient, full_name: "just for june", recorded_at: jan_2019, assigned_facility: facility, registration_user: user)
-    patient_from_other_facility = create(:patient, full_name: "other facility", recorded_at: jan_2019, assigned_facility: facility_2, registration_user: user)
+    controlled_in_jan_and_june = create_list(:patient, 2, full_name: "controlled", recorded_at: jan_2019, registration_facility: facility, registration_user: user)
+    uncontrolled_in_jan = create_list(:patient, 2, full_name: "uncontrolled", recorded_at: jan_2019, registration_facility: facility, registration_user: user)
+    controlled_just_for_june = create(:patient, full_name: "just for june", recorded_at: jan_2019, registration_facility: facility, registration_user: user)
+    patient_from_other_facility = create(:patient, full_name: "other facility", recorded_at: jan_2019, registration_facility: facility_2, registration_user: user)
 
     Timecop.freeze(jan_2020) do
       controlled_in_jan_and_june.map do |patient|
@@ -115,7 +123,7 @@ RSpec.describe ControlRateService, type: :model do
       create(:blood_pressure, :under_control, facility: facility, patient: controlled_just_for_june, recorded_at: 4.days.ago, user: user)
 
       # register 5 more patients in feb 2020
-      uncontrolled_in_june = create_list(:patient, 5, recorded_at: 4.months.ago, assigned_facility: facility, registration_user: user)
+      uncontrolled_in_june = create_list(:patient, 5, recorded_at: 4.months.ago, registration_facility: facility, registration_user: user)
       uncontrolled_in_june.map do |patient|
         create(:blood_pressure, :hypertensive, facility: facility, patient: patient, recorded_at: 1.days.ago, user: user)
         create(:blood_pressure, :under_control, facility: facility, patient: patient, recorded_at: 2.days.ago, user: user)
@@ -129,17 +137,22 @@ RSpec.describe ControlRateService, type: :model do
     result = service.call
 
     expect(result[:registrations][Period.month(jan_2019)]).to eq(5)
+    expect(result[:assigned_patients][Period.month(jan_2019)]).to eq(5)
     expect(result[:cumulative_registrations][Period.month(jan_2019)]).to eq(5)
+    expect(result[:cumulative_assigned_patients][Period.month(jan_2019)]).to eq(5)
     expect(result[:adjusted_registrations][Period.month(jan_2019)]).to eq(0)
 
     expect(result[:cumulative_registrations][Period.month(jan_2020)]).to eq(5)
+    expect(result[:cumulative_assigned_patients][Period.month(jan_2020)]).to eq(5)
     expect(result[:adjusted_registrations][Period.month(jan_2020)]).to eq(5)
     expect(result[:controlled_patients][Period.month(jan_2020)]).to eq(controlled_in_jan_and_june.size)
     expect(result[:controlled_patients_rate][Period.month(jan_2020)]).to eq(40.0)
 
     # 3 controlled patients in june and 10 cumulative registered patients
     expect(result[:cumulative_registrations][Period.month(june_1_2020)]).to eq(10)
+    expect(result[:cumulative_assigned_patients][Period.month(june_1_2020)]).to eq(10)
     expect(result[:registrations][Period.month(june_1_2020)]).to eq(0)
+    expect(result[:assigned_patients][Period.month(june_1_2020)]).to eq(0)
     expect(result[:controlled_patients][Period.month(june_1_2020)]).to eq(3)
     expect(result[:controlled_patients_rate][Period.month(june_1_2020)]).to eq(30.0)
     expect(result[:uncontrolled_patients][Period.month(june_1_2020)]).to eq(5)
@@ -149,7 +162,7 @@ RSpec.describe ControlRateService, type: :model do
   it "excludes patients registered in the last 3 months" do
     facility = FactoryBot.create(:facility, facility_group: facility_group_1)
 
-    controlled_jan2020_registration = create(:patient, full_name: "controlled jan2020 registration", recorded_at: jan_2020, assigned_facility: facility, registration_user: user)
+    controlled_jan2020_registration = create(:patient, full_name: "controlled jan2020 registration", recorded_at: jan_2020, registration_facility: facility, registration_user: user)
 
     Timecop.freeze(jan_2020) do
       create(:blood_pressure, :under_control, facility: facility, patient: controlled_jan2020_registration, recorded_at: 2.days.ago)
@@ -172,8 +185,8 @@ RSpec.describe ControlRateService, type: :model do
     it "excludes patients who are dead or LTFU" do
       facility = FactoryBot.create(:facility, facility_group: facility_group_1)
       patients = [
-        create(:patient, recorded_at: jan_2019, assigned_facility: facility, registration_user: user),
-        create(:patient, status: :dead, recorded_at: jan_2019, assigned_facility: facility, registration_user: user)
+        create(:patient, recorded_at: jan_2019, registration_facility: facility, registration_user: user),
+        create(:patient, status: :dead, recorded_at: jan_2019, registration_facility: facility, registration_user: user)
       ]
 
       Timecop.freeze(june_1_2020) do
@@ -192,6 +205,7 @@ RSpec.describe ControlRateService, type: :model do
         ControlRateService.new(facility_group_1, periods: report_range).call
 
       expect(result[:cumulative_registrations][report_month]).to eq(2)
+      expect(result[:cumulative_assigned_patients][report_month]).to eq(2)
       expect(result[:adjusted_registrations][report_month]).to eq(2)
       expect(result[:controlled_patients][report_month]).to eq(2)
       expect(result[:controlled_patients_rate][report_month]).to eq(100.0)
@@ -202,6 +216,7 @@ RSpec.describe ControlRateService, type: :model do
         ControlRateService.new(facility_group_1, periods: report_range, with_exclusions: true).call
 
       expect(result_with_exclusions[:cumulative_registrations][report_month]).to eq(2)
+      expect(result_with_exclusions[:cumulative_assigned_patients][report_month]).to eq(1)
       expect(result_with_exclusions[:adjusted_registrations_with_ltfu][report_month]).to eq(1)
       expect(result_with_exclusions[:adjusted_registrations][report_month]).to eq(0)
       expect(result_with_exclusions[:controlled_patients][report_month]).to eq(1)
@@ -260,11 +275,11 @@ RSpec.describe ControlRateService, type: :model do
     facility = facilities.first
 
     controlled = create_list(:patient, 2, full_name: "controlled", recorded_at: jan_2019,
-                                          assigned_facility: facility, registration_user: user)
+                             registration_facility: facility, registration_user: user)
     uncontrolled = create_list(:patient, 4, full_name: "uncontrolled", recorded_at: jan_2019,
-                                            assigned_facility: facility, registration_user: user)
+                               registration_facility: facility, registration_user: user)
     patient_from_other_facility = create(:patient, full_name: "other facility", recorded_at: jan_2019,
-                                                   assigned_facility: facilities.last, registration_user: user)
+                                         registration_facility: facilities.last, registration_user: user)
 
     Timecop.freeze(jan_2020) do
       controlled.map do |patient|

--- a/spec/services/facility_stats_service_spec.rb
+++ b/spec/services/facility_stats_service_spec.rb
@@ -94,18 +94,21 @@ RSpec.describe FacilityStatsService do
       expect(small.map { |_, v| v[:controlled_patients] }).to eq [0, 0, 0, 2, 0, 0]
       expect(small.map { |_, v| v[:adjusted_registrations] }).to eq [0, 0, 0, 3, 3, 3]
       expect(small.map { |_, v| v[:cumulative_registrations] }).to eq [3, 3, 3, 3, 3, 3]
+      expect(small.map { |_, v| v[:cumulative_assigned_patients] }).to eq [3, 3, 3, 3, 3, 3]
       expect(small.map { |_, v| v[:controlled_patients_rate] }).to eq [0, 0, 0, 67, 0, 0]
 
       medium = stats_by_size[:medium][:periods]
       expect(medium.map { |_, v| v[:controlled_patients] }).to eq [0, 0, 0, 0, 1, 0]
       expect(medium.map { |_, v| v[:adjusted_registrations] }).to eq [0, 0, 0, 0, 2, 2]
       expect(medium.map { |_, v| v[:cumulative_registrations] }).to eq [0, 2, 2, 2, 2, 2]
+      expect(medium.map { |_, v| v[:cumulative_assigned_patients] }).to eq [0, 2, 2, 2, 2, 2]
       expect(medium.map { |_, v| v[:controlled_patients_rate] }).to eq [0, 0, 0, 0, 50, 0]
 
       large = stats_by_size[:large][:periods]
       expect(large.map { |_, v| v[:controlled_patients] }).to eq [0, 0, 0, 0, 0, 1]
       expect(large.map { |_, v| v[:adjusted_registrations] }).to eq [0, 0, 0, 0, 0, 3]
       expect(large.map { |_, v| v[:cumulative_registrations] }).to eq [0, 0, 3, 3, 3, 3]
+      expect(large.map { |_, v| v[:cumulative_assigned_patients] }).to eq [0, 0, 3, 3, 3, 3]
       expect(large.map { |_, v| v[:controlled_patients_rate] }).to eq [0, 0, 0, 0, 0, 33]
     end
 
@@ -138,27 +141,9 @@ RSpec.describe FacilityStatsService do
                                                 period: period, rate_numerator: :womp)
       stat_keys = stats_by_size[:small][:periods].values.first.keys
       stat_values = stats_by_size[:small][:periods].values.first.values
-      expected_keys = ["womp", "adjusted_registrations", "cumulative_registrations", "womp_rate"]
+      expected_keys = ["womp", "adjusted_registrations", "cumulative_registrations", "cumulative_assigned_patients", "womp_rate"]
       expect(stat_keys).to match_array(expected_keys)
-      expect(stat_values).to match_array([0, 0, 0, 0])
-    end
-
-    it "sets total_registered_hypertensive_patients for each size" do
-      small_facility
-      month = december - 4.months
-      medium_facility1 = create(:facility, name: "medium_1", facility_size: "medium")
-      medium_facility2 = create(:facility, name: "medium_2", facility_size: "medium")
-      create_list(:patient, 2, :hypertension, full_name: "medium_uncontrolled", registration_user: user,
-                                              registration_facility: medium_facility1, recorded_at: month)
-      create_list(:patient, 1, :without_hypertension, full_name: "medium_controlled", registration_user: user,
-                                                      registration_facility: medium_facility2, recorded_at: month)
-      facilities = [small_facility, medium_facility1, medium_facility2]
-      refresh_views
-      facilities_reports = facilities_data(facilities)
-      stats_by_size = FacilityStatsService.call(facilities: facilities_reports,
-                                                period: period, rate_numerator: :controlled_patients)
-      expect(stats_by_size[:small][:total_registered_hypertensive_patients]).to eq 0
-      expect(stats_by_size[:medium][:total_registered_hypertensive_patients]).to eq 2
+      expect(stat_values).to match_array([0, 0, 0, 0, 0])
     end
   end
 end


### PR DESCRIPTION
**Story card:** [ch2650](https://app.clubhouse.io/simpledotorg/story/2650/update-assigned-patients-card?vc_group_by=day)

## Because

We're showing the wrong data in the "Assigned patients" card in the Reports Overview section. We got approval from Reena, Daniel, and Praveen to display raw registration trends in that card for all regions.

## This addresses

![image](https://user-images.githubusercontent.com/16785131/108077574-ac88e980-703a-11eb-818b-c1e05b40558a.png)


**Front-end**
* Updates "Assigned patients" card title and subtitle
* Updates "Assigned patients" card "Total assigned patients" and "Monthly assigned patients" copy
* Updates "Assigned patients" tooltip copy
* Updates "Patient registrations and follow-up" copy, tooltips, and column titles
* Updates "Overview" and "Details" footnotes copy
