### PR TITLE
Update Facility Report follow-up table

### DIFF
--- a/app/views/reports/regions/_details_footnotes.html.erb
+++ b/app/views/reports/regions/_details_footnotes.html.erb
@@ -57,7 +57,11 @@
   </div>
   <div class="mb-24px">
     <p class="mb-8px fs-16px fw-bold c-grey-dark">
-      Follow-up patients
+      <% if @region.facility_region? %>
+        Follow-up patients per user
+      <% else %>
+        Follow-up patients
+      <% end %>
     </p>
     <div class="pl-16px">
       <p class="mb-8px fs-14px c-grey-dark">

--- a/app/views/reports/regions/_facility_details.html.erb
+++ b/app/views/reports/regions/_facility_details.html.erb
@@ -5,7 +5,7 @@
     </h3>
     <%= render "definition_tooltip",
                 definitions: { "Monthly registered patients" => t("registered_patients_copy.monthly_registered_patients", region_name: @region.name),
-                              "Follow-up patients" => t("follow_up_patients_copy", region_name: @region.name) } %>
+                              "Follow-up patients per user" => t("follow_up_patients_copy", region_name: @region.name) } %>
   </div>
   <div class="table-responsive">
     <table class="analytics-table table-compact">
@@ -34,7 +34,7 @@
             Monthly registered patients
           </th>
           <th colspan="6">
-            Follow-up patients
+            Follow-up patients per user
           </th>
         </tr>
         <tr class="sorts" data-sort-method="thead">
@@ -58,27 +58,6 @@
         </tr>
       </thead>
       <tbody>
-        <tr class="row-title row-total" data-sort-method="none">
-          <td class="row-title row-total">
-            Total
-          </td>
-          <td class="row-total ta-center">
-            <%= number_or_dash_with_delimiter(@repository.cumulative_registrations[@region.region.slug][@period]) %>
-          </td>
-          <% @period_range.each do |period| %>
-            <td class="row-total ta-center">
-              <%= number_or_dash_with_delimiter(@repository.registration_counts[@region.region.slug][period]) %>
-            </td>
-          <% end %>
-          <% @period_range.each do |period| %>
-            <td class="row-total ta-center">
-              <%= period_follow_ups = @repository.hypertension_follow_ups(group_by: "blood_pressures.user_id").dig(@region.slug, period)
-                  total = period_follow_ups&.values&.sum
-                  number_or_dash_with_delimiter(total)
-              %>
-            </td>
-          <% end %>
-        </tr>
         <% current_admin.accessible_users(:view_reports).order(:full_name).each do |resource| %>
           <% if @dashboard_analytics[resource.id].present? %>
             <tr>


### PR DESCRIPTION
**Story card:** [ch3663](https://app.clubhouse.io/simpledotorg/story/3663/update-user-follow-up-query-so-that-a-patient-follow-up-is-only-counted-once-per-month-for-all-users-at-a-facility)

## Because

The language used in the "Patient registrations and follow-ups" card in Facility Reports is confusing. Follow-ups per user are different than follow-ups per region. Follow-ups per user counts ALL patients a user took BP measures of. On the other hand, follow-ups per region counts unique patients with a BP taken by users in the region. The numbers don't match up.

## This addresses

* Removes the "Total" row in the "Patient registrations and follow-ups" card in Facility Report details
* Updates the "Follow-ups" section name in the "Patient registrations and follow-ups" card to "Follow-ups per user"
* Updates the Definitions section in Facility Reports to display "Follow-ups per user"
* Updates the tooltip indicator name to "Follow-ups per user" in the "Patient registrations and follow-ups" card in the Facility Reports

## Test instructions

Verify that the changes listed above were made