### PR TITLE
Registration buffer reporting bug (and fix some other possible edge cases)

### DIFF
--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -59,8 +59,8 @@ class Period
   # Returns a range of dates that correspond to the 'control range' for this period.
   # For example, for a month period of July 1st 2020, this will return the range of April 30th..July 31st.
   def blood_pressure_control_range
-    three_months_ago = end_date.advance(months: -3).end_of_month
-    (three_months_ago..end_date)
+    three_months_ago = end_time.advance(months: -3).end_of_month
+    (three_months_ago..end_time)
   end
 
   alias_method :bp_control_range, :blood_pressure_control_range
@@ -94,14 +94,14 @@ class Period
   end
   alias_method :begin, :start_date
 
-  def end_date
+  def end
     if quarter?
       value.end
     else
       value.end_of_month.end_of_day
     end
   end
-  alias_method :end, :end_date
+  alias_method :end_time, :end
 
   def succ
     if quarter?

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -85,14 +85,14 @@ class Period
     value.to_date
   end
 
-  def start_date
+  def begin
     if quarter?
       value.begin
     else
       value.beginning_of_month.beginning_of_day
     end
   end
-  alias_method :begin, :start_date
+  alias_method :start_time, :begin
 
   def end
     if quarter?

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -59,7 +59,7 @@ class Period
   # Returns a range of times that correspond to the 'BP control range' for this period.
   # For example, for a reporting period of July 1st 2020, this will return the times of April 30th..July 31st.
   def blood_pressure_control_range
-    start_time = end_time.advance(months: -2).beginning_of_month.beginning_of_day
+    start_time = advance(months: -2).begin
     (start_time..end_time)
   end
 

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -6,6 +6,8 @@ class Period
 
   attr_accessor :type, :value
 
+  REGISTRATION_BUFFER_MONTHS = -3
+
   def self.month(date)
     new(type: :month, value: date.to_date)
   end
@@ -40,6 +42,10 @@ class Period
 
   def attributes
     {type: type, value: value}
+  end
+
+  def adjusted_period
+    advance(months: REGISTRATION_BUFFER_MONTHS)
   end
 
   # Convert this Period to a quarter period - so:
@@ -86,6 +92,7 @@ class Period
       value.beginning_of_month.to_date
     end
   end
+  alias_method :begin, :start_date
 
   def end_date
     if quarter?
@@ -94,6 +101,7 @@ class Period
       value.end_of_month.to_date
     end
   end
+  alias_method :end, :end_date
 
   def succ
     if quarter?

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -56,11 +56,11 @@ class Period
     self.class.quarter(value)
   end
 
-  # Returns a range of dates that correspond to the 'control range' for this period.
-  # For example, for a month period of July 1st 2020, this will return the range of April 30th..July 31st.
+  # Returns a range of times that correspond to the 'BP control range' for this period.
+  # For example, for a reporting period of July 1st 2020, this will return the times of April 30th..July 31st.
   def blood_pressure_control_range
-    three_months_ago = end_time.advance(months: -3).end_of_month
-    (three_months_ago..end_time)
+    start_time = end_time.advance(months: -2).beginning_of_month.beginning_of_day
+    (start_time..end_time)
   end
 
   alias_method :bp_control_range, :blood_pressure_control_range

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -87,18 +87,18 @@ class Period
 
   def start_date
     if quarter?
-      value.start_date
+      value.begin
     else
-      value.beginning_of_month.to_date
+      value.beginning_of_month.beginning_of_day
     end
   end
   alias_method :begin, :start_date
 
   def end_date
     if quarter?
-      value.end_date
+      value.end
     else
-      value.end_of_month.to_date
+      value.end_of_month.end_of_day
     end
   end
   alias_method :end, :end_date

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -66,11 +66,11 @@ class Period
   alias_method :bp_control_range, :blood_pressure_control_range
 
   def bp_control_registrations_until_date
-    bp_control_range.begin.to_s(:day_mon_year)
+    adjusted_period.end.to_s(:day_mon_year)
   end
 
   def bp_control_range_start_date
-    bp_control_range.begin.next_day.to_s(:day_mon_year)
+    bp_control_range.begin.to_s(:day_mon_year)
   end
 
   def bp_control_range_end_date

--- a/app/models/quarter.rb
+++ b/app/models/quarter.rb
@@ -69,20 +69,20 @@ class Quarter
     date
   end
 
-  def start_date
-    date.beginning_of_quarter
+  def begin
+    date.beginning_of_quarter.beginning_of_day
   end
 
-  def end_date
-    date.end_of_quarter
+  def end
+    date.end_of_quarter.end_of_day
   end
 
   def to_period
     Period.quarter(self)
   end
 
-  alias_method :beginning_of_quarter, :start_date
-  alias_method :end_of_quarter, :end_date
+  alias_method :beginning_of_quarter, :begin
+  alias_method :end_of_quarter, :end
 
   def inspect
     "#<Quarter:#{object_id} #{to_s.inspect}>"

--- a/app/models/reports/result.rb
+++ b/app/models/reports/result.rb
@@ -179,7 +179,7 @@ module Reports
       self.period_info = range.each_with_object({}) do |period, hsh|
         hsh[period] = {
           name: period.to_s,
-          ltfu_since_date: period.start_date.advance(months: -12).end_of_month.to_s(:day_mon_year),
+          ltfu_since_date: period.start.advance(months: -12).end_of_month.to_s(:day_mon_year),
           bp_control_start_date: period.bp_control_range_start_date,
           bp_control_end_date: period.bp_control_range_end_date,
           bp_control_registration_date: period.bp_control_registrations_until_date

--- a/app/models/reports/result.rb
+++ b/app/models/reports/result.rb
@@ -179,7 +179,7 @@ module Reports
       self.period_info = range.each_with_object({}) do |period, hsh|
         hsh[period] = {
           name: period.to_s,
-          ltfu_since_date: period.start.advance(months: -12).end_of_month.to_s(:day_mon_year),
+          ltfu_since_date: period.begin.advance(months: -12).end_of_month.to_s(:day_mon_year),
           bp_control_start_date: period.bp_control_range_start_date,
           bp_control_end_date: period.bp_control_range_end_date,
           bp_control_registration_date: period.bp_control_registrations_until_date

--- a/app/queries/control_rate_query.rb
+++ b/app/queries/control_rate_query.rb
@@ -41,8 +41,8 @@ class ControlRateQuery
       .for_reports(with_exclusions: with_exclusions)
       .select("distinct on (latest_blood_pressures_per_patient_per_months.patient_id) *")
       .where(assigned_facility_id: region.facilities)
-      .where("patient_recorded_at < ?", control_range.begin) # TODO this doesn't seem right -- revisit this exclusion
-      .where("bp_recorded_at > ? and bp_recorded_at <= ?", control_range.begin, control_range.end)
+      .where("patient_recorded_at <= ?", period.adjusted_period.end)
+      .where("bp_recorded_at >= ? and bp_recorded_at <= ?", control_range.begin, control_range.end)
       .order("latest_blood_pressures_per_patient_per_months.patient_id, bp_recorded_at DESC, bp_id")
   end
 end

--- a/app/queries/no_bp_measure_query.rb
+++ b/app/queries/no_bp_measure_query.rb
@@ -4,21 +4,21 @@ class NoBPMeasureQuery
   def call(region, period, with_exclusions: false)
     facility_ids = region.facilities.map(&:id)
     return 0 if facility_ids.blank?
-    start_date = period.blood_pressure_control_range.begin
-    end_date = period.blood_pressure_control_range.end
+    start_time = period.blood_pressure_control_range.begin
+    end_time = period.blood_pressure_control_range.end
     registration_date = period.blood_pressure_control_range.begin
 
     Patient
-      .for_reports(with_exclusions: with_exclusions, exclude_ltfu_as_of: period.end_date)
+      .for_reports(with_exclusions: with_exclusions, exclude_ltfu_as_of: period.end_time)
       .joins(sanitize_sql(["LEFT OUTER JOIN appointments ON appointments.patient_id = patients.id
           AND appointments.device_created_at > ?
-          AND appointments.device_created_at <= ?", start_date, end_date]))
+          AND appointments.device_created_at <= ?", start_time, end_time]))
       .joins(sanitize_sql(["LEFT OUTER JOIN prescription_drugs ON prescription_drugs.patient_id = patients.id
           AND prescription_drugs.device_created_at > ?
-          AND prescription_drugs.device_created_at <= ?", start_date, end_date]))
+          AND prescription_drugs.device_created_at <= ?", start_time, end_time]))
       .joins(sanitize_sql(["LEFT OUTER JOIN blood_sugars ON blood_sugars.patient_id = patients.id
           AND blood_sugars.recorded_at > ?
-          AND blood_sugars.recorded_at <= ?", start_date, end_date]))
+          AND blood_sugars.recorded_at <= ?", start_time, end_time]))
       .where(assigned_facility_id: facility_ids)
       .where("patients.recorded_at <= ?", registration_date)
       .where("appointments.id IS NOT NULL
@@ -29,7 +29,7 @@ class NoBPMeasureQuery
                   FROM blood_pressures bps
                   WHERE patients.id = bps.patient_id
                   AND bps.recorded_at > ?
-                  AND bps.recorded_at <= ?)", start_date, end_date)
+                  AND bps.recorded_at <= ?)", start_time, end_time)
       .distinct("patients.id")
       .count
   end

--- a/app/queries/no_bp_measure_query.rb
+++ b/app/queries/no_bp_measure_query.rb
@@ -11,13 +11,13 @@ class NoBPMeasureQuery
     Patient
       .for_reports(with_exclusions: with_exclusions, exclude_ltfu_as_of: period.end_time)
       .joins(sanitize_sql(["LEFT OUTER JOIN appointments ON appointments.patient_id = patients.id
-          AND appointments.device_created_at > ?
+          AND appointments.device_created_at >= ?
           AND appointments.device_created_at <= ?", start_time, end_time]))
       .joins(sanitize_sql(["LEFT OUTER JOIN prescription_drugs ON prescription_drugs.patient_id = patients.id
-          AND prescription_drugs.device_created_at > ?
+          AND prescription_drugs.device_created_at >= ?
           AND prescription_drugs.device_created_at <= ?", start_time, end_time]))
       .joins(sanitize_sql(["LEFT OUTER JOIN blood_sugars ON blood_sugars.patient_id = patients.id
-          AND blood_sugars.recorded_at > ?
+          AND blood_sugars.recorded_at >= ?
           AND blood_sugars.recorded_at <= ?", start_time, end_time]))
       .where(assigned_facility_id: facility_ids)
       .where("patients.recorded_at <= ?", registration_date)
@@ -28,7 +28,7 @@ class NoBPMeasureQuery
                  (SELECT 1
                   FROM blood_pressures bps
                   WHERE patients.id = bps.patient_id
-                  AND bps.recorded_at > ?
+                  AND bps.recorded_at >= ?
                   AND bps.recorded_at <= ?)", start_time, end_time)
       .distinct("patients.id")
       .count

--- a/app/services/control_rate_service.rb
+++ b/app/services/control_rate_service.rb
@@ -93,7 +93,7 @@ class ControlRateService
     Patient
       .for_reports(with_exclusions: with_exclusions)
       .where(assigned_facility: facilities.pluck(:id))
-      .ltfu_as_of(period.end_date)
+      .ltfu_as_of(period.end)
       .count
   end
 

--- a/app/services/no_bp_measure_service.rb
+++ b/app/services/no_bp_measure_service.rb
@@ -38,23 +38,23 @@ class NoBPMeasureService
 
   def execute_sql(period)
     return 0 if facility_ids.blank?
-    start_date = period.blood_pressure_control_range.begin
-    end_date = period.blood_pressure_control_range.end
-    registration_date = period.blood_pressure_control_range.begin
+    start_time = period.blood_pressure_control_range.begin
+    end_time = period.blood_pressure_control_range.end
+    registration_buffer = period.blood_pressure_control_range.begin
 
     Patient
       .for_reports(with_exclusions: with_exclusions, exclude_ltfu_as_of: period.end)
       .joins(sanitize_sql(["LEFT OUTER JOIN appointments ON appointments.patient_id = patients.id
           AND appointments.device_created_at > ?
-          AND appointments.device_created_at <= ?", start_date, end_date]))
+          AND appointments.device_created_at <= ?", start_time, end_time]))
       .joins(sanitize_sql(["LEFT OUTER JOIN prescription_drugs ON prescription_drugs.patient_id = patients.id
           AND prescription_drugs.device_created_at > ?
-          AND prescription_drugs.device_created_at <= ?", start_date, end_date]))
+          AND prescription_drugs.device_created_at <= ?", start_time, end_time]))
       .joins(sanitize_sql(["LEFT OUTER JOIN blood_sugars ON blood_sugars.patient_id = patients.id
           AND blood_sugars.recorded_at > ?
-          AND blood_sugars.recorded_at <= ?", start_date, end_date]))
+          AND blood_sugars.recorded_at <= ?", start_time, end_time]))
       .where(assigned_facility_id: facility_ids)
-      .where("patients.recorded_at <= ?", registration_date)
+      .where("patients.recorded_at <= ?", registration_buffer)
       .where("appointments.id IS NOT NULL
                 OR prescription_drugs.id IS NOT NULL
                 OR blood_sugars.id IS NOT NULL")
@@ -63,7 +63,7 @@ class NoBPMeasureService
                   FROM blood_pressures bps
                   WHERE patients.id = bps.patient_id
                   AND bps.recorded_at > ?
-                  AND bps.recorded_at <= ?)", start_date, end_date)
+                  AND bps.recorded_at <= ?)", start_time, end_time)
       .distinct("patients.id")
       .count
   end

--- a/app/services/no_bp_measure_service.rb
+++ b/app/services/no_bp_measure_service.rb
@@ -45,13 +45,13 @@ class NoBPMeasureService
     Patient
       .for_reports(with_exclusions: with_exclusions, exclude_ltfu_as_of: period.end)
       .joins(sanitize_sql(["LEFT OUTER JOIN appointments ON appointments.patient_id = patients.id
-          AND appointments.device_created_at > ?
+          AND appointments.device_created_at >= ?
           AND appointments.device_created_at <= ?", start_time, end_time]))
       .joins(sanitize_sql(["LEFT OUTER JOIN prescription_drugs ON prescription_drugs.patient_id = patients.id
-          AND prescription_drugs.device_created_at > ?
+          AND prescription_drugs.device_created_at >= ?
           AND prescription_drugs.device_created_at <= ?", start_time, end_time]))
       .joins(sanitize_sql(["LEFT OUTER JOIN blood_sugars ON blood_sugars.patient_id = patients.id
-          AND blood_sugars.recorded_at > ?
+          AND blood_sugars.recorded_at >= ?
           AND blood_sugars.recorded_at <= ?", start_time, end_time]))
       .where(assigned_facility_id: facility_ids)
       .where("patients.recorded_at <= ?", registration_buffer)
@@ -62,7 +62,7 @@ class NoBPMeasureService
                  (SELECT 1
                   FROM blood_pressures bps
                   WHERE patients.id = bps.patient_id
-                  AND bps.recorded_at > ?
+                  AND bps.recorded_at >= ?
                   AND bps.recorded_at <= ?)", start_time, end_time)
       .distinct("patients.id")
       .count

--- a/app/services/no_bp_measure_service.rb
+++ b/app/services/no_bp_measure_service.rb
@@ -43,7 +43,7 @@ class NoBPMeasureService
     registration_date = period.blood_pressure_control_range.begin
 
     Patient
-      .for_reports(with_exclusions: with_exclusions, exclude_ltfu_as_of: period.end_date)
+      .for_reports(with_exclusions: with_exclusions, exclude_ltfu_as_of: period.end)
       .joins(sanitize_sql(["LEFT OUTER JOIN appointments ON appointments.patient_id = patients.id
           AND appointments.device_created_at > ?
           AND appointments.device_created_at <= ?", start_date, end_date]))

--- a/app/services/patient_breakdown_service.rb
+++ b/app/services/patient_breakdown_service.rb
@@ -17,15 +17,15 @@ class PatientBreakdownService
 
   def call
     Rails.cache.fetch(cache_key, version: cache_version, expires_in: 7.days, force: bust_cache?) {
-      breakdown_date = @period.end_date
+      period_end = @period.end
       patients = Patient.with_hypertension.where(assigned_facility: facilities)
 
       {
         dead_patients: patients.status_dead.count,
-        ltfu_patients: patients.excluding_dead.ltfu_as_of(breakdown_date).count,
-        not_ltfu_patients: patients.excluding_dead.not_ltfu_as_of(breakdown_date).count,
-        ltfu_transferred_patients: patients.ltfu_as_of(breakdown_date).status_migrated.count,
-        not_ltfu_transferred_patients: patients.not_ltfu_as_of(breakdown_date).status_migrated.count,
+        ltfu_patients: patients.excluding_dead.ltfu_as_of(period_end).count,
+        not_ltfu_patients: patients.excluding_dead.not_ltfu_as_of(period_end).count,
+        ltfu_transferred_patients: patients.ltfu_as_of(period_end).status_migrated.count,
+        not_ltfu_transferred_patients: patients.not_ltfu_as_of(period_end).status_migrated.count,
         total_patients: patients.count
       }
     }

--- a/app/views/my_facilities/facility_performance/show.html.erb
+++ b/app/views/my_facilities/facility_performance/show.html.erb
@@ -51,11 +51,11 @@
               </th>
               <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="controlled_patients_rate" colspan="2">
                 Patients with controlled BP from<br>
-                <%= @period.start_date.advance(months: -2).to_s(:day_mon_year) %> to <%= @period.end_date.to_s(:day_mon_year) %>
+                <%= @period.begin.advance(months: -2).to_s(:day_mon_year) %> to <%= @period.end.to_s(:day_mon_year) %>
               </th>
               <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="missed_visits_rate" colspan="2">
                 Patients with no visit from<br>
-                <%= @period.start_date.advance(months: -2).to_s(:day_mon_year) %> to <%= @period.end_date.to_s(:day_mon_year) %>
+                <%= @period.begin.advance(months: -2).to_s(:day_mon_year) %> to <%= @period.end.to_s(:day_mon_year) %>
               </th>
               <th class="row-label sort-label" data-sort-method="number" data-sort-column-key="monthly_registrations" colspan="2">
                 Registrations as % of OPD load<br>

--- a/spec/models/period_spec.rb
+++ b/spec/models/period_spec.rb
@@ -119,15 +119,15 @@ RSpec.describe Period, type: :model do
 
   it "can return its blood pressure control range" do
     range = jan_1_2020_month_period.blood_pressure_control_range
-    expect(range.begin).to eq(Date.parse("October 31st 2019").end_of_day)
+    expect(range.begin).to eq(Date.parse("November 1st 2019").beginning_of_day)
     expect(range.end).to eq(Date.parse("January 31st 2020").end_of_day)
 
     range = Period.month("July 1st 2020").blood_pressure_control_range
-    expect(range.begin).to eq(Date.parse("April 30th 2020").end_of_day)
+    expect(range.begin).to eq(Date.parse("May 1st 2020").beginning_of_day)
     expect(range.end).to eq(Date.parse("July 31st 2020").end_of_day)
 
     range = Period.month("February 1st 2020").blood_pressure_control_range
-    expect(range.begin).to eq(Date.parse("November 30th 2019").end_of_day)
+    expect(range.begin).to eq(Date.parse("December 1st 2019").beginning_of_day)
     expect(range.end).to eq(Date.parse("February 29th 2020").end_of_day)
   end
 

--- a/spec/models/period_spec.rb
+++ b/spec/models/period_spec.rb
@@ -64,6 +64,17 @@ RSpec.describe Period, type: :model do
     end
   end
 
+  context "display dates" do
+    it "knows the registration end date" do
+      expect(jan_1_2019.to_period.bp_control_registrations_until_date).to eq("31-Oct-2018")
+    end
+
+    it "can display the begin / end range of the BP control range" do
+      expect(jan_1_2019.to_period.bp_control_range_start_date).to eq("1-Nov-2018")
+      expect(jan_1_2019.to_period.bp_control_range_end_date).to eq("31-Jan-2019")
+    end
+  end
+
   it "times and dates can convert themselves into periods" do
     expect(jan_1_2019.to_period).to eq(Date.parse("January 1st 2019").to_period)
     expect(jan_1_2019.to_period.value).to eq(Date.parse("January 1st 2019").to_period.value)

--- a/spec/models/period_spec.rb
+++ b/spec/models/period_spec.rb
@@ -119,16 +119,16 @@ RSpec.describe Period, type: :model do
 
   it "can return its blood pressure control range" do
     range = jan_1_2020_month_period.blood_pressure_control_range
-    expect(range.begin).to eq(Date.parse("October 31st 2019"))
-    expect(range.end).to eq(Date.parse("January 31st 2020"))
+    expect(range.begin).to eq(Date.parse("October 31st 2019").end_of_day)
+    expect(range.end).to eq(Date.parse("January 31st 2020").end_of_day)
 
     range = Period.month("July 1st 2020").blood_pressure_control_range
-    expect(range.begin).to eq(Date.parse("April 30th 2020"))
-    expect(range.end).to eq(Date.parse("July 31st 2020"))
+    expect(range.begin).to eq(Date.parse("April 30th 2020").end_of_day)
+    expect(range.end).to eq(Date.parse("July 31st 2020").end_of_day)
 
     range = Period.month("February 1st 2020").blood_pressure_control_range
-    expect(range.begin).to eq(Date.parse("November 30th 2019"))
-    expect(range.end).to eq(Date.parse("February 29th 2020"))
+    expect(range.begin).to eq(Date.parse("November 30th 2019").end_of_day)
+    expect(range.end).to eq(Date.parse("February 29th 2020").end_of_day)
   end
 
   it "can be used in ranges" do
@@ -146,14 +146,14 @@ RSpec.describe Period, type: :model do
     expect(q1_01.hash).to_not eq(q2.hash)
   end
 
-  it "months provide start and end dates" do
-    expect(may_8_2020_month_period.start_date).to eq(Date.parse("May 1st, 2020"))
-    expect(may_8_2020_month_period.end_date).to eq(Date.parse("May 31st, 2020"))
+  it "months provide begin and end" do
+    expect(may_8_2020_month_period.begin).to eq(Time.zone.parse("May 1st, 2020").beginning_of_day)
+    expect(may_8_2020_month_period.end).to eq(Time.zone.parse("May 31st, 2020").end_of_day)
   end
 
-  it "quarters provide start and end dates" do
-    expect(q2_2020_period.start_date).to eq(Date.parse("April 1st, 2020"))
-    expect(q2_2020_period.end_date).to eq(Date.parse("June 30, 2020"))
+  it "quarters provide start and end" do
+    expect(q2_2020_period.begin).to eq(Date.parse("April 1st, 2020").beginning_of_day)
+    expect(q2_2020_period.end).to eq(Date.parse("June 30, 2020").end_of_day)
   end
 
   it "has adjective description" do

--- a/spec/models/quarter_spec.rb
+++ b/spec/models/quarter_spec.rb
@@ -103,10 +103,10 @@ RSpec.describe Quarter, type: :model do
     end
   end
 
-  it "can return its start and end dates" do
+  it "can return its begin and end times" do
     date = Time.parse("May 21st, 2020")
     quarter = Quarter.new(date: date)
-    expect(quarter.start_date).to eq(Date.parse("April 1, 2020"))
-    expect(quarter.end_date).to eq(Date.parse("June 30, 2020"))
+    expect(quarter.begin).to eq(Date.parse("April 1, 2020").beginning_of_day)
+    expect(quarter.end).to eq(Date.parse("June 30, 2020").end_of_day)
   end
 end

--- a/spec/queries/control_rate_query_spec.rb
+++ b/spec/queries/control_rate_query_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ControlRateQuery do
       expect(august).to eq(0)
     end
 
-    fit "includes patients who were registered at the end of the registration buffer" do
+    it "includes patients who were registered at the end of the registration buffer" do
       facility = FactoryBot.create(:facility, facility_group: facility_group_1)
       controlled = create(:patient, recorded_at: Time.parse("December 31st 2020 23:59:00 UTC"), assigned_facility: facility, registration_user: user)
       uncontrolled = create(:patient, status: :dead, recorded_at: jan_2019, assigned_facility: facility, registration_user: user)

--- a/spec/queries/control_rate_query_spec.rb
+++ b/spec/queries/control_rate_query_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ControlRateQuery do
       expect(august).to eq(0)
     end
 
-    it "includes patients who were registered at the end of the registration buffer" do
+    fit "includes patients who were registered at the end of the registration buffer" do
       facility = FactoryBot.create(:facility, facility_group: facility_group_1)
       controlled = create(:patient, recorded_at: Time.parse("December 31st 2020 23:59:00 UTC"), assigned_facility: facility, registration_user: user)
       uncontrolled = create(:patient, status: :dead, recorded_at: jan_2019, assigned_facility: facility, registration_user: user)


### PR DESCRIPTION
**Story card:** [ch2861](https://app.clubhouse.io/simpledotorg/story/2861/reports-bug-missing-visits)

We are miscounting some patients where their registration date falls on the boundary of our three month 'registration buffer'.

For example:

Patient registers on December 31st.  An admin views a report in March, which _should_ include that patient in the control / uncontrolled counts for the current report. Currently the report does not include that patient for controlled counts, because the Period object returns a Date for the `recorded_at` where clause, and not a Time.  So we have a clause like this in the SQL:

```
AND (patient_recorded_at <= '2020-12-31')
```

which PostgreSQL converts to a timestamp on the fly (since recorded_at is a timestamp), and when that is done it ends up being `2020-12-31 00:00:00` ...i.e the beginning of the day.

This PR get consistent with the names `begin` and `end` to determine the begin and end of Periods, and then ensures that we return the beginning of the day timestamp or the end of the day timestamp, respectively, to fix this issue.