### PR TITLE
Show LTFU toggle for org managers

### DIFF
--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -25,7 +25,7 @@
               BP controlled
             </h3>
           <% end %>
-          <% if current_admin.feature_enabled?(:report_with_exclusions) && current_admin.feature_enabled?(:ltfu_toggle) %>
+          <% if current_admin.feature_enabled?(:report_with_exclusions) && current_admin.power_user? %>
             <div class="align-right custom-control custom-switch">
               <form method="get">
                 <input type="checkbox"

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -25,7 +25,7 @@
               BP controlled
             </h3>
           <% end %>
-          <% if current_admin.feature_enabled?(:report_with_exclusions) && current_admin.power_user? %>
+          <% if current_admin.feature_enabled?(:report_with_exclusions) && current_admin.accessible_organizations(:manage).any? %>
             <div class="align-right custom-control custom-switch">
               <form method="get">
                 <input type="checkbox"


### PR DESCRIPTION
**Story card:** -

## Because

We are depending on a separate feature flag (`ltfu_toggle`) to show the LTFU toggle to leadership (Dr. Kiran/Dr. Prabhdeep etc.). We planned on making leadership power users, remove this flag and show the toggle to all power users. However a power user's permissions are too wide in scope and we don't want to make non-devs power users. 

We would like to show the toggle to org owners, which covers our needs.

## This addresses

Removes the `ltfu_toggle` feature flag. 
