### PR TITLE
English names for Ethiopia states

### DIFF
--- a/config/data/canonical_states.yml
+++ b/config/data/canonical_states.yml
@@ -51,5 +51,6 @@ Bangladesh:
   - Sylhet
 Ethiopia:
   - Addis Ababa
+  - Dire Dawa
   - Oromia
   - Tigray

--- a/config/data/canonical_states.yml
+++ b/config/data/canonical_states.yml
@@ -51,5 +51,5 @@ Bangladesh:
   - Sylhet
 Ethiopia:
   - Addis Ababa
-  - Tigray
   - Oromia
+  - Tigray

--- a/config/data/canonical_states.yml
+++ b/config/data/canonical_states.yml
@@ -50,6 +50,6 @@ Bangladesh:
   - Rangpur
   - Sylhet
 Ethiopia:
-  - አዲስ አበባ
-  - ትግራይ
-  - Oromiyaa
+  - Addis Ababa
+  - Tigray
+  - Oromia


### PR DESCRIPTION
**Story card:** [ch2782](https://app.clubhouse.io/simpledotorg/story/2782/add-dire-dawa-to-canonical-region-list)

## Because

Facility registry in Ethiopia is in English - so our canonical state names should be as well, to ensure future facility groups have matching states.