### PR TITLE
Warm patient breakdown cache also

### DIFF
--- a/app/assets/javascripts/common/patient_breakdown_reports.js
+++ b/app/assets/javascripts/common/patient_breakdown_reports.js
@@ -166,7 +166,7 @@ PatientBreakdownReports = function () {
         },
         label: (tooltipItem, tooltipData) => {
           const label = tooltipData.labels[tooltipItem.index];
-          let tooltipBody = [`Total: ${data[label]}`];
+          let tooltipBody = [`Total: ${reports.formatNumberWithCommas(data[label])}`];
           if (transferredPatients[label] !== undefined) {
             tooltipBody.push(`Transferred-out: ${transferredPatients[label]}`)
           }

--- a/app/jobs/region_cache_warmer_job.rb
+++ b/app/jobs/region_cache_warmer_job.rb
@@ -19,6 +19,9 @@ class RegionCacheWarmerJob
 
       Reports::RegionService.call(region: region, period: period, with_exclusions: true)
       Statsd.instance.increment("region_cache_warmer.with_exclusions.#{region.region_type}.cache")
+
+      PatientBreakdownService.call(region: region, period: period)
+      Statsd.instance.increment("patient_breakdown_service.#{region.region_type}.cache")
     end
     notify "finished region caching for region #{region_id}"
   end

--- a/spec/services/patient_breakdown_service_spec.rb
+++ b/spec/services/patient_breakdown_service_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe PatientBreakdownService do
   describe ".call" do
     it "gets the patient breakdowns by status and ltfu-ness and caches it" do
       facility = create(:facility)
-      ltfu_patient = create(:patient, :hypertension, recorded_at: 2.years.ago, assigned_facility: facility)
-      not_ltfu_patient = create(:patient, :hypertension, assigned_facility: facility)
-      ltfu_transferred_patient = create(:patient, :hypertension, recorded_at: 2.years.ago, status: :migrated, assigned_facility: facility)
-      not_ltfu_transferred_patient = create(:patient, :hypertension, status: :migrated, assigned_facility: facility)
-      dead_patient = create(:patient, :hypertension, status: :dead, assigned_facility: facility)
-      not_hypertensive_patient = create(:patient, :without_hypertension, assigned_facility: facility)
+      _ltfu_patient = create(:patient, :hypertension, recorded_at: 2.years.ago, assigned_facility: facility)
+      _not_ltfu_patient = create(:patient, :hypertension, assigned_facility: facility)
+      _ltfu_transferred_patient = create(:patient, :hypertension, recorded_at: 2.years.ago, status: :migrated, assigned_facility: facility)
+      _not_ltfu_transferred_patient = create(:patient, :hypertension, status: :migrated, assigned_facility: facility)
+      _dead_patient = create(:patient, :hypertension, status: :dead, assigned_facility: facility)
+      _not_hypertensive_patient = create(:patient, :without_hypertension, assigned_facility: facility)
 
       expected_result = {
         dead_patients: 1,


### PR DESCRIPTION
**Story card:** [ch2701](https://app.clubhouse.io/simpledotorg/story/2701/fix-ltfu-charts)

## Because

We want to cache the patient breakdown data at the same frequency as the region reports data so they are always in sync. 

## This addresses

This adds `PatientBreakdownService` to the cache warmer. This also improves load time on the details page since the breakdown queries can be slow (~2-3s) for regions with a large number of patients (states etc.). Also adds a small UI enhancement to display commas in tooltips on the pie chart.
