### PR TITLE
2117: replace password confirmation with password visibility toggle

### DIFF
--- a/app/assets/javascripts/common/password_visibility_toggle.js
+++ b/app/assets/javascripts/common/password_visibility_toggle.js
@@ -1,0 +1,20 @@
+PasswordVisibilityToggle = function () {
+  const passwordInput = document.getElementById("password");
+  const togglePasswordButton = document.getElementById("toggle-password");
+  togglePasswordButton.addEventListener("click", togglePassword);
+
+  function togglePassword() {
+    if (passwordInput.type === "password") {
+      passwordInput.type = "text";
+      togglePasswordButton.setAttribute("aria-label", "Hide password.");
+      togglePasswordButton.value = "Hide"
+    } else {
+      passwordInput.type = "password";
+      togglePasswordButton.setAttribute(
+        "aria-label",
+        "Show password as plain text. Warning: this will display your password on the screen."
+      );
+      togglePasswordButton.value = "Show"
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -626,3 +626,13 @@ span.inactive {
   font-weight: bold;
   cursor: pointer;
 }
+
+.password-toggle-button {
+	color: $blue;
+	height: 34px;
+	position: absolute;
+	right: 2px;
+	top: calc(1em + 17px);
+	width: 60px;
+	z-index: 10;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -630,6 +630,7 @@ span.inactive {
 .password-toggle-button {
 	color: $blue;
 	height: 34px;
+	line-height: 0;
 	position: absolute;
 	right: 2px;
 	top: calc(1em + 17px);

--- a/app/views/email_authentications/invitations/edit.html.erb
+++ b/app/views/email_authentications/invitations/edit.html.erb
@@ -4,13 +4,15 @@
   <div class="col-md-6">
     <%= bootstrap_form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
       <%= f.hidden_field :invitation_token, readonly: true %>
-
-      <% if f.object.class.require_password_on_accepting %>
-        <%= f.password_field :password %>
-        <%= f.password_field :password_confirmation %>
-      <% end %>
-
+        <div style="position: relative;">
+          <%= f.password_field :password, type: "password", id: "password", class: "password-field", autofocus: true, autocomplete: "off" %>
+          <input id="toggle-password" type="button" class="btn btn-light password-toggle-button" value="Show">
+        </div>
       <%= f.primary t("devise.invitations.edit.submit_button") %>
     <% end %>
   </div>
 </div>
+
+<script>
+  new PasswordVisibilityToggle
+</script>

--- a/app/views/email_authentications/invitations/edit.html.erb
+++ b/app/views/email_authentications/invitations/edit.html.erb
@@ -14,5 +14,5 @@
 </div>
 
 <script>
-  new PasswordVisibilityToggle
+  new PasswordVisibilityToggle();
 </script>

--- a/app/views/email_authentications/passwords/edit.html.erb
+++ b/app/views/email_authentications/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<h2>Change your password</h2>
+<h1>Change your password</h1>
 
 <div class="row">
   <div class="col-md-6">

--- a/app/views/email_authentications/passwords/edit.html.erb
+++ b/app/views/email_authentications/passwords/edit.html.erb
@@ -4,10 +4,10 @@
   <div class="col-md-6">
     <%= bootstrap_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, label_errors: false) do |f| %>
       <%= f.hidden_field :reset_password_token %>
-
-      <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
-      <%= f.password_field :password_confirmation, autocomplete: "off", label: "Confirm new password" %>
-
+        <div style="position: relative;">
+          <%= f.password_field :password, type: "password", id: "password", class: "password-field", autofocus: true, autocomplete: "off" %>
+          <input id="toggle-password" type="button" class="btn btn-light password-toggle-button" value="Show">
+        </div>
       <%= f.primary "Change my password" %>
     <% end %>
   </div>
@@ -16,3 +16,7 @@
 <div class="actions mt-4">
   <%= render "email_authentications/shared/links" %>
 </div>
+
+<script>
+  new PasswordVisibilityToggle
+</script>

--- a/app/views/email_authentications/passwords/edit.html.erb
+++ b/app/views/email_authentications/passwords/edit.html.erb
@@ -18,5 +18,5 @@
 </div>
 
 <script>
-  new PasswordVisibilityToggle
+  new PasswordVisibilityToggle();
 </script>


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/2117

## Because

This is part of an epic that involves changing our password requirements to a checklist that goes green as the requirements are met. The confirmation process doesn't suit that design well, but removing the confirmation necessitates a visibility toggle. 

## This addresses

These are entirely front end changes that improve UI and move us toward a new design.

## Testing

1) Test the new invitations page.
In Simple server, go to the More tab then down to Dashboard Admin. Invite a new user
Get the invitation email either from the rails logs or mail catcher. 
Follow the link and test for the conditions listed below.

2) Test the email reset page
At the login page, click "forgot my password" and enter your email
Get the invitation email either from the rails logs or mail catcher. 
Follow the link and test for the conditions listed below.

Tests for each page:
- Confirm that the toggle hides and unhides as expected.
- Confirm that appearance is as expected (this primarily applies to Claudio)
- Confirm that incorrect passwords fail and present an error message
- Confirm that correct passwords succeed

