### PR TITLE
Correct the Marathi language key

### DIFF
--- a/config/locales/notifications/mr_IN.yml
+++ b/config/locales/notifications/mr_IN.yml
@@ -1,4 +1,4 @@
-mr:
+mr-IN:
   notifications:
     set01:
       basic: "%{patient_name}, कृपया रक्तदाब (बीपी) मोजण्यासाठी आणि औषधे मिळवण्यासाठी  %{appointment_date} रोजी %{facility_name} येथे भेट द्या "


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/3566/deployment-plan-send-medication-reminders-in-india

The Marathi key should be `mr-IN`, not `mr`.