### PR TITLE
CH-3110: add A/B framework models to users purge script

### DIFF
--- a/lib/tasks/scripts/purge_users_data.rb
+++ b/lib/tasks/scripts/purge_users_data.rb
@@ -5,6 +5,8 @@ module PurgeUsersData
     # These are in a "valid" order so that we don't run into Foreign-Key violations
     models = [BloodPressure,
       BloodSugar,
+      AppointmentReminder,
+      Experimentation::TreatmentGroupMembership,
       Appointment,
       CallLog,
       Communication,


### PR DESCRIPTION
**Story card:** [ch3110](https://app.clubhouse.io/simpledotorg/story/3110/bug-report-replace-with-your-title-here)

## Because

We recently added new models that create a new foreign key dependency but didn't add them to the users purge script.

## This addresses

This prevents this error that does not occur in production. 
https://sentry.io/organizations/resolve-to-save-lives/issues/2318392801/?project=1217715&referrer=slack

## Test instructions

- Go to rails console. 
- require Rails.root + "lib/tasks/scripts/purge_users_data.rb"
- PurgeUsersData.perform

Expect no errors.