### PR TITLE
Psuedocode on how to unify registration counts

### DIFF
--- a/app/queries/district_analytics_query.rb
+++ b/app/queries/district_analytics_query.rb
@@ -48,7 +48,8 @@ class DistrictAnalyticsQuery
     # @total_registered_patients
     #   .map { |facility_id, count| [facility_id, {total_registered_patients: count}] }
     #   .to_h
-    RegisteredPatientsQuery.new.total(region)
+
+    region.registered_hypertension_patients.count
   end
 
   def registered_patients_by_period

--- a/app/queries/district_analytics_query.rb
+++ b/app/queries/district_analytics_query.rb
@@ -35,25 +35,27 @@ class DistrictAnalyticsQuery
   end
 
   def total_registered_patients
-    @total_registered_patients ||=
-      Patient
-        .with_hypertension
-        .joins(:registration_facility)
-        .where(facilities: {id: facilities})
-        .group("facilities.id")
-        .count
+    # @total_registered_patients ||=
+    #   Patient
+    #     .with_hypertension
+    #     .joins(:registration_facility)
+    #     .where(facilities: {id: facilities})
+    #     .group("facilities.id")
+    #     .count
 
-    return if @total_registered_patients.blank?
+    # return if @total_registered_patients.blank?
 
-    @total_registered_patients
-      .map { |facility_id, count| [facility_id, {total_registered_patients: count}] }
-      .to_h
+    # @total_registered_patients
+    #   .map { |facility_id, count| [facility_id, {total_registered_patients: count}] }
+    #   .to_h
+    RegisteredPatientsQuery.new.total(region)
   end
 
   def registered_patients_by_period
-    result = ActivityService.new(region, group: [:registration_facility_id]).registrations
+    # result = ActivityService.new(region, group: [:registration_facility_id]).registrations
 
-    group_by_date_and_facility(result, :registered_patients_by_period)
+    # group_by_date_and_facility(result, :registered_patients_by_period)
+    RegisteredPatientsQuery.new.count(region, :month, group_by: :facility_id)
   end
 
   def follow_up_patients_by_period

--- a/app/queries/facility_analytics_query.rb
+++ b/app/queries/facility_analytics_query.rb
@@ -38,7 +38,7 @@ class FacilityAnalyticsQuery
     # @total_registered_patients
     #   .map { |user_id, count| [user_id, {total_registered_patients: count}] }
     #   .to_h
-    RegisteredPatientsQuery.new.count(@facility, :month, group_by: :registration_user_id)
+    region.registered_patients.with_hypertension.count
   end
 
   def registered_patients_by_period

--- a/app/queries/facility_analytics_query.rb
+++ b/app/queries/facility_analytics_query.rb
@@ -30,24 +30,22 @@ class FacilityAnalyticsQuery
   end
 
   def total_registered_patients
-    @total_registered_patients ||=
-      @facility
-        .registered_hypertension_patients
-        .group("registration_user_id")
-        .distinct("patients.id")
-        .count
+    # @total_registered_patients ||=
+    #   @facility.registered_hypertension_patients.group("registration_user_id").distinct("patients.id").count
 
-    return if @total_registered_patients.blank?
+    # return if @total_registered_patients.blank?
 
-    @total_registered_patients
-      .map { |user_id, count| [user_id, {total_registered_patients: count}] }
-      .to_h
+    # @total_registered_patients
+    #   .map { |user_id, count| [user_id, {total_registered_patients: count}] }
+    #   .to_h
+    RegisteredPatientsQuery.new.count(@facility, :month, group_by: :registration_user_id)
   end
 
   def registered_patients_by_period
-    result = ActivityService.new(@facility, group: [:registration_user_id]).registrations
+    # result = ActivityService.new(@facility, group: [:registration_user_id]).registrations
 
-    group_by_date_and_user(result, :registered_patients_by_period)
+    # group_by_date_and_user(result, :registered_patients_by_period)
+    RegisteredPatientsQuery.new.count(region, :month, group_by: :registration_user_id)
   end
 
   def follow_up_patients_by_period


### PR DESCRIPTION
[ch2923](https://app.clubhouse.io/simpledotorg/story/2923/monthly-registered-patients-and-total-registered-patients-query-updates?vc_group_by=day)

Pushing this up as an example of how we can unify the registration patient counts.  This is just one way we could do this - the main thing we want to do is unify the queries used for registration counts to avoid any discrepancies between the overview tab and the details tab.

We need to make some changes to teach `RegisteredPatientsQuery` to group on the `registration_user` and the `facility`, as those are the additional thing we group on for the details tab.



