### PR TITLE
Remove analytics from regions details

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -64,9 +64,6 @@ class Reports::RegionsController < AdminController
     end
     @repository = Reports::Repository.new(regions, periods: @period_range)
 
-    @dashboard_analytics = @region.dashboard_analytics(period: @period.type,
-                                                       prev_periods: 6,
-                                                       include_current_period: true)
     @chart_data = {
       patient_breakdown: PatientBreakdownService.call(region: @region, period: @period),
       ltfu_trend: Reports::RegionService.new(region: @region, period: @period).call

--- a/app/helpers/reports/regions_helper.rb
+++ b/app/helpers/reports/regions_helper.rb
@@ -21,6 +21,13 @@ module Reports::RegionsHelper
       .flatten.compact.sum
   end
 
+  def sum_bp_measures(repository, *keys)
+    slug, user_id = keys
+    repository.bp_measures_by_user.dig(slug)
+      .map { |period, user_counts| user_counts.dig(user_id) }
+      .flatten.compact.sum
+  end
+
   def percentage_or_na(value, options)
     return "N/A" if value.blank?
     number_to_percentage(value, options)

--- a/app/views/reports/regions/_facility_details.html.erb
+++ b/app/views/reports/regions/_facility_details.html.erb
@@ -59,27 +59,27 @@
       </thead>
       <tbody>
         <% current_admin.accessible_users(:view_reports).order(:full_name).each do |resource| %>
-          <% if @dashboard_analytics[resource.id].present? %>
-            <tr>
-              <td class="row-title">
-                <%= link_to resource.full_name, admin_user_path(resource, period: @period) %>
-              </td>
+          <% next unless sum_registration_counts(@repository, @region.slug, resource.id)&.nonzero? ||
+                         sum_bp_measures(@repository, @region.slug, resource.id)&.nonzero? %>
+          <tr>
+            <td class="row-title">
+              <%= link_to resource.full_name, admin_user_path(resource, period: @period) %>
+            </td>
+            <td class="ta-center">
+              <%= number_or_dash_with_delimiter(sum_registration_counts(@repository, @region.slug, resource.id)) %>
+            </td>
+            <% @period_range.each do |period| %>
               <td class="ta-center">
-                <%= number_or_dash_with_delimiter(sum_registration_counts(@repository, @region.slug, resource.id)) %>
+                <%= number_or_dash_with_delimiter(@repository.registration_counts_by_user.dig(@region.slug, period, resource.id)) %>
               </td>
-              <% @period_range.each do |period| %>
-                <td class="ta-center">
-                  <%= number_or_dash_with_delimiter(@repository.registration_counts_by_user.dig(@region.slug, period, resource.id)) %>
-                </td>
-              <% end %>
-              <% @period_range.each do |period| %>
-                <td class="ta-center">
-                  <%= val = @repository.hypertension_follow_ups(group_by: "blood_pressures.user_id").dig(@region.slug, period, resource.id)
-                    number_or_dash_with_delimiter(val) %>
-                </td>
-              <% end %>
-            </tr>
-          <% end %>
+            <% end %>
+            <% @period_range.each do |period| %>
+              <td class="ta-center">
+                <%= val = @repository.hypertension_follow_ups(group_by: "blood_pressures.user_id").dig(@region.slug, period, resource.id)
+                  number_or_dash_with_delimiter(val) %>
+              </td>
+            <% end %>
+          </tr>
         <% end %>
       </tbody>
     </table>
@@ -147,26 +147,26 @@
       </thead>
       <tbody>
         <% current_admin.accessible_users(:view_reports).order(:full_name).each do |resource| %>
-          <% if @dashboard_analytics[resource.id].present? %>
-            <tr>
-              <td class="row-title">
-                <%= link_to resource.full_name, admin_user_path(resource, period: @period) %>
-              </td>
+          <% next unless sum_registration_counts(@repository, @region.slug, resource.id)&.nonzero? ||
+                         sum_bp_measures(@repository, @region.slug, resource.id)&.nonzero? %>
+          <tr>
+            <td class="row-title">
+              <%= link_to resource.full_name, admin_user_path(resource, period: @period) %>
+            </td>
+            <td class="ta-center">
+              <%= number_or_dash_with_delimiter(sum_registration_counts(@repository, @region.slug, resource.id)) %>
+            </td>
+            <% @period_range.each do |period| %>
               <td class="ta-center">
-                <%= number_or_dash_with_delimiter(sum_registration_counts(@repository, @region.slug, resource.id)) %>
+                <%= number_or_dash_with_delimiter(@repository.registration_counts_by_user.dig(@region.slug, period, resource.id)) %>
               </td>
-              <% @period_range.each do |period| %>
-                <td class="ta-center">
-                  <%= number_or_dash_with_delimiter(@repository.registration_counts_by_user.dig(@region.slug, period, resource.id)) %>
-                </td>
-              <% end %>
-              <% @period_range.each do |period| %>
-                <td class="ta-center">
-                  <%= number_or_dash_with_delimiter(@repository.bp_measures_by_user.dig(@region.slug, period, resource.id)) %>
-                </td>
-              <% end %>
-            </tr>
-          <% end %>
+            <% end %>
+            <% @period_range.each do |period| %>
+              <td class="ta-center">
+                <%= number_or_dash_with_delimiter(@repository.bp_measures_by_user.dig(@region.slug, period, resource.id)) %>
+              </td>
+            <% end %>
+          </tr>
         <% end %>
       </tbody>
     </table>


### PR DESCRIPTION
**Story card:** [ch3447](https://app.clubhouse.io/simpledotorg/story/3447/retire-the-legacy-analyticsquery-objects)

Removing the call to `dashboard_analytics` from regions#details now that we don't need any of the data anymore, as it is all coming from the repository.