### PR TITLE
Enable org caching only if the feature is on or conditionally on

### DIFF
--- a/app/services/reports/region_cache_warmer.rb
+++ b/app/services/reports/region_cache_warmer.rb
@@ -17,8 +17,14 @@ module Reports
         return
       end
 
-      Region.where.not(region_type: "root").pluck(:id).each do |region_id|
+      Region.where.not(region_type: ["organization", "root"]).pluck(:id).each do |region_id|
         RegionCacheWarmerJob.perform_async(region_id, period.attributes)
+      end
+
+      if Flipper.feature(:organization_reports).state.in?([:on, :conditional])
+        Region.where(region_type: "organization").pluck(:id).each do |region_id|
+          RegionCacheWarmerJob.perform_async(region_id, period.attributes)
+        end
       end
 
       notify "queued region reports cache warming"

--- a/spec/services/reports/region_cache_warmer_spec.rb
+++ b/spec/services/reports/region_cache_warmer_spec.rb
@@ -14,9 +14,19 @@ RSpec.describe Reports::RegionCacheWarmer, type: :model do
 
   it "queues a job on the default queue for every region" do
     create(:patient)
-    reporting_regions = Region.where.not(region_type: ["root"])
+    reporting_regions = Region.where.not(region_type: ["organization", "root"])
     expect {
       Reports::RegionCacheWarmer.call
     }.to change(Sidekiq::Queues["default"], :size).by(reporting_regions.count)
+  end
+
+  it "queues a job for organization(s) if the organization_reports feature is enabled" do
+    user = create(:user)
+    Flipper.enable(:organization_reports, user)
+    Reports::RegionCacheWarmer.call
+    org_job_queued = Sidekiq::Queues["default"].any? { |job|
+      job["args"].first == Region.organization_regions.first.id
+    }
+    expect(org_job_queued).to be true
   end
 end


### PR DESCRIPTION
**Story card:** [ch3020](https://app.clubhouse.io/simpledotorg/story/3020/organization-wide-reports)

Only warm the org reporting cache if the feature is turned on.