### PR TITLE
Fix download name spec

### DIFF
--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -504,7 +504,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
       get :monthly_district_data_report, params: {id: region.slug, report_scope: "district", format: "csv"}
       expect(response.status).to eq(200)
       expect(response.body).to include("Monthly District Data: #{region.name} #{Date.current.strftime("%B %Y")}")
-      report_date = Date.current.strftime("%b-%Y").downcase
+      report_date = Date.current.strftime("%B-%Y").downcase
       expected_filename = "monthly-district-data-#{region.slug}-#{report_date}.csv"
       expect(response.headers["Content-Disposition"]).to include(%(filename="#{expected_filename}"))
     end

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -504,7 +504,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
       get :monthly_district_data_report, params: {id: region.slug, report_scope: "district", format: "csv"}
       expect(response.status).to eq(200)
       expect(response.body).to include("Monthly District Data: #{region.name} #{Date.current.strftime("%B %Y")}")
-      report_date = Date.current.strftime("%B-%Y").downcase
+      report_date = Date.current.strftime("%b-%Y").downcase
       expected_filename = "monthly-district-data-#{region.slug}-#{report_date}.csv"
       expect(response.headers["Content-Disposition"]).to include(%(filename="#{expected_filename}"))
     end


### PR DESCRIPTION
**Story card:** N/A

We were mistakenly asserting the full month name to be in the file download, but we only put the month abbreviation in. We missed this when we added the spec because we were in the month of... yeah... May when we wrote it. 

This spec started failing today. June 1.