### PR TITLE
Rename experiment types to 'current_patients' and 'stale_patients'

### DIFF
--- a/app/models/experimentation/experiment.rb
+++ b/app/models/experimentation/experiment.rb
@@ -7,14 +7,14 @@ module Experimentation
     validates :state, presence: true
     validates :experiment_type, presence: true
     validate :date_range, if: proc { |experiment| experiment.start_date_changed? || experiment.end_date_changed? }
-    validate :one_live_experiment_per_type
+    validate :one_active_experiment_per_type
 
     enum state: {
       new: "new",
       selecting: "selecting",
-      live: "live",
+      running: "running",
       complete: "complete"
-    }, _prefix: true
+    }, _suffix: true
 
     enum experiment_type: {
       active_patients: "active_patients",
@@ -28,11 +28,11 @@ module Experimentation
 
     private
 
-    def one_live_experiment_per_type
-      existing = self.class.where(state: ["live", "selecting"], experiment_type: experiment_type)
+    def one_active_experiment_per_type
+      existing = self.class.where(state: ["running", "selecting"], experiment_type: experiment_type)
       existing = existing.where("id != ?", id) if persisted?
       if existing.any?
-        errors.add(:state, "you cannot have multiple selecting or live experiments of type #{experiment_type}")
+        errors.add(:state, "you cannot have multiple active experiments of type #{experiment_type}")
       end
     end
 

--- a/app/models/experimentation/experiment.rb
+++ b/app/models/experimentation/experiment.rb
@@ -17,7 +17,7 @@ module Experimentation
     }, _suffix: true
 
     enum experiment_type: {
-      active_patients: "active_patients",
+      current_patients: "current_patients",
       stale_patients: "stale_patients"
     }, _prefix: true
 

--- a/app/models/experimentation/experiment.rb
+++ b/app/models/experimentation/experiment.rb
@@ -15,9 +15,10 @@ module Experimentation
       live: "live",
       complete: "complete"
     }, _prefix: true
+
     enum experiment_type: {
-      current_patient_reminder: "current_patient_reminder",
-      inactive_patient_reminder: "inactive_patient_reminder"
+      active_patients: "active_patients",
+      stale_patients: "stale_patients"
     }, _prefix: true
 
     def group_for(uuid)

--- a/app/services/experiment_control_service.rb
+++ b/app/services/experiment_control_service.rb
@@ -7,7 +7,7 @@ class ExperimentControlService
 
   class << self
     def start_current_patient_experiment(name, days_til_start, days_til_end, percentage_of_patients = 100)
-      experiment = Experimentation::Experiment.find_by!(name: name, experiment_type: "active_patients")
+      experiment = Experimentation::Experiment.find_by!(name: name, experiment_type: "current_patients")
       experiment_start = days_til_start.days.from_now.beginning_of_day
       experiment_end = days_til_end.days.from_now.end_of_day
 

--- a/app/services/experiment_control_service.rb
+++ b/app/services/experiment_control_service.rb
@@ -7,7 +7,7 @@ class ExperimentControlService
 
   class << self
     def start_current_patient_experiment(name, days_til_start, days_til_end, percentage_of_patients = 100)
-      experiment = Experimentation::Experiment.find_by!(name: name, experiment_type: "current_patient_reminder")
+      experiment = Experimentation::Experiment.find_by!(name: name, experiment_type: "active_patients")
       experiment_start = days_til_start.days.from_now.beginning_of_day
       experiment_end = days_til_end.days.from_now.end_of_day
 
@@ -44,7 +44,7 @@ class ExperimentControlService
     end
 
     def start_inactive_patient_experiment(name, days_til_start, days_til_end)
-      experiment = Experimentation::Experiment.find_by!(name: name, experiment_type: "inactive_patient_reminder")
+      experiment = Experimentation::Experiment.find_by!(name: name, experiment_type: "stale_patients")
       total_days = days_til_end - days_til_start + 1
       date = days_til_start.days.from_now.to_date
       eligibility_start = (date - INACTIVE_PATIENTS_ELIGIBILITY_START).beginning_of_day

--- a/app/services/experiment_control_service.rb
+++ b/app/services/experiment_control_service.rb
@@ -40,7 +40,7 @@ class ExperimentControlService
         end
       end
 
-      experiment.update!(state: "live")
+      experiment.update!(state: "running")
     end
 
     def start_inactive_patient_experiment(name, days_til_start, days_til_end)
@@ -77,7 +77,7 @@ class ExperimentControlService
         date += 1.day
       end
 
-      experiment.update!(state: "live")
+      experiment.update!(state: "running")
     end
 
     protected

--- a/lib/seed/experiment_seeder.rb
+++ b/lib/seed/experiment_seeder.rb
@@ -7,7 +7,7 @@ module Seed
     end
 
     def call
-      experiment = Experimentation::Experiment.create!(name: "test-experiment", experiment_type: "active_patients",
+      experiment = Experimentation::Experiment.create!(name: "test-experiment", experiment_type: "current_patients",
                                                        state: "new", start_date: 2.days.from_now, end_date: 42.days.from_now)
       experiment.treatment_groups.create!(description: "control", index: 0)
       single = experiment.treatment_groups.create!(description: "single message", index: 1)

--- a/lib/seed/experiment_seeder.rb
+++ b/lib/seed/experiment_seeder.rb
@@ -7,7 +7,7 @@ module Seed
     end
 
     def call
-      experiment = Experimentation::Experiment.create!(name: "test-experiment", experiment_type: "current_patient_reminder",
+      experiment = Experimentation::Experiment.create!(name: "test-experiment", experiment_type: "active_patients",
                                                        state: "new", start_date: 2.days.from_now, end_date: 42.days.from_now)
       experiment.treatment_groups.create!(description: "control", index: 0)
       single = experiment.treatment_groups.create!(description: "single message", index: 1)

--- a/spec/factories/experimentation/experiments.rb
+++ b/spec/factories/experimentation/experiments.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :experiment, class: Experimentation::Experiment do
     name { Faker::Lorem.unique.word }
     state { "new" }
-    experiment_type { "current_patient_reminder" }
+    experiment_type { "active_patients" }
     start_date {}
     end_date {}
   end

--- a/spec/factories/experimentation/experiments.rb
+++ b/spec/factories/experimentation/experiments.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :experiment, class: Experimentation::Experiment do
     name { Faker::Lorem.unique.word }
     state { "new" }
-    experiment_type { "active_patients" }
+    experiment_type { "current_patients" }
     start_date {}
     end_date {}
   end

--- a/spec/models/experimentation/experiment_spec.rb
+++ b/spec/models/experimentation/experiment_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe Experimentation::Experiment, type: :model do
     it { should validate_presence_of(:experiment_type) }
 
     it "there can only be one live experiment of a particular type at a time" do
-      create(:experiment, state: :live, experiment_type: "current_patient_reminder")
-      create(:experiment, state: :live, experiment_type: "inactive_patient_reminder")
+      create(:experiment, state: :live, experiment_type: "active_patients")
+      create(:experiment, state: :live, experiment_type: "stale_patients")
 
-      experiment_3 = build(:experiment, state: :live, experiment_type: "current_patient_reminder")
+      experiment_3 = build(:experiment, state: :live, experiment_type: "active_patients")
       expect(experiment_3).to be_invalid
 
-      experiment_4 = build(:experiment, state: :live, experiment_type: "inactive_patient_reminder")
+      experiment_4 = build(:experiment, state: :live, experiment_type: "stale_patients")
       expect(experiment_4).to be_invalid
     end
 

--- a/spec/models/experimentation/experiment_spec.rb
+++ b/spec/models/experimentation/experiment_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Experimentation::Experiment, type: :model do
     it { should validate_presence_of(:experiment_type) }
 
     it "there can only be one active experiment of a particular type at a time" do
-      create(:experiment, state: :running, experiment_type: "active_patients")
+      create(:experiment, state: :running, experiment_type: "current_patients")
       create(:experiment, state: :selecting, experiment_type: "stale_patients")
 
-      experiment_3 = build(:experiment, state: :running, experiment_type: "active_patients")
+      experiment_3 = build(:experiment, state: :running, experiment_type: "current_patients")
       expect(experiment_3).to be_invalid
 
       experiment_4 = build(:experiment, state: :running, experiment_type: "stale_patients")

--- a/spec/models/experimentation/experiment_spec.rb
+++ b/spec/models/experimentation/experiment_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe Experimentation::Experiment, type: :model do
     it { should validate_presence_of(:state) }
     it { should validate_presence_of(:experiment_type) }
 
-    it "there can only be one live experiment of a particular type at a time" do
-      create(:experiment, state: :live, experiment_type: "active_patients")
-      create(:experiment, state: :live, experiment_type: "stale_patients")
+    it "there can only be one active experiment of a particular type at a time" do
+      create(:experiment, state: :running, experiment_type: "active_patients")
+      create(:experiment, state: :selecting, experiment_type: "stale_patients")
 
-      experiment_3 = build(:experiment, state: :live, experiment_type: "active_patients")
+      experiment_3 = build(:experiment, state: :running, experiment_type: "active_patients")
       expect(experiment_3).to be_invalid
 
-      experiment_4 = build(:experiment, state: :live, experiment_type: "stale_patients")
+      experiment_4 = build(:experiment, state: :running, experiment_type: "stale_patients")
       expect(experiment_4).to be_invalid
     end
 

--- a/spec/services/experiment_control_service_spec.rb
+++ b/spec/services/experiment_control_service_spec.rb
@@ -204,7 +204,7 @@ describe ExperimentControlService, type: :model do
       old_patient = create(:patient, age: 18)
       create(:encounter, patient: old_patient, device_created_at: 100.days.ago)
 
-      experiment = create(:experiment, :with_treatment_group, experiment_type: "inactive_patient_reminder")
+      experiment = create(:experiment, :with_treatment_group, experiment_type: "stale_patients")
 
       ExperimentControlService.start_inactive_patient_experiment(experiment.name, 1, 31)
 
@@ -218,7 +218,7 @@ describe ExperimentControlService, type: :model do
       patient2 = create(:patient, :without_hypertension, age: 80)
       create(:encounter, patient: patient2, device_created_at: 100.days.ago)
 
-      experiment = create(:experiment, :with_treatment_group, experiment_type: "inactive_patient_reminder")
+      experiment = create(:experiment, :with_treatment_group, experiment_type: "stale_patients")
 
       ExperimentControlService.start_inactive_patient_experiment(experiment.name, 1, 31)
 
@@ -233,7 +233,7 @@ describe ExperimentControlService, type: :model do
       patient2 = create(:patient, age: 80)
       create(:encounter, patient: patient2, device_created_at: 100.days.ago)
 
-      experiment = create(:experiment, :with_treatment_group, experiment_type: "inactive_patient_reminder")
+      experiment = create(:experiment, :with_treatment_group, experiment_type: "stale_patients")
 
       ExperimentControlService.start_inactive_patient_experiment(experiment.name, 1, 31)
 
@@ -249,7 +249,7 @@ describe ExperimentControlService, type: :model do
       patient3 = create(:patient, age: 80)
       create(:encounter, patient: patient3, device_created_at: 1.days.ago)
 
-      experiment = create(:experiment, :with_treatment_group, experiment_type: "inactive_patient_reminder")
+      experiment = create(:experiment, :with_treatment_group, experiment_type: "stale_patients")
 
       ExperimentControlService.start_inactive_patient_experiment(experiment.name, 1, 31)
 
@@ -267,7 +267,7 @@ describe ExperimentControlService, type: :model do
       create(:appointment, patient: patient2, scheduled_date: 100.days.ago, status: "scheduled")
       create(:encounter, patient: patient2, device_created_at: 100.days.ago)
 
-      experiment = create(:experiment, :with_treatment_group, experiment_type: "inactive_patient_reminder")
+      experiment = create(:experiment, :with_treatment_group, experiment_type: "stale_patients")
 
       ExperimentControlService.start_inactive_patient_experiment(experiment.name, 1, 31)
 
@@ -293,7 +293,7 @@ describe ExperimentControlService, type: :model do
       patient3 = create(:patient, age: 80)
       create(:encounter, patient: patient3, device_created_at: 100.days.ago)
 
-      experiment = create(:experiment, :with_treatment_group, experiment_type: "inactive_patient_reminder")
+      experiment = create(:experiment, :with_treatment_group, experiment_type: "stale_patients")
 
       ExperimentControlService.start_inactive_patient_experiment(experiment.name, 1, 31)
 
@@ -308,7 +308,7 @@ describe ExperimentControlService, type: :model do
       patient2 = create(:patient, age: 80, id: "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff")
       create(:encounter, patient: patient2, device_created_at: 100.days.ago)
 
-      experiment = create(:experiment, experiment_type: "inactive_patient_reminder")
+      experiment = create(:experiment, experiment_type: "stale_patients")
       group1 = create(:treatment_group, experiment: experiment, index: 0)
       group2 = create(:treatment_group, experiment: experiment, index: 1)
 
@@ -323,7 +323,7 @@ describe ExperimentControlService, type: :model do
       create(:encounter, patient: patient1, device_created_at: 100.days.ago)
       create(:appointment, patient: patient1, scheduled_date: 100.days.ago)
 
-      experiment = create(:experiment, :with_treatment_group, experiment_type: "inactive_patient_reminder")
+      experiment = create(:experiment, :with_treatment_group, experiment_type: "stale_patients")
       group = experiment.treatment_groups.first
       create(:reminder_template, treatment_group: group, message: "come today", remind_on_in_days: 0)
       create(:reminder_template, treatment_group: group, message: "you're late", remind_on_in_days: 3)
@@ -337,7 +337,7 @@ describe ExperimentControlService, type: :model do
     end
 
     it "updates the experiment state, start date, and end date" do
-      experiment = create(:experiment, experiment_type: "inactive_patient_reminder")
+      experiment = create(:experiment, experiment_type: "stale_patients")
       ExperimentControlService.start_inactive_patient_experiment(experiment.name, 0, 30)
       experiment.reload
 
@@ -347,8 +347,8 @@ describe ExperimentControlService, type: :model do
     end
 
     it "does not create appointment reminders or update the experiment if there's another experiment of the same type in progress" do
-      experiment = create(:experiment, experiment_type: "inactive_patient_reminder")
-      create(:experiment, experiment_type: "inactive_patient_reminder", state: "selecting")
+      experiment = create(:experiment, experiment_type: "stale_patients")
+      create(:experiment, experiment_type: "stale_patients", state: "selecting")
       expect {
         begin
           ExperimentControlService.start_inactive_patient_experiment(experiment.name, 1, 31)
@@ -364,7 +364,7 @@ describe ExperimentControlService, type: :model do
       create(:encounter, patient: patient1, device_created_at: 100.days.ago)
       patient2 = create(:patient, age: 80)
       create(:encounter, patient: patient2, device_created_at: 100.days.ago)
-      experiment = create(:experiment, :with_treatment_group, experiment_type: "inactive_patient_reminder")
+      experiment = create(:experiment, :with_treatment_group, experiment_type: "stale_patients")
 
       expect {
         ExperimentControlService.start_inactive_patient_experiment(experiment.name, 1, 1)

--- a/spec/services/experiment_control_service_spec.rb
+++ b/spec/services/experiment_control_service_spec.rb
@@ -171,7 +171,7 @@ describe ExperimentControlService, type: :model do
       ExperimentControlService.start_current_patient_experiment(experiment.name, days_til_start, days_til_end)
       experiment.reload
 
-      expect(experiment.state).to eq("live")
+      expect(experiment).to be_running_state
       expect(experiment.start_date).to eq(days_til_start.days.from_now.to_date)
       expect(experiment.end_date).to eq(days_til_end.days.from_now.to_date)
     end
@@ -341,7 +341,7 @@ describe ExperimentControlService, type: :model do
       ExperimentControlService.start_inactive_patient_experiment(experiment.name, 0, 30)
       experiment.reload
 
-      expect(experiment.state).to eq("live")
+      expect(experiment).to be_running_state
       expect(experiment.start_date).to eq(Date.current)
       expect(experiment.end_date).to eq(30.days.from_now.to_date)
     end


### PR DESCRIPTION
"active" and "stale" is a bit more intuitive for these, and also we can
leave off the "reminder" part because we know these experiments are
_only_ about AB testing reminders to get patients back to care.

No story for this, this is a name we talked about quite a bit during pairing and I wanted to propose this before moving forward on other things.