### PR TITLE
Add workaround for RubyMine debugger issue with datadog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "bootstrap-datepicker-rails", "~> 1.9"
 gem "connection_pool"
 gem "data-anonymization", require: false
 gem "data_migrate"
-gem "ddtrace"
+gem "ddtrace", ">= 0.50.0"
 gem "devise", ">= 4.7.1"
 gem "devise_invitable", "~> 1.7.0"
 gem "dhis2", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,8 @@ GEM
       thor (~> 0.20.3)
     data_migrate (6.3.0)
       rails (>= 5.0)
-    ddtrace (0.43.0)
+    ddtrace (0.50.0)
+      ffi (~> 1.0)
       msgpack
     devise (4.7.1)
       bcrypt (~> 3.0)
@@ -632,7 +633,7 @@ DEPENDENCIES
   connection_pool
   data-anonymization
   data_migrate
-  ddtrace
+  ddtrace (>= 0.50.0)
   devise (>= 4.7.1)
   devise_invitable (~> 1.7.0)
   dhis2

--- a/config/initializers/00_datadog.rb
+++ b/config/initializers/00_datadog.rb
@@ -16,3 +16,18 @@ end
 
 require "statsd"
 require "metrics"
+
+# This is a workaround for https://youtrack.jetbrains.com/issue/RUBY-27489
+if defined?(:Debase)
+  if Datadog::VERSION::STRING != "0.50.0"
+    raise "Since you updated ddtrace, please check if this workaround is still needed"
+  end
+
+  module FixThreadLocalContext
+    def local(thread = Thread.current)
+      thread[@key] ||= Datadog::Context.new
+    end
+  end
+
+  Datadog::ThreadLocalContext.prepend FixThreadLocalContext
+end


### PR DESCRIPTION
See issue: https://youtrack.jetbrains.com/issue/RUBY-27489
This is a fix only for rubymine users, but seems worth adding to the codebase instead of having to patch it everytime we use the debugger. We can remove it when the original issue has been addressed.