### PR TITLE
fix notification localization when notification has no subject

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -32,6 +32,14 @@ class Notification < ApplicationRecord
         appointment_date: subject.scheduled_date,
         locale: subject.facility.locale
       )
+    when nil
+      # this is a temporary fix. we need to figure out a better way of making the message more flexible
+      I18n.t(
+        message,
+        facility_name: patient.assigned_facility.name,
+        patient_name: patient.full_name,
+        locale: patient.assigned_facility.locale
+      )
     else
       raise ArgumentError, "Must provide some a subject or default behavior"
     end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -41,7 +41,7 @@ class Notification < ApplicationRecord
         locale: patient.assigned_facility.locale
       )
     else
-      raise ArgumentError, "Must provide some a subject or default behavior"
+      raise ArgumentError, "Must provide a subject or a default behavior for a notification"
     end
   end
 


### PR DESCRIPTION
**Story card:**

## Because

We made a mistake when refactoring appointment reminders into notifications and making appointment a polymorphic relationship and didn't handle the case when subject is nil. I'm fixing this in the ugliest way possible to ensure that we come up with a better long-term fix. Tim and I were talking earlier today for the need to refactor some of our communications modeling, and I think this ties into that issue. We need to make notifications less tied to the text within the notification. 