### PR TITLE
Hide current month option from drug stock entry

### DIFF
--- a/app/views/my_facilities/drug_stocks/drug_consumption.html.erb
+++ b/app/views/my_facilities/drug_stocks/drug_consumption.html.erb
@@ -30,7 +30,7 @@
             <%= @for_end_of_month_display %>
           </a>
           <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-            <% last_n_months(n: 6, inclusive: true).each do |month| %>
+            <% last_n_months(n: 6, inclusive: (Date.current.end_of_month - Date.current).to_i < 8).each do |month| %>
               <% button_class = "dropdown-item query-filter-size filter-by-size" %>
               <% button_class = "dropdown-item active " if month.end_of_month == @for_end_of_month %>
               <button class="<%= button_class %>" value="<%= month.strftime("%b-%Y") %>" name="for_end_of_month" type="submit" form="query-filters">

--- a/app/views/webview/drug_stocks/new.html.erb
+++ b/app/views/webview/drug_stocks/new.html.erb
@@ -41,7 +41,7 @@
 
           <div class="form-group">
             <div class="form-row">
-              <% choices = last_n_months(n: 6, inclusive: true).map { |d| [d.to_date.to_s(:mon_year), d.to_date.end_of_month] }
+              <% choices = last_n_months(n: 6, inclusive: (Date.current.end_of_month - Date.current).to_i < 8).map { |d| [d.to_date.to_s(:mon_year), d.to_date.end_of_month] }
               %>
               <%= form.select :for_end_of_month, choices, { selected: @for_end_of_month }, { id: "for_end_of_month", class: "card-dropdown" } %>
             </div>


### PR DESCRIPTION
**Story card:** [ch3444](https://app.clubhouse.io/simpledotorg/story/3444/disallow-selecting-the-current-month-in-the-drug-stock-webview)

## Because

Quick follow-on from #2475, missed hiding the current month option 

## This addresses

Excludes current month from the drop down options depending on the current date