### PR TITLE
Automatic COVID reminder fixes

### DIFF
--- a/lib/tasks/scripts/covid_medication_reminders.rb
+++ b/lib/tasks/scripts/covid_medication_reminders.rb
@@ -1,10 +1,12 @@
 class CovidMedicationReminders
   def self.call(number_of_patients: 10_000)
-    if CountryConfig.current[:name] != "India" || !SimpleServer.env.production?
-      raise "Cannot send Covid medication reminders in this env"
+    raise "Experiments are not enabled in this env" unless Flipper.enabled?(:experiment)
+
+    if CountryConfig.current[:name] != "India" || ENV["SIMPLE_SERVER_ENV"] != "production"
+      return "Cannot send Covid medication reminders in this env"
     end
 
-    raise "Experiments are not enabled in this env" unless Flipper.enabled?(:experiment)
+    return if Date.today.sunday?
 
     Experimentation::MedicationReminderService.schedule_daily_notifications(patients_per_day: number_of_patients)
     AppointmentNotification::ScheduleExperimentReminders.perform_later

--- a/lib/tasks/scripts/covid_medication_reminders.rb
+++ b/lib/tasks/scripts/covid_medication_reminders.rb
@@ -1,12 +1,10 @@
 class CovidMedicationReminders
   def self.call(number_of_patients: 10_000)
-    raise "Experiments are not enabled in this env" unless Flipper.enabled?(:experiment)
-
     if CountryConfig.current[:name] != "India" || ENV["SIMPLE_SERVER_ENV"] != "production"
       return "Cannot send Covid medication reminders in this env"
     end
-
-    return if Date.today.sunday?
+    raise "Experiments are not enabled in this env" unless Flipper.enabled?(:experiment)
+    return if Date.current.sunday?
 
     Experimentation::MedicationReminderService.schedule_daily_notifications(patients_per_day: number_of_patients)
     AppointmentNotification::ScheduleExperimentReminders.perform_later

--- a/spec/tasks/scripts/covid_medication_reminders_spec.rb
+++ b/spec/tasks/scripts/covid_medication_reminders_spec.rb
@@ -2,6 +2,9 @@ require "rails_helper"
 require "tasks/scripts/covid_medication_reminders"
 
 RSpec.describe CovidMedicationReminders do
+  let(:sunday) { "6 Jun 2021" }
+  let(:tuesday) { "1 Jun 2021" }
+
   it "creates notifications when experiments are enabled, not sunday and in india production" do
     enable_flag(:experiment)
     allow(CountryConfig.current).to receive("[]").with(:name).and_return("India")
@@ -10,7 +13,7 @@ RSpec.describe CovidMedicationReminders do
 
     expect(Experimentation::MedicationReminderService).to receive(:schedule_daily_notifications)
 
-    Timecop.freeze("1 Jun 2021") do # Not a Sunday
+    Timecop.freeze(tuesday) do
       described_class.call
     end
   end
@@ -20,7 +23,9 @@ RSpec.describe CovidMedicationReminders do
     allow(ENV).to receive(:[]).and_call_original
     allow(ENV).to receive(:[]).with("SIMPLE_SERVER_ENV").and_return("production")
 
-    Timecop.freeze("1 Jun 2021") do # Not a Sunday
+    expect(Experimentation::MedicationReminderService).not_to receive(:schedule_daily_notifications)
+
+    Timecop.freeze(tuesday) do
       expect { described_class.call }.to raise_error "Experiments are not enabled in this env"
     end
   end
@@ -33,7 +38,7 @@ RSpec.describe CovidMedicationReminders do
 
     expect(Experimentation::MedicationReminderService).not_to receive(:schedule_daily_notifications)
 
-    Timecop.freeze("6 Jun 2021") do # Not a Sunday
+    Timecop.freeze(sunday) do
       described_class.call
     end
   end
@@ -46,7 +51,7 @@ RSpec.describe CovidMedicationReminders do
 
     expect(Experimentation::MedicationReminderService).not_to receive(:schedule_daily_notifications)
 
-    Timecop.freeze("1 Jun 2021") do # Not a Sunday
+    Timecop.freeze(tuesday) do
       described_class.call
     end
   end

--- a/spec/tasks/scripts/covid_medication_reminders_spec.rb
+++ b/spec/tasks/scripts/covid_medication_reminders_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+require "tasks/scripts/covid_medication_reminders"
+
+RSpec.describe CovidMedicationReminders do
+  it "creates notifications when experiments are enabled, not sunday and in india production" do
+    enable_flag(:experiment)
+    allow(CountryConfig.current).to receive("[]").with(:name).and_return("India")
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("SIMPLE_SERVER_ENV").and_return("production")
+
+    expect(Experimentation::MedicationReminderService).to receive(:schedule_daily_notifications)
+
+    Timecop.freeze("1 Jun 2021") do # Not a Sunday
+      described_class.call
+    end
+  end
+
+  it "does not send notifications reminders if experiments aren't enabled" do
+    allow(CountryConfig.current).to receive("[]").with(:name).and_return("India")
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("SIMPLE_SERVER_ENV").and_return("production")
+
+    Timecop.freeze("1 Jun 2021") do # Not a Sunday
+      expect { described_class.call }.to raise_error "Experiments are not enabled in this env"
+    end
+  end
+
+  it "does not send notifications reminders if day is sunday" do
+    enable_flag(:experiment)
+    allow(CountryConfig.current).to receive("[]").with(:name).and_return("India")
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("SIMPLE_SERVER_ENV").and_return("production")
+
+    expect(Experimentation::MedicationReminderService).not_to receive(:schedule_daily_notifications)
+
+    Timecop.freeze("6 Jun 2021") do # Not a Sunday
+      described_class.call
+    end
+  end
+
+  it "does not send notifications if env is not india production" do
+    enable_flag(:experiment)
+    allow(CountryConfig.current).to receive("[]").with(:name).and_return("India")
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("SIMPLE_SERVER_ENV").and_return("sandbox")
+
+    expect(Experimentation::MedicationReminderService).not_to receive(:schedule_daily_notifications)
+
+    Timecop.freeze("1 Jun 2021") do # Not a Sunday
+      described_class.call
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** [chXXXX](URL)

## Because

We don't want to send covid medication reminders on sundays.

## This addresses

The job doesn't run if day is sunday. It also silently returns on non prod envs instead of throwing and exception.