### PR TITLE
Count LTFU numbers as of end of period

### DIFF
--- a/app/assets/javascripts/common/patient_breakdown_reports.js
+++ b/app/assets/javascripts/common/patient_breakdown_reports.js
@@ -109,7 +109,7 @@ PatientBreakdownReports = function () {
         totalPatientsNode.innerHTML = reports.formatNumberWithCommas(totalPatients);
         periodStartNode.innerHTML = period.ltfu_since_date;
         registrationsNode.innerHTML = reports.formatNumberWithCommas(cumulativeAssignedPatients);
-        registrationsPeriodEndNode.innerHTML = period.start_date;
+        registrationsPeriodEndNode.innerHTML = period.bp_control_end_date;
       }
     };
 

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -2,7 +2,7 @@ class Reports::RegionsController < AdminController
   include Pagination
   include GraphicsDownload
 
-  before_action :set_period, only: [:show, :details, :cohort]
+  before_action :set_period, only: [:show, :cohort]
   before_action :set_page, only: [:details]
   before_action :set_per_page, only: [:details]
   before_action :set_force_cache
@@ -45,14 +45,14 @@ class Reports::RegionsController < AdminController
     authorize { current_admin.accessible_facilities(:view_reports).any? }
 
     @show_current_period = true
+    @period = Period.month(Time.current)
     @dashboard_analytics = @region.dashboard_analytics(period: @period.type,
                                                        prev_periods: 6,
                                                        include_current_period: true)
-    @current_month_period = Period.month(Time.current)
     @chart_data = {
-      patient_breakdown: PatientBreakdownService.call(region: @region, period: @current_month_period),
+      patient_breakdown: PatientBreakdownService.call(region: @region, period: @period),
       ltfu_trend: Reports::RegionService.new(region: @region,
-                                             period: @current_month_period,
+                                             period: @period,
                                              with_exclusions: report_with_exclusions?).call
     }
 

--- a/app/models/concerns/patient_reportable.rb
+++ b/app/models/concerns/patient_reportable.rb
@@ -12,15 +12,15 @@ module PatientReportable
     scope :ltfu_as_of, ->(date) do
       joins("LEFT OUTER JOIN latest_blood_pressures_per_patient_per_months
              ON patients.id = latest_blood_pressures_per_patient_per_months.patient_id
-             AND #{sanitize_sql(["bp_recorded_at > ? AND bp_recorded_at < ?", date - LTFU_TIME, date])}")
-        .where("bp_recorded_at IS NULL AND patients.recorded_at < ?", date - LTFU_TIME)
+             AND #{sanitize_sql(["bp_recorded_at > ? AND bp_recorded_at < ?", (date - LTFU_TIME).end_of_month, date])}")
+        .where("bp_recorded_at IS NULL AND patients.recorded_at < ?", (date - LTFU_TIME).end_of_month)
         .distinct(:patient_id)
     end
 
     scope :not_ltfu_as_of, ->(date) do
       joins("LEFT OUTER JOIN latest_blood_pressures_per_patient_per_months
              ON patients.id = latest_blood_pressures_per_patient_per_months.patient_id")
-        .where("bp_recorded_at > ? AND bp_recorded_at < ? OR patients.recorded_at >= ?", date - LTFU_TIME, date, date - LTFU_TIME)
+        .where("bp_recorded_at > ? AND bp_recorded_at < ? OR patients.recorded_at >= ?", (date - LTFU_TIME).end_of_month, date, (date - LTFU_TIME).end_of_month)
         .distinct(:patient_id)
     end
 

--- a/app/models/concerns/patient_reportable.rb
+++ b/app/models/concerns/patient_reportable.rb
@@ -12,15 +12,16 @@ module PatientReportable
     scope :ltfu_as_of, ->(date) do
       joins("LEFT OUTER JOIN latest_blood_pressures_per_patient_per_months
              ON patients.id = latest_blood_pressures_per_patient_per_months.patient_id
-             AND #{sanitize_sql(["bp_recorded_at > ? AND bp_recorded_at < ?", (date - LTFU_TIME).end_of_month, date])}")
-        .where("bp_recorded_at IS NULL AND patients.recorded_at < ?", (date - LTFU_TIME).end_of_month)
+             AND #{sanitize_sql(["bp_recorded_at > ? AND bp_recorded_at < ?", (date.to_date - LTFU_TIME).end_of_month, date])}")
+        .where("bp_recorded_at IS NULL AND patients.recorded_at < ?", (date.to_date - LTFU_TIME).end_of_month)
         .distinct(:patient_id)
     end
 
     scope :not_ltfu_as_of, ->(date) do
       joins("LEFT OUTER JOIN latest_blood_pressures_per_patient_per_months
              ON patients.id = latest_blood_pressures_per_patient_per_months.patient_id")
-        .where("bp_recorded_at > ? AND bp_recorded_at < ? OR patients.recorded_at >= ?", (date - LTFU_TIME).end_of_month, date, (date - LTFU_TIME).end_of_month)
+        .where("bp_recorded_at > ? AND bp_recorded_at < ? OR patients.recorded_at >= ?",
+          ltfu_time_ago(date), date, ltfu_time_ago(date))
         .distinct(:patient_id)
     end
 
@@ -37,6 +38,10 @@ module PatientReportable
       else
         with_hypertension
       end
+    end
+
+    def ltfu_time_ago(date)
+      (date.to_date - LTFU_TIME).end_of_month
     end
   end
 end

--- a/app/models/concerns/patient_reportable.rb
+++ b/app/models/concerns/patient_reportable.rb
@@ -40,7 +40,7 @@ module PatientReportable
       end
     end
 
-    def ltfu_time_ago(date)
+    def self.ltfu_time_ago(date)
       (date.to_date - LTFU_TIME).end_of_month
     end
   end

--- a/app/models/concerns/patient_reportable_matview.rb
+++ b/app/models/concerns/patient_reportable_matview.rb
@@ -12,13 +12,13 @@ module PatientReportableMatview
     scope :excluding_dead, -> { where.not(patient_status: :dead) }
 
     scope :ltfu_as_of, ->(date) do
-      where.not("bp_recorded_at > ? AND bp_recorded_at < ?", (date - LTFU_TIME).end_of_month, date.to_date)
-        .where("patient_recorded_at < ?", (date - LTFU_TIME).end_of_month)
+      where.not("bp_recorded_at > ? AND bp_recorded_at < ?", ltfu_time_ago(date), date.to_date)
+        .where("patient_recorded_at < ?", ltfu_time_ago(date))
     end
 
     scope :not_ltfu_as_of, ->(date) do
-      where("bp_recorded_at > ? AND bp_recorded_at < ?", (date - LTFU_TIME).end_of_month, date.to_date)
-        .or(where("patient_recorded_at >= ?", (date - LTFU_TIME).end_of_month))
+      where("bp_recorded_at > ? AND bp_recorded_at < ?", ltfu_time_ago(date), date.to_date)
+        .or(where("patient_recorded_at >= ?", ltfu_time_ago(date)))
     end
   end
 end

--- a/app/models/concerns/patient_reportable_matview.rb
+++ b/app/models/concerns/patient_reportable_matview.rb
@@ -12,13 +12,13 @@ module PatientReportableMatview
     scope :excluding_dead, -> { where.not(patient_status: :dead) }
 
     scope :ltfu_as_of, ->(date) do
-      where.not("bp_recorded_at > ? AND bp_recorded_at < ?", date.to_date - LTFU_TIME, date.to_date)
-        .where("patient_recorded_at < ?", date - LTFU_TIME)
+      where.not("bp_recorded_at > ? AND bp_recorded_at < ?", (date - LTFU_TIME).end_of_month, date.to_date)
+        .where("patient_recorded_at < ?", (date - LTFU_TIME).end_of_month)
     end
 
     scope :not_ltfu_as_of, ->(date) do
-      where("bp_recorded_at > ? AND bp_recorded_at < ?", date.to_date - LTFU_TIME, date.to_date)
-        .or(where("patient_recorded_at >= ?", date - LTFU_TIME))
+      where("bp_recorded_at > ? AND bp_recorded_at < ?", (date - LTFU_TIME).end_of_month, date.to_date)
+        .or(where("patient_recorded_at >= ?", (date - LTFU_TIME).end_of_month))
     end
   end
 end

--- a/app/models/reports/result.rb
+++ b/app/models/reports/result.rb
@@ -179,8 +179,7 @@ module Reports
       self.period_info = range.each_with_object({}) do |period, hsh|
         hsh[period] = {
           name: period.to_s,
-          start_date: period.start_date.to_s(:day_mon_year),
-          ltfu_since_date: period.start_date.advance(months: -12).to_s(:day_mon_year),
+          ltfu_since_date: period.start_date.advance(months: -12).end_of_month.to_s(:day_mon_year),
           bp_control_start_date: period.bp_control_range_start_date,
           bp_control_end_date: period.bp_control_range_end_date,
           bp_control_registration_date: period.bp_control_registrations_until_date

--- a/app/queries/blood_pressure_control_query.rb
+++ b/app/queries/blood_pressure_control_query.rb
@@ -82,7 +82,7 @@ class BloodPressureControlQuery
       Patient
         .for_reports(
           with_exclusions: @with_exclusions,
-          exclude_ltfu_as_of: Date.today
+          exclude_ltfu_as_of: Date.today.end_of_month
         )
         .where(assigned_facility: facilities)
         .where("recorded_at < ?", Time.current.beginning_of_day - REGISTRATION_BUFFER)

--- a/app/queries/missed_visits_query.rb
+++ b/app/queries/missed_visits_query.rb
@@ -59,7 +59,7 @@ class MissedVisitsQuery
   def total_patients_per_facility
     @total_patients_per_facility ||=
       Patient
-        .for_reports(with_exclusions: @with_exclusions, exclude_ltfu_as_of: Date.today)
+        .for_reports(with_exclusions: @with_exclusions, exclude_ltfu_as_of: Date.today.end_of_month)
         .where(assigned_facility: facilities)
         .group(:assigned_facility_id)
         .count

--- a/app/queries/no_bp_measure_query.rb
+++ b/app/queries/no_bp_measure_query.rb
@@ -9,7 +9,7 @@ class NoBPMeasureQuery
     registration_date = period.blood_pressure_control_range.begin
 
     Patient
-      .for_reports(with_exclusions: with_exclusions, exclude_ltfu_as_of: period.start_date)
+      .for_reports(with_exclusions: with_exclusions, exclude_ltfu_as_of: period.end_date)
       .joins(sanitize_sql(["LEFT OUTER JOIN appointments ON appointments.patient_id = patients.id
           AND appointments.device_created_at > ?
           AND appointments.device_created_at <= ?", start_date, end_date]))

--- a/app/services/control_rate_service.rb
+++ b/app/services/control_rate_service.rb
@@ -92,7 +92,7 @@ class ControlRateService
     Patient
       .for_reports(with_exclusions: with_exclusions)
       .where(assigned_facility: facilities.pluck(:id))
-      .ltfu_as_of(period.start_date)
+      .ltfu_as_of(period.end_date)
       .count
   end
 

--- a/app/services/no_bp_measure_service.rb
+++ b/app/services/no_bp_measure_service.rb
@@ -42,7 +42,7 @@ class NoBPMeasureService
     registration_date = period.blood_pressure_control_range.begin
 
     Patient
-      .for_reports(with_exclusions: with_exclusions, exclude_ltfu_as_of: period.start_date)
+      .for_reports(with_exclusions: with_exclusions, exclude_ltfu_as_of: period.end_date)
       .joins(sanitize_sql(["LEFT OUTER JOIN appointments ON appointments.patient_id = patients.id
           AND appointments.device_created_at > ?
           AND appointments.device_created_at <= ?", start_date, end_date]))

--- a/app/services/patient_breakdown_service.rb
+++ b/app/services/patient_breakdown_service.rb
@@ -16,7 +16,7 @@ class PatientBreakdownService
 
   def call
     Rails.cache.fetch(cache_key, version: cache_version, expires_in: 7.days, force: force_cache?) {
-      breakdown_date = @period.start_date
+      breakdown_date = @period.end_date
       patients = Patient.with_hypertension.where(assigned_facility: facilities)
 
       {

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -41,8 +41,8 @@
                   <%= number_with_delimiter(@chart_data[:ltfu_trend].last_value(:cumulative_assigned_patients)) %>
                 </span>
                 <%= "patient".pluralize(@chart_data[:ltfu_trend].last_value(:cumulative_assigned_patients)) %> registered till
-                <span data-registrations-period-end="<%= @chart_data[:ltfu_trend].last_value(:period_info)["start_date"] %>">
-                  <%= @chart_data[:ltfu_trend].last_value(:period_info)["start_date"] %>
+                <span data-registrations-period-end="<%= @chart_data[:ltfu_trend].last_value(:period_info)["bp_control_end_date"] %>">
+                  <%= @chart_data[:ltfu_trend].last_value(:period_info)["bp_control_end_date"] %>
                 </span>
               </p>
             <% else %>
@@ -81,7 +81,7 @@
                                     "Lost to follow-up" => t("lost_to_follow_up_copy.reports_card_subtitle") } %>
         </div>
         <p class="mb-0px c-grey-dark mr-lg-12px"><%= number_with_delimiter(@chart_data[:patient_breakdown][:total_patients]) %>
-          hypertension patients assigned to <%= @region.name %> as of <%= @chart_data[:ltfu_trend].last_value(:period_info)["start_date"] %></p>
+          hypertension patients assigned to <%= @region.name %> as of <%= @chart_data[:ltfu_trend].last_value(:period_info)["bp_control_end_date"] %></p>
       </div>
       <div class="p-relative mb-16px d-lg-flex">
         <div class="w-360px h-360px">

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
         "name" => "Dec-2019",
         "bp_control_start_date" => "1-Oct-2019",
         "bp_control_end_date" => "31-Dec-2019",
-        "ltfu_since_date" => "1-Dec-2018",
+        "ltfu_since_date" => "31-Dec-2018",
         "bp_control_registration_date" => "30-Sep-2019"
       }
       expect(data[:period_info][dec_2019_period]).to eq(period_hash)

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -203,7 +203,6 @@ RSpec.describe Reports::RegionsController, type: :controller do
         "name" => "Dec-2019",
         "bp_control_start_date" => "1-Oct-2019",
         "bp_control_end_date" => "31-Dec-2019",
-        "start_date" => "1-Dec-2019",
         "ltfu_since_date" => "1-Dec-2018",
         "bp_control_registration_date" => "30-Sep-2019"
       }

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Reports::Repository, type: :model do
 
   it "gets no bp measure counts" do
     facility_1 = FactoryBot.create_list(:facility, 1, facility_group: facility_group_1).first
-    facility_1_no_bp = create_list(:patient, 1, full_name: "controlled", recorded_at: jan_2019, assigned_facility: facility_1, registration_user: user)
+    facility_1_no_bp = create_list(:patient, 1, full_name: "controlled", recorded_at: jan_2019.advance(months: 1), assigned_facility: facility_1, registration_user: user)
     facility_1_with_bp = create_list(:patient, 1, full_name: "controlled", recorded_at: jan_2019, assigned_facility: facility_1, registration_user: user)
 
     Timecop.freeze(jan_2020) do


### PR DESCRIPTION
**Story card:** [ch2860](https://app.clubhouse.io/simpledotorg/story/2860)

## Because

We currently exclude LTFU numbers as of the beginning of the month in our all time reports. This is bad math while calculating controlled/uncontrolled rates for the current month. Since the BPs that we count are until the end of month but LTFU patients are excluded _as of the beginning of the month_, it's possible we undercount a patient who is registered.

Showing end of month numbers everywhere also keeps things consistent with other graphs.

More detailed discussion [in this Slack thread](https://simpledotorg.slack.com/archives/C01GF5R35RB/p1614696084007400)

## This addresses

### LTFU chart 
This now shows exclusion numbers as of end of month. This means we are counting LTFU since end of month of 12 months ago.
#### Before
![image](https://user-images.githubusercontent.com/16774200/110601759-4e6ba400-81ab-11eb-83af-f09d25741919.png)
#### After
![image](https://user-images.githubusercontent.com/16774200/110601801-588da280-81ab-11eb-8774-1dd96cb75884.png)

### Breakdown pie chart
This shows `Dead` patients as of today and the rest of the patients are LTFU as of the end of the month. The `Transferred` count inside each section is also as of today.
#### Before
![image](https://user-images.githubusercontent.com/16774200/110602202-c1751a80-81ab-11eb-8a43-e3c7c8912492.png)
#### After
![image](https://user-images.githubusercontent.com/16774200/110602060-9a1e4d80-81ab-11eb-913c-cef1c74a9308.png)


### Region reports

The denominator now excludes LTFU patients as of the end of month instead of beginning of month.