### PR TITLE
Improve performance of sync to user

### DIFF
--- a/app/controllers/concerns/api/v3/sync_to_user.rb
+++ b/app/controllers/concerns/api/v3/sync_to_user.rb
@@ -17,7 +17,7 @@ module Api::V3::SyncToUser
         other_facilities_limit = limit - current_facility_records.size
         @other_facility_records ||=
           model_sync_scope
-            .where("patient_id = ANY (array(?))",
+            .where("patient_id IN (?)",
               current_sync_region
                 .syncable_patients
                 .where.not(registration_facility: current_facility)


### PR DESCRIPTION
**Story card:** [ch3313](https://app.clubhouse.io/simpledotorg/story/3313/explore-postgres-in-vs-any-performance-characteristics)

## Because

CPU on the production database has been hitting 100% in the last couple of days after scaling down the DB box. One of the reasons for high CPU seems to be this particular query that runs when syncing any data to the user. From a quick check on the rails production db console, it seems like changing `= ANY (ARRAY (?))` to IN(?) gave a 5x performance improvement.

This is along the lines of these documented scenarios:
- https://www.datadoghq.com/blog/100x-faster-postgres-performance-by-changing-1-line/
- https://www.postgresql.org/message-id/5373.1158351561%40sss.pgh.pa.us

Here are the query profiles:
- [Before, with ANY](https://explain.depesz.com/s/1RQw)
- [After, with IN](https://explain.depesz.com/s/SDQo)

## This addresses

Changing the query from ANY(ARRAY) to a performant variant.
