### PR TITLE
Change link for drug stock progress-tab

### DIFF
--- a/app/views/webview/drug_stocks/index.html.erb
+++ b/app/views/webview/drug_stocks/index.html.erb
@@ -15,7 +15,7 @@
   <div id="progress-start" class="progress-body">
     <div class="progress-contents">
 
-      <a href="#" title="Go Back" class="help-back">
+      <a href="simple://progress-tab" title="Go Back" class="help-back">
         <%= inline_svg("icon_back.svg") %>
       </a>
       


### PR DESCRIPTION
**Story card:** [ch2929](https://app.clubhouse.io/simpledotorg/story/2929/handle-navigation-and-from-drug-stock-success-page-in-the-android-app)

Change the link to something the android app can bind to.