### PR TITLE
Add rspec to main bundle to fix deploys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem "redis"
 gem "request_store"
 gem "request_store-sidekiq"
 gem "roo", "~> 2.8.0"
+gem "rspec-rails", "~> 4.0.1"
 gem "rswag", "~> 1.6.0"
 gem "ruby-progressbar", require: false
 gem "rubyzip"
@@ -99,7 +100,6 @@ group :development, :test do
   gem "parallel_tests", group: %i[development test]
   gem "rails-controller-testing"
   gem "rb-readline"
-  gem "rspec-rails"
   gem "shoulda-matchers", "~> 4.1.2"
   gem "standard", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -643,7 +643,7 @@ DEPENDENCIES
   request_store
   request_store-sidekiq
   roo (~> 2.8.0)
-  rspec-rails
+  rspec-rails (~> 4.0.1)
   rspec-sidekiq
   rswag (~> 1.6.0)
   ruby-progressbar


### PR DESCRIPTION
Deploys fail with ```LoadError: cannot load such file -- rspec/core``` if we don't have rspec in the main bundle.
https://simple.semaphoreci.com/jobs/ed27e88b-fcac-4273-b330-f39a90ffa449

This might not be the long term fix, we should look to remove dependency on rspec from the production app. Doing this to unblock deploys now.
