### PR TITLE
Performance table improvements

### DIFF
--- a/app/views/reports/regions/_child_data_tables_with_exclusions.html.erb
+++ b/app/views/reports/regions/_child_data_tables_with_exclusions.html.erb
@@ -16,38 +16,66 @@
         <col>
       </colgroup>
       <thead>
+        <tr>
+          <th></th>
+          <th colspan="2">
+            BP controlled
+            <%= render "definition_tooltip",
+                    definitions: { "Numerator" => t("bp_controlled_copy.numerator"),
+                                  "Denominator" => t("denominator_excluding_ltfu_copy", region_name: @region.name) }
+            %>
+          </th>
+          <th colspan="2">
+            BP not controlled
+            <%= render "definition_tooltip",
+                    definitions: { "Numerator" => t("bp_not_controlled_copy.numerator"),
+                                  "Denominator" => t("denominator_excluding_ltfu_copy", region_name: @region.name) }
+            %>
+          </th>
+          <th colspan="2">
+            Missed visits
+            <%= render "definition_tooltip",
+                    definitions: { "Numerator" => t("missed_visits_copy.numerator"),
+                                  "Denominator" => t("denominator_excluding_ltfu_copy", region_name: @region.name) }
+            %>
+          </th>
+          <th colspan="2">
+            Registrations
+            <%= render "definition_tooltip",
+                      definitions: {
+                        "Total registered patients" => t("registered_patients_copy.total_registered_patients", region_name: @region.name),
+                        "Monthly registered patients" => t("registered_patients_copy.monthly_registered_patients", region_name: @region.name)
+                      }
+            %>
+          </th>
+        </tr>
         <tr class="sorts" data-sort-method="thead">
           <th class="row-label sort-label sort-label-small ta-left" data-sort-default>
             <%= region_type.capitalize %>
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            BP controlled
+            Percent
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Patients with<br>
-            BP controlled
+            Total patients
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            BP not controlled
+            Percent
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Patients with<br>
-            BP not controlled
+            Total patients
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Missed visits
+            Percent
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Patients with<br>
-            a missed visit
+            Total patients
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Total registered<br>
-            patients
+            Total
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Patients registered<br>
-            in <%= @period.to_s %>
+            <%= @period.to_s %>
           </th>
         </tr>
       </thead>
@@ -56,20 +84,44 @@
           <td class="type-title">
             <%= @region.name %>
           </td>
-          <td class="ta-left">
-            <%= number_to_percentage(@data.last_value(:controlled_patients_rate), precision: 0) %>
+          <td
+            class="type-percent"
+            data-sort-column-key="bp-controlled-rate"
+            data-sort="<%= @data.last_value(:controlled_patients_rate) %>"
+            data-toggle="tooltip"
+            title="<%= number_with_delimiter(@data.last_value(:controlled_patients)) %> / <%= number_with_delimiter(@data.last_value(:adjusted_registrations)) %> patients"
+          >
+            <em data-rate="<%= @data.last_value(:controlled_patients_rate) %>">
+              <%= number_to_percentage(@data.last_value(:controlled_patients_rate), precision: 0) %>
+            </em>
           </td>
           <td class="ta-left">
             <%= number_with_delimiter(@data.last_value(:controlled_patients)) %>
           </td>
-          <td class="ta-left">
-            <%= number_to_percentage(@data.last_value(:uncontrolled_patients_rate), precision: 0) %>
+          <td
+            class="type-percent"
+            data-sort-column-key="bp-not-controlled-rate"
+            data-sort="<%= @data.last_value(:uncontrolled_patients_rate) %>"
+            data-toggle="tooltip"
+            title="<%= number_with_delimiter(@data.last_value(:uncontrolled_patients)) %> / <%= number_with_delimiter(@data.last_value(:adjusted_registrations)) %> patients"
+          >
+            <em data-rate="<%= @data.last_value(:uncontrolled_patients_rate) %>">
+              <%= number_to_percentage(@data.last_value(:uncontrolled_patients_rate), precision: 0) %>
+            </em>
           </td>
           <td class="ta-left">
             <%= number_with_delimiter(@data.last_value(:uncontrolled_patients)) %>
           </td>
-          <td class="ta-left">
-            <%= number_to_percentage(@data.last_value(:missed_visits_rate), precision: 0) %>
+          <td
+            class="type-percent"
+            data-sort-column-key="missed-visits-rate"
+            data-sort="<%= @data.last_value(:missed_visits_rate) %>"
+            data-toggle="tooltip"
+            title="<%= number_with_delimiter(@data.last_value(:missed_visits)) %> / <%= number_with_delimiter(@data.last_value(:adjusted_registrations)) %> patients"
+          >
+            <em data-rate="<%= @data.last_value(:missed_visits_rate) %>">
+              <%= number_to_percentage(@data.last_value(:missed_visits_rate), precision: 0) %>
+            </em>
           </td>
           <td class="ta-left">
             <%= number_with_delimiter(@data.last_value(:missed_visits)) %>
@@ -92,20 +144,44 @@
                 <%= result.region.name %>
               <% end %>
             </td>
-            <td class="ta-left">
-              <%= number_to_percentage(result["controlled_patients_rate"].values.last || 0, precision: 0) %>
+            <td
+              class="type-percent"
+              data-sort-column-key="bp-controlled-rate"
+              data-sort="<%= result["controlled_patients_rate"].values.last %>"
+              data-toggle="tooltip"
+              title="<%= number_with_delimiter(result["controlled_patients"].values.last) %> / <%= number_with_delimiter(result["adjusted_registrations"].values.last) %> patients"
+            >
+              <em data-rate="<%= result["controlled_patients_rate"].values.last %>">
+                <%= number_to_percentage(result["controlled_patients_rate"].values.last || 0, precision: 0) %>
+              </em>
             </td>
             <td class="ta-left">
               <%= number_with_delimiter(result["controlled_patients"].values.last) %>
             </td>
-            <td class="ta-left">
-              <%= number_to_percentage(result["uncontrolled_patients_rate"].values.last || 0, precision: 0) %>
+            <td
+              class="type-percent"
+              data-sort-column-key="bp-not-controlled-rate"
+              data-sort="<%= result["uncontrolled_patients_rate"].values.last %>"
+              data-toggle="tooltip"
+              title="<%= number_with_delimiter(result["uncontrolled_patients"].values.last) %> / <%= number_with_delimiter(result["adjusted_registrations"].values.last) %> patients"
+            >
+              <em data-rate="<%= result["uncontrolled_patients_rate"].values.last %>">
+                <%= number_to_percentage(result["uncontrolled_patients_rate"].values.last || 0, precision: 0) %>
+              </em>
             </td>
             <td class="ta-left">
               <%= number_with_delimiter(result["uncontrolled_patients"].values.last) %>
             </td>
-            <td class="ta-left">
-              <%= number_to_percentage(result["missed_visits_rate"].values.last || 0, precision: 0) %>
+            <td
+              class="type-percent"
+              data-sort-column-key="missed-vists-rate"
+              data-sort="<%= result["missed_visits_rate"].values.last %>"
+              data-toggle="tooltip"
+              title="<%= number_with_delimiter(result["missed_visits"].values.last) %> / <%= number_with_delimiter(result["adjusted_registrations"].values.last) %> patients"
+            >
+              <em data-rate="<%= result["missed_visits_rate"].values.last %>">
+                <%= number_to_percentage(result["missed_visits_rate"].values.last || 0, precision: 0) %>
+              </em>
             </td>
             <td class="ta-left">
               <%= number_with_delimiter(result["missed_visits"].values.last) %>

--- a/app/views/reports/regions/_child_data_tables_with_exclusions.html.erb
+++ b/app/views/reports/regions/_child_data_tables_with_exclusions.html.erb
@@ -7,75 +7,32 @@
       <colgroup>
         <col>
         <col class="table-divider">
-        <col>
         <col class="table-divider">
-        <col>
         <col class="table-divider">
-        <col>
         <col class="table-divider">
         <col>
       </colgroup>
       <thead>
-        <tr>
-          <th></th>
-          <th colspan="2">
-            BP controlled
-            <%= render "definition_tooltip",
-                    definitions: { "Numerator" => t("bp_controlled_copy.numerator"),
-                                  "Denominator" => t("denominator_excluding_ltfu_copy", region_name: @region.name) }
-            %>
-          </th>
-          <th colspan="2">
-            BP not controlled
-            <%= render "definition_tooltip",
-                    definitions: { "Numerator" => t("bp_not_controlled_copy.numerator"),
-                                  "Denominator" => t("denominator_excluding_ltfu_copy", region_name: @region.name) }
-            %>
-          </th>
-          <th colspan="2">
-            Missed visits
-            <%= render "definition_tooltip",
-                    definitions: { "Numerator" => t("missed_visits_copy.numerator"),
-                                  "Denominator" => t("denominator_excluding_ltfu_copy", region_name: @region.name) }
-            %>
-          </th>
-          <th colspan="2">
-            Registrations
-            <%= render "definition_tooltip",
-                      definitions: {
-                        "Total registered patients" => t("registered_patients_copy.total_registered_patients", region_name: @region.name),
-                        "Monthly registered patients" => t("registered_patients_copy.monthly_registered_patients", region_name: @region.name)
-                      }
-            %>
-          </th>
-        </tr>
         <tr class="sorts" data-sort-method="thead">
           <th class="row-label sort-label sort-label-small ta-left" data-sort-default>
             <%= region_type.capitalize %>
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Percent
+            BP controlled
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Total patients
+            BP not controlled
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Percent
+            Missed visits
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Total patients
+            Total registered<br>
+            patients
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Percent
-          </th>
-          <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Total patients
-          </th>
-          <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Total
-          </th>
-          <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            <%= @period.to_s %>
+            Patients registered<br>
+            in <%= @period.to_s %>
           </th>
         </tr>
       </thead>
@@ -95,9 +52,6 @@
               <%= number_to_percentage(@data.last_value(:controlled_patients_rate), precision: 0) %>
             </em>
           </td>
-          <td class="ta-left">
-            <%= number_with_delimiter(@data.last_value(:controlled_patients)) %>
-          </td>
           <td
             class="type-percent"
             data-sort-column-key="bp-not-controlled-rate"
@@ -109,9 +63,6 @@
               <%= number_to_percentage(@data.last_value(:uncontrolled_patients_rate), precision: 0) %>
             </em>
           </td>
-          <td class="ta-left">
-            <%= number_with_delimiter(@data.last_value(:uncontrolled_patients)) %>
-          </td>
           <td
             class="type-percent"
             data-sort-column-key="missed-visits-rate"
@@ -122,9 +73,6 @@
             <em data-rate="<%= @data.last_value(:missed_visits_rate) %>">
               <%= number_to_percentage(@data.last_value(:missed_visits_rate), precision: 0) %>
             </em>
-          </td>
-          <td class="ta-left">
-            <%= number_with_delimiter(@data.last_value(:missed_visits)) %>
           </td>
           <td class="ta-left">
             <%= number_with_delimiter(@data.last_value(:cumulative_registrations)) %>
@@ -155,9 +103,6 @@
                 <%= number_to_percentage(result["controlled_patients_rate"].values.last || 0, precision: 0) %>
               </em>
             </td>
-            <td class="ta-left">
-              <%= number_with_delimiter(result["controlled_patients"].values.last) %>
-            </td>
             <td
               class="type-percent"
               data-sort-column-key="bp-not-controlled-rate"
@@ -169,9 +114,6 @@
                 <%= number_to_percentage(result["uncontrolled_patients_rate"].values.last || 0, precision: 0) %>
               </em>
             </td>
-            <td class="ta-left">
-              <%= number_with_delimiter(result["uncontrolled_patients"].values.last) %>
-            </td>
             <td
               class="type-percent"
               data-sort-column-key="missed-vists-rate"
@@ -182,9 +124,6 @@
               <em data-rate="<%= result["missed_visits_rate"].values.last %>">
                 <%= number_to_percentage(result["missed_visits_rate"].values.last || 0, precision: 0) %>
               </em>
-            </td>
-            <td class="ta-left">
-              <%= number_with_delimiter(result["missed_visits"].values.last) %>
             </td>
             <td class="ta-left">
               <%= number_with_delimiter(result["cumulative_registrations"].values.last) %>


### PR DESCRIPTION
**Story card:** [ch2839](https://app.clubhouse.io/simpledotorg/story/2839/region-performance-improvements?vc_group_by=day)

## Because

Implementing table improvements suggested by Daniel.

## This addresses

* Add headings row for "BP controlled", "BP not controlled", and "Missed visits"
* Add tooltips to new heading row cells
* Update subheading row titles to "Rate" and "Total patients"
* Display pills for percent values

## Test instructions

+ [ ] Rate displayed in "BP controlled" card matches rate displayed in "BP controlled, Rate" cell
+ [ ] Patient number displayed in numerator subtitle in "BP controlled" card matches number displayed in "BP controlled, Total" cell
+ [ ] Rate displayed in "BP not controlled" card matches rate displayed in "BP not controlled, Rate" cell
+ [ ] Patient number displayed in numerator subtitle in "BP not controlled" card matches number displayed in "BP not controlled, Total" cell
+ [ ] Rate displayed in "Missed visits" card matches rate displayed in "Missed visits, Rate" cell
+ [ ] Patient number displayed in numerator subtitle in "Missed visits" card matches number displayed in "Missed visits, Total" cell