### PR TITLE
Disallow selecting the current month in the drug stock webview when not in the last week of the month

### DIFF
--- a/app/controllers/webview/drug_stocks_controller.rb
+++ b/app/controllers/webview/drug_stocks_controller.rb
@@ -80,9 +80,12 @@ class Webview::DrugStocksController < ApplicationController
     @for_end_of_month ||= if params[:for_end_of_month]
       logger.info "parsing for_end_of_month from #{params[:for_end_of_month]}"
       Date.parse(params[:for_end_of_month]).end_of_month
-    else
+    elsif (Date.current.end_of_month - Date.current).to_i < 8
       logger.info "using current date for_end_of_month"
       Date.current.end_of_month
+    else
+      logger.info "using previous month for_end_of_month"
+      Date.current.prev_month.end_of_month
     end
   end
 


### PR DESCRIPTION
**Story card:** [ch3444](https://app.clubhouse.io/simpledotorg/story/3444/disallow-selecting-the-current-month-in-the-drug-stock-webview)

## Because
 
 Users should only be able to select the current month during the last week of the month