### PR TITLE
Explicitly filter dead patients from overdue list

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -53,6 +53,8 @@ class Appointment < ApplicationRecord
     where(status: "scheduled")
       .where(arel_table[:scheduled_date].lt(Date.current))
       .where(arel_table[:remind_on].eq(nil).or(arel_table[:remind_on].lteq(Date.current)))
+      .joins(:patient)
+      .where.not(patients: {status: "dead"})
   end
 
   def self.overdue

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -54,7 +54,7 @@ class Appointment < ApplicationRecord
       .where(arel_table[:scheduled_date].lt(Date.current))
       .where(arel_table[:remind_on].eq(nil).or(arel_table[:remind_on].lteq(Date.current)))
       .joins(:patient)
-      .where.not(patients: {status: "dead"})
+      .where.not(patients: {status: :dead})
   end
 
   def self.overdue

--- a/spec/features/appointments_spec.rb
+++ b/spec/features/appointments_spec.rb
@@ -21,50 +21,36 @@ RSpec.feature "Overdue appointments", type: :feature do
     end
 
     describe "Overdue patients tab" do
-      let!(:authorized_facility_group) { ihmi_group }
-
-      let!(:facility_1) { create(:facility, facility_group: authorized_facility_group) }
-
-      let!(:overdue_patient_in_facility_1) do
-        patient = create(:patient, full_name: "patient_1", registration_facility: facility_1)
-        create(:appointment, :overdue, facility: facility_1, patient: patient, scheduled_date: 10.days.ago)
-        create(:blood_pressure, :critical, facility: facility_1, patient: patient)
-        patient
-      end
-
-      let!(:non_overdue_patient_in_facility_1) { create(:patient, full_name: "patient_2", registration_facility: facility_1) }
-
-      let!(:dead_overdue_patient_in_facility_1) do
-        patient = create(:patient, full_name: "patient_3", registration_facility: facility_1, status: :dead)
-        create(:appointment, :overdue, facility: facility_1, patient: patient, scheduled_date: 10.days.ago)
-        create(:blood_pressure, :critical, facility: facility_1, patient: patient)
-        patient
-      end
-
-      let!(:facility_2) { create(:facility, facility_group: authorized_facility_group) }
-
-      let!(:overdue_patient_in_facility_2) do
-        patient = create(:patient, full_name: "patient_4", registration_facility: facility_2)
-        create(:appointment, :overdue, facility: facility_2, patient: patient, scheduled_date: 5.days.ago)
-        create(:blood_pressure, :hypertensive, facility: facility_2, patient: patient)
-        patient
-      end
-
-      let!(:unauthorized_facility_group) { create(:facility_group) }
-
-      let!(:unauthorized_facility) { create(:facility, facility_group: unauthorized_facility_group) }
-
-      let!(:overdue_patient_in_unauthorized_facility) do
-        patient = create(:patient, full_name: "patient_5", registration_facility: unauthorized_facility)
-        create(:appointment, :overdue, facility: unauthorized_facility, patient: patient)
-        patient
-      end
-
-      before do
-        visit appointments_path
-      end
-
       it "shows all overdue patients" do
+        authorized_facility_group = ihmi_group
+
+        facility_1 = create(:facility, facility_group: authorized_facility_group)
+        facility_2 = create(:facility, facility_group: authorized_facility_group)
+
+        overdue_patient_in_facility_1 = create(:patient, full_name: "patient_1", registration_facility: facility_1)
+        create(:appointment, :overdue, facility: facility_1, patient: overdue_patient_in_facility_1, scheduled_date: 10.days.ago)
+        create(:blood_pressure, :critical, facility: facility_1, patient: overdue_patient_in_facility_1)
+
+        non_overdue_patient_in_facility_1 = create(:patient, full_name: "patient_2", registration_facility: facility_1)
+
+        dead_overdue_patient_in_facility_1 = create(:patient, full_name: "patient_3", registration_facility: facility_1, status: :dead)
+        create(:appointment, :overdue, facility: facility_1, patient: dead_overdue_patient_in_facility_1, scheduled_date: 10.days.ago)
+        create(:blood_pressure, :critical, facility: facility_1, patient: dead_overdue_patient_in_facility_1)
+
+
+        overdue_patient_in_facility_2 = create(:patient, full_name: "patient_4", registration_facility: facility_2)
+        create(:appointment, :overdue, facility: facility_2, patient: overdue_patient_in_facility_2, scheduled_date: 5.days.ago)
+        create(:blood_pressure, :hypertensive, facility: facility_2, patient: overdue_patient_in_facility_2)
+
+        unauthorized_facility_group = create(:facility_group)
+
+        unauthorized_facility = create(:facility, facility_group: unauthorized_facility_group)
+
+        overdue_patient_in_unauthorized_facility = create(:patient, full_name: "patient_5", registration_facility: unauthorized_facility)
+        create(:appointment, :overdue, facility: unauthorized_facility, patient: overdue_patient_in_unauthorized_facility)
+
+        visit appointments_path
+
         expect(page).to have_content(overdue_patient_in_facility_1.full_name)
         expect(page).to have_content(overdue_patient_in_facility_2.full_name)
         expect(page).to have_content("Registered on")

--- a/spec/features/appointments_spec.rb
+++ b/spec/features/appointments_spec.rb
@@ -34,10 +34,18 @@ RSpec.feature "Overdue appointments", type: :feature do
 
       let!(:non_overdue_patient_in_facility_1) { create(:patient, full_name: "patient_2", registration_facility: facility_1) }
 
+      let!(:dead_overdue_patient_in_facility_1) do
+        patient = create(:patient, full_name: "patient_3", registration_facility: facility_1, status: :dead)
+        create(:appointment, :overdue, facility: facility_1, patient: patient, scheduled_date: 10.days.ago)
+        create(:blood_pressure, :critical, facility: facility_1, patient: patient)
+        patient
+      end
+
+
       let!(:facility_2) { create(:facility, facility_group: authorized_facility_group) }
 
       let!(:overdue_patient_in_facility_2) do
-        patient = create(:patient, full_name: "patient_3", registration_facility: facility_2)
+        patient = create(:patient, full_name: "patient_4", registration_facility: facility_2)
         create(:appointment, :overdue, facility: facility_2, patient: patient, scheduled_date: 5.days.ago)
         create(:blood_pressure, :hypertensive, facility: facility_2, patient: patient)
         patient
@@ -48,7 +56,7 @@ RSpec.feature "Overdue appointments", type: :feature do
       let!(:unauthorized_facility) { create(:facility, facility_group: unauthorized_facility_group) }
 
       let!(:overdue_patient_in_unauthorized_facility) do
-        patient = create(:patient, full_name: "patient_4", registration_facility: unauthorized_facility)
+        patient = create(:patient, full_name: "patient_5", registration_facility: unauthorized_facility)
         create(:appointment, :overdue, facility: unauthorized_facility, patient: patient)
         patient
       end
@@ -62,6 +70,7 @@ RSpec.feature "Overdue appointments", type: :feature do
         expect(page).to have_content(overdue_patient_in_facility_2.full_name)
         expect(page).to have_content("Registered on")
         expect(page).not_to have_content(non_overdue_patient_in_facility_1.full_name)
+        expect(page).not_to have_content(dead_overdue_patient_in_facility_1.full_name)
         expect(page).not_to have_content(overdue_patient_in_unauthorized_facility.full_name)
         expect(page).to have_content(/select a facility/i)
         expect(page).not_to have_selector("a", text: "Download Overdue List")

--- a/spec/features/appointments_spec.rb
+++ b/spec/features/appointments_spec.rb
@@ -27,6 +27,9 @@ RSpec.feature "Overdue appointments", type: :feature do
         facility_1 = create(:facility, facility_group: authorized_facility_group)
         facility_2 = create(:facility, facility_group: authorized_facility_group)
 
+        unauthorized_facility_group = create(:facility_group)
+        unauthorized_facility = create(:facility, facility_group: unauthorized_facility_group)
+
         overdue_patient_in_facility_1 = create(:patient, full_name: "patient_1", registration_facility: facility_1)
         create(:appointment, :overdue, facility: facility_1, patient: overdue_patient_in_facility_1, scheduled_date: 10.days.ago)
         create(:blood_pressure, :critical, facility: facility_1, patient: overdue_patient_in_facility_1)
@@ -37,14 +40,9 @@ RSpec.feature "Overdue appointments", type: :feature do
         create(:appointment, :overdue, facility: facility_1, patient: dead_overdue_patient_in_facility_1, scheduled_date: 10.days.ago)
         create(:blood_pressure, :critical, facility: facility_1, patient: dead_overdue_patient_in_facility_1)
 
-
         overdue_patient_in_facility_2 = create(:patient, full_name: "patient_4", registration_facility: facility_2)
         create(:appointment, :overdue, facility: facility_2, patient: overdue_patient_in_facility_2, scheduled_date: 5.days.ago)
         create(:blood_pressure, :hypertensive, facility: facility_2, patient: overdue_patient_in_facility_2)
-
-        unauthorized_facility_group = create(:facility_group)
-
-        unauthorized_facility = create(:facility, facility_group: unauthorized_facility_group)
 
         overdue_patient_in_unauthorized_facility = create(:patient, full_name: "patient_5", registration_facility: unauthorized_facility)
         create(:appointment, :overdue, facility: unauthorized_facility, patient: overdue_patient_in_unauthorized_facility)

--- a/spec/features/appointments_spec.rb
+++ b/spec/features/appointments_spec.rb
@@ -41,7 +41,6 @@ RSpec.feature "Overdue appointments", type: :feature do
         patient
       end
 
-
       let!(:facility_2) { create(:facility, facility_group: authorized_facility_group) }
 
       let!(:overdue_patient_in_facility_2) do

--- a/spec/rachets/lets_not_spec.rb
+++ b/spec/rachets/lets_not_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe "Rachet down usage of let!" do
-  expected_usages = 549
+  expected_usages = 540
 
   it "prevents new usages" do
     command = %{grep -rn "\slet\!(:" spec}


### PR DESCRIPTION
**Story card:** [ch3761](https://app.clubhouse.io/simpledotorg/story/3761/overdue-list-does-not-explicitly-filter-out-dead-patients)

## Because

The overdue list depends on appointment status being `cancelled` to remove patients from the list. It does not explicitly exclude dead patients.

## This addresses

This explicitly filters out patients with status `dead`.

## Test instructions

1. Load the overdue list
2. Go into the console and mark the first patient that appears as `patient.status = :dead`
3. Make sure they disappear from the overdue list on reload