### PR TITLE
Simple App: "Help" BP Passport section fixes

### DIFF
--- a/app/views/api/v3/help/show.html.erb
+++ b/app/views/api/v3/help/show.html.erb
@@ -496,7 +496,7 @@
           <p style="margin-top: 2.5em;"><%= t("help.bp_passport_app.features.learn_more_html") %>: <a href="http://simple.org/bp-passport">simple.org/bp-passport</a></p>
         </div>
         <div class="card">
-          <h3><%= t("help.bp_passport_app.platforms.heading_html") %></h3>
+          <h3><%= t("help.bp_passport_app.platforms.headings_html") %></h3>
           <p style="margin-bottom: 2.5em;"><%= t("help.bp_passport_app.platforms.contents_html") %></p>
           <a href="https://apps.apple.com/us/app/bp-passport/id1510811893" class="app-button button"><%= inline_svg('icon_apple_icon.svg') %> <%= t("help.bp_passport_app.platforms.apple_app_store_html") %></a>
           <a href="https://play.google.com/store/apps/details?id=org.simple.bppassport" class="app-button button"><%= inline_svg('icon_google_play_icon.svg') %> <%= t("help.bp_passport_app.platforms.google_play_store_html") %></a>


### PR DESCRIPTION
**Story card:** [ch3478](https://app.clubhouse.io/simpledotorg/story/3478/simple-app-help-screen-card-title-and-store-icons)

## Because

There are a few things that are broken (wrong title in card, broken CSS for platform store buttons)

## This addresses

* Fixes "platform" card title
* Fixes "platform" card Google Play Store and Apple App Store buttons

## Test instructions

1. Go to `http://localhost:3000/api/v3/help.html`
2. Click the "Learn more" link at the bottom of the screen
3. Make sure the title of the second card is "Apple and Android"
4. Make sure the Apple App Store and Google Play Store buttons look like normal-sized buttons (the icons used to scale to the size of the entire card)