### PR TITLE
Remove focus from test group

### DIFF
--- a/spec/controllers/webview/drug_stocks_controller_spec.rb
+++ b/spec/controllers/webview/drug_stocks_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Webview::DrugStocksController, type: :controller do
     Flipper.disable(:drug_stocks)
   end
 
-  fdescribe "GET #new" do
+  describe "GET #new" do
     let(:facility) { create(:facility) }
 
     it "renders 404 for anonymous users" do


### PR DESCRIPTION
**Story card:** N/A

Remove a stray `focus` from a test group. This was used for dev purposes, should not have been merged.