### PR TITLE
Reduce cache warmer concurrency

### DIFF
--- a/app/jobs/region_cache_warmer_job.rb
+++ b/app/jobs/region_cache_warmer_job.rb
@@ -1,9 +1,11 @@
 class RegionCacheWarmerJob
+  DEFAULT_CONCURRENCY_LIMIT = 3
+
   include Sidekiq::Worker
   include Sidekiq::Throttled::Worker
 
   sidekiq_options queue: :default
-  sidekiq_throttle(concurrency: {limit: 5})
+  sidekiq_throttle(concurrency: {limit: ENV["REGION_CACHE_WARMER_CONCURRENCY"] || DEFAULT_CONCURRENCY_LIMIT})
 
   def perform(region_id, period_attributes)
     region = Region.find(region_id)


### PR DESCRIPTION
**Story card:** - 

## Because

We noticed a DB CPU spike after parallelizing the region cache warmer via sidekiq and added a throttle in #2083. This still causes a CPU spike on the sidekiq box in IHCI prod.

## This addresses

Reduces the concurrency limit to `5` from `3`.
