### PR TITLE
Automate covid medication reminders

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -49,6 +49,10 @@ every :monday, at: local("6:00 am"), roles: [:cron] do
   end
 end
 
+every :day, at: local("07:00 am"), roles: [:cron] do
+  rake "appointment_notification:covid_medication_reminders[20000]"
+end
+
 every 2.minutes, roles: [:cron] do
   runner "TracerJob.perform_async(Time.current.iso8601, false)"
 end

--- a/lib/tasks/appointment_notification.rake
+++ b/lib/tasks/appointment_notification.rake
@@ -1,3 +1,5 @@
+require "tasks/scripts/covid_medication_reminders"
+
 namespace :appointment_notification do
   desc "Send automatic SMS reminder to patients who missed their scheduled visit by three days"
   task three_days_after_missed_visit: :environment do
@@ -6,6 +8,8 @@ namespace :appointment_notification do
 
   desc "Schedule one time COVID medication reminders for next communication window"
   task :covid_medication_reminders, [:number_of_patients] => :environment do |_t, args|
-    CovidMedicationReminders.call(number_of_patients: args[:number_of_patients]&.to_i)
+    raise "Number of patients required" unless args[:number_of_patients].present?
+
+    CovidMedicationReminders.call(number_of_patients: args[:number_of_patients].to_i)
   end
 end

--- a/lib/tasks/appointment_notification.rake
+++ b/lib/tasks/appointment_notification.rake
@@ -3,4 +3,9 @@ namespace :appointment_notification do
   task three_days_after_missed_visit: :environment do
     AppointmentNotification::MissedVisitJob.perform_later
   end
+
+  desc "Schedule one time COVID medication reminders for next communication window"
+  task :covid_medication_reminders, [:number_of_patients] => :environment do |_t, args|
+    CovidMedicationReminders.call(number_of_patients: args[:number_of_patients]&.to_i)
+  end
 end

--- a/lib/tasks/scripts/covid_medication_reminders.rb
+++ b/lib/tasks/scripts/covid_medication_reminders.rb
@@ -1,8 +1,10 @@
 class CovidMedicationReminders
   def self.call(number_of_patients: 10_000)
-    if CountryConfig.current[:name] != "India" || !SimpleServer.env.production? || !Flipper.enabled?(:experiment)
+    if CountryConfig.current[:name] != "India" || !SimpleServer.env.production?
       raise "Cannot send Covid medication reminders in this env"
     end
+
+    raise "Experiments are not enabled in this env" unless Flipper.enabled?(:experiment)
 
     Experimentation::MedicationReminderService.schedule_daily_notifications(patients_per_day: number_of_patients)
     AppointmentNotification::ScheduleExperimentReminders.perform_later

--- a/lib/tasks/scripts/covid_medication_reminders.rb
+++ b/lib/tasks/scripts/covid_medication_reminders.rb
@@ -1,0 +1,10 @@
+class CovidMedicationReminders
+  def self.call(number_of_patients: 10_000)
+    if CountryConfig.current[:name] != "India" || !SimpleServer.env.production? || !Flipper.enabled?(:experiment)
+      raise "Cannot send Covid medication reminders in this env"
+    end
+
+    Experimentation::MedicationReminderService.schedule_daily_notifications(patients_per_day: number_of_patients)
+    AppointmentNotification::ScheduleExperimentReminders.perform_later
+  end
+end


### PR DESCRIPTION
**Story card:** [ch3566](https://app.clubhouse.io/simpledotorg/story/3566/deployment-plan-send-medication-reminders-in-india)

## Because

We want to automate sending COVID medication reminders over the next few days.

## This addresses

Sends 20,000 medication reminders every day