### PR TITLE
Bootstrap tooltip bug

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -169,6 +169,7 @@ nav.secondary-nav a.active {
 .tooltip-inner {
     font-family: $font-condensed;
     padding: 6px 8px;
+    max-width: 200px;
 }
 
 #app-footer {


### PR DESCRIPTION
**Story card:** [ch3058](https://app.clubhouse.io/simpledotorg/story/3058/bootstrap-tooltip-bug)

## Because

Bootstrap tooltips no longer have a width set. They are super long and hard to read.

## This addresses

Tooltip width issue. Sets `max-width: 200px` to the `.tooltip-inner` class.

## Test instructions

Go to Reports Overview, and hover on any tooltip in the page. The tooltip should have a max-width of 200px, like the screenshot below.
![image](https://user-images.githubusercontent.com/16785131/112913319-66a65300-90c7-11eb-84f7-fd0a9cbe7cd9.png)