### PR TITLE
Throttle cache warmer job

### DIFF
--- a/app/jobs/region_cache_warmer_job.rb
+++ b/app/jobs/region_cache_warmer_job.rb
@@ -1,7 +1,9 @@
 class RegionCacheWarmerJob
   include Sidekiq::Worker
+  include Sidekiq::Throttled::Worker
 
   sidekiq_options queue: :default
+  sidekiq_throttle(concurrency: {limit: 5})
 
   def perform(region_id, period_attributes)
     region = Region.find(region_id)


### PR DESCRIPTION
**Story card:** -

## Because

We made region cache warmer run in parallel via sidekiq. This chokes the DB since a lot of connections get opened by the jobs and the queries don't release them quickly enough.

## This addresses

This adds a concurrency limit to the job. Tested on perf, this manages to warm prod sized data with peak 60% CPU on a `t3.small` RDS.