### PR TITLE
3641: log prescription drug creation when patient is part of medicati…

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -44,6 +44,8 @@ class Patient < ApplicationRecord
   has_many :appointments
   has_many :notifications
   has_many :treatment_group_memberships, class_name: "Experimentation::TreatmentGroupMembership"
+  has_many :treatment_groups, through: :treatment_group_memberships, class_name: "Experimentation::TreatmentGroup"
+  has_many :experiments, through: :treatment_groups, class_name: "Experimentation::Experiment"
   has_one :medical_history
   has_many :teleconsultations
 

--- a/app/models/prescription_drug.rb
+++ b/app/models/prescription_drug.rb
@@ -47,11 +47,11 @@ class PrescriptionDrug < ApplicationRecord
   # this code should only be temporary, as it's part of monitoring a one-off experiment
   # https://app.clubhouse.io/simpledotorg/story/3642/remove-unnecessary-medication-reminder-code
   def log_medication_reminder_success
-    experiment_membership = patient.treatment_group_memberships.find {|membership| membership.treatment_group.experiment.experiment_type == "medication_reminder" }
+    experiment_membership = patient.treatment_group_memberships.find { |membership| membership.treatment_group.experiment.experiment_type == "medication_reminder" }
     return unless experiment_membership
     experiment = experiment_membership.treatment_group.experiment
     notification = patient.notifications.find_by(experiment_id: experiment.id)
-    communication = notification.communications.find {|communication| communication.successful? }
+    communication = notification.communications.find { |communication| communication.successful? }
     return unless communication
     time_till_visit = device_created_at - communication.detailable.delivered_on
 

--- a/app/models/prescription_drug.rb
+++ b/app/models/prescription_drug.rb
@@ -60,7 +60,7 @@ class PrescriptionDrug < ApplicationRecord
       msg: "log_medication_reminder_success",
       treatment_group_membership: experiment_membership.id, # for tracking patient without exposing patient id
       facility_id: facility.id,
-      time_till_visit: time_till_visit
+      time_till_visit: time_till_visit.round
     }
 
     logger.info(log_info)

--- a/app/models/prescription_drug.rb
+++ b/app/models/prescription_drug.rb
@@ -47,9 +47,9 @@ class PrescriptionDrug < ApplicationRecord
   # this code should only be temporary, as it's part of monitoring a one-off experiment
   # https://app.clubhouse.io/simpledotorg/story/3642/remove-unnecessary-medication-reminder-code
   def log_medication_reminder_success
-    experiment_membership = patient.treatment_group_memberships.find { |membership| membership.treatment_group.experiment.experiment_type == "medication_reminder" }
-    return unless experiment_membership
-    experiment = experiment_membership.treatment_group.experiment
+    experiment = patient.experiments.find_by(experiment_type: "medication_reminder")
+
+    return unless experiment
     notification = patient.notifications.find_by(experiment_id: experiment.id)
     communication = notification.communications.find { |communication| communication.successful? }
     return unless communication
@@ -58,8 +58,6 @@ class PrescriptionDrug < ApplicationRecord
     log_info = {
       class: self.class.name,
       msg: "log_medication_reminder_success",
-      treatment_group_membership: experiment_membership.id, # for tracking patient without exposing patient id
-      facility_id: facility.id,
       time_till_visit: time_till_visit.round
     }
 

--- a/app/models/prescription_drug.rb
+++ b/app/models/prescription_drug.rb
@@ -21,6 +21,8 @@ class PrescriptionDrug < ApplicationRecord
   validates :is_protocol_drug, inclusion: {in: [true, false]}
   validates :is_deleted, inclusion: {in: [true, false]}
 
+  after_create_commit :log_medication_reminder_success
+
   scope :for_sync, -> { with_discarded }
 
   def self.prescribed_as_of(date)
@@ -38,5 +40,29 @@ class PrescriptionDrug < ApplicationRecord
      user_id: hash_uuid(patient&.registration_user&.id),
      medicine_name: name,
      dosage: dosage}
+  end
+
+  private
+
+  # this code should only be temporary, as it's part of monitoring a one-off experiment
+  # https://app.clubhouse.io/simpledotorg/story/3642/remove-unnecessary-medication-reminder-code
+  def log_medication_reminder_success
+    experiment_membership = patient.treatment_group_memberships.find {|membership| membership.treatment_group.experiment.experiment_type == "medication_reminder" }
+    return unless experiment_membership
+    experiment = experiment_membership.treatment_group.experiment
+    notification = patient.notifications.find_by(experiment_id: experiment.id)
+    communication = notification.communications.find {|communication| communication.successful? }
+    return unless communication
+    time_till_visit = device_created_at - communication.detailable.delivered_on
+
+    log_info = {
+      class: self.class.name,
+      msg: "log_medication_reminder_success",
+      treatment_group_membership: experiment_membership.id, # for tracking patient without exposing patient id
+      facility_id: facility.id,
+      time_till_visit: time_till_visit
+    }
+
+    logger.info(log_info)
   end
 end

--- a/spec/factories/experimentation/experiments.rb
+++ b/spec/factories/experimentation/experiments.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :experiment, class: Experimentation::Experiment do
+    id { SecureRandom.uuid }
     name { Faker::Lorem.unique.word }
     state { "new" }
     experiment_type { "current_patients" }

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -37,6 +37,8 @@ describe Patient, type: :model do
     it { is_expected.to have_many(:appointments) }
     it { is_expected.to have_many(:notifications) }
     it { is_expected.to have_many(:treatment_group_memberships) }
+    it { is_expected.to have_many(:treatment_groups).through(:treatment_group_memberships) }
+    it { is_expected.to have_many(:experiments).through(:treatment_groups) }
     it { is_expected.to have_many(:teleconsultations) }
 
     it { is_expected.to have_many(:encounters) }

--- a/spec/models/prescription_drug_spec.rb
+++ b/spec/models/prescription_drug_spec.rb
@@ -98,12 +98,13 @@ RSpec.describe PrescriptionDrug, type: :model do
       experiment = create(:experiment, :with_treatment_group, experiment_type: "medication_reminder")
       experiment.treatment_groups.first.patients << patient
       notification = create(:notification, patient: patient, experiment: experiment)
-      Timecop.freeze do
+      now = Time.current
+      Timecop.freeze(now) do
         communication = create(:communication, :missed_visit_whatsapp_reminder, notification: notification)
         create(:twilio_sms_delivery_detail, :delivered, communication: communication, delivered_on: 1.day.ago)
         facility = create(:facility)
 
-        time_till_visit = Time.current - communication.detailable.delivered_on
+        time_till_visit = now - communication.detailable.delivered_on
         expected_logs = {
           class: described_class.name,
           msg: "log_medication_reminder_success",

--- a/spec/models/prescription_drug_spec.rb
+++ b/spec/models/prescription_drug_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe PrescriptionDrug, type: :model do
           msg: "log_medication_reminder_success",
           treatment_group_membership: patient.treatment_group_memberships.first.id,
           facility_id: facility.id,
-          time_till_visit: time_till_visit
+          time_till_visit: time_till_visit.round
         }
 
         expect(Rails.logger).to receive(:info).with(expected_logs)

--- a/spec/models/prescription_drug_spec.rb
+++ b/spec/models/prescription_drug_spec.rb
@@ -108,8 +108,6 @@ RSpec.describe PrescriptionDrug, type: :model do
         expected_logs = {
           class: described_class.name,
           msg: "log_medication_reminder_success",
-          treatment_group_membership: patient.treatment_group_memberships.first.id,
-          facility_id: facility.id,
           time_till_visit: time_till_visit.round
         }
 


### PR DESCRIPTION
…on reminder experiment

**Story card:** [ch3641](https://app.clubhouse.io/simpledotorg/story/3641/log-when-a-prescription-drug-is-created-for-medication-reminder-experiment-patients)

## Because

We want to be able to track the success rate of medication reminders.

