### PR TITLE
Make notification scheduled again if it's communication fails

### DIFF
--- a/app/controllers/api/v3/twilio_sms_delivery_controller.rb
+++ b/app/controllers/api/v3/twilio_sms_delivery_controller.rb
@@ -13,10 +13,10 @@ class Api::V3::TwilioSmsDeliveryController < ApplicationController
     metrics.increment(event)
 
     reminder = twilio_message.communication.notification
-    communication_type = reminder&.next_communication_type
-    if twilio_message.unsuccessful? && communication_type
-      notification = twilio_message.communication.notification
-      AppointmentNotification::Worker.perform_at(Communication.next_messaging_time, notification.id)
+
+    if twilio_message.unsuccessful? && reminder&.next_communication_type
+      reminder.status_scheduled!
+      AppointmentNotification::Worker.perform_at(Communication.next_messaging_time, reminder.id)
     end
 
     head :ok

--- a/spec/controllers/api/v3/twilio_sms_delivery_controller_spec.rb
+++ b/spec/controllers/api/v3/twilio_sms_delivery_controller_spec.rb
@@ -137,6 +137,8 @@ RSpec.describe Api::V3::TwilioSmsDeliveryController, type: :controller do
           expect(Statsd.instance).to receive(:increment).with("twilio_callback.missed_visit_whatsapp_reminder.failed")
 
           post :create, params: params
+
+          expect(communication.notification.reload.status).to eq("scheduled")
         end
       end
     end


### PR DESCRIPTION
**Story card:** [ch3633](https://app.clubhouse.io/simpledotorg/story/3633/fix-sms-fallback)

## Because

We set a notification's status to `sent` once a communication is sent for it. When a whatsapp communication fails to be delivered, we queue a fallback job to send an SMS. However the fallback job makes sure that the notification's status is `scheduled` before sending the message. Since the failed communication does, the fallback job does not send the SMS. 

## This addresses

When a communication fails, this marks the notification back as `scheduled` so the fallback job can send an SMS.
