### PR TITLE
Monthly district reports for FacilityDistrict

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -109,8 +109,7 @@ class Reports::RegionsController < AdminController
       case report_scope
       when "facility_district"
         scope = current_admin.accessible_facilities(:view_reports)
-        region = current_admin.accessible_district_regions(:view_reports).find_by!(slug: report_params[:id])
-        FacilityDistrict.new(name: region.name, scope: scope)
+        FacilityDistrict.new(name: report_params[:id], scope: scope)
       when "district"
         current_admin.accessible_district_regions(:view_reports).find_by!(slug: report_params[:id])
       else

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -513,8 +513,10 @@ RSpec.describe Reports::RegionsController, type: :controller do
       facility
       sign_in(cvho.email_authentication)
 
-      get :monthly_district_data_report, params: {id: region.slug, report_scope: "facility_district", format: "csv"}
+      get :monthly_district_data_report, params: {id: region.name, report_scope: "facility_district", format: "csv"}
+
       expect(response.status).to eq(200)
+      expect(response.body).to include(facility.name)
     end
 
     it "passes the provided period to the csv service" do


### PR DESCRIPTION
**Story card:** [chXXXX](URL)

## Because

Monthly district reports are breaking for `FacilityDistrict`s.
![image](https://user-images.githubusercontent.com/16774200/117264187-9e47ae00-ae70-11eb-8875-d2bc5c6b3671.png)

https://simpledotorg.slack.com/archives/C013HS4N9U3/p1620285572126300

## This addresses

We lookup the district region by slug for facility districts, however the facility district links use the district's name.
Eg. `https://api.simple.org/reports/regions/facility_district/Bathinda`. This fixes the bug.

