### PR TITLE
Default Experiments to 'new' state

### DIFF
--- a/db/migrate/20210407214406_default_experiment_to_new_state.rb
+++ b/db/migrate/20210407214406_default_experiment_to_new_state.rb
@@ -1,0 +1,5 @@
+class DefaultExperimentToNewState < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :experiments, :state, from: nil, to: "new"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_29_202937) do
+ActiveRecord::Schema.define(version: 2021_04_07_214406) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -265,7 +265,7 @@ ActiveRecord::Schema.define(version: 2021_03_29_202937) do
 
   create_table "experiments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
-    t.string "state", null: false
+    t.string "state", default: "new", null: false
     t.string "experiment_type", null: false
     t.date "start_date"
     t.date "end_date"


### PR DESCRIPTION
This is the default safe state to put experiments in.  A new experiment
is not running and not active, so best to default to that state.

Story: [ch2938](https://app.clubhouse.io/simpledotorg/story/2938/start-active-patient-experiment)