### PR TITLE
Make appointment optional from communication

### DIFF
--- a/app/models/communication.rb
+++ b/app/models/communication.rb
@@ -2,7 +2,7 @@ class Communication < ApplicationRecord
   include Mergeable
   include Hashable
 
-  belongs_to :appointment
+  belongs_to :appointment, optional: true
   belongs_to :notification, optional: true
   belongs_to :user, optional: true
   belongs_to :detailable, polymorphic: true, optional: true

--- a/spec/models/communication_spec.rb
+++ b/spec/models/communication_spec.rb
@@ -5,6 +5,7 @@ describe Communication, type: :model do
     it { should belong_to(:user).optional }
     it { should belong_to(:notification).optional }
     it { should belong_to(:detailable).optional }
+    it { should belong_to(:appointment).optional }
   end
 
   context "Validations" do


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/3566/deployment-plan-send-medication-reminders-in-india

## Because

Appointment communication was made optional earlier in the DB but got missed in the model.

## This addresses

Makes appointment - communication relation optional in the model.