### PR TITLE
Move patient's assigned facility in rake task

### DIFF
--- a/lib/tasks/scripts/move_facility_data.rb
+++ b/lib/tasks/scripts/move_facility_data.rb
@@ -26,6 +26,7 @@ class MoveFacilityData
     )
     fix_pbi_metadata(patients)
     fix_data_for_relation(patients, facility_key: :registration_facility)
+    fix_data_for_relation(patients, facility_key: :assigned_facility)
   end
 
   def fix_appointment_data
@@ -66,7 +67,7 @@ class MoveFacilityData
   private
 
   def fix_data_for_relation(relation, facility_key: :facility)
-    Rails.logger.info "Moving #{relation.count} #{relation.klass} records"\
+    Rails.logger.info "Moving #{facility_key} of #{relation.count} #{relation.klass} records"\
                       "to #{destination_facility.name}"
     updated_records = relation.update(facility_key => destination_facility)
     updated_records.count

--- a/lib/tasks/scripts/move_facility_data.rb
+++ b/lib/tasks/scripts/move_facility_data.rb
@@ -19,14 +19,20 @@ class MoveFacilityData
   end
 
   def fix_patient_data
-    patients = records_to_move(
+    registered_patients = records_to_move(
       Patient,
       user_key: :registration_user,
       facility_key: :registration_facility
     )
-    fix_pbi_metadata(patients)
-    fix_data_for_relation(patients, facility_key: :registration_facility)
-    fix_data_for_relation(patients, facility_key: :assigned_facility)
+    fix_pbi_metadata(registered_patients)
+    fix_data_for_relation(registered_patients, facility_key: :registration_facility)
+
+    assigned_patients = records_to_move(
+      Patient,
+      user_key: :registration_user,
+      facility_key: :assigned_facility
+    )
+    fix_data_for_relation(assigned_patients, facility_key: :assigned_facility)
   end
 
   def fix_appointment_data

--- a/spec/lib/tasks/scripts/move_facility_data_spec.rb
+++ b/spec/lib/tasks/scripts/move_facility_data_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe MoveFacilityData do
   describe "#fix_patient_data" do
     it "Moves all patients registered at the source facility to the destination facility" do
       create_list(:patient, 2, registration_user: user, registration_facility: source_facility)
-      expect {
-        described_class.new(source_facility, destination_facility, user: user).fix_patient_data
-      }.to change(Patient.where(registration_user: user, registration_facility: destination_facility), :count).by(2)
+
+      described_class.new(source_facility, destination_facility, user: user).fix_patient_data
+
+      expect(Patient.where(registration_user: user, registration_facility: destination_facility).count).to eq(2)
+      expect(Patient.where(registration_user: user, assigned_facility: destination_facility).count).to eq(2)
     end
 
     it "Does not move patients from a different facility" do

--- a/spec/lib/tasks/scripts/move_facility_data_spec.rb
+++ b/spec/lib/tasks/scripts/move_facility_data_spec.rb
@@ -9,12 +9,14 @@ RSpec.describe MoveFacilityData do
 
   describe "#fix_patient_data" do
     it "Moves all patients registered at the source facility to the destination facility" do
-      create_list(:patient, 2, registration_user: user, registration_facility: source_facility)
+      patient_1 = create(:patient, registration_user: user, registration_facility: source_facility)
+      patient_2 = create(:patient, registration_user: user, registration_facility: source_facility, assigned_facility: create(:facility))
 
       described_class.new(source_facility, destination_facility, user: user).fix_patient_data
 
-      expect(Patient.where(registration_user: user, registration_facility: destination_facility).count).to eq(2)
-      expect(Patient.where(registration_user: user, assigned_facility: destination_facility).count).to eq(2)
+      expect(Patient.where(id: [patient_1, patient_2]).pluck(:registration_facility_id)).to all eq(destination_facility.id)
+      expect(patient_1.reload.assigned_facility_id).to eq(destination_facility.id)
+      expect(patient_2.reload.assigned_facility_id).not_to eq(destination_facility.id)
     end
 
     it "Does not move patients from a different facility" do


### PR DESCRIPTION
**Story card:** -

## Because

This is a follow up to #2424. The script needs to move the assigned facility of patients in the old facility to the new facility.

## This addresses

This fixes the task to also set the assigned facility of patients to the new facility
