### PR TITLE
2890 add assigned patients to progress tab

### DIFF
--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -148,6 +148,33 @@ a.help-back {
       font-weight: normal;
       margin: 0 0 8px 0;
     }
+
+    &.assigned-patients-card {
+      text-align: center;
+      padding: 20px 16px;
+
+      .assigned-count {
+        font-size: 48px;
+        font-weight: bold;
+        line-height: 56px;
+        margin: 0px;
+      }
+
+      .assigned-label {
+        font-size: 18px;
+        font-weight: normal;
+        line-height: 32px;
+        margin: 0px 0px 24px 0px;
+      }
+
+      .assigned-description {
+        font-size: 14px;
+        font-weight: normal;
+        line-height: 22px;
+        margin: 0;
+        padding: 0;
+      }
+    }
 }
 
 .float-right {

--- a/app/presenters/user_analytics_presenter.rb
+++ b/app/presenters/user_analytics_presenter.rb
@@ -348,7 +348,8 @@ class UserAnalyticsPresenter
           follow_ups: follow_ups,
           registrations: registrations
         }
-      }
+      },
+      assigned_hypertension_patients_count: current_facility.assigned_hypertension_patients.count
     }
   end
 

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -75,6 +75,12 @@
     </div>
   </div>
 
+  <div class="card">
+    <h1><%= @user_analytics.current_facility.assigned_hypertension_patients.count %></h1>
+    <h2>Total assigned patients</h2>
+    All hypertension patients assigned to <%= @user_analytics.current_facility.name %>. <%= @user_analytics.current_facility.name %> is responsible to control their hypertension.
+  </div>
+
   <!-- monthly registered patients view -->
   <div class="card">
     <a href="#"  onclick="openWindow('progress-help-registered', 'progress-start'); return false" class="info"><span>?</span></a>

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -75,10 +75,11 @@
     </div>
   </div>
 
-  <div class="card">
-    <h1><%= @user_analytics.current_facility.assigned_hypertension_patients.count %></h1>
-    <h2>Total assigned patients</h2>
-    All hypertension patients assigned to <%= @user_analytics.current_facility.name %>. <%= @user_analytics.current_facility.name %> is responsible to control their hypertension.
+  <!-- display number of patients assigned to facility -->
+  <div class="card assigned-patients-card">
+    <p class="assigned-count"><%= @user_analytics.current_facility.assigned_hypertension_patients.count %></p>
+    <p class="assigned-label">Total assigned patients</p>
+    <p class="assigned-description">All hypertension patients assigned to <%= @user_analytics.current_facility.name %>. <%= @user_analytics.current_facility.name %> is responsible to control their hypertension.</p>
   </div>
 
   <!-- monthly registered patients view -->

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -78,8 +78,8 @@
   <!-- display number of patients assigned to facility -->
   <div class="card assigned-patients-card">
     <p class="assigned-count"><%= @user_analytics.current_facility.assigned_hypertension_patients.count %></p>
-    <p class="assigned-label">Total assigned patients</p>
-    <p class="assigned-description">All hypertension patients assigned to <%= @user_analytics.current_facility.name %>. <%= @user_analytics.current_facility.name %> is responsible to control their hypertension.</p>
+    <p class="assigned-label"> <%= t("analytics.assigned_patients_label") %></p>
+    <p class="assigned-description"> <%= t("analytics.assigned_patients_description", facility_name: @user_analytics.current_facility.name) %></p>
   </div>
 
   <!-- monthly registered patients view -->

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -77,9 +77,9 @@
 
   <!-- display number of patients assigned to facility -->
   <div class="card assigned-patients-card">
-    <p class="assigned-count"><%= @user_analytics.current_facility.assigned_hypertension_patients.count %></p>
-    <p class="assigned-label"> <%= t("analytics.assigned_patients_label") %></p>
-    <p class="assigned-description"> <%= t("analytics.assigned_patients_description", facility_name: @user_analytics.current_facility.name) %></p>
+    <p class="assigned-count"><%= @user_analytics.statistics.dig(:all_time, :assigned_hypertension_patients_count) %></p>
+    <p class="assigned-label"><%= t("analytics.assigned_patients_label") %></p>
+    <p class="assigned-description"><%= t("analytics.assigned_patients_description", facility_name: @user_analytics.current_facility.name) %></p>
   </div>
 
   <!-- monthly registered patients view -->

--- a/config/locales/api/en.yml
+++ b/config/locales/api/en.yml
@@ -75,4 +75,4 @@ en:
       male: "Male"
       transgender: "Transgender"
     assigned_patients_label: "Total assigned patients"
-    assigned_patients_description: "All hypertension patients assigned to %{facility_name}. %{facility_name} is responsible to control their hypertension."
+    assigned_patients_description: "All hypertension patients assigned to %{facility_name}. %{facility_name} is responsible for controlling their hypertension."

--- a/config/locales/api/en.yml
+++ b/config/locales/api/en.yml
@@ -74,3 +74,5 @@ en:
       female: "Female"
       male: "Male"
       transgender: "Transgender"
+    assigned_patients_label: "Total assigned patients"
+    assigned_patients_description: "All hypertension patients assigned to %{facility_name}. %{facility_name} is responsible to control their hypertension."

--- a/spec/presenters/user_analytics_presenter_spec.rb
+++ b/spec/presenters/user_analytics_presenter_spec.rb
@@ -365,6 +365,13 @@ RSpec.describe UserAnalyticsPresenter, type: :model do
           expect(data.dig(:all_time, :grouped_by_date)).to eq(expected_output)
         end
       end
+
+      it "has assigned_hypertension_patients_count" do
+        data = described_class.new(current_facility).statistics
+        expected_output = current_facility.assigned_hypertension_patients.count
+
+        expect(data.dig(:all_time, :assigned_hypertension_patients_count)).to eq(expected_output)
+      end
     end
 
     context "when diabetes management is disabled" do


### PR DESCRIPTION
**Story card:** [ch2890](https://app.clubhouse.io/simpledotorg/story/2890/add-total-assigned-patients-to-progress-bar-web-view)

## Because

We want to display the total assigned patients to the user in the android app. 

## This addresses

## Test instructions

This can be tested either with the android app (more difficult) or by changing headers (see instructions in the readme) and going to: http://localhost:3000/api/v3/analytics/user_analytics.html
Confirm that web view contains the new assigned patients section and matches the mocks.