### PR TITLE
Replace "Not lost to follow-up" with "Patients under care"

### DIFF
--- a/app/assets/javascripts/common/patient_breakdown_reports.js
+++ b/app/assets/javascripts/common/patient_breakdown_reports.js
@@ -124,7 +124,7 @@ PatientBreakdownReports = function () {
 
     const chartSegments = {
       "ltfu_patients": { "description" : "Lost to follow-up", color: reports.darkBlueColor},
-      "not_ltfu_patients": { "description": "Not lost to follow-up", color: reports.mediumGreenColor},
+      "not_ltfu_patients": { "description": "Patients under care", color: reports.mediumGreenColor},
       "dead_patients": {"description": "Died", color: reports.mediumRedColor}
     }
 

--- a/app/views/reports/regions/_details_footnotes.html.erb
+++ b/app/views/reports/regions/_details_footnotes.html.erb
@@ -47,11 +47,11 @@
   </div>
   <div class="mb-24px">
     <p class="mb-8px fs-16px fw-bold c-grey-dark">
-      Not lost to follow-up
+      Patients under care
     </p>
     <div class="pl-16px">
       <p class="mb-0px fs-14px c-grey-dark">
-        <%= t("not_lost_to_follow_up_copy", region_name: @region.name) %>
+        <%= t("patients_under_care_copy", region_name: @region.name) %>
       </p>
     </div>
   </div>

--- a/app/views/reports/regions/_overview_footnotes.html.erb
+++ b/app/views/reports/regions/_overview_footnotes.html.erb
@@ -91,6 +91,16 @@
   </div>
   <div class="mb-24px">
     <p class="mb-8px fs-16px fw-bold c-grey-dark">
+      Patients under care
+    </p>
+    <div class="pl-16px">
+      <p class="mb-0px fs-14px c-grey-dark">
+        <%= t("patients_under_care_copy") %>
+      </p>
+    </div>
+  </div>
+  <div class="mb-24px">
+    <p class="mb-8px fs-16px fw-bold c-grey-dark">
       Lost to follow-up
     </p>
     <div class="pl-16px">

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -77,7 +77,7 @@
             Assigned patients breakdown
           </h3>
           <%= render "definition_tooltip",
-                     definitions: { "Not lost to follow-up" => t("not_lost_to_follow_up_copy"),
+                     definitions: { "Patients under care" => t("patients_under_care_copy"),
                                     "Lost to follow-up" => t("lost_to_follow_up_copy.reports_card_subtitle") } %>
         </div>
         <p class="mb-0px c-grey-dark mr-lg-12px"><%= number_with_delimiter(@chart_data[:patient_breakdown][:total_patients]) %>

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -91,7 +91,7 @@
           <div class="mr-16px mb-12px">
             <p class="mb-1">
               <span class="legend-label bg-green"></span>
-              Not lost to follow-up
+              Patients under care
             </p>
             <p class="mb-1">
               <span class="legend-label bg-blue-dark"></span>

--- a/app/views/reports/regions/_treatment_outcomes_card.html.erb
+++ b/app/views/reports/regions/_treatment_outcomes_card.html.erb
@@ -1,6 +1,6 @@
 <div id="visit-details" data-period="<%= @period.to_s %>" class="mt-8px mx-0px mb-16px p-20px py-lg-20px pr-lg-20px pl-lg-0px bg-white br-4px bs-small d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid pb-after-always b-print-black w-print-16cm">
   <h3 class="mb-0px pl-20px">
-    Treatment outcomes for patients under care
+    Treatment outcomes of patients under care
   </h3>
   <% if @data[:cumulative_assigned_patients].values&.last %>
     <div class="d-flex fd-column fd-lg-row">

--- a/app/views/reports/regions/_treatment_outcomes_card.html.erb
+++ b/app/views/reports/regions/_treatment_outcomes_card.html.erb
@@ -1,6 +1,6 @@
 <div id="visit-details" data-period="<%= @period.to_s %>" class="mt-8px mx-0px mb-16px p-20px py-lg-20px pr-lg-20px pl-lg-0px bg-white br-4px bs-small d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid pb-after-always b-print-black w-print-16cm">
   <h3 class="mb-0px pl-20px">
-    Treatment outcomes for hypertension patients under care
+    Treatment outcomes for patients under care
   </h3>
   <% if @data[:cumulative_assigned_patients].values&.last %>
     <div class="d-flex fd-column fd-lg-row">

--- a/app/views/reports/regions/_treatment_outcomes_card.html.erb
+++ b/app/views/reports/regions/_treatment_outcomes_card.html.erb
@@ -1,6 +1,6 @@
 <div id="visit-details" data-period="<%= @period.to_s %>" class="mt-8px mx-0px mb-16px p-20px py-lg-20px pr-lg-20px pl-lg-0px bg-white br-4px bs-small d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid pb-after-always b-print-black w-print-16cm">
   <h3 class="mb-0px pl-20px">
-    Visit details of all assigned hypertension patients
+    Treatment outcomes for hypertension patients under care
   </h3>
   <% if @data[:cumulative_assigned_patients].values&.last %>
     <div class="d-flex fd-column fd-lg-row">

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -457,7 +457,7 @@
   </div>
 </div>
 
-<%= render "visit_details_card" %>
+<%= render "treatment_outcomes_card" %>
 
 <% if @children_data.any? %>
   <%= render "child_data_tables", data: @children_data, region_type: @children.first.region_type %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,7 +68,7 @@ en:
   denominator_excluding_ltfu_copy: "Hypertension patients assigned to %{region_name}, registered before the last 3 months. Dead and lost to follow-up patients are excluded."
   ltfu_denominator_copy: "Hypertension patients assigned to %{region_name}. Dead patients are excluded."
   follow_up_patients_copy: "Hypertension patients with a BP measure taken during a month in %{region_name}."
-  not_lost_to_follow_up_copy: "Hypertension patients with a BP taken in the last 12 months."
+  patients_under_care_copy: "Hypertension patients with a BP taken in the last 12 months."
   bp_measures_taken_copy: "All BP measures taken in a month by healthcare workers at %{region_name}."
 
   admin:


### PR DESCRIPTION
**Story card:** [ch2978](https://app.clubhouse.io/simpledotorg/story/2978/update-patients-under-care-copy)

## Because

Dr. Prabhdeep requested we add a "Patients under care" definition to the Dashboard and make a few changes to card titles so copy more accurately reflects data displayed.

## This addresses

**Reports, Details, Assigned patients breakdown:**
* Replace "Not lost to follow-up" tooltip title to "Patients under care"
* Replace "Not lost to follow-up" chart legend with "Patients under care"
* Replace "Not lost to follow-up" chart tooltip title with "Patients under care"

![image](https://user-images.githubusercontent.com/16785131/111835666-9b4a2b80-88cb-11eb-9fa0-408611199c2f.png)

**Reports, Details, Definitions**
* Replace "Not lost to follow-up" definition title with "Patients under care"

![image](https://user-images.githubusercontent.com/16785131/111835712-aa30de00-88cb-11eb-89b2-3990dbd27318.png)

**Reports, Overview, Definitions:**
* Replace "Visit details of all assigned hypertension patients" with "Treatment outcomes for patients under care"

![image](https://user-images.githubusercontent.com/16785131/111835546-781f7c00-88cb-11eb-8b15-4b866d24ea26.png)

## Test instructions

*Go through list above and verify that copy changes are implemented without any typos.*