### PR TITLE
Disable reminders in the worker as well

### DIFF
--- a/app/jobs/appointment_notification/worker.rb
+++ b/app/jobs/appointment_notification/worker.rb
@@ -12,6 +12,11 @@ class AppointmentNotification::Worker
 
   def perform(appointment_id, communication_type, locale = nil)
     metrics.increment("attempts")
+    unless Flipper.enabled?(:appointment_reminders)
+      metrics.increment("skipped.feature_disabled")
+      return
+    end
+
     appointment = Appointment.find_by(id: appointment_id)
     unless appointment
       metrics.increment("skipped.missed_appointment")

--- a/spec/jobs/appointment_notification/worker_spec.rb
+++ b/spec/jobs/appointment_notification/worker_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe AppointmentNotification::Worker, type: :job do
   let(:callback_url) { "https://localhost/api/v3/twilio_sms_delivery" }
 
   before do
+    Flipper.enable(:appointment_reminders)
     notification_response = double("NotificationServiceResponse")
     allow_any_instance_of(NotificationService).to receive(:send_sms).and_return(notification_response)
     allow_any_instance_of(NotificationService).to receive(:send_whatsapp).and_return(notification_response)


### PR DESCRIPTION
We want to disable closer to the source as well for appointment reminders, otherwise we could have cases where Twilio callbacks or re-running jobs still end up sending reminders.