### PR TITLE
Exclude non web requests from Rack mini profiler

### DIFF
--- a/config/initializers/rack_mini_profiler.rb
+++ b/config/initializers/rack_mini_profiler.rb
@@ -1,0 +1,1 @@
+Rack::MiniProfiler.config.skip_paths = [%r{/webview/}, %r{/api}]


### PR DESCRIPTION
[rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler) will sometimes gum up the works when you are
developing against simple-server from the android app. We shouldn't have
it sending its own requests for API or webview requests.

no story, this just makes our dev life easier