### PR TITLE
Sync - Don't touch "same" records

### DIFF
--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -6,7 +6,8 @@ class AuditLog
     invalid: "invalid",
     new: "create",
     updated: "update",
-    old: "touch"
+    old: "touch",
+    identical: "no-op"
   }.freeze
 
   validates :action, presence: true

--- a/app/models/concerns/mergeable.rb
+++ b/app/models/concerns/mergeable.rb
@@ -18,6 +18,8 @@ module Mergeable
         :discarded
       elsif new_record.device_updated_at > existing_record.device_updated_at
         :updated
+      elsif new_record.device_updated_at == existing_record.device_updated_at
+        :identical
       else
         :old
       end
@@ -36,8 +38,10 @@ module Mergeable
         create_new_record(attributes)
       when :updated
         update_existing_record(existing_record, attributes)
+      when :identical
+        return_identical_record(existing_record)
       when :old
-        return_old_record(existing_record, new_record)
+        return_old_record(existing_record)
       end
     end
 
@@ -82,12 +86,16 @@ module Mergeable
       existing_record
     end
 
-    def return_old_record(existing_record, new_record)
+    def return_identical_record(existing_record)
+      logger.debug "#{self} with id #{existing_record.id} is identical, doing nothing."
+      increment_metric(:identical)
+      existing_record.merge_status = :identical
+      existing_record
+    end
+
+    def return_old_record(existing_record)
       logger.debug "#{self} with id #{existing_record.id} is old, keeping existing."
       increment_metric(:old)
-      if existing_record.device_updated_at == new_record.device_updated_at
-        increment_metric(:same_device_updated_at)
-      end
       existing_record.touch
       existing_record.merge_status = :old
       existing_record

--- a/spec/models/concerns/mergeable_spec.rb
+++ b/spec/models/concerns/mergeable_spec.rb
@@ -36,7 +36,7 @@ describe Mergeable do
     expect(Patient.count).to eq 1
   end
 
-  it "returns the existing record touchced if input record is older" do
+  it "returns the existing record touched if input record is older" do
     existing_patient = FactoryBot.create(:patient, updated_at: 10.minutes.ago, address: FactoryBot.create(:address))
     updated_patient = Patient.find(existing_patient.id)
     now = Time.current

--- a/spec/models/concerns/mergeable_spec.rb
+++ b/spec/models/concerns/mergeable_spec.rb
@@ -36,31 +36,50 @@ describe Mergeable do
     expect(Patient.count).to eq 1
   end
 
-  it "returns the existing record if input record is older" do
-    existing_patient = FactoryBot.create(:patient, address: FactoryBot.create(:address))
+  it "returns the existing record touchced if input record is older" do
+    existing_patient = FactoryBot.create(:patient, updated_at: 10.minutes.ago, address: FactoryBot.create(:address))
     updated_patient = Patient.find(existing_patient.id)
-    updated_patient.updated_at = 10.minutes.ago
-    updated_patient.device_updated_at = 10.minutes.ago
-    Patient.merge(updated_patient.attributes)
-    expect(Patient.find(existing_patient.id).updated_at.to_i).to_not eq updated_patient.updated_at.to_i
+    now = Time.current
+
+    updated_patient.updated_at = 20.minutes.ago
+    updated_patient.device_updated_at = 20.minutes.ago
+
+    Timecop.freeze(now) do
+      Patient.merge(updated_patient.attributes)
+    end
+
+    expect(Patient.find(existing_patient.id).updated_at.to_i).to eq now.to_i
+    expect(Patient.count).to eq 1
+  end
+
+  it "returns the existing record untouched if input record is equally up-to-date" do
+    existing_patient = FactoryBot.create(:patient, address: FactoryBot.create(:address))
+    updated_at = existing_patient.updated_at
+
+    Patient.merge(existing_patient.attributes)
+
+    expect(Patient.find(existing_patient.id).updated_at.to_i).to eq updated_at.to_i
     expect(Patient.count).to eq 1
   end
 
   it "counts metrics for old merges" do
-    expect(Statsd.instance).to receive(:increment).with("merge.Patient.old")
     existing_patient = FactoryBot.create(:patient, address: FactoryBot.create(:address))
     updated_patient = Patient.find(existing_patient.id)
+
     updated_patient.device_updated_at = 10.minutes.ago
+
+    expect(Statsd.instance).to receive(:increment).with("merge.Patient.old")
     Patient.merge(updated_patient.attributes)
   end
 
-  it "counts additional metric if the existing record device_updated_at is the same as the new one" do
-    expect(Statsd.instance).to receive(:increment).with("merge.Patient.old")
-    expect(Statsd.instance).to receive(:increment).with("merge.Patient.same_device_updated_at")
+  it "counts metrics if the existing record device_updated_at is the same as the new one" do
     timestamp = Time.zone.parse("March 1st 04:00:00 IST")
     existing_patient = FactoryBot.create(:patient, address: FactoryBot.create(:address), device_updated_at: timestamp)
     updated_patient = Patient.find(existing_patient.id)
+
     updated_patient.device_updated_at = existing_patient.device_updated_at
+
+    expect(Statsd.instance).to receive(:increment).with("merge.Patient.identical")
     Patient.merge(updated_patient.attributes)
   end
 


### PR DESCRIPTION
**Story card:** [ch3843](https://app.clubhouse.io/simpledotorg/story/3843/high-database-load-around-10-am-ist-time-june-16-17th)

## Because

After launching #2606 , we discovered that most repetitive sync requests were touching the records, even though the record is most likely up-to-date on the client (since the timestamp matches exactly)

## This addresses

Stop `touch`ing these "identical" records.

## Assumptions/Consequences

* We assume that the same record updated by two different clients will never have the same `device_updated_at` timestamp
* We assume that the `.touch` was for the initiating client to re-fetch the existing record. We assume that this `touch` is used because sometimes the client's process token moves forward, even though it has not yet fetched latest updates for all records. Hence it _thinks_ it's up-to-date, but it's not. Touching the record will bump the records' timestamp to _after_ the client's process token again, forcing the client to refetch the existing record the next time it syncs.