### PR TITLE
Properly handle the remind_on date by using next_messaging_time

### DIFF
--- a/app/services/appointment_notification_service.rb
+++ b/app/services/appointment_notification_service.rb
@@ -19,18 +19,18 @@ class AppointmentNotificationService
     next_messaging_time = Communication.next_messaging_time
 
     eligible_appointments.each do |appointment|
-      appointment_reminder = create_appointment_reminder(appointment)
+      appointment_reminder = create_appointment_reminder(appointment, remind_on: next_messaging_time)
       AppointmentNotification::Worker.perform_at(next_messaging_time, appointment_reminder.id)
     end
   end
 
   private
 
-  def create_appointment_reminder(appointment)
+  def create_appointment_reminder(appointment, remind_on:)
     AppointmentReminder.create!(
       appointment: appointment,
       patient: appointment.patient,
-      remind_on: appointment.remind_on,
+      remind_on: remind_on,
       status: "scheduled",
       message: "sms.appointment_reminders.#{communication_type}"
     )

--- a/spec/services/appointment_notification_service_spec.rb
+++ b/spec/services/appointment_notification_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AppointmentNotificationService do
       allow_any_instance_of(AppointmentNotification::Worker).to receive(:perform)
     end
 
-    it "spawns a reminder job for each appointment that is overdue by at least 3 daysjj" do
+    it "spawns a reminder job for each appointment that is overdue by at least 3 days" do
       create(:appointment, scheduled_date: 3.days.ago, remind_on: Date.current)
       create(:appointment, scheduled_date: 4.days.ago, remind_on: Date.current)
 
@@ -17,24 +17,35 @@ RSpec.describe AppointmentNotificationService do
       }.to change(AppointmentNotification::Worker.jobs, :size).by(2)
     end
 
-    it "does not schedule for appointments that are overdue by fewer than 3 days, have an appointment reminder, or have a communication" do
+    it "spawns a reminder job for appointments with nil remind_on" do
+      create(:appointment, scheduled_date: 3.days.ago, remind_on: nil)
+
+      expect {
+        AppointmentNotificationService.send_after_missed_visit(appointments: common_org.appointments)
+      }.to change(AppointmentNotification::Worker.jobs, :size).by(1)
+    end
+
+    it "does not schedule for appointments that are overdue by fewer than 3 days, have a remind_on in the future, have an appointment reminder, or have a communication" do
       _recently_overdue_appointment_ids = create(:appointment, scheduled_date: 2.days.ago, status: :scheduled, remind_on: 2.days.ago)
       appointment_with_reminder = create(:appointment, scheduled_date: 3.days.ago, remind_on: Date.current)
       create(:appointment_reminder, appointment: appointment_with_reminder)
       appointment_with_communication = create(:appointment, scheduled_date: 3.days.ago, remind_on: Date.current)
       create(:appointment_reminder, appointment: appointment_with_communication)
+      create(:appointment, scheduled_date: 3.days.ago, remind_on: 1.day.from_now)
 
       expect {
         AppointmentNotificationService.send_after_missed_visit(appointments: common_org.appointments)
       }.to change(AppointmentNotification::Worker.jobs, :size).by(0)
     end
 
-    it "creates appointment reminders for provided appointments" do
+    it "creates appointment reminders for provided appointments with a remind_on derived from Communication.next_messaging_time" do
       overdue_appointment
       expect {
         AppointmentNotificationService.send_after_missed_visit(appointments: common_org.appointments)
       }.to change { overdue_appointment.appointment_reminders.count }.by(1)
-      expect(overdue_appointment.appointment_reminders.last.status).to eq("scheduled")
+      appointment_reminder = overdue_appointment.appointment_reminders.last
+      expect(appointment_reminder.status).to eq("scheduled")
+      expect(appointment_reminder.remind_on).to eq(Communication.next_messaging_time.to_date)
     end
 
     it "should only send reminders to patients who are eligible" do


### PR DESCRIPTION
**Story card:** [chXXXX](URL)


You can kick off the three_days_after job via the below on sandbox from `~/apps/simple-server/current`

```
RAILS_ENV=production rake "appointment_notification:three_days_after_missed_visit"
```