### PR TITLE
Show states in region breadcrumbs

### DIFF
--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -11,7 +11,7 @@
 
     <% # we can get rid of this check when FacilityDistrict goes away %>
     <% if @region.respond_to?(:ancestors) %>
-      <% @region.ancestors.where(region_type: %w[district block facility]).order(:path).each do |region| %>
+      <% @region.ancestors.where(region_type: %w[state district block facility]).order(:path).each do |region| %>
         <i class="fas fa-chevron-right"></i>
         <%= link_to_if(accessible_region?(region, :view_reports), region.name, reports_region_path(region.slug, report_scope: region.region_type)) %>
       <% end %>


### PR DESCRIPTION
**Story card:** [ch2707](https://app.clubhouse.io/simpledotorg/story/2707/region-breadcrumbs-not-right-region-in-the-nav-should-show-up-under-punjab-gt-bathinda-and-mansa-g)

We weren't showing states in the region breadcrumbs previously.  This fixes that.