### PR TITLE
Fix cache warming timezone

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -103,7 +103,7 @@ class Admin::UsersController < AdminController
   end
 
   def set_time_zone
-    Time.use_zone(Period::ANALYTICS_TIME_ZONE) { yield }
+    Time.use_zone(Period::REPORTING_TIMEZONE) { yield }
   end
 
   def user_params

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -6,7 +6,7 @@ class AnalyticsController < AdminController
   CACHE_VERSION = 1
 
   def set_time_zone
-    time_zone = Period::ANALYTICS_TIME_ZONE
+    time_zone = Period::REPORTING_TIMEZONE
 
     Groupdate.time_zone = time_zone
 

--- a/app/controllers/api/v3/analytics_controller.rb
+++ b/app/controllers/api/v3/analytics_controller.rb
@@ -4,7 +4,7 @@ class Api::V3::AnalyticsController < APIController
   private
 
   def set_time_zone
-    time_zone = Period::ANALYTICS_TIME_ZONE
+    time_zone = Period::REPORTING_TIMEZONE
 
     Groupdate.time_zone = time_zone
 

--- a/app/controllers/my_facilities/facility_performance_controller.rb
+++ b/app/controllers/my_facilities/facility_performance_controller.rb
@@ -52,7 +52,7 @@ class MyFacilities::FacilityPerformanceController < AdminController
   end
 
   def set_time_zone
-    Time.use_zone(Period::ANALYTICS_TIME_ZONE) { yield }
+    Time.use_zone(Period::REPORTING_TIMEZONE) { yield }
   end
 
   def authorize_my_facilities

--- a/app/controllers/my_facilities_controller.rb
+++ b/app/controllers/my_facilities_controller.rb
@@ -59,7 +59,7 @@ class MyFacilitiesController < AdminController
   end
 
   def set_time_zone
-    Time.use_zone(Period::ANALYTICS_TIME_ZONE) { yield }
+    Time.use_zone(Period::REPORTING_TIMEZONE) { yield }
   end
 
   def authorize_my_facilities

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -217,7 +217,7 @@ class Reports::RegionsController < AdminController
   end
 
   def set_time_zone
-    time_zone = Period::ANALYTICS_TIME_ZONE
+    time_zone = Period::REPORTING_TIMEZONE
 
     Groupdate.time_zone = time_zone
 

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -1,6 +1,6 @@
 class Period
   REGISTRATION_BUFFER_MONTHS = 3
-  ANALYTICS_TIME_ZONE = CountryConfig.current[:time_zone] || "Asia/Kolkata"
+  REPORTING_TIMEZONE = CountryConfig.current[:time_zone] || "Asia/Kolkata"
 
   include Comparable
   include ActiveModel::Model

--- a/app/services/reports/region_cache_warmer.rb
+++ b/app/services/reports/region_cache_warmer.rb
@@ -32,7 +32,7 @@ module Reports
     end
 
     def warm_region_cache(region)
-      Time.use_zone(Period::ANALYTICS_TIME_ZONE) do
+      Time.use_zone(Period::REPORTING_TIMEZONE) do
         RequestStore.store[:bust_cache] = true
 
         notify "starting region caching for region #{region.id}"

--- a/app/services/reports/region_cache_warmer.rb
+++ b/app/services/reports/region_cache_warmer.rb
@@ -32,7 +32,7 @@ module Reports
     end
 
     def warm_region_cache(region)
-      Time.use_zone(Rails.application.config.country[:time_zone] do
+      Time.use_zone(Period::ANALYTICS_TIME_ZONE) do
         RequestStore.store[:bust_cache] = true
 
         notify "starting region caching for region #{region.id}"

--- a/app/services/reports/region_cache_warmer.rb
+++ b/app/services/reports/region_cache_warmer.rb
@@ -32,19 +32,21 @@ module Reports
     end
 
     def warm_region_cache(region)
-      RequestStore.store[:bust_cache] = true
+      Time.use_zone(Rails.application.config.country[:time_zone] do
+        RequestStore.store[:bust_cache] = true
 
-      notify "starting region caching for region #{region.id}"
-      Statsd.instance.time("region_cache_warmer.time") do
-        Reports::RegionService.call(region: region, period: period)
-        Statsd.instance.increment("region_cache_warmer.#{region.region_type}.cache")
-        Reports::RepositoryCacheWarmer.call(region: region, period: period)
+        notify "starting region caching for region #{region.id}"
+        Statsd.instance.time("region_cache_warmer.time") do
+          Reports::RegionService.call(region: region, period: period)
+          Statsd.instance.increment("region_cache_warmer.#{region.region_type}.cache")
+          Reports::RepositoryCacheWarmer.call(region: region, period: period)
 
-        PatientBreakdownService.call(region: region, period: period)
-        Statsd.instance.increment("patient_breakdown_service.#{region.region_type}.cache")
+          PatientBreakdownService.call(region: region, period: period)
+          Statsd.instance.increment("patient_breakdown_service.#{region.region_type}.cache")
+        end
+
+        notify "finished region caching for region #{region.id}"
       end
-
-      notify "finished region caching for region #{region.id}"
     end
 
     private

--- a/app/services/reports/region_service.rb
+++ b/app/services/reports/region_service.rb
@@ -4,7 +4,7 @@ module Reports
 
     # The default period we report on is the current month.
     def self.default_period
-      Period.month(Time.current.in_time_zone(Period::ANALYTICS_TIME_ZONE))
+      Period.month(Time.current.in_time_zone(Period::REPORTING_TIMEZONE))
     end
 
     def self.call(*args)


### PR DESCRIPTION
**Story card:** https://app.clubhouse.io/simpledotorg/story/3660/fix-timezone-inconsistencies-in-current-reporting

Extraction of cache-warming fixes only from #2560 

We used to warm the cache in Sidekiq, and we explicitly [set the application's timezone](https://github.com/simpledotorg/simple-server/blob/master/config/initializers/sidekiq.rb#L1-L5) around all Sidekiq jobs, similar to how we do [for web requests](https://github.com/simpledotorg/simple-server/blob/master/app/controllers/reports/regions_controller.rb#L219-L226).

When we un-backgrounded the warming job recently (#2423), we inadvertently started warming our caches in UTC, which would place patient activity in the wrong day/time if it occurred between midnight and 530am IST. It's unlikely to happen in reality, but an inconsistency we should avoid. It is definitely prevalent in our Sandbox data, and makes it hard for us to compare new reporting work against existing dashboard data.