### PR TITLE
Bugfix: Follow ups mismatch

### DIFF
--- a/app/services/reports/repository_cache_warmer.rb
+++ b/app/services/reports/repository_cache_warmer.rb
@@ -18,10 +18,7 @@ class Reports::RepositoryCacheWarmer
   def call
     repository.missed_visits
     repository.missed_visits_rate
-    if region.facility_region?
-      repository.hypertension_follow_ups(group_by: "blood_pressures.user_id")
-    else
-      repository.hypertension_follow_ups
-    end
+    repository.hypertension_follow_ups
+    repository.hypertension_follow_ups(group_by: "blood_pressures.user_id") if region.facility_region?
   end
 end


### PR DESCRIPTION
**Story card:** [ch3564](https://app.clubhouse.io/simpledotorg/story/3564)

## Because

Follow up numbers on a facility level were not matching the numbers shown on the district page.

## This addresses

There are two issues at hand:
- The facility wise follow up number was not being updated, only the user split was being refreshed (added in #2504). This PR fixes the caching issue.
- The follow up total on a facility's page is the sum of each user's follow ups. The facility wise follow up on a district page is unique patient follow ups at a facility. These are essentially different numbers. A solution to this is being discussed in https://simpledotorg.slack.com/archives/CFHKJ5WJY/p1621608592010900. This does not address this issue.

