### PR TITLE
Revert bump low queue priority

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,5 +5,5 @@
 :queues:
   - [high, 3]
   - [default, 2]
-  - [low, 3]
+  - [low, 1]
   - [audit_log_queue, 1]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,4 +6,3 @@
   - [high, 3]
   - [default, 2]
   - [low, 1]
-  - [audit_log_queue, 1]


### PR DESCRIPTION
**Story card:** -

## Because

We temporarily wanted to bump the `low` queue's priority on IHCI sidekiq to drain jobs quickly during the [redis outage today](https://simpledotorg.slack.com/archives/CFHMC60P5/p1613461369349600). We didn't have to use this change since we fixed the issue by bumping RAM on the redis instance. 

## This addresses

This reverts the change. This also removes the old (now unused) `audit_log_queue` queue from config.