### PR TITLE
3637: add feature flag that allows us to ignore the notifications mes…

### DIFF
--- a/app/models/communication.rb
+++ b/app/models/communication.rb
@@ -65,6 +65,7 @@ class Communication < ApplicationRecord
 
   def self.next_messaging_time
     now = DateTime.now.in_time_zone(Rails.application.config.country[:time_zone])
+    return now if Flipper.enabled?(:disregard_messaging_window)
 
     if now.hour < messaging_start_hour
       now.change(hour: messaging_start_hour)

--- a/spec/models/communication_spec.rb
+++ b/spec/models/communication_spec.rb
@@ -17,7 +17,7 @@ describe Communication, type: :model do
   end
 
   context "Utilities" do
-    describe ".next_appointment_time" do
+    describe ".next_messaging_time" do
       before do
         @original_time_zone = Time.zone
         Time.zone = Rails.application.config.country[:time_zone]
@@ -44,6 +44,14 @@ describe Communication, type: :model do
       it "returns the next time tomorrow if currently after the messaging window" do
         Timecop.freeze(Time.zone.parse("January 1, 2020 4:30pm")) do
           expect(Communication.next_messaging_time).to eq(Time.zone.parse("January 2, 2020 10:00am"))
+        end
+      end
+
+      it "returns the current time if send_notifications_immediately flag is enabled" do
+        Flipper.enable(:disregard_messaging_window)
+        now = "January 1, 2020 4:00am"
+        Timecop.freeze(Time.zone.parse(now)) do
+          expect(Communication.next_messaging_time).to eq(Time.zone.parse(now))
         end
       end
     end


### PR DESCRIPTION
…saging window

**Story card:** [ch3637](https://app.clubhouse.io/simpledotorg/story/3637/add-ability-to-ignore-next-messaging-window)

## Because

Testing notifications on Sandbox and Production is difficult due to the mix of background workers and the fact that messages only send during specified windows of time. Tim suggested adding an ability to send messages outside the window. 
