### PR TITLE
Recent Updates: Week of 29-Mar-2021

### DIFF
--- a/app/views/my_facilities/_recent_updates.html.erb
+++ b/app/views/my_facilities/_recent_updates.html.erb
@@ -3,8 +3,18 @@
     Recent updates
   </h2>
   <p class="c-grey-dark">
-    Last updated on Wednesday 17-Feb-2021. If you have Dashboard feedback contact the Simple tech team at help@simple.org.
+    Last updated on Friday 02-Apr-2021. If you have Dashboard feedback contact the Simple tech team at help@simple.org.
   </p>
+  <h5 class="font-weight-bold mt-2">
+    Week of 29-Mar-2021
+  </h5>
+  <ul class="mt-3 mb-0">
+    <li>
+      <p>
+        "BP not controlled" and "Missed visits" cards in "Reports, Overview" now have a "with LTFU" toggle that allows you to see the rates and trends with and without lost to follow-up patients.
+      </p>
+    </li>
+  </ul>
   <h5 class="font-weight-bold mt-2">
     Week of 15-Mar-2021
   </h5>
@@ -59,16 +69,6 @@
     <li>
       <p>
         The "BP controlled", "BP not controlled", and "Missed visits" tabs of the "Home" page display overall monthly trends for the last 6 months.
-      </p>
-    </li>
-  </ul>
-  <h5 class="font-weight-bold mt-2">
-    Week of 18-Jan-2021
-  </h5>
-  <ul class="mt-3 mb-0">
-    <li>
-      <p>
-        You can now filter "Home" tables by district
       </p>
     </li>
   </ul>


### PR DESCRIPTION
Updated "Recent updates" card with the following:
* "BP not controlled" and "Missed visits" cards now show a "with LTFU" toggle
* Removed the "Week of 18-Jan-2021" update