### PR TITLE
Fix report links for BD

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -107,6 +107,7 @@ class Reports::RegionsController < AdminController
   private
 
   def accessible_region?(region, action)
+    return false unless region.reportable_region?
     current_admin.region_access(memoized: true).accessible_region?(region, action)
   end
 

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -40,6 +40,11 @@ class Region < ApplicationRecord
     REGION_TYPES[current_index + 1]
   end
 
+  def reportable_region?
+    return true if CountryConfig.current[:extended_region_reports]
+    region_type.in?(["district", "facility"])
+  end
+
   def reportable_children
     return children if CountryConfig.current[:extended_region_reports]
     legacy_children


### PR DESCRIPTION
reports besides district and facility should be linkable in countries
that don't have extened region reports

Fixes [ch2652](https://app.clubhouse.io/simpledotorg/story/2652/reports-broken-in-bd-argumenterror-unsupported-region-type-state-for-legacy-children)

Fixes https://sentry.io/organizations/resolve-to-save-lives/issues/2210183543/?project=1793711
