### PR TITLE
Updated 'Assigned patients breakdown' copy

### DIFF
--- a/app/assets/javascripts/common/patient_breakdown_reports.js
+++ b/app/assets/javascripts/common/patient_breakdown_reports.js
@@ -168,7 +168,7 @@ PatientBreakdownReports = function () {
           const label = tooltipData.labels[tooltipItem.index];
           let tooltipBody = [`Total: ${reports.formatNumberWithCommas(data[label])}`];
           if (transferredPatients[label] !== undefined) {
-            tooltipBody.push(`Transferred-out: ${transferredPatients[label]}`)
+            tooltipBody.push(`Transferred out: ${transferredPatients[label]}`)
           }
           return tooltipBody;
         },

--- a/app/views/reports/regions/_details_footnotes.html.erb
+++ b/app/views/reports/regions/_details_footnotes.html.erb
@@ -65,6 +65,16 @@
       </p>
     </div>
   </div>
+  <div class="mb-24px">
+    <p class="mb-8px fs-16px fw-bold c-grey-dark">
+      Transferred out
+    </p>
+    <div class="pl-16px">
+      <p class="mb-8px fs-14px c-grey-dark">
+        <%= t("transferred_out_patients_copy") %>
+      </p>
+    </div>
+  </div>
   <% if @region.facility_region? %>
     <div class="mb-0px">
       <p class="mb-8px fs-16px fw-bold c-grey-dark">

--- a/app/views/reports/regions/_details_footnotes.html.erb
+++ b/app/views/reports/regions/_details_footnotes.html.erb
@@ -67,7 +67,7 @@
   </div>
   <div class="mb-24px">
     <p class="mb-8px fs-16px fw-bold c-grey-dark">
-      Transferred out
+      Transferred out patients
     </p>
     <div class="pl-16px">
       <p class="mb-8px fs-14px c-grey-dark">

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -78,7 +78,8 @@
           </h3>
           <%= render "definition_tooltip",
                      definitions: { "Patients under care" => t("patients_under_care_copy"),
-                                    "Lost to follow-up" => t("lost_to_follow_up_copy.reports_card_subtitle") } %>
+                                    "Lost to follow-up" => t("lost_to_follow_up_copy.reports_card_subtitle"),
+                                    "Transferred out" => t("transferred_out_patients_copy")} %>
         </div>
         <p class="mb-0px c-grey-dark mr-lg-12px">
           Hypertension patients who have died, been lost to follow-up, and transferred out

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -74,14 +74,15 @@
       <div class="pt-20px px-20px">
         <div class="d-flex flex-1 mb-8px">
           <h3 class="mb-0px mr-8px">
-            Assigned patients breakdown
+            Hypertension patients
           </h3>
           <%= render "definition_tooltip",
                      definitions: { "Patients under care" => t("patients_under_care_copy"),
                                     "Lost to follow-up" => t("lost_to_follow_up_copy.reports_card_subtitle") } %>
         </div>
-        <p class="mb-0px c-grey-dark mr-lg-12px"><%= number_with_delimiter(@chart_data[:patient_breakdown][:total_patients]) %>
-          hypertension patients assigned to <%= @region.name %> as of <%= @chart_data[:ltfu_trend].last_value(:period_info)["bp_control_end_date"] %></p>
+        <p class="mb-0px c-grey-dark mr-lg-12px">
+          Hypertension patients who have died, been lost to follow-up, and transferred out
+        </p>
       </div>
       <div class="p-relative mb-16px d-lg-flex">
         <div class="w-360px h-360px">

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -82,7 +82,7 @@
                                     "Transferred out" => t("transferred_out_patients_copy")} %>
         </div>
         <p class="mb-0px c-grey-dark mr-lg-12px">
-          Hypertension patients who have died, been lost to follow-up, and transferred out
+          Hypertension patients who have died, been lost to follow-up, or transferred out
         </p>
       </div>
       <div class="p-relative mb-16px d-lg-flex">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,7 @@ en:
   follow_up_patients_copy: "Hypertension patients with a BP measure taken during a month in %{region_name}."
   patients_under_care_copy: "Hypertension patients with a BP taken in the last 12 months."
   bp_measures_taken_copy: "All BP measures taken in a month by healthcare workers at %{region_name}."
+  transferred_out_patients_copy: "Patients who have moved to another public facility or to a private practitioner"
 
   admin:
     reset_otp_alert: 'Are you sure you want to reset the OTP? This will invalidate the previous OTP and a SMS will be sent to the user with the new OTP'


### PR DESCRIPTION
**Story card:** [ch3332](https://app.clubhouse.io/simpledotorg/story/3332/update-assigned-patients-breakdown-copy)

## Because

The "Assigned patients breakdown" card copy is confusing for the following reasons:

1. The title is not accurate
2. The number displayed in the subtitle is not useful
3. It's not clear what "Transferred out" means

## This addresses

Card copy is much clearer and "Transferred out" copy is now displayed in tooltip and footnoes

## Test instructions

* Updated card title
* Updated card subtitle
* Created new "Transferred out" definition in `en.yml`
* Added "Transferred out" definition to card tooltip
* Added "Transferred out" definition to footnotes section
* Removed hyphen from "Transferred-out" copy in chart tooltip