### PR TITLE
Fix visit details graph for new regions

### DIFF
--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -563,7 +563,7 @@ Reports = function () {
         periodStartNodes.forEach(node => node.innerHTML = period.bp_control_start_date);
         periodEndNodes.forEach(node => node.innerHTML = period.bp_control_end_date);
         registrationPeriodEndNodes.forEach(node => node.innerHTML = period.bp_control_registration_date);
-        adjustedPatientCountsNodes.forEach(node => node.innerHTML = adjustedPatientCounts);
+        adjustedPatientCountsNodes.forEach(node => node.innerHTML = this.formatNumberWithCommas(adjustedPatientCounts));
       },
     };
 

--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -436,35 +436,39 @@ Reports = function () {
 
     const visitDetailsGraphConfig = this.createBaseGraphConfig();
     visitDetailsGraphConfig.type = "bar";
+
+    const maxBarsToDisplay = 6;
+    const barsToDisplay = Math.min(Object.keys(data.controlRate).length, maxBarsToDisplay);
+
     visitDetailsGraphConfig.data = {
-      labels: Object.keys(data.controlRate).slice(-6),
+      labels: Object.keys(data.controlRate).slice(-barsToDisplay),
       datasets: [
         {
           label: "BP controlled",
           backgroundColor: this.mediumGreenColor,
           hoverBackgroundColor: this.darkGreenColor,
-          data: Object.values(data.controlRate).slice(-6),
+          data: Object.values(data.controlRate).slice(-barsToDisplay),
           type: "bar",
         },
         {
           label: "BP uncontrolled",
           backgroundColor: this.mediumRedColor,
           hoverBackgroundColor: this.darkRedColor,
-          data: Object.values(data.uncontrolledRate).slice(-6),
+          data: Object.values(data.uncontrolledRate).slice(-barsToDisplay),
           type: "bar",
         },
         {
           label: "Visit but no BP measure",
           backgroundColor: this.mediumGreyColor,
           hoverBackgroundColor: this.darkGreyColor,
-          data: Object.values(data.visitButNoBPMeasureRate).slice(-6),
+          data: Object.values(data.visitButNoBPMeasureRate).slice(-barsToDisplay),
           type: "bar",
         },
         {
           label: "Missed visits",
           backgroundColor: this.mediumBlueColor,
           hoverBackgroundColor: this.darkBlueColor,
-          data: Object.values(data.missedVisitsRate).slice(-6),
+          data: Object.values(data.missedVisitsRate).slice(-barsToDisplay),
           type: "bar",
         },
       ],


### PR DESCRIPTION
**Story card:** [ch2987](https://app.clubhouse.io/simpledotorg/story/2987)

## Because

We found a bug in the visit details card for newer regions. [Slack ref](https://simpledotorg.slack.com/archives/CFHKJ5WJY/p1615901170010000)

## This addresses

This happens because the number of bars we show is fixed in code right now. We display the last 6 numbers for each data point. This can break for `visit but no BP` if the number of available bars (determined by the number of control rate points) is less than 6.

This fixes the JS code to pluck the available number of data points for `visit but no BP` only.

### Before
![image](https://user-images.githubusercontent.com/16774200/112021407-4589b380-8b57-11eb-8434-b0375ff61e33.png)

### After
![image](https://user-images.githubusercontent.com/16774200/112023099-ed53b100-8b58-11eb-8d4d-9e799a20a468.png)
