### PR TITLE
Don't auto deploy to performance env

### DIFF
--- a/.semaphore/deploy.yml
+++ b/.semaphore/deploy.yml
@@ -41,26 +41,6 @@ blocks:
             - bundle install --deployment --path vendor/bundle
             - cache store
             - BRANCH=$SEMAPHORE_GIT_BRANCH bundle exec cap qa deploy
-  - name: Deploy to Performance
-    dependencies: []
-    task:
-      secrets:
-        - name: sentry-release-auth-token
-        - name: semaphore-deploy-key
-      prologue:
-        commands:
-          - chmod 600 ~/.ssh/semaphore_id_rsa
-          - ssh-add ~/.ssh/semaphore_id_rsa
-      jobs:
-        - name: Deploy to Performance
-          commands:
-            - checkout
-            - sem-version ruby 2.6.6
-            - cache restore
-            - yarn install
-            - bundle install --deployment --path vendor/bundle
-            - cache store
-            - BRANCH=$SEMAPHORE_GIT_BRANCH bundle exec cap india:performance:primary deploy
 agent:
   machine:
     type: e1-standard-2


### PR DESCRIPTION
**Story card:** -

## Because
We shouldn't auto deploy to perf envs since we use it for testing branches on. Auto deploys can put fresh code on the boxes in between a test (which happened yesterday while we were testing patient merge).

## This addresses

This removes perf from semaphore config.