### PR TITLE
Overdue bugfix

### DIFF
--- a/db/migrate/20210514060816_update_patient_summaries_to_version_5.rb
+++ b/db/migrate/20210514060816_update_patient_summaries_to_version_5.rb
@@ -1,0 +1,5 @@
+class UpdatePatientSummariesToVersion5 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :patient_summaries, version: 5, revert_to_version: 4
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_13_211941) do
+ActiveRecord::Schema.define(version: 2021_05_14_060816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -899,143 +899,6 @@ ActiveRecord::Schema.define(version: 2021_04_13_211941) do
   SQL
   add_index "patient_registrations_per_day_per_facilities", ["facility_id", "day", "year"], name: "index_patient_registrations_per_day_per_facilities", unique: true
 
-  create_view "patient_summaries", sql_definition: <<-SQL
-      SELECT p.recorded_at,
-      concat(date_part('year'::text, p.recorded_at), ' Q', date_part('quarter'::text, p.recorded_at)) AS registration_quarter,
-      p.full_name,
-          CASE
-              WHEN (p.date_of_birth IS NOT NULL) THEN date_part('year'::text, age((p.date_of_birth)::timestamp with time zone))
-              ELSE ((p.age)::double precision + date_part('years'::text, age(now(), (p.age_updated_at)::timestamp with time zone)))
-          END AS current_age,
-      p.gender,
-      p.status,
-      p.assigned_facility_id,
-      latest_phone_number.number AS latest_phone_number,
-      addresses.village_or_colony,
-      addresses.street_address,
-      addresses.district,
-      addresses.state,
-      reg_facility.name AS registration_facility_name,
-      reg_facility.facility_type AS registration_facility_type,
-      reg_facility.district AS registration_district,
-      reg_facility.state AS registration_state,
-      latest_blood_pressure.systolic AS latest_blood_pressure_systolic,
-      latest_blood_pressure.diastolic AS latest_blood_pressure_diastolic,
-      latest_blood_pressure.recorded_at AS latest_blood_pressure_recorded_at,
-      concat(date_part('year'::text, latest_blood_pressure.recorded_at), ' Q', date_part('quarter'::text, latest_blood_pressure.recorded_at)) AS latest_blood_pressure_quarter,
-      latest_blood_pressure_facility.name AS latest_blood_pressure_facility_name,
-      latest_blood_pressure_facility.facility_type AS latest_blood_pressure_facility_type,
-      latest_blood_pressure_facility.district AS latest_blood_pressure_district,
-      latest_blood_pressure_facility.state AS latest_blood_pressure_state,
-      latest_blood_sugar.blood_sugar_type AS latest_blood_sugar_type,
-      latest_blood_sugar.blood_sugar_value AS latest_blood_sugar_value,
-      latest_blood_sugar.recorded_at AS latest_blood_sugar_recorded_at,
-      concat(date_part('year'::text, latest_blood_sugar.recorded_at), ' Q', date_part('quarter'::text, latest_blood_sugar.recorded_at)) AS latest_blood_sugar_quarter,
-      latest_blood_sugar_facility.name AS latest_blood_sugar_facility_name,
-      latest_blood_sugar_facility.facility_type AS latest_blood_sugar_facility_type,
-      latest_blood_sugar_facility.district AS latest_blood_sugar_district,
-      latest_blood_sugar_facility.state AS latest_blood_sugar_state,
-      GREATEST((0)::double precision, date_part('day'::text, (now() - (next_appointment.scheduled_date)::timestamp with time zone))) AS days_overdue,
-      next_appointment.id AS next_appointment_id,
-      next_appointment.scheduled_date AS next_appointment_scheduled_date,
-      next_appointment.status AS next_appointment_status,
-      next_appointment.remind_on AS next_appointment_remind_on,
-      next_appointment_facility.id AS next_appointment_facility_id,
-      next_appointment_facility.name AS next_appointment_facility_name,
-      next_appointment_facility.facility_type AS next_appointment_facility_type,
-      next_appointment_facility.district AS next_appointment_district,
-      next_appointment_facility.state AS next_appointment_state,
-          CASE
-              WHEN (next_appointment.scheduled_date IS NULL) THEN 0
-              WHEN (next_appointment.scheduled_date > date_trunc('day'::text, (now() - '30 days'::interval))) THEN 0
-              WHEN ((latest_blood_pressure.systolic >= 180) OR (latest_blood_pressure.diastolic >= 110)) THEN 1
-              WHEN (((mh.prior_heart_attack = 'yes'::text) OR (mh.prior_stroke = 'yes'::text)) AND ((latest_blood_pressure.systolic >= 140) OR (latest_blood_pressure.diastolic >= 90))) THEN 1
-              WHEN ((((latest_blood_sugar.blood_sugar_type)::text = 'random'::text) AND (latest_blood_sugar.blood_sugar_value >= (300)::numeric)) OR (((latest_blood_sugar.blood_sugar_type)::text = 'post_prandial'::text) AND (latest_blood_sugar.blood_sugar_value >= (300)::numeric)) OR (((latest_blood_sugar.blood_sugar_type)::text = 'fasting'::text) AND (latest_blood_sugar.blood_sugar_value >= (200)::numeric)) OR (((latest_blood_sugar.blood_sugar_type)::text = 'hba1c'::text) AND (latest_blood_sugar.blood_sugar_value >= 9.0))) THEN 1
-              ELSE 0
-          END AS risk_level,
-      latest_bp_passport.identifier AS latest_bp_passport,
-      p.id
-     FROM (((((((((((patients p
-       LEFT JOIN addresses ON ((addresses.id = p.address_id)))
-       LEFT JOIN facilities reg_facility ON ((reg_facility.id = p.registration_facility_id)))
-       LEFT JOIN medical_histories mh ON ((mh.patient_id = p.id)))
-       LEFT JOIN ( SELECT DISTINCT ON (patient_phone_numbers.patient_id) patient_phone_numbers.id,
-              patient_phone_numbers.number,
-              patient_phone_numbers.phone_type,
-              patient_phone_numbers.active,
-              patient_phone_numbers.created_at,
-              patient_phone_numbers.updated_at,
-              patient_phone_numbers.patient_id,
-              patient_phone_numbers.device_created_at,
-              patient_phone_numbers.device_updated_at,
-              patient_phone_numbers.deleted_at,
-              patient_phone_numbers.dnd_status
-             FROM patient_phone_numbers
-            ORDER BY patient_phone_numbers.patient_id, patient_phone_numbers.device_created_at DESC) latest_phone_number ON ((latest_phone_number.patient_id = p.id)))
-       LEFT JOIN ( SELECT DISTINCT ON (blood_pressures.patient_id) blood_pressures.id,
-              blood_pressures.systolic,
-              blood_pressures.diastolic,
-              blood_pressures.patient_id,
-              blood_pressures.created_at,
-              blood_pressures.updated_at,
-              blood_pressures.device_created_at,
-              blood_pressures.device_updated_at,
-              blood_pressures.facility_id,
-              blood_pressures.user_id,
-              blood_pressures.deleted_at,
-              blood_pressures.recorded_at
-             FROM blood_pressures
-            ORDER BY blood_pressures.patient_id, blood_pressures.recorded_at DESC) latest_blood_pressure ON ((latest_blood_pressure.patient_id = p.id)))
-       LEFT JOIN facilities latest_blood_pressure_facility ON ((latest_blood_pressure_facility.id = latest_blood_pressure.facility_id)))
-       LEFT JOIN ( SELECT DISTINCT ON (blood_sugars.patient_id) blood_sugars.id,
-              blood_sugars.blood_sugar_type,
-              blood_sugars.blood_sugar_value,
-              blood_sugars.patient_id,
-              blood_sugars.user_id,
-              blood_sugars.facility_id,
-              blood_sugars.device_created_at,
-              blood_sugars.device_updated_at,
-              blood_sugars.deleted_at,
-              blood_sugars.recorded_at,
-              blood_sugars.created_at,
-              blood_sugars.updated_at
-             FROM blood_sugars
-            ORDER BY blood_sugars.patient_id, blood_sugars.recorded_at DESC) latest_blood_sugar ON ((latest_blood_sugar.patient_id = p.id)))
-       LEFT JOIN facilities latest_blood_sugar_facility ON ((latest_blood_sugar_facility.id = latest_blood_sugar.facility_id)))
-       LEFT JOIN ( SELECT DISTINCT ON (patient_business_identifiers.patient_id) patient_business_identifiers.id,
-              patient_business_identifiers.identifier,
-              patient_business_identifiers.identifier_type,
-              patient_business_identifiers.patient_id,
-              patient_business_identifiers.metadata_version,
-              patient_business_identifiers.metadata,
-              patient_business_identifiers.device_created_at,
-              patient_business_identifiers.device_updated_at,
-              patient_business_identifiers.deleted_at,
-              patient_business_identifiers.created_at,
-              patient_business_identifiers.updated_at
-             FROM patient_business_identifiers
-            WHERE ((patient_business_identifiers.identifier_type)::text = 'simple_bp_passport'::text)
-            ORDER BY patient_business_identifiers.patient_id, patient_business_identifiers.device_created_at DESC) latest_bp_passport ON ((latest_bp_passport.patient_id = p.id)))
-       LEFT JOIN ( SELECT DISTINCT ON (appointments.patient_id) appointments.id,
-              appointments.patient_id,
-              appointments.facility_id,
-              appointments.scheduled_date,
-              appointments.status,
-              appointments.cancel_reason,
-              appointments.device_created_at,
-              appointments.device_updated_at,
-              appointments.created_at,
-              appointments.updated_at,
-              appointments.remind_on,
-              appointments.agreed_to_visit,
-              appointments.deleted_at,
-              appointments.appointment_type,
-              appointments.user_id,
-              appointments.creation_facility_id
-             FROM appointments
-            ORDER BY appointments.patient_id, appointments.scheduled_date DESC) next_appointment ON ((next_appointment.patient_id = p.id)))
-       LEFT JOIN facilities next_appointment_facility ON ((next_appointment_facility.id = next_appointment.facility_id)));
-  SQL
   create_view "patients_blood_pressures_facilities", sql_definition: <<-SQL
       SELECT patients.id AS p_id,
       patients.age AS p_age,
@@ -1313,4 +1176,142 @@ ActiveRecord::Schema.define(version: 2021_04_13_211941) do
   add_index "latest_blood_pressures_per_patients", ["bp_id"], name: "index_latest_blood_pressures_per_patients", unique: true
   add_index "latest_blood_pressures_per_patients", ["patient_id"], name: "index_latest_bp_per_patient_patient_id"
 
+  create_view "patient_summaries", sql_definition: <<-SQL
+      SELECT p.recorded_at,
+      concat(date_part('year'::text, p.recorded_at), ' Q', date_part('quarter'::text, p.recorded_at)) AS registration_quarter,
+      p.full_name,
+          CASE
+              WHEN (p.date_of_birth IS NOT NULL) THEN date_part('year'::text, age((p.date_of_birth)::timestamp with time zone))
+              ELSE ((p.age)::double precision + date_part('years'::text, age(now(), (p.age_updated_at)::timestamp with time zone)))
+          END AS current_age,
+      p.gender,
+      p.status,
+      p.assigned_facility_id,
+      latest_phone_number.number AS latest_phone_number,
+      addresses.village_or_colony,
+      addresses.street_address,
+      addresses.district,
+      addresses.state,
+      reg_facility.name AS registration_facility_name,
+      reg_facility.facility_type AS registration_facility_type,
+      reg_facility.district AS registration_district,
+      reg_facility.state AS registration_state,
+      latest_blood_pressure.systolic AS latest_blood_pressure_systolic,
+      latest_blood_pressure.diastolic AS latest_blood_pressure_diastolic,
+      latest_blood_pressure.recorded_at AS latest_blood_pressure_recorded_at,
+      concat(date_part('year'::text, latest_blood_pressure.recorded_at), ' Q', date_part('quarter'::text, latest_blood_pressure.recorded_at)) AS latest_blood_pressure_quarter,
+      latest_blood_pressure_facility.name AS latest_blood_pressure_facility_name,
+      latest_blood_pressure_facility.facility_type AS latest_blood_pressure_facility_type,
+      latest_blood_pressure_facility.district AS latest_blood_pressure_district,
+      latest_blood_pressure_facility.state AS latest_blood_pressure_state,
+      latest_blood_sugar.blood_sugar_type AS latest_blood_sugar_type,
+      latest_blood_sugar.blood_sugar_value AS latest_blood_sugar_value,
+      latest_blood_sugar.recorded_at AS latest_blood_sugar_recorded_at,
+      concat(date_part('year'::text, latest_blood_sugar.recorded_at), ' Q', date_part('quarter'::text, latest_blood_sugar.recorded_at)) AS latest_blood_sugar_quarter,
+      latest_blood_sugar_facility.name AS latest_blood_sugar_facility_name,
+      latest_blood_sugar_facility.facility_type AS latest_blood_sugar_facility_type,
+      latest_blood_sugar_facility.district AS latest_blood_sugar_district,
+      latest_blood_sugar_facility.state AS latest_blood_sugar_state,
+      GREATEST((0)::double precision, date_part('day'::text, (now() - (next_appointment.scheduled_date)::timestamp with time zone))) AS days_overdue,
+      next_appointment.id AS next_appointment_id,
+      next_appointment.scheduled_date AS next_appointment_scheduled_date,
+      next_appointment.status AS next_appointment_status,
+      next_appointment.remind_on AS next_appointment_remind_on,
+      next_appointment_facility.id AS next_appointment_facility_id,
+      next_appointment_facility.name AS next_appointment_facility_name,
+      next_appointment_facility.facility_type AS next_appointment_facility_type,
+      next_appointment_facility.district AS next_appointment_district,
+      next_appointment_facility.state AS next_appointment_state,
+          CASE
+              WHEN (next_appointment.scheduled_date IS NULL) THEN 0
+              WHEN (next_appointment.scheduled_date > date_trunc('day'::text, (now() - '30 days'::interval))) THEN 0
+              WHEN ((latest_blood_pressure.systolic >= 180) OR (latest_blood_pressure.diastolic >= 110)) THEN 1
+              WHEN (((mh.prior_heart_attack = 'yes'::text) OR (mh.prior_stroke = 'yes'::text)) AND ((latest_blood_pressure.systolic >= 140) OR (latest_blood_pressure.diastolic >= 90))) THEN 1
+              WHEN ((((latest_blood_sugar.blood_sugar_type)::text = 'random'::text) AND (latest_blood_sugar.blood_sugar_value >= (300)::numeric)) OR (((latest_blood_sugar.blood_sugar_type)::text = 'post_prandial'::text) AND (latest_blood_sugar.blood_sugar_value >= (300)::numeric)) OR (((latest_blood_sugar.blood_sugar_type)::text = 'fasting'::text) AND (latest_blood_sugar.blood_sugar_value >= (200)::numeric)) OR (((latest_blood_sugar.blood_sugar_type)::text = 'hba1c'::text) AND (latest_blood_sugar.blood_sugar_value >= 9.0))) THEN 1
+              ELSE 0
+          END AS risk_level,
+      latest_bp_passport.identifier AS latest_bp_passport,
+      p.id
+     FROM (((((((((((patients p
+       LEFT JOIN addresses ON ((addresses.id = p.address_id)))
+       LEFT JOIN facilities reg_facility ON ((reg_facility.id = p.registration_facility_id)))
+       LEFT JOIN medical_histories mh ON ((mh.patient_id = p.id)))
+       LEFT JOIN ( SELECT DISTINCT ON (patient_phone_numbers.patient_id) patient_phone_numbers.id,
+              patient_phone_numbers.number,
+              patient_phone_numbers.phone_type,
+              patient_phone_numbers.active,
+              patient_phone_numbers.created_at,
+              patient_phone_numbers.updated_at,
+              patient_phone_numbers.patient_id,
+              patient_phone_numbers.device_created_at,
+              patient_phone_numbers.device_updated_at,
+              patient_phone_numbers.deleted_at,
+              patient_phone_numbers.dnd_status
+             FROM patient_phone_numbers
+            ORDER BY patient_phone_numbers.patient_id, patient_phone_numbers.device_created_at DESC) latest_phone_number ON ((latest_phone_number.patient_id = p.id)))
+       LEFT JOIN ( SELECT DISTINCT ON (blood_pressures.patient_id) blood_pressures.id,
+              blood_pressures.systolic,
+              blood_pressures.diastolic,
+              blood_pressures.patient_id,
+              blood_pressures.created_at,
+              blood_pressures.updated_at,
+              blood_pressures.device_created_at,
+              blood_pressures.device_updated_at,
+              blood_pressures.facility_id,
+              blood_pressures.user_id,
+              blood_pressures.deleted_at,
+              blood_pressures.recorded_at
+             FROM blood_pressures
+            ORDER BY blood_pressures.patient_id, blood_pressures.recorded_at DESC) latest_blood_pressure ON ((latest_blood_pressure.patient_id = p.id)))
+       LEFT JOIN facilities latest_blood_pressure_facility ON ((latest_blood_pressure_facility.id = latest_blood_pressure.facility_id)))
+       LEFT JOIN ( SELECT DISTINCT ON (blood_sugars.patient_id) blood_sugars.id,
+              blood_sugars.blood_sugar_type,
+              blood_sugars.blood_sugar_value,
+              blood_sugars.patient_id,
+              blood_sugars.user_id,
+              blood_sugars.facility_id,
+              blood_sugars.device_created_at,
+              blood_sugars.device_updated_at,
+              blood_sugars.deleted_at,
+              blood_sugars.recorded_at,
+              blood_sugars.created_at,
+              blood_sugars.updated_at
+             FROM blood_sugars
+            ORDER BY blood_sugars.patient_id, blood_sugars.recorded_at DESC) latest_blood_sugar ON ((latest_blood_sugar.patient_id = p.id)))
+       LEFT JOIN facilities latest_blood_sugar_facility ON ((latest_blood_sugar_facility.id = latest_blood_sugar.facility_id)))
+       LEFT JOIN ( SELECT DISTINCT ON (patient_business_identifiers.patient_id) patient_business_identifiers.id,
+              patient_business_identifiers.identifier,
+              patient_business_identifiers.identifier_type,
+              patient_business_identifiers.patient_id,
+              patient_business_identifiers.metadata_version,
+              patient_business_identifiers.metadata,
+              patient_business_identifiers.device_created_at,
+              patient_business_identifiers.device_updated_at,
+              patient_business_identifiers.deleted_at,
+              patient_business_identifiers.created_at,
+              patient_business_identifiers.updated_at
+             FROM patient_business_identifiers
+            WHERE ((patient_business_identifiers.identifier_type)::text = 'simple_bp_passport'::text)
+            ORDER BY patient_business_identifiers.patient_id, patient_business_identifiers.device_created_at DESC) latest_bp_passport ON ((latest_bp_passport.patient_id = p.id)))
+       LEFT JOIN ( SELECT DISTINCT ON (appointments.patient_id) appointments.id,
+              appointments.patient_id,
+              appointments.facility_id,
+              appointments.scheduled_date,
+              appointments.status,
+              appointments.cancel_reason,
+              appointments.device_created_at,
+              appointments.device_updated_at,
+              appointments.created_at,
+              appointments.updated_at,
+              appointments.remind_on,
+              appointments.agreed_to_visit,
+              appointments.deleted_at,
+              appointments.appointment_type,
+              appointments.user_id,
+              appointments.creation_facility_id
+             FROM appointments
+            ORDER BY appointments.patient_id, appointments.scheduled_date DESC) next_appointment ON ((next_appointment.patient_id = p.id)))
+       LEFT JOIN facilities next_appointment_facility ON ((next_appointment_facility.id = next_appointment.facility_id)))
+    WHERE (p.deleted_at IS NULL);
+  SQL
 end

--- a/db/views/patient_summaries_v05.sql
+++ b/db/views/patient_summaries_v05.sql
@@ -1,0 +1,116 @@
+SELECT
+p.recorded_at,
+CONCAT(date_part('year', p.recorded_at), ' Q', EXTRACT(QUARTER FROM p.recorded_at)) AS registration_quarter,
+p.full_name,
+(
+    CASE
+      WHEN p.date_of_birth IS NOT NULL THEN date_part('year', age(p.date_of_birth))
+      ELSE p.age + date_part('years', age(NOW(), p.age_updated_at))
+    END
+) AS current_age,
+p.gender,
+p.status,
+p.assigned_facility_id AS assigned_facility_id,
+latest_phone_number.number AS latest_phone_number,
+addresses.village_or_colony AS village_or_colony,
+addresses.street_address AS street_address,
+addresses.district AS district,
+addresses.state AS state,
+reg_facility.name AS registration_facility_name,
+reg_facility.facility_type AS registration_facility_type,
+reg_facility.district AS registration_district,
+reg_facility.state AS registration_state,
+latest_blood_pressure.systolic AS latest_blood_pressure_systolic,
+latest_blood_pressure.diastolic AS latest_blood_pressure_diastolic,
+latest_blood_pressure.recorded_at AS latest_blood_pressure_recorded_at,
+CONCAT(date_part('year', latest_blood_pressure.recorded_at), ' Q', EXTRACT(QUARTER FROM latest_blood_pressure.recorded_at)) AS latest_blood_pressure_quarter,
+latest_blood_pressure_facility.name AS latest_blood_pressure_facility_name,
+latest_blood_pressure_facility.facility_type AS latest_blood_pressure_facility_type,
+latest_blood_pressure_facility.district AS latest_blood_pressure_district,
+latest_blood_pressure_facility.state AS latest_blood_pressure_state,
+latest_blood_sugar.blood_sugar_type AS latest_blood_sugar_type,
+latest_blood_sugar.blood_sugar_value AS latest_blood_sugar_value,
+latest_blood_sugar.recorded_at AS latest_blood_sugar_recorded_at,
+CONCAT(date_part('year', latest_blood_sugar.recorded_at), ' Q', EXTRACT(QUARTER FROM latest_blood_sugar.recorded_at)) AS latest_blood_sugar_quarter,
+latest_blood_sugar_facility.name AS latest_blood_sugar_facility_name,
+latest_blood_sugar_facility.facility_type AS latest_blood_sugar_facility_type,
+latest_blood_sugar_facility.district AS latest_blood_sugar_district,
+latest_blood_sugar_facility.state AS latest_blood_sugar_state,
+greatest(0, date_part('day', NOW() - next_appointment.scheduled_date)) AS days_overdue,
+next_appointment.id AS next_appointment_id,
+next_appointment.scheduled_date AS next_appointment_scheduled_date,
+next_appointment.status AS next_appointment_status,
+next_appointment.remind_on AS next_appointment_remind_on,
+next_appointment_facility.id AS next_appointment_facility_id,
+next_appointment_facility.name AS next_appointment_facility_name,
+next_appointment_facility.facility_type AS next_appointment_facility_type,
+next_appointment_facility.district AS next_appointment_district,
+next_appointment_facility.state AS next_appointment_state,
+
+(
+    CASE
+      WHEN next_appointment.scheduled_date IS NULL THEN 0
+      WHEN next_appointment.scheduled_date > date_trunc('day', NOW() - interval '30 days') THEN 0
+      WHEN (latest_blood_pressure.systolic >= 180 OR latest_blood_pressure.diastolic >= 110) THEN 1
+      WHEN (
+        (mh.prior_heart_attack = 'yes' OR mh.prior_stroke = 'yes')
+        AND (latest_blood_pressure.systolic >= 140 OR latest_blood_pressure.diastolic >= 90)
+      ) THEN 1
+      WHEN (
+        (latest_blood_sugar.blood_sugar_type = 'random' AND latest_blood_sugar.blood_sugar_value >= 300)
+        OR (latest_blood_sugar.blood_sugar_type = 'post_prandial' AND latest_blood_sugar.blood_sugar_value >= 300)
+        OR (latest_blood_sugar.blood_sugar_type = 'fasting' AND latest_blood_sugar.blood_sugar_value >= 200)
+        OR (latest_blood_sugar.blood_sugar_type = 'hba1c' AND latest_blood_sugar.blood_sugar_value >= 9.0)
+      ) THEN 1
+      ELSE 0
+    END
+) AS risk_level,
+
+latest_bp_passport.identifier AS latest_bp_passport,
+p.id
+
+FROM patients p
+
+LEFT OUTER JOIN addresses ON addresses.id = p.address_id
+LEFT OUTER JOIN facilities reg_facility ON reg_facility.id = p.registration_facility_id
+LEFT OUTER JOIN medical_histories mh ON mh.patient_id = p.id
+
+LEFT OUTER JOIN (
+    SELECT DISTINCT ON (patient_id) *
+    FROM patient_phone_numbers
+    ORDER BY patient_id, device_created_at DESC
+) AS latest_phone_number
+ON latest_phone_number.patient_id = p.id
+
+LEFT OUTER JOIN (
+    SELECT DISTINCT ON (patient_id) *
+    FROM blood_pressures
+    ORDER BY patient_id, recorded_at DESC
+) AS latest_blood_pressure
+ON latest_blood_pressure.patient_id = p.id
+LEFT OUTER JOIN facilities latest_blood_pressure_facility ON latest_blood_pressure_facility.id = latest_blood_pressure.facility_id
+
+LEFT OUTER JOIN (
+    SELECT DISTINCT ON (patient_id) *
+    FROM blood_sugars
+    ORDER BY patient_id, recorded_at DESC
+) AS latest_blood_sugar
+ON latest_blood_sugar.patient_id = p.id
+LEFT OUTER JOIN facilities latest_blood_sugar_facility ON latest_blood_sugar_facility.id = latest_blood_sugar.facility_id
+
+LEFT OUTER JOIN (
+    SELECT DISTINCT ON (patient_id) *
+    FROM patient_business_identifiers
+    WHERE identifier_type = 'simple_bp_passport'
+    ORDER BY patient_id, device_created_at DESC
+) AS latest_bp_passport
+ON latest_bp_passport.patient_id = p.id
+
+LEFT OUTER JOIN (
+    SELECT DISTINCT ON (patient_id) *
+    FROM appointments
+    ORDER BY patient_id, scheduled_date DESC
+) AS next_appointment
+ON next_appointment.patient_id = p.id
+LEFT OUTER JOIN facilities next_appointment_facility ON next_appointment_facility.id = next_appointment.facility_id
+WHERE p.deleted_at IS NULL;

--- a/spec/models/patient_summary_spec.rb
+++ b/spec/models/patient_summary_spec.rb
@@ -210,4 +210,14 @@ describe PatientSummary, type: :model do
       expect(PatientSummary.overdue.map(&:id)).not_to include(upcoming_appointment.patient_id)
     end
   end
+
+  describe "discarded patients" do
+    it "does not include discarded patients" do
+      patient = create(:patient)
+      discarded_patient = create(:patient).tap(&:discard)
+
+      expect(PatientSummary.find_by(id: patient.id)).to be_present
+      expect(PatientSummary.find_by(id: discarded_patient.id)).not_to be_present
+    end
+  end
 end


### PR DESCRIPTION
**Story card:** [ch3498](https://app.clubhouse.io/simpledotorg/story/3498/user-unable-to-open-overdue-list-in-dashboard)

## Because

Sometimes discarded patients have undiscarded appointments, and our dashboard tries to render them in the overdue list and breaks.

## This addresses

Omits discarded patients from the PatientSummary **not**-materialized view.

Notes
* I've chosen not to prevent this data situation (discarded patient with undiscarded appointments) from arising because we have a very distributed data model with syncs coming from everywhere all the time. I think it's more valuable to be tolerant in this case, rather than introducing callbacks, validations, etc.
* I have verified that the only touchpoints of the PatientSummary view is for this overdue list. Patient linelists utilize a separate MaterializedPatientSummary view, and will be unaffected
* The MaterializedPatientSummary does a similar discarded exclusion, so I've done the same for consistency. The alternative would be to add the `deleted_at` field to the view, and do the scoping at query time.

Additional fun things

* Speaking of MaterializedPatientSummary, it would be great for that view to be re-written as `SELECT * FROM patient_summaries`, so that it stays consistent with the changes we're making to PatientSummary in the future.

## Test instructions

* Find an overdue patient in the dashboard.
* Discard them, not their appointments,
* Make sure the overdue list still works, and they're no longer there.