### PR TITLE
Updated 'Facilities using Simple' and 'Inactive facilities' cards

### DIFF
--- a/app/views/shared/my_facilities/_facilities_by_size.html.erb
+++ b/app/views/shared/my_facilities/_facilities_by_size.html.erb
@@ -2,9 +2,6 @@
   <h2>
     Facilities using Simple
   </h2>
-  <p>
-    Active facilities have &ge;10 patients with BPs recorded in the last 7 days
-  </p>
   <section id="facilities-by-size">
     <table class="table table-compact table-hover">
       <colgroup>
@@ -16,7 +13,20 @@
       <tr>
         <th></th>
         <th>Total</th>
-        <th>Inactive</th>
+        <th>
+          Inactive
+          <span class="p-relative t-1px">
+            <i
+              class="fas fa-question-circle fs-14px c-grey-dark"
+              data-toggle="tooltip"
+              data-placement="right"
+              data-trigger="hover click"
+              data-html="true"
+              title="Facilities with &lt;10 patients with a BP taken in the last 7 days"
+            >
+            </i>
+          </span>
+        </th>
       </tr>
       </thead>
       <tbody>

--- a/app/views/shared/my_facilities/_inactive_facilities.html.erb
+++ b/app/views/shared/my_facilities/_inactive_facilities.html.erb
@@ -4,7 +4,7 @@
       Inactive facilities
     </h2>
     <p>
-      Facilities where &lt;10 patients had any BPs recorded in the last 7 days
+      Facilities with &lt;10 patients with a BP taken in the last 7 days
     </p>
     <section id="facilities-inactive">
       <table class="table table-compact table-hover table-responsive-md analytics-table">


### PR DESCRIPTION
**Story card:** [ch3127](https://app.clubhouse.io/simpledotorg/story/3127/update-facilities-using-simple-and-inactive-facilities-cards)

## Because

Card subtitle copy isn't clear and the copy is a bit outdated.

## This addresses

(1) Removes the subtitle from the "Facilities using Simple" card
(2) Adds a tooltip next to the "Inactive" column header of the "Facilities using Simple" card
(3) Updates the subtitle copy of the "Inactive facilities" card

**BEFORE**
![image](https://user-images.githubusercontent.com/16785131/113623450-5f81c680-962c-11eb-905b-613cd85dbacd.png)

**AFTER**
![image](https://user-images.githubusercontent.com/16785131/113623497-70323c80-962c-11eb-9728-d0c8a099c4da.png)

## Test instructions

N/A