### PR TITLE
Show current deploy ref in HTML header

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <% if email_authentication_signed_in? && current_admin.power_user? %>
+<!--
+      current deploy: <%= SimpleServer.github_url %>
+-->
+    <% end -%>
     <% if ENV["GOOGLE_ANALYTICS_ID"].present? %>
       <!-- Global site tag (gtag.js) - Google Analytics -->
       <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV["GOOGLE_ANALYTICS_ID"] %>"></script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
 <!--
       current deploy: <%= SimpleServer.github_url %>
 -->
-    <% end -%>
+    <% end %>
     <% if ENV["GOOGLE_ANALYTICS_ID"].present? %>
       <!-- Global site tag (gtag.js) - Google Analytics -->
       <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV["GOOGLE_ANALYTICS_ID"] %>"></script>

--- a/lib/simple_server_extensions.rb
+++ b/lib/simple_server_extensions.rb
@@ -18,6 +18,10 @@ module SimpleServerExtensions
   def git_ref(short: false)
     short ? GIT_REF[0..6] : GIT_REF
   end
+
+  def github_url
+    "https://github.com/simpledotorg/simple-server/commit/#{git_ref}"
+  end
 end
 
 # Add on to the top level application constant to make things easy


### PR DESCRIPTION
Helpful to be able to tell what is deployed on prod.  This will include a link to the commit on GitHub in the HTML header in comments. Only for power users

<img width="871" alt="image" src="https://user-images.githubusercontent.com/69/122277303-5d997680-ceab-11eb-8a96-781851eba443.png">


(no story)