### PR TITLE
3557: feature flap whatsapp notifications

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -41,9 +41,7 @@ class Notification < ApplicationRecord
     if preferred_communication_method && !previously_communicated_by?(preferred_communication_method)
       return preferred_communication_method
     end
-    unless previously_communicated_by?(backup_communication_method)
-      return backup_communication_method
-    end
+    return backup_communication_method unless previously_communicated_by?(backup_communication_method)
     nil
   end
 
@@ -54,7 +52,7 @@ class Notification < ApplicationRecord
   end
 
   def preferred_communication_method
-    CountryConfig.current[:name] == "India" ? "missed_visit_whatsapp_reminder" : nil
+    Flipper.enabled?(:whatsapp_appointment_reminders) ? "missed_visit_whatsapp_reminder" : nil
   end
 
   def backup_communication_method

--- a/spec/jobs/appointment_notification/worker_spec.rb
+++ b/spec/jobs/appointment_notification/worker_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe AppointmentNotification::Worker, type: :job do
       mock_successful_delivery
       allow_any_instance_of(Notification).to receive(:next_communication_type).and_return("missed_visit_sms_reminder")
 
-
       expect(Statsd.instance).to receive(:increment).with("appointment_notification.worker.sent.sms")
       expect_any_instance_of(NotificationService).to receive(:send_sms)
       described_class.perform_async(notification.id)

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -35,7 +35,9 @@ describe Notification, type: :model do
   end
 
   describe "#next_communication_type" do
-    context "in India" do
+    context "when WhatsApp flag is on" do
+      before { Flipper.enable(:whatsapp_appointment_reminders) }
+
       it "returns missed_visit_whatsapp_reminder if it has no whatsapp communications" do
         expect(notification.next_communication_type).to eq("missed_visit_whatsapp_reminder")
       end
@@ -52,11 +54,7 @@ describe Notification, type: :model do
       end
     end
 
-    context "outside of India" do
-      before :each do
-        allow(CountryConfig).to receive(:current).and_return(CountryConfig.for(:BD))
-      end
-
+    context "when WhatsApp flag is off" do
       it "returns missed_visit_sms_reminder if it has no sms communication" do
         expect(notification.next_communication_type).to eq("missed_visit_sms_reminder")
       end


### PR DESCRIPTION
**Story card:** [ch3557](https://app.clubhouse.io/simpledotorg/story/3557/feature-flag-whatsapp-in-new-notification-system)

## Because

I made a mistake when developing this. It should be feature flagged, not geographical. 

## This addresses

We may need to send medical reminders without whatsapp, which will be easier if we can simply turn off the whatsapp feature flag in India. 