### PR TITLE
Bug: "Registrations" card not showing right monthly registrations date and data

### DIFF
--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -378,16 +378,16 @@
             <div class="flex-1 d-lg-flex align-lg-center flex-lg-1">
               <p
                 class="mb-0px fs-32px fw-bold <% if @data.last_value(:registrations).blank? %>c-grey-medium<% else %>c-purple-medium<% end %> mr-lg-12px"
-                data-monthly-registrations="<%= number_with_delimiter(@data.last_value(:registrations)) %>"
+                data-monthly-registrations="<%= number_with_delimiter(@data.dig(:registrations, @period)) %>"
               >
-                <%= number_with_delimiter(@data.last_value(:registrations)) %>
+                <%= number_with_delimiter(@data.dig(:registrations, @period)) %>
               </p>
               <div>
                 <% if @data.last_value(:registrations) %>
                   <p class="m-0px c-black c-print-black">
-                    new <%= "registration".pluralize(@data.last_value(:registrations)) %><br>in
-                    <span data-registrations-month-end="<%= @data.last_key(:registrations) %>">
-                      <%= @data.last_key(:registrations) %>
+                    new <%= "registration".pluralize(@data.dig(:registrations, @period)) %><br>in
+                    <span data-registrations-month-end="<%= @period %>">
+                      <%= @period %>
                     </span>
                   </p>
                 <% else %>
@@ -417,12 +417,12 @@
                   </span>
                 </p>
                 <p class="m-0px c-grey-dark c-print-black">
-                  <span data-monthly-registrations="<%= number_with_delimiter(@data.last_value(:registrations)) %>">
-                    <%= number_with_delimiter(@data.last_value(:registrations)) %>
+                  <span data-monthly-registrations="<%= @data.dig(:registrations, @period) %>">
+                    <%= number_with_delimiter(@data.dig(:registrations, @period)) %>
                   </span>
-                  new <%= "patient".pluralize(@data.last_value(:registrations)) %> registered in
-                  <span data-registrations-month-end="<%= @data.last_key(:registrations) %>">
-                    <%= @data.last_key(:registrations) %>
+                  new <%= "patient".pluralize(@data.dig(:registrations, @period)) %> registered in
+                  <span data-registrations-month-end="<%= @period %>">
+                    <%= @period %>
                   </span>
                 </p>
               <% else %>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -417,7 +417,7 @@
                   </span>
                 </p>
                 <p class="m-0px c-grey-dark c-print-black">
-                  <span data-monthly-registrations="<%= @data.dig(:registrations, @period) %>">
+                  <span data-monthly-registrations="<%= number_with_delimiter(@data.dig(:registrations, @period)) %>">
                     <%= number_with_delimiter(@data.dig(:registrations, @period)) %>
                   </span>
                   new <%= "patient".pluralize(@data.dig(:registrations, @period)) %> registered in


### PR DESCRIPTION
**Story card:** [ch2850](https://app.clubhouse.io/simpledotorg/story/2850/registrations-card-not-showing-right-monthly-registrations-data)

## Because

The "Registrations" monthly data and date display the wrong values when the monthly registrations in the current period are `0`. This is because we use `last_value` to display the last value in the hash, but since the hash doesn't include period data if the period has `0` monthly registrations, the front-end displays the last month's value.

## This addresses

Uses `dig` to display the selected month's monthly registration data and date.

## Test instructions

* [ ] **With `report_with_exclusions` on:** In the "Registrations" card in Reports overview, check that the monthly registrations data and date show the current month's values.
* [ ] **With `report_with_exclusions` off:** In the "Monthly and cumulative registrations" card in Reports overview, check that the monthly registrations data and date show the current month's values.