### PR TITLE
Capture attempted notifications for a 'total' metric

### DIFF
--- a/app/jobs/appointment_notification/worker.rb
+++ b/app/jobs/appointment_notification/worker.rb
@@ -11,6 +11,7 @@ class AppointmentNotification::Worker
   end
 
   def perform(appointment_id, communication_type, locale = nil)
+    metrics.increment("attempts")
     appointment = Appointment.find_by(id: appointment_id)
     unless appointment
       metrics.increment("skipped.missed_appointment")

--- a/spec/jobs/appointment_notification/worker_spec.rb
+++ b/spec/jobs/appointment_notification/worker_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe AppointmentNotification::Worker, type: :job do
     allow_any_instance_of(NotificationService).to receive(:send_whatsapp).and_return(notification_response)
     allow(notification_response).to receive(:sid).and_return(SecureRandom.uuid)
     allow(notification_response).to receive(:status).and_return("queued")
+    allow(Statsd.instance).to receive(:increment).with(anything)
   end
 
   describe "#perform" do


### PR DESCRIPTION
If we sent the count of attempts to Datadog, we can then make a graph to
see the breakdown of success / failures

**Story card:** [ch3300](https://app.clubhouse.io/simpledotorg/story/3300/as-a-developer-i-want-to-have-a-working-and-verifiable-sbx-twilio-setup)
