### PR TITLE
Assigned patients query: Show only HTN patients

### DIFF
--- a/app/queries/assigned_patients_query.rb
+++ b/app/queries/assigned_patients_query.rb
@@ -1,10 +1,12 @@
 class AssignedPatientsQuery
-  # Returns ALL assigned counts for a region
+  # Returns hypertensive assigned counts for a region
   def count(region, period_type, with_exclusions: false)
     formatter = lambda { |v| period_type == :quarter ? Period.quarter(v) : Period.month(v) }
 
-    query = region.assigned_patients
-    query = query.for_reports(with_exclusions: with_exclusions) if with_exclusions
-    query.group_by_period(period_type, :recorded_at, {format: formatter}).count
+    region
+      .assigned_patients
+      .for_reports(with_exclusions: with_exclusions)
+      .group_by_period(period_type, :recorded_at, {format: formatter})
+      .count
   end
 end

--- a/app/queries/registered_patients_query.rb
+++ b/app/queries/registered_patients_query.rb
@@ -1,5 +1,5 @@
 class RegisteredPatientsQuery
-  def count(region, period_type, with_exclusions: false)
+  def count(region, period_type)
     formatter = lambda { |v| period_type == :quarter ? Period.quarter(v) : Period.month(v) }
     region.registered_patients
       .with_hypertension

--- a/spec/queries/assigned_patients_query_spec.rb
+++ b/spec/queries/assigned_patients_query_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe AssignedPatientsQuery do
+  context "with_exclusions false" do
+    it "should include only assigned hypertension patients" do
+      facility = create(:facility)
+      create(:patient, registration_facility: facility)
+      create(:patient, :without_hypertension, registration_facility: facility)
+      expect(AssignedPatientsQuery.new.count(facility, :month, with_exclusions: false).values.first).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** -

## Because

We want to display only hypertension patients in all our dashboards. The refactor in #2089 broke the `for_reports` scoping for assigned patients counts.

## This addresses

This fixes `AssignedPatientsQuery`.
