### PR TITLE
Update Reports "Definitions"

### DIFF
--- a/app/views/reports/regions/_details_footnotes.html.erb
+++ b/app/views/reports/regions/_details_footnotes.html.erb
@@ -4,24 +4,11 @@
   </h3>
   <div class="mb-24px">
     <p class="mb-8px fs-16px fw-bold c-grey-dark">
-      Lost to follow-up
+      Total assigned patients
     </p>
     <div class="pl-16px">
       <p class="mb-8px fs-14px c-grey-dark">
-        <strong>Numerator:</strong> <%= t("lost_to_follow_up_copy.numerator") %>
-      </p>
-      <p class="mb-0px fs-14px c-grey-dark">
-        <strong>Denominator</strong> <%= t("ltfu_denominator_copy", region_name: @region.name) %>
-      </p>
-    </div>
-  </div>
-  <div class="mb-24px">
-    <p class="mb-8px fs-16px fw-bold c-grey-dark">
-      Not lost to follow-up
-    </p>
-    <div class="pl-16px">
-      <p class="mb-0px fs-14px c-grey-dark">
-        <%= t("not_lost_to_follow_up_copy", region_name: @region.name) %>
+        <%= t("assigned_patients_copy.total_assigned_patients", region_name: @region.name) %>
       </p>
     </div>
   </div>
@@ -42,6 +29,29 @@
     <div class="pl-16px">
       <p class="mb-0px fs-14px c-grey-dark">
         <%= t("registered_patients_copy.monthly_registered_patients", region_name: @region.name) %>
+      </p>
+    </div>
+  </div>
+  <div class="mb-24px">
+    <p class="mb-8px fs-16px fw-bold c-grey-dark">
+      Lost to follow-up
+    </p>
+    <div class="pl-16px">
+      <p class="mb-8px fs-14px c-grey-dark">
+        <strong>Numerator:</strong> <%= t("lost_to_follow_up_copy.numerator") %>
+      </p>
+      <p class="mb-0px fs-14px c-grey-dark">
+        <strong>Denominator</strong> <%= t("ltfu_denominator_copy", region_name: @region.name) %>
+      </p>
+    </div>
+  </div>
+  <div class="mb-24px">
+    <p class="mb-8px fs-16px fw-bold c-grey-dark">
+      Not lost to follow-up
+    </p>
+    <div class="pl-16px">
+      <p class="mb-0px fs-14px c-grey-dark">
+        <%= t("not_lost_to_follow_up_copy", region_name: @region.name) %>
       </p>
     </div>
   </div>

--- a/app/views/reports/regions/_overview_footnotes.html.erb
+++ b/app/views/reports/regions/_overview_footnotes.html.erb
@@ -4,6 +4,36 @@
   </h3>
   <div class="mb-24px">
     <p class="mb-8px fs-16px fw-bold c-grey-dark">
+      Total assigned patients
+    </p>
+    <div class="pl-16px">
+      <p class="mb-0px fs-14px c-grey-dark">
+        <%= t("assigned_patients_copy.total_assigned_patients", region_name: @region.name) %>
+      </p>
+    </div>
+  </div>
+  <div class="mb-24px">
+    <p class="mb-8px fs-16px fw-bold c-grey-dark">
+      Total registered patients
+    </p>
+    <div class="pl-16px">
+      <p class="mb-0px fs-14px c-grey-dark">
+        <%= t("registered_patients_copy.total_registered_patients", region_name: @region.name) %>
+      </p>
+    </div>
+  </div>
+  <div class="mb-24px">
+    <p class="mb-8px fs-16px fw-bold c-grey-dark">
+      Monthly registered patients
+    </p>
+    <div class="pl-16px">
+      <p class="mb-0px fs-14px c-grey-dark">
+        <%= t("registered_patients_copy.monthly_registered_patients", region_name: @region.name) %>
+      </p>
+    </div>
+  </div>
+  <div class="mb-24px">
+    <p class="mb-8px fs-16px fw-bold c-grey-dark">
       BP controlled
     </p>
     <div class="pl-16px">
@@ -69,36 +99,6 @@
       </p>
       <p class="mb-0px fs-14px c-grey-dark">
         <strong>Denominator</strong> <%= t("ltfu_denominator_copy", region_name: @region.name) %>
-      </p>
-    </div>
-  </div>
-  <div class="mb-24px">
-    <p class="mb-8px fs-16px fw-bold c-grey-dark">
-      Monthly registered patients
-    </p>
-    <div class="pl-16px">
-      <p class="mb-0px fs-14px c-grey-dark">
-        <%= t("registered_patients_copy.monthly_registered_patients", region_name: @region.name) %>
-      </p>
-    </div>
-  </div>
-  <div class="mb-24px">
-    <p class="mb-8px fs-16px fw-bold c-grey-dark">
-      Total registered patients
-    </p>
-    <div class="pl-16px">
-      <p class="mb-0px fs-14px c-grey-dark">
-        <%= t("registered_patients_copy.total_registered_patients", region_name: @region.name) %>
-      </p>
-    </div>
-  </div>
-  <div class="mb-24px">
-    <p class="mb-8px fs-16px fw-bold c-grey-dark">
-      Total assigned patients
-    </p>
-    <div class="pl-16px">
-      <p class="mb-0px fs-14px c-grey-dark">
-        <%= t("assigned_patients_copy.total_assigned_patients", region_name: @region.name) %>
       </p>
     </div>
   </div>

--- a/app/views/reports/regions/_overview_footnotes.html.erb
+++ b/app/views/reports/regions/_overview_footnotes.html.erb
@@ -92,4 +92,14 @@
       </p>
     </div>
   </div>
+  <div class="mb-24px">
+    <p class="mb-8px fs-16px fw-bold c-grey-dark">
+      Total assigned patients
+    </p>
+    <div class="pl-16px">
+      <p class="mb-0px fs-14px c-grey-dark">
+        <%= t("assigned_patients_copy.total_assigned_patients", region_name: @region.name) %>
+      </p>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
**Story card:** [ch2813](https://app.clubhouse.io/simpledotorg/story/2813/add-total-assigned-patients-definition-to-reports-pages)

## Because

* The "Total assigned patients" definition is missing from the new Reports section
* The terms listed in the definition section need to be reordered to reflect the order terms are displayed in each page

## This addresses

* Adds "Total assigned patients" to the "Overview" and "Details" sections of Reports
* Reorders the definition sections of the "Overview" and "Details" sections of Reports

**Reports, Overview**
![image](https://user-images.githubusercontent.com/16785131/109727542-257b5b80-7b7a-11eb-8e24-c7684d809794.png)

**Reports, Details**
![image](https://user-images.githubusercontent.com/16785131/109727570-3330e100-7b7a-11eb-9536-6d66c1598090.png)