### PR TITLE
Bug: Pluralize "patients" in LTFU numerator and denominator copy

### DIFF
--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -30,7 +30,7 @@
                 <span data-total-patients="<%= number_with_delimiter(@chart_data[:ltfu_trend].last_value(:ltfu_patients)) %>">
                   <%= number_with_delimiter(@chart_data[:ltfu_trend].last_value(:ltfu_patients)) %>
                 </span>
-                patients with no BP taken since
+                <%= "patient".pluralize(@chart_data[:ltfu_trend].last_value(:ltfu_patients)) %> with no BP taken since
                 <span data-period-start="<%= @chart_data[:ltfu_trend].last_value(:period_info)["ltfu_since_date"] %>">
                   <%= @chart_data[:ltfu_trend].last_value(:period_info)["ltfu_since_date"] %>
                 </span>

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -40,7 +40,7 @@
                 <span data-registrations="<%= number_with_delimiter(@chart_data[:ltfu_trend].last_value(:cumulative_assigned_patients)) %>">
                   <%= number_with_delimiter(@chart_data[:ltfu_trend].last_value(:cumulative_assigned_patients)) %>
                 </span>
-                patients registered till
+                <%= "patient".pluralize(@chart_data[:ltfu_trend].last_value(:cumulative_assigned_patients)) %> registered till
                 <span data-registrations-period-end="<%= @chart_data[:ltfu_trend].last_value(:period_info)["start_date"] %>">
                   <%= @chart_data[:ltfu_trend].last_value(:period_info)["start_date"] %>
                 </span>


### PR DESCRIPTION
**Story card:** [ch2853](https://app.clubhouse.io/simpledotorg/story/2853/fix-patients-tense-in-ltfu-card)

## Because

The "Lost to follow-up" card numerator and denominator copy uses "patients" in the wrong tense

## This addresses

Use `pluralize` to format "patient" copy in the numerator and denominator with the right tense

## Test instructions

+ [ ] **Numerator, plural example:** Go to the "Details" section of the "Marble State" Report. The LTFU numerator should say "129 _patients_ with no BP taken..."
+ [ ] **Numerator, singular example:** Go to the "Details" section of the "Standalone North Chard" Report. The LTFU numerator should say "1 patient with no BP taken..."
+ [ ] **Denominator, plural example:** Go to the "Details" section of the "Standalone North Chard" Report. The LTFU denominator should say "of 9 _patients_ registered..."

**Note:** I can't find a region report with only 1 total registered patient