### PR TITLE
Start a CODEOWNERS files for request review on reporting queries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,8 @@
 # Ensure Claudio gets requested review for reporting queries
 /app/queries/ @@claudiovallejo
 
-# See docs and examples for this file at 
+# Ensure Hari gets requested review canonical medications
+/config/data/medications.yml @harimohanraj89
+
+# See docs and examples for this file at
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Ensure Claudio gets requested review for reporting queries
-/app/queries/ @@claudiovallejo
+/app/queries/ @claudiovallejo
 
 # Ensure Hari gets requested review canonical medications
 /config/data/medications.yml @harimohanraj89

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Ensure Claudio gets requested review for reporting queries
+/app/queries/ @@claudiovallejo
+
+# See docs and examples for this file at 
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners


### PR DESCRIPTION
This adds a CODEOWNERS file that should request review from @claudiovallejo for any changes to the `app/queries` directory. This is covers the reporting queries, as well as other unrelated queries...which isn't perfect but I think that's fine to start as see how this works. 

See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
for docs and examples
