### PR TITLE
2698 reset expiration

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -693,3 +693,40 @@ span.inactive {
 	height: 43px;
 	width: 141px;
 }
+
+.error-body {
+    background-color: #F0F2F5;
+    color: #2E2F30;
+    text-align: center;
+    font-family: Roboto, sans-serif;
+    margin: 0;
+    padding: 20px;
+    line-height: 1.4;
+
+    a:link,
+    a:hover,
+    a:visited {
+        font-weight: bold;
+        color: #0075EB;
+        letter-spacing: 2px;
+        text-decoration: none;
+    }
+
+    img {
+        width: 80px;
+        margin-bottom: 2em;
+    }
+
+    .dialog {
+        max-width: 33em;
+        margin: 4em auto 0;
+        background: #fff;
+        padding: 40px;
+        border-radius: 7px;
+        box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+    }
+
+    .text {
+        padding-bottom: 2em;
+    }
+}

--- a/app/views/email_authentications/invitations/edit.html.erb
+++ b/app/views/email_authentications/invitations/edit.html.erb
@@ -4,23 +4,23 @@
   <div class="col-md-8">
     <%= bootstrap_form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }, inline_errors: false) do |f| %>
       <%= f.hidden_field :invitation_token, readonly: true %>
-        <div class="password-form">
-          <%= f.password_field :password, type: "password", id: "password-input", class: "password-input", autofocus: true, autocomplete: "off" %>
-          <input id="toggle-password" type="button" class="btn btn-light password-toggle-button" value="Show">
-        </div>
-        <% if resource.errors[:password].any? %>
-          <div class="error-message"><%= t("devise.password_creation.submission_error") %></div>
-        <% end %>
-        <div id="validation-error-message" class="error-message hidden">
-          <%= t("devise.password_creation.validation_error") %>
-        </div>
-        <p class="password-prompt"><%= t("devise.password_creation.prompt") %></p>
-        <ul class="password-validation-checklist">
-          <li id="too_short"><i class="fas fa-check-circle"></i><%= t("devise.password_creation.too_short") %></li>
-          <li id="needs_number"><i class="fas fa-check-circle"></i><%= t("devise.password_creation.needs_number") %></li>
-          <li id="needs_lower"><i class="fas fa-check-circle"></i><%= t("devise.password_creation.needs_lower_case") %></li>
-          <li id="needs_upper"><i class="fas fa-check-circle"></i><%= t("devise.password_creation.needs_upper_case") %></li>
-        </ul>
+      <div class="password-form">
+        <%= f.password_field :password, type: "password", id: "password-input", class: "password-input", autofocus: true, autocomplete: "off" %>
+        <input id="toggle-password" type="button" class="btn btn-light password-toggle-button" value="Show">
+      </div>
+      <% if resource.errors[:password].any? %>
+        <div class="error-message"><%= t("devise.password_creation.submission_error") %></div>
+      <% end %>
+      <div id="validation-error-message" class="error-message hidden">
+        <%= t("devise.password_creation.validation_error") %>
+      </div>
+      <p class="password-prompt"><%= t("devise.password_creation.prompt") %></p>
+      <ul class="password-validation-checklist">
+        <li id="too_short"><i class="fas fa-check-circle"></i><%= t("devise.password_creation.too_short") %></li>
+        <li id="needs_number"><i class="fas fa-check-circle"></i><%= t("devise.password_creation.needs_number") %></li>
+        <li id="needs_lower"><i class="fas fa-check-circle"></i><%= t("devise.password_creation.needs_lower_case") %></li>
+        <li id="needs_upper"><i class="fas fa-check-circle"></i><%= t("devise.password_creation.needs_upper_case") %></li>
+      </ul>
       <%= f.primary t("devise.invitations.edit.submit_button"), id: "password-submit", disabled: true %>
     <% end %>
   </div>

--- a/app/views/email_authentications/passwords/_expired_reset_token.html.erb
+++ b/app/views/email_authentications/passwords/_expired_reset_token.html.erb
@@ -1,0 +1,12 @@
+<body class="error-body">
+  <div class="dialog">
+    <div class="text">
+      <img src="http://simple.org/images/simple-wordmark-standard.svg">
+      <h1>Reset link expired</h1>
+      <p>
+        The password link expired. <%= link_to "Click here", new_email_authentication_password_path %> to request a new link.
+      </p>
+    </div>
+    <%= link_to "RETURN HOME", "/" %>
+  </div>
+</body>

--- a/app/views/email_authentications/passwords/edit.html.erb
+++ b/app/views/email_authentications/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<% unless resource.reset_password_period_valid? == false # explicitly check false because it can be nil %>
+<% unless resource.reset_password_period_valid? == false %>
   <h1><%= t("devise.password_creation.reset_header") %></h1>
 
   <div class="row">

--- a/app/views/email_authentications/passwords/edit.html.erb
+++ b/app/views/email_authentications/passwords/edit.html.erb
@@ -1,9 +1,10 @@
-<h1><%= t("devise.password_creation.reset_header") %></h1>
+<% unless resource.reset_password_period_valid? == false # explicitly check false because it can be nil %>
+  <h1><%= t("devise.password_creation.reset_header") %></h1>
 
-<div class="row">
-  <div class="col-md-8">
-    <%= bootstrap_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, inline_errors: false) do |f| %>
-      <%= f.hidden_field :reset_password_token, readonly: true %>
+  <div class="row">
+    <div class="col-md-8">
+      <%= bootstrap_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, inline_errors: false) do |f| %>
+        <%= f.hidden_field :reset_password_token, readonly: true %>
         <div class="password-form">
           <%= f.password_field :password, type: "password", id: "password-input", class: "password-input", autofocus: true, autocomplete: "off" %>
           <input id="toggle-password" type="button" class="btn btn-light password-toggle-button" value="Show">
@@ -21,17 +22,20 @@
           <li id="needs_lower"><i class="fas fa-check-circle"></i><%= t("devise.password_creation.needs_lower_case") %></li>
           <li id="needs_upper"><i class="fas fa-check-circle"></i><%= t("devise.password_creation.needs_upper_case") %></li>
         </ul>
-      <%= f.primary t("devise.password_creation.reset_button"), id: "password-submit", disabled: true %>
-    <% end %>
+        <%= f.primary t("devise.password_creation.reset_button"), id: "password-submit", disabled: true %>
+      <% end %>
+    </div>
   </div>
-</div>
 
-<div class="actions mt-4">
-  <%= render "email_authentications/shared/links" %>
-</div>
+  <div class="actions mt-4">
+    <%= render "email_authentications/shared/links" %>
+  </div>
 
-<script>
-  new PasswordVisibilityToggle();
-  const validator = new PasswordValidation();
-  validator.initialize();
-</script>
+  <script>
+    new PasswordVisibilityToggle();
+    const validator = new PasswordValidation();
+    validator.initialize();
+  </script>
+<% else %>
+  <%= render partial: "expired_reset_token" %>
+<% end %>


### PR DESCRIPTION
**Story card:** [ch2783](https://app.clubhouse.io/simpledotorg/story/2783/flapping-test-invitations-controller)

## Because

It's confusing for a user if they're trying to reset a password and they can't because their reset token is expired. This probably doesn't impact many users, but it did impact me a couple of times while I was working on password resets. 

## This addresses

Currently, if a user's password reset token is expired, the password reset page will not in any way inform them and will silently fail. 

## Testing

- It can be helpful to change the devise config `  config.reset_password_within = 6.hours` to `1.second` to ensure that your token is expired. 
- go to reset link
- enter valid password
- submission should route you to the error page

It would be a better user experience if the link went directly to the error page rather than requiring submission, but I don't think that's possible without subclassing the devise controller because the validated EmailAuthentication in the view doesn't have any reset token errors. Subclassing the controller wouldn't be terribly difficult but would probably require learning some devise internals and I didn't think it was worth it in this case. 
