### PR TITLE
Make org wide reports viewable behind a feature flag

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -161,6 +161,9 @@ class Reports::RegionsController < AdminController
     report_scope = report_params[:report_scope]
     @region ||= authorize {
       case report_scope
+      when "organization"
+        organization = current_admin.user_access.accessible_organizations(:view_reports).find_by!(slug: report_params[:id])
+        organization.region
       when "state"
         current_admin.user_access.accessible_state_regions(:view_reports).find_by!(slug: report_params[:id])
       when "facility_district"

--- a/app/services/reports/region_cache_warmer.rb
+++ b/app/services/reports/region_cache_warmer.rb
@@ -17,7 +17,7 @@ module Reports
         return
       end
 
-      Region.where.not(region_type: ["root", "organization"]).pluck(:id).each do |region_id|
+      Region.where.not(region_type: ["root").pluck(:id).each do |region_id|
         RegionCacheWarmerJob.perform_async(region_id, period.attributes)
       end
 

--- a/app/services/reports/region_cache_warmer.rb
+++ b/app/services/reports/region_cache_warmer.rb
@@ -17,7 +17,7 @@ module Reports
         return
       end
 
-      Region.where.not(region_type: ["root").pluck(:id).each do |region_id|
+      Region.where.not(region_type: "root").pluck(:id).each do |region_id|
         RegionCacheWarmerJob.perform_async(region_id, period.attributes)
       end
 

--- a/app/views/reports/regions/_downloads.html.erb
+++ b/app/views/reports/regions/_downloads.html.erb
@@ -19,7 +19,7 @@
       Monthly cohort report
     <% end %>
 
-    <% unless @region.region_type.in?(["state", "block"]) %>
+    <% if @region.region_type.in?(["district", "facility"]) %>
       <% if @region.facilities.to_set.subset?(current_admin.accessible_facilities(:view_pii).to_set) %>
         <%= link_to(reports_patient_list_path(@region, report_scope: params[:report_scope]), class: "dropdown-item") do %>
           <i class="far fa-file w-16px ta-center mr-4px c-grey-medium"></i>

--- a/app/views/reports/regions/index.html.erb
+++ b/app/views/reports/regions/index.html.erb
@@ -12,7 +12,11 @@
         <% @accessible_regions.each do |org, children| %>
           <div class="card organization show region-index">
             <div class="access-tree__section-header">
-              <%= org.name %>
+              <% if current_admin.feature_enabled?(:organization_reports) %>
+                <%= link_to(org.name, reports_region_path(org.source.slug, report_scope: org.region_type)) %>
+              <% else %>
+                <%= org.name %>
+              <% end %>
             </div>
 
             <%= render Reports::RegionTreeComponent.new(parent: org, children: children) %>

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -112,7 +112,6 @@ RSpec.describe Reports::RegionsController, type: :controller do
       end
       expect(response).to be_successful
     end
-
   end
 
   context "cohort" do

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -174,6 +174,15 @@ RSpec.describe Reports::RegionsController, type: :controller do
       expect(response).to be_redirect
     end
 
+    it "redirects if user does not have proper access to org" do
+      district_official = create(:admin, :viewer_reports_only, :with_access, resource: @facility_group)
+
+      sign_in(district_official.email_authentication)
+      get :show, params: {id: @facility_group.organization.slug, report_scope: "organization"}
+      expect(flash[:alert]).to eq("You are not authorized to perform this action.")
+      expect(response).to be_redirect
+    end
+
     it "raises error if user does not have authorization to region" do
       other_fg = create(:facility_group, name: "other facility group")
       other_fg.facilities << build(:facility, name: "other facility")

--- a/spec/services/reports/region_cache_warmer_spec.rb
+++ b/spec/services/reports/region_cache_warmer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Reports::RegionCacheWarmer, type: :model do
 
   it "queues a job on the default queue for every region" do
     create(:patient)
-    reporting_regions = Region.where.not(region_type: ["root", "organization"])
+    reporting_regions = Region.where.not(region_type: ["root"])
     expect {
       Reports::RegionCacheWarmer.call
     }.to change(Sidekiq::Queues["default"], :size).by(reporting_regions.count)


### PR DESCRIPTION
**Story card:** [ch3020](https://app.clubhouse.io/simpledotorg/story/3020/organization-wide-reports)

## Because

Some countries (like ET and BD) could benefit from seeing _all_ the data available in their country in dashboard reports.

## This addresses

Adds org wide reports behind a feature flag `organization_reports`.