### PR TITLE
Multiple twilio senders

### DIFF
--- a/app/jobs/appointment_notification/worker.rb
+++ b/app/jobs/appointment_notification/worker.rb
@@ -34,12 +34,11 @@ class AppointmentNotification::Worker
   private
 
   def send_message(notification, communication_type)
-    if notification.experiment&.experiment_type == "medication_reminder" && medication_reminder_sms_sender
-      notification_service = NotificationService.new(sms_sender: medication_reminder_sms_sender)
+    notification_service = if notification.experiment&.experiment_type == "medication_reminder" && medication_reminder_sms_sender
+      NotificationService.new(sms_sender: medication_reminder_sms_sender)
     else
-      notification_service = NotificationService.new
+      NotificationService.new
     end
-
 
     if communication_type == "missed_visit_whatsapp_reminder"
       notification_service.send_whatsapp(

--- a/app/jobs/appointment_notification/worker.rb
+++ b/app/jobs/appointment_notification/worker.rb
@@ -58,8 +58,17 @@ class AppointmentNotification::Worker
       end
     end
 
-    logger.info class: self.class.name, msg: "send_message", failed: !!notification_service.failed?,
-                communication_type: communication_type, notification_id: notification.id
+    log_info = {
+      class: self.class.name,
+      msg: "send_message",
+      failed: !!notification_service.failed?,
+      error: notification_service.error,
+      sender: medication_reminder_sms_sender || "default",
+      communication_type: communication_type,
+      notification_id: notification.id
+    }
+
+    logger.info log_info
 
     return if notification_service.failed?
 

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -12,7 +12,7 @@ class NotificationService
   TWILIO_TEST_SMS_NUMBER = "+15005550006"
   TWILIO_TEST_WHATSAPP_NUMBER = "+14155238886"
 
-  def initialize
+  def initialize(sms_sender: nil)
     @test_mode = !SimpleServer.env.production?
 
     @twilio_account_sid = ENV.fetch("TWILIO_ACCOUNT_SID")
@@ -21,7 +21,13 @@ class NotificationService
     @twilio_test_account_sid = ENV.fetch("TWILIO_TEST_ACCOUNT_SID")
     @twilio_test_auth_token = ENV.fetch("TWILIO_TEST_AUTH_TOKEN")
 
-    @twilio_sender_sms_number = test_mode? ? TWILIO_TEST_SMS_NUMBER : ENV.fetch("TWILIO_PHONE_NUMBER")
+    @twilio_sender_sms_number = if test_mode?
+      TWILIO_TEST_SMS_NUMBER
+    elsif sms_sender
+      sms_sender
+    else
+      ENV.fetch("TWILIO_PHONE_NUMBER")
+    end
     @twilio_sender_whatsapp_number = test_mode? ? TWILIO_TEST_WHATSAPP_NUMBER : ENV.fetch("TWILIO_PHONE_NUMBER")
 
     @client = if @test_mode

--- a/spec/models/experimentation/experiment_spec.rb
+++ b/spec/models/experimentation/experiment_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Experimentation::Experiment, type: :model do
     end
 
     it "only allows one instance of type 'medication_reminder'" do
-      existing = create(:experiment, experiment_type: "medication_reminder")
+      _existing = create(:experiment, experiment_type: "medication_reminder")
       expect(build(:experiment, experiment_type: "medication_reminder")).to be_invalid
     end
   end

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -33,6 +33,23 @@ RSpec.describe NotificationService do
     end
   end
 
+  describe "specifying an SMS sender" do
+    it "uses the provided SMS sender number in production" do
+      stub_const("SIMPLE_SERVER_ENV", "production")
+      notification_service = NotificationService.new(sms_sender: "1234567890")
+      expect(notification_service.twilio_sender_sms_number).to eq("1234567890")
+    end
+
+    it "uses the test number in test environments" do
+      notification_service = NotificationService.new(sms_sender: "1234567890")
+      expect(notification_service.twilio_sender_sms_number).to eq(NotificationService::TWILIO_TEST_SMS_NUMBER)
+    end
+
+    it "uses the primary number when no explicit sender is specified" do
+      expect(notification_service.twilio_sender_sms_number).to eq(ENV.fetch("TWILIO_PHONE_NUMBER"))
+    end
+  end
+
   describe "#send_sms" do
     it "correctly calls the Twilio API" do
       stub_client

--- a/spec/services/patient_import/spreadsheet_transformer_spec.rb
+++ b/spec/services/patient_import/spreadsheet_transformer_spec.rb
@@ -211,7 +211,6 @@ RSpec.describe PatientImport::SpreadsheetTransformer do
       params = PatientImport::SpreadsheetTransformer.call(data, facility: facility)
 
       patient = params.find { |p| p[:patient][:full_name] == "No Rxnorm Code" }.deep_symbolize_keys
-      registration_time = Time.parse("2020-10-16").rfc3339
 
       expect(patient[:prescription_drugs].first).not_to have_key(:rxnorm_code)
     end


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/3640/send-covid-messages-from-multiple-senders

## Because

We need to send covid messages through multiple senders to avoid hitting Twilio SMS limits. Details in story.

## This addresses

Picking a random sender out of 3 dedicated covid message senders that we just provisioned in Twilio. See story for details.

Corresponding config updates are here: https://github.com/simpledotorg/deployment/pull/336