### PR TITLE
Fix facility admin search for exact name

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -49,7 +49,7 @@ class Facility < ApplicationRecord
     class_name: "Patient",
     foreign_key: "assigned_facility_id"
 
-  pg_search_scope :search_by_name, against: {name: "A", slug: "B"}, using: {tsearch: {prefix: true, any_word: true}}
+  pg_search_scope :search_by_name, against: {name: "A", slug: "B"}, using: {tsearch: {prefix: true}}
   scope :with_block_region_id, -> {
     joins("INNER JOIN regions facility_regions ON facility_regions.source_id = facilities.id")
       .joins("INNER JOIN regions block_region ON block_region.path @> facility_regions.path AND block_region.region_type = 'block'")


### PR DESCRIPTION
we don't want to return results for "any_word", because it means a
search for "CHC Chicory" will return results for all facilities with CHC
in the name, which is a lot.

**Story card:** [ch2588](https://app.clubhouse.io/simpledotorg/story/2588/fix-facility-admin-search-results)
