### PR TITLE
Add a back button on drug stock success page

### DIFF
--- a/app/views/webview/drug_stocks/index.html.erb
+++ b/app/views/webview/drug_stocks/index.html.erb
@@ -13,33 +13,38 @@
 
 <body id="progress">
   <div id="progress-start" class="progress-body">
-    
     <div class="progress-contents">
+
+      <a href="#" title="Go Back" class="help-back">
+        <%= inline_svg("icon_back.svg") %>
+      </a>
       
-    <div class="card" style="margin: 80px 0 80px 0;">
-      <div style="height: 200px; background: transparent url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTMyIiBoZWlnaHQ9IjEzMiIgdmlld0JveD0iMCAwIDEzMiAxMzIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxjaXJjbGUgY3g9IjY2IiBjeT0iNjYiIHI9IjY2IiBmaWxsPSIjRTBGRkVEIi8+CjxwYXRoIGQ9Ik01My4xMTE3IDg0Ljc5MTdMMzguMDc1IDY5Ljc1NUMzNy4yNjU0IDY4Ljk0MzYgMzYuMTY2MyA2OC40ODc1IDM1LjAyIDY4LjQ4NzVDMzMuODczOCA2OC40ODc1IDMyLjc3NDYgNjguOTQzNiAzMS45NjUgNjkuNzU1QzMwLjI3NSA3MS40NDUgMzAuMjc1IDc0LjE3NSAzMS45NjUgNzUuODY1TDUwLjA3ODMgOTMuOTc4M0M1MS43NjgzIDk1LjY2ODMgNTQuNDk4MyA5NS42NjgzIDU2LjE4ODMgOTMuOTc4M0wxMDIuMDM1IDQ4LjEzMTZDMTAzLjcyNSA0Ni40NDE2IDEwMy43MjUgNDMuNzExNiAxMDIuMDM1IDQyLjAyMTZDMTAxLjIyNSA0MS4yMTAyIDEwMC4xMjYgNDAuNzU0MiA5OC45OCA0MC43NTQyQzk3LjgzMzggNDAuNzU0MiA5Ni43MzQ2IDQxLjIxMDIgOTUuOTI1IDQyLjAyMTZMNTMuMTExNyA4NC43OTE3WiIgZmlsbD0iIzAwQjg0OSIvPgo8L3N2Zz4K) 50% 50% no-repeat; background-size: 180px;"></div>
-      <h2 style="text-align: center;">Complete!</h2>
-      <p>View drug stock in estimated patient days below</p>
-    </div>
+      <div class="card" style="margin: 80px 0 80px 0;">
+        <div style="height: 200px; background: transparent url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTMyIiBoZWlnaHQ9IjEzMiIgdmlld0JveD0iMCAwIDEzMiAxMzIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxjaXJjbGUgY3g9IjY2IiBjeT0iNjYiIHI9IjY2IiBmaWxsPSIjRTBGRkVEIi8+CjxwYXRoIGQ9Ik01My4xMTE3IDg0Ljc5MTdMMzguMDc1IDY5Ljc1NUMzNy4yNjU0IDY4Ljk0MzYgMzYuMTY2MyA2OC40ODc1IDM1LjAyIDY4LjQ4NzVDMzMuODczOCA2OC40ODc1IDMyLjc3NDYgNjguOTQzNiAzMS45NjUgNjkuNzU1QzMwLjI3NSA3MS40NDUgMzAuMjc1IDc0LjE3NSAzMS45NjUgNzUuODY1TDUwLjA3ODMgOTMuOTc4M0M1MS43NjgzIDk1LjY2ODMgNTQuNDk4MyA5NS42NjgzIDU2LjE4ODMgOTMuOTc4M0wxMDIuMDM1IDQ4LjEzMTZDMTAzLjcyNSA0Ni40NDE2IDEwMy43MjUgNDMuNzExNiAxMDIuMDM1IDQyLjAyMTZDMTAxLjIyNSA0MS4yMTAyIDEwMC4xMjYgNDAuNzU0MiA5OC45OCA0MC43NTQyQzk3LjgzMzggNDAuNzU0MiA5Ni43MzQ2IDQxLjIxMDIgOTUuOTI1IDQyLjAyMTZMNTMuMTExNyA4NC43OTE3WiIgZmlsbD0iIzAwQjg0OSIvPgo8L3N2Zz4K) 50% 50% no-repeat; background-size: 180px;">
+        </div>
 
-    <h3>Drug stock report for end of <%= @for_end_of_month %></h3>
+        <h2 style="text-align: center;">Complete!</h2>
+        <p>View drug stock in estimated patient days below</p>
+      </div>
 
-    <% @protocol_drugs.each do |protocol_drug| %>
-      <div class="card">
-  
-        <h3><%= protocol_drug.name %></h3>
-        <p></p>
-  
-        <div class="form-row">
-          <div class="col">
-            <strong>Received</strong> <%= @drug_stocks[protocol_drug.id].try(&:received) %>
-          </div>
-          <div class="col">
-            <strong>In Stock</strong> <%= @drug_stocks[protocol_drug.id].try(&:in_stock) %>
+      <h3>Drug stock report for end of <%= @for_end_of_month %></h3>
+
+      <% @protocol_drugs.each do |protocol_drug| %>
+        <div class="card">
+    
+          <h3><%= protocol_drug.name %></h3>
+          <p></p>
+    
+          <div class="form-row">
+            <div class="col">
+              <strong>Received</strong> <%= @drug_stocks[protocol_drug.id].try(&:received) %>
+            </div>
+            <div class="col">
+              <strong>In Stock</strong> <%= @drug_stocks[protocol_drug.id].try(&:in_stock) %>
+            </div>
           </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
-
 </body>


### PR DESCRIPTION
To send a user back to the progress tab.  The back button is anchored to the upper left of the screen.  This will be wired up from the Android side via https://github.com/simpledotorg/simple-android/pull/2468.

**Story card:** [ch2929](https://app.clubhouse.io/simpledotorg/story/2929/handle-navigation-and-from-drug-stock-success-page-in-the-android-app)

<img width="446" alt="image" src="https://user-images.githubusercontent.com/69/111354636-84e66a80-8654-11eb-8c3a-a6523a6e5efc.png">
