### PR TITLE
Fix redis config for review apps

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   config.cache_store = if ENV["RAILS_CACHE_REDIS_URL"].present?
     [:redis_cache_store, {url: ENV["RAILS_CACHE_REDIS_URL"]}]
   else
-    [:redis_cache_store, ENV["REDIS_URL"]]
+    [:redis_cache_store, {url: ENV["REDIS_URL"]}]
   end
 
   # Enable/disable caching. By default caching is disabled.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   config.cache_store = if ENV["RAILS_CACHE_REDIS_URL"].present?
     [:redis_cache_store, {url: ENV["RAILS_CACHE_REDIS_URL"]}]
   else
-    [:redis_cache_store, ENV["REDIS_URL"]]
+    [:redis_cache_store, {url: ENV["REDIS_URL"]}]
   end
 
   # Use a real queuing backend for Active Job (and separate queues per environment)


### PR DESCRIPTION
**Story card:** [ch2653](https://app.clubhouse.io/simpledotorg/story/2653/make-sure-we-are-force-setting-the-cache-w-multi-entry-calls)

## Because

Review app redis config got broken in #2076.

## This addresses

Fixes redis config for review apps.
