### PR TITLE
Region performance card improvements

### DIFF
--- a/app/views/reports/regions/_child_data_tables_with_exclusions.html.erb
+++ b/app/views/reports/regions/_child_data_tables_with_exclusions.html.erb
@@ -16,6 +16,21 @@
         <col>
       </colgroup>
       <thead>
+        <tr>
+          <th></th>
+          <th colspan="2">
+            BP controlled
+          </th>
+          <th colspan="2">
+            BP not controlled
+          </th>
+          <th colspan="2">
+            Missed visits
+          </th>
+          <th colspan="2">
+            Registrations
+          </th>
+        </tr>
         <tr class="sorts" data-sort-method="thead">
           <th class="row-label sort-label sort-label-small ta-left" data-sort-default>
             <%= region_type.capitalize %>

--- a/app/views/reports/regions/_child_data_tables_with_exclusions.html.erb
+++ b/app/views/reports/regions/_child_data_tables_with_exclusions.html.erb
@@ -90,20 +90,44 @@
           <td class="type-title">
             <%= @region.name %>
           </td>
-          <td class="ta-left">
-            <%= number_to_percentage(@data.dig(:controlled_patients_rate, @period), precision: 0) %>
+          <td
+            class="type-percent"
+            data-sort-column-key="total-patients-<%= @period %>"
+            data-sort="<%= @data.dig(:controlled_patients_rate, @period) %>"
+            data-toggle="tooltip"
+            title="<%= number_with_delimiter(@data.dig(:controlled_patients, @period)) %> / <%= number_with_delimiter(@data.dig(:adjusted_registrations, @period)) %> patients"
+          >
+            <em data-rate="<%= @data.dig(:controlled_patients_rate, @period) %>">
+              <%= number_to_percentage(@data.dig(:controlled_patients_rate, @period) || 0, precision: 0) %>
+            </em>
           </td>
           <td class="ta-left">
-            <%= number_with_delimiter(@data.dig(:controlled_patients, @period)) %>
+            <%= number_with_delimiter(@data.dig(:controlled_patients, @period), precision: 0) %>
           </td>
-          <td class="ta-left">
-            <%= number_to_percentage(@data.dig(:uncontrolled_patients_rate, @period), precision: 0) %>
+          <td
+            class="type-percent"
+            data-sort-column-key="total-patients-<%= @period %>"
+            data-sort="<%= @data.dig(:uncontrolled_patients_rate, @period) %>"
+            data-toggle="tooltip"
+            title="<%= number_with_delimiter(@data.dig(:uncontrolled_patients, @period)) %> / <%= number_with_delimiter(@data.dig(:adjusted_registrations, @period)) %> patients"
+          >
+            <em data-rate="<%= @data.dig(:uncontrolled_patients_rate, @period) %>">
+              <%= number_to_percentage(@data.dig(:uncontrolled_patients_rate, @period) || 0, precision: 0) %>
+            </em>
           </td>
           <td class="ta-left">
             <%= number_with_delimiter(@data.dig(:uncontrolled_patients, @period)) %>
           </td>
-          <td class="ta-left">
-            <%= number_to_percentage(@data.dig(:missed_visits_rate, @period), precision: 0) %>
+          <td
+            class="type-percent"
+            data-sort-column-key="total-patients-<%= @period %>"
+            data-sort="<%= @data.dig(:missed_visits_rate, @period) %>"
+            data-toggle="tooltip"
+            title="<%= number_with_delimiter(@data.dig(:missed_visits, @period)) %> / <%= number_with_delimiter(@data.dig(:adjusted_registrations, @period)) %> patients"
+          >
+            <em data-rate="<%= @data.dig(:missed_visits_rate, @period) %>">
+              <%= number_to_percentage(@data.dig(:missed_visits_rate, @period) || 0, precision: 0) %>
+            </em>
           </td>
           <td class="ta-left">
             <%= number_with_delimiter(@data.dig(:missed_visits, @period)) %>

--- a/app/views/reports/regions/_child_data_tables_with_exclusions.html.erb
+++ b/app/views/reports/regions/_child_data_tables_with_exclusions.html.erb
@@ -20,15 +20,39 @@
           <th></th>
           <th colspan="2">
             BP controlled
+            <%= render "definition_tooltip",
+                       definitions: {
+                         "Numerator" => t("bp_controlled_copy.numerator"),
+                         "Denominator" => t("denominator_excluding_ltfu_copy", region_name: @region.name)
+                       }
+            %>
           </th>
           <th colspan="2">
             BP not controlled
+            <%= render "definition_tooltip",
+                       definitions: {
+                         "Numerator" => t("bp_not_controlled_copy.numerator"),
+                         "Denominator" => t("denominator_excluding_ltfu_copy", region_name: @region.name)
+                       }
+            %>
           </th>
           <th colspan="2">
             Missed visits
+            <%= render "definition_tooltip",
+                       definitions: {
+                         "Numerator" => t("missed_visits_copy.numerator"),
+                         "Denominator" => t("denominator_excluding_ltfu_copy", region_name: @region.name)
+                       }
+            %>
           </th>
           <th colspan="2">
             Registrations
+            <%= render "definition_tooltip",
+                       definitions: {
+                         "Total registered patients" => t("registered_patients_copy.total_registered_patients", region_name: @region.name),
+                         "Monthly registered patients" => t("registered_patients_copy.monthly_registered_patients", region_name: @region.name)
+                       }
+            %>
           </th>
         </tr>
         <tr class="sorts" data-sort-method="thead">

--- a/app/views/reports/regions/_child_data_tables_with_exclusions.html.erb
+++ b/app/views/reports/regions/_child_data_tables_with_exclusions.html.erb
@@ -147,20 +147,44 @@
                 <%= result.region.name %>
               <% end %>
             </td>
-            <td class="ta-left">
-              <%= number_to_percentage(result.dig(:controlled_patients_rate, @period), precision: 0) %>
+            <td
+              class="type-percent"
+              data-sort-column-key="total-patients-<%= @period %>"
+              data-sort="<%= result.dig(:controlled_patients_rate, @period) %>"
+              data-toggle="tooltip"
+              title="<%= number_with_delimiter(result.dig(:controlled_patients, @period)) %> / <%= number_with_delimiter(result.dig(:adjusted_registrations, @period)) %> patients"
+            >
+              <em data-rate="<%= result.dig(:controlled_patients_rate, @period) %>">
+                <%= number_to_percentage(result.dig(:controlled_patients_rate, @period) || 0, precision: 0) %>
+              </em>
             </td>
             <td class="ta-left">
               <%= number_with_delimiter(result.dig(:controlled_patients, @period)) %>
             </td>
-            <td class="ta-left">
-              <%= number_to_percentage(result.dig(:uncontrolled_patients_rate, @period), precision: 0) %>
+            <td
+              class="type-percent"
+              data-sort-column-key="total-patients-<%= @period %>"
+              data-sort="<%= result.dig(:uncontrolled_patients_rate, @period) %>"
+              data-toggle="tooltip"
+              title="<%= number_with_delimiter(result.dig(:uncontrolled_patients, @period)) %> / <%= number_with_delimiter(result.dig(:adjusted_registrations, @period)) %> patients"
+            >
+              <em data-rate="<%= result.dig(:uncontrolled_patients_rate, @period) %>">
+                <%= number_to_percentage(result.dig(:uncontrolled_patients_rate, @period) || 0, precision: 0) %>
+              </em>
             </td>
             <td class="ta-left">
               <%= number_with_delimiter(result.dig(:uncontrolled_patients, @period)) %>
             </td>
-            <td class="ta-left">
-              <%= number_to_percentage(result.dig(:missed_visits_rate, @period), precision: 0) %>
+            <td
+              class="type-percent"
+              data-sort-column-key="total-patients-<%= @period %>"
+              data-sort="<%= result.dig(:missed_visits_rate, @period) %>"
+              data-toggle="tooltip"
+              title="<%= number_with_delimiter(result.dig(:missed_visits, @period)) %> / <%= number_with_delimiter(result.dig(:adjusted_registrations, @period)) %> patients"
+            >
+              <em data-rate="<%= result.dig(:missed_visits_rate, @period) %>">
+                <%= number_to_percentage(result.dig(:missed_visits_rate, @period) || 0, precision: 0) %>
+              </em>
             </td>
             <td class="ta-left">
               <%= number_with_delimiter(result.dig(:missed_visits, @period)) %>

--- a/app/views/reports/regions/_child_data_tables_with_exclusions.html.erb
+++ b/app/views/reports/regions/_child_data_tables_with_exclusions.html.erb
@@ -60,33 +60,28 @@
             <%= region_type.capitalize %>
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            BP controlled
+            Percent
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Patients with<br>
-            BP controlled
+            Total
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            BP not controlled
+            Percent
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Patients with<br>
-            BP not controlled
+            Total
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Missed visits
+            Percent
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Patients with<br>
-            a missed visit
+            Total
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Total registered<br>
-            patients
+            Total
           </th>
           <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
-            Patients registered<br>
-            in <%= @period.to_s %>
+            <%= @period.to_s %>
           </th>
         </tr>
       </thead>


### PR DESCRIPTION
**Story card:** [ch2839](https://app.clubhouse.io/simpledotorg/story/2839/region-performance-improvements)

## Because

The region performance card could use some improvements to make copy / data easier to read

## This addresses

* Adds a new header row
* Adds tooltips to header row titles
* Updates sub-header row titles
* Uses tooltips to display percent values

![image](https://user-images.githubusercontent.com/16785131/110388424-14769280-8031-11eb-8287-78a97b15ff82.png)

## Test instructions

**Note:** Turn the `report_with_exclusions` feature flag

* [ ] The last card in the "Overview" section has a white header row with "BP controlled", "BP not controlled", "Missed visits", and "Registrations" sections
* [ ] The last card in the "Overview" section has a sub-header row with "Facility", "Percent", "Total", "Percent", "Total", "Percent", "Total", "Total", "Mar-2021" column titles
* [ ] All "Percent" cells display a pill. When the user hovers over the pill the pill displays the numerator and denominator