### PR TITLE
Bug: My Facilities table sorting

### DIFF
--- a/app/views/my_facilities/bp_controlled.html.erb
+++ b/app/views/my_facilities/bp_controlled.html.erb
@@ -77,7 +77,12 @@
             </thead>
             <tbody>
               <% facility_size_six_month_rate_change = facility_size_six_month_rate_change(@stats_by_size[size][:periods], "controlled_patients_rate") %>
-              <tr class="row-total" data-row="<%= size %>" data-trend-color="<% if facility_size_six_month_rate_change > 0 %>green<% elsif facility_size_six_month_rate_change < 0 %>red<% else %>grey<% end %>">
+              <tr
+                class="row-total"
+                data-sort-method="none"
+                data-row="<%= size %>"
+                data-trend-color="<% if facility_size_six_month_rate_change > 0 %>green<% elsif facility_size_six_month_rate_change < 0 %>red<% else %>grey<% end %>"
+              >
                 <td class="type-title">
                   All <%= Facility.localized_facility_size(size) %>s
                 </td>

--- a/app/views/my_facilities/bp_not_controlled.html.erb
+++ b/app/views/my_facilities/bp_not_controlled.html.erb
@@ -77,7 +77,12 @@
             </thead>
             <tbody>
               <% facility_size_six_month_rate_change = facility_size_six_month_rate_change(@stats_by_size[size][:periods], "uncontrolled_patients_rate") %>
-              <tr class="row-total" data-row="<%= size %>" data-trend-color="<% if facility_size_six_month_rate_change > 0 %>red<% elsif facility_size_six_month_rate_change < 0 %>green<% else %>grey<% end %>">
+              <tr
+                class="row-total"
+                data-sort-method="none"
+                data-row="<%= size %>"
+                data-trend-color="<% if facility_size_six_month_rate_change > 0 %>red<% elsif facility_size_six_month_rate_change < 0 %>green<% else %>grey<% end %>"
+              >
                 <td class="type-title">
                   All <%= Facility.localized_facility_size(size) %>s
                 </td>

--- a/app/views/my_facilities/missed_visits.html.erb
+++ b/app/views/my_facilities/missed_visits.html.erb
@@ -77,7 +77,12 @@
             </thead>
             <tbody>
               <% facility_size_six_month_rate_change = facility_size_six_month_rate_change(@stats_by_size[size][:periods], "missed_visits_rate") %>
-              <tr class="row-total" data-row="<%= size %>" data-trend-color="<% if facility_size_six_month_rate_change > 0 %>red<% elsif facility_size_six_month_rate_change < 0 %>green<% else %>grey<% end %>">
+              <tr
+                class="row-total"
+                data-sort-method="none"
+                data-row="<%= size %>"
+                data-trend-color="<% if facility_size_six_month_rate_change > 0 %>red<% elsif facility_size_six_month_rate_change < 0 %>green<% else %>grey<% end %>"
+              >
                 <td class="type-title">
                   All <%= Facility.localized_facility_size(size) %>s
                 </td>


### PR DESCRIPTION
**Story card:** [ch2687](https://app.clubhouse.io/simpledotorg/story/2687/fix-my-facilities-subtotal-table-sorting)

## Because

The "Total" row in "My Facilities" should always be the first row. Currently, changing the default sort method changes the "Total" row's placement in the table.

## This addresses

* Adds `data-default-method="none"` to the "Total" row in each view