### PR TITLE
Refresh missed_visits cache in repository

### DIFF
--- a/app/services/reports/region_service.rb
+++ b/app/services/reports/region_service.rb
@@ -39,6 +39,10 @@ module Reports
       result.calculate_missed_visits_percentages(calc_range, with_ltfu: true)
       result.calculate_period_info(calc_range)
 
+      # This is a temporary hack to refresh repository's missed visits from the RegionCacheWarmer.
+      # We should deprecate result.rb and move all calculations to Repository.
+      repository.missed_visits
+
       result
     end
 


### PR DESCRIPTION
**Story card:** -

## Because

We noticed the missed visits number between the `Repository` and `Result` was not matching. This happens because the `Repository` missed visits cache doesn't get refreshed via the cache warmer and only refreshes after the TTL which is 7 days.

## This addresses

This calls the missed visits method in the cache warmer code path so it gets refreshed. We're adding this since it blocks this report: https://github.com/simpledotorg/simple-server/pull/2458. 

The long term fix is to remove the missed visit calculation from result and use the method in repository for `ControlRateService`.

