### PR TITLE
Don't use record ids for statsd / datadog metrics

### DIFF
--- a/app/services/reports/region_cache_warmer.rb
+++ b/app/services/reports/region_cache_warmer.rb
@@ -35,7 +35,7 @@ module Reports
       RequestStore.store[:bust_cache] = true
 
       notify "starting region caching for region #{region.id}"
-      Statsd.instance.time("region_cache_warmer.#{region.id}") do
+      Statsd.instance.time("region_cache_warmer.time") do
         Reports::RegionService.call(region: region, period: period)
         Statsd.instance.increment("region_cache_warmer.#{region.region_type}.cache")
 


### PR DESCRIPTION
We shouldn't ever include unique id's in datadog metric names, as it will
blow out our Datadog usage and drive up our costs there.  It also makes finding events really hard in DataDog, because we will have thousands of values to search through. 😁 

Any custom metric names need to have limited cardinality, so maybe a couple hundred at most.

