### PR TITLE
Add a feature flag for LTFU toggle

### DIFF
--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -25,7 +25,7 @@
               BP controlled
             </h3>
           <% end %>
-          <% if current_admin.feature_enabled?(:report_with_exclusions) && current_admin.power_user? %>
+          <% if current_admin.feature_enabled?(:report_with_exclusions) && current_admin.feature_enabled?(:ltfu_toggle) %>
             <div class="align-right custom-control custom-switch">
               <form method="get">
                 <input type="checkbox"


### PR DESCRIPTION
**Story card:** [ch2227](https://app.clubhouse.io/simpledotorg/story/2227/exclude-dead-patients-from-all-necessary-queries)

## Because

We want to allow alpha users of denominator exclusions (folks at ICMR and WHO) to be able to see the LTFU toggle, even though they aren't power users.
![image](https://user-images.githubusercontent.com/16774200/108813087-52f26300-75d6-11eb-9e99-a810c5adbdea.png)

## This addresses

This adds another feature toggle for the LTFU toggle that will be enabled for the alpha users. We can probably revert to allowing powers users when #2094 is merged.


