### PR TITLE
Add meaningful page titles for reports

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,9 +3,8 @@ module ApplicationHelper
   STANDARD_DATE_DISPLAY_FORMAT = "%d-%^b-%Y"
 
   def page_title
-    str = get_title_for_environment
-    str << " |" << content_for(:title) if content_for?(:title)
-    str
+    title = content_for?(:title) ? content_for(:title) : I18n.t("admin.dashboard_title")
+    [env_prefix, title].compact.join(" ")
   end
 
   def bootstrap_class_for_flash(flash_type)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,6 +2,12 @@ module ApplicationHelper
   DEFAULT_PROGRAM_INCEPTION_DATE = Time.new(2018, 0o1, 0o1)
   STANDARD_DATE_DISPLAY_FORMAT = "%d-%^b-%Y"
 
+  def page_title
+    str = get_title_for_environment
+    str << " |" << content_for(:title) if content_for?(:title)
+    str
+  end
+
   def bootstrap_class_for_flash(flash_type)
     case flash_type
     when "success"

--- a/app/helpers/simple_server_env_helper.rb
+++ b/app/helpers/simple_server_env_helper.rb
@@ -1,5 +1,6 @@
 module SimpleServerEnvHelper
-  CUSTOMIZED_ENVS = %w[development qa sandbox demo production].freeze
+  CUSTOMIZED_ENVS = %w[development demo qa sandbox production].freeze
+  ENV_ABBREVIATIONS = {development: "DEV", demo: "DEMO", qa: "QA", sandbox: "SBX"}.freeze
 
   def style_class_for_environment
     env = ENV.fetch("SIMPLE_SERVER_ENV")
@@ -17,8 +18,12 @@ module SimpleServerEnvHelper
 
     return title if env.downcase == "production"
 
-    prefix = CUSTOMIZED_ENVS.include?(env) ? "[#{env.humanize}] " : ""
-    prefix + title
+    "#{env_prefix}#{title}"
+  end
+
+  def env_prefix
+    env = ENV.fetch("SIMPLE_SERVER_ENV").to_sym
+    ENV_ABBREVIATIONS[env] ? "[#{ENV_ABBREVIATIONS[env]}] " : ""
   end
 
   def logo_for_environment

--- a/app/helpers/simple_server_env_helper.rb
+++ b/app/helpers/simple_server_env_helper.rb
@@ -13,12 +13,12 @@ module SimpleServerEnvHelper
   end
 
   def get_title_for_environment
-    title = I18n.t("admin.dashboard_title")
+    dashboard_title = I18n.t("admin.dashboard_title")
     env = ENV.fetch("SIMPLE_SERVER_ENV")
 
     return title if env.downcase == "production"
 
-    "#{env_prefix}#{title}"
+    "#{env_prefix}#{dashboard_title}"
   end
 
   def env_prefix

--- a/app/helpers/simple_server_env_helper.rb
+++ b/app/helpers/simple_server_env_helper.rb
@@ -1,6 +1,6 @@
 module SimpleServerEnvHelper
   CUSTOMIZED_ENVS = %w[development demo qa sandbox production].freeze
-  ENV_ABBREVIATIONS = {development: "DEV", demo: "DEMO", qa: "QA", sandbox: "SBX"}.freeze
+  ENV_ABBREVIATIONS = {development: "DEV", demo: "DEMO", test: "TEST", qa: "QA", sandbox: "SBX"}.freeze
 
   def style_class_for_environment
     env = ENV.fetch("SIMPLE_SERVER_ENV")
@@ -12,18 +12,9 @@ module SimpleServerEnvHelper
     styles.join(" ")
   end
 
-  def get_title_for_environment
-    dashboard_title = I18n.t("admin.dashboard_title")
-    env = ENV.fetch("SIMPLE_SERVER_ENV")
-
-    return dashboard_title if env.downcase == "production"
-
-    "#{env_prefix}#{dashboard_title}"
-  end
-
   def env_prefix
     env = ENV.fetch("SIMPLE_SERVER_ENV").to_sym
-    ENV_ABBREVIATIONS[env] ? "[#{ENV_ABBREVIATIONS[env]}] " : ""
+    ENV_ABBREVIATIONS[env] ? "[#{ENV_ABBREVIATIONS[env]}]" : nil
   end
 
   def logo_for_environment

--- a/app/helpers/simple_server_env_helper.rb
+++ b/app/helpers/simple_server_env_helper.rb
@@ -16,7 +16,7 @@ module SimpleServerEnvHelper
     dashboard_title = I18n.t("admin.dashboard_title")
     env = ENV.fetch("SIMPLE_SERVER_ENV")
 
-    return title if env.downcase == "production"
+    return dashboard_title if env.downcase == "production"
 
     "#{env_prefix}#{dashboard_title}"
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
       </script>
     <% end %>
     <title>
-      <%= get_title_for_environment %>
+      <%= page_title %>
     </title>
     <%= csrf_meta_tags %>
     <meta charset="utf-8">

--- a/app/views/my_facilities/index.html.erb
+++ b/app/views/my_facilities/index.html.erb
@@ -1,8 +1,12 @@
+<% content_for :title do %>
+ Overview
+<% end %>
+
 <div class="d-flex row">
   <div class="col-lg-6">
     <%= render "shared/user_approvals" %>
-    <%= render "recent_updates" %> 
-    <%= render "upcoming_improvements" %> 
+    <%= render "recent_updates" %>
+    <%= render "upcoming_improvements" %>
   </div>
   <div class="col-lg-6">
     <%= render 'shared/my_facilities/facilities_by_size' %>

--- a/app/views/reports/regions/cohort.html.erb
+++ b/app/views/reports/regions/cohort.html.erb
@@ -1,3 +1,7 @@
+<% content_for :title do %>
+ <%= @region.name %> | Cohort
+<% end %>
+
 <%= render "header"%>
 <div class="d-lg-flex">
   <div class="card w-100pt mt-lg-0">

--- a/app/views/reports/regions/details.html.erb
+++ b/app/views/reports/regions/details.html.erb
@@ -1,3 +1,7 @@
+<% content_for :title do %>
+ <%= @region.name %> | Details
+<% end %>
+
 <%= render "header", period_selector: false %>
 
 <%= render "reports/regions/patient_breakdown_charts" %>

--- a/app/views/reports/regions/index.html.erb
+++ b/app/views/reports/regions/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for :title do %>
+ Reports
+<% end %>
+
 <div class="container">
   <div class="row">
     <div class="col-sm-5 col-lg-7">

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :title do %>
+ <%= @region.name %> | Overview
+<% end %>
+
 <%= render "header" %>
 
 <% control_graph_denominator_copy = @with_ltfu ? "denominator_with_ltfu_copy" : "denominator_copy" %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -13,13 +13,13 @@ describe ApplicationHelper, type: :helper do
 
     it "uses page_title content when set" do
       helper.content_for(:title) { "My Custom Title" }
-      expect(helper.page_title).to eq("[TEST] My Custom Title" )
+      expect(helper.page_title).to eq("[TEST] My Custom Title")
     end
 
     it "has no prefix in production" do
       ENV["SIMPLE_SERVER_ENV"] = "production"
       helper.content_for(:title) { "My Custom Title" }
-      expect(helper.page_title).to eq("My Custom Title" )
+      expect(helper.page_title).to eq("My Custom Title")
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,28 @@
 require "rails_helper"
 
 describe ApplicationHelper, type: :helper do
+  context "page_title" do
+    after { ENV["SIMPLE_SERVER_ENV"] = "test" }
+
+    it "defaults to prefix and default title if no explicit title is set" do
+      expect(helper.page_title).to eq("[TEST] Simple Dashboard")
+      stub_const("SIMPLE_SERVER_ENV", "sandbox")
+      ENV["SIMPLE_SERVER_ENV"] = "sandbox"
+      expect(helper.page_title).to eq("[SBX] Simple Dashboard")
+    end
+
+    it "uses page_title content when set" do
+      helper.content_for(:title) { "My Custom Title" }
+      expect(helper.page_title).to eq("[TEST] My Custom Title" )
+    end
+
+    it "has no prefix in production" do
+      ENV["SIMPLE_SERVER_ENV"] = "production"
+      helper.content_for(:title) { "My Custom Title" }
+      expect(helper.page_title).to eq("My Custom Title" )
+    end
+  end
+
   describe "#bootstrap_class_for_flash" do
     specify { expect(helper.bootstrap_class_for_flash("success")).to eq("alert-success") }
     specify { expect(helper.bootstrap_class_for_flash("error")).to eq("alert-danger") }

--- a/spec/helpers/simple_server_env_helper_spec.rb
+++ b/spec/helpers/simple_server_env_helper_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe SimpleServerEnvHelper do
       it "should return the QA alt for the logo" do
         ENV[simple_server_env] = "qa"
 
-        expect(get_title_for_environment).to eq "[Qa] Simple Dashboard"
+        expect(get_title_for_environment).to eq "[QA] Simple Dashboard"
       end
     end
 
@@ -74,7 +74,7 @@ RSpec.describe SimpleServerEnvHelper do
       it "should return the demo alt for the logo" do
         ENV[simple_server_env] = "demo"
 
-        expect(get_title_for_environment).to eq "[Demo] Simple Dashboard"
+        expect(get_title_for_environment).to eq "[DEMO] Simple Dashboard"
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe SimpleServerEnvHelper do
       it "should return the sandbox alt for the logo" do
         ENV[simple_server_env] = "sandbox"
 
-        expect(get_title_for_environment).to eq "[Sandbox] Simple Dashboard"
+        expect(get_title_for_environment).to eq "[SBX] Simple Dashboard"
       end
     end
 

--- a/spec/helpers/simple_server_env_helper_spec.rb
+++ b/spec/helpers/simple_server_env_helper_spec.rb
@@ -51,47 +51,21 @@ RSpec.describe SimpleServerEnvHelper do
     end
   end
 
-  describe "get_title_for_environment" do
-    before { allow(I18n).to receive(:t).with("admin.dashboard_title").and_return "Simple Dashboard" }
-
-    context "when in the default environment" do
-      it "should return the default alt for the logo" do
-        ENV[simple_server_env] = "default"
-
-        expect(get_title_for_environment).to eq "Simple Dashboard"
-      end
+  describe "env_prefix" do
+    it "returns abbreviated name for our environments" do
+      expect(env_prefix).to eq("[TEST]")
+      ENV[simple_server_env] = "sandbox"
+      expect(env_prefix).to eq("[SBX]")
     end
 
-    context "when in the qa environment" do
-      it "should return the QA alt for the logo" do
-        ENV[simple_server_env] = "qa"
-
-        expect(get_title_for_environment).to eq "[QA] Simple Dashboard"
-      end
+    it "defaults to nil" do
+      ENV[simple_server_env] = "default"
+      expect(env_prefix).to be_nil
     end
 
-    context "when in the demo environment" do
-      it "should return the demo alt for the logo" do
-        ENV[simple_server_env] = "demo"
-
-        expect(get_title_for_environment).to eq "[DEMO] Simple Dashboard"
-      end
-    end
-
-    context "when in the sandbox environment" do
-      it "should return the sandbox alt for the logo" do
-        ENV[simple_server_env] = "sandbox"
-
-        expect(get_title_for_environment).to eq "[SBX] Simple Dashboard"
-      end
-    end
-
-    context "when in the production environment" do
-      it "should return the production alt for the logo" do
-        ENV[simple_server_env] = "production"
-
-        expect(get_title_for_environment).to eq "Simple Dashboard"
-      end
+    it "returns nil for production" do
+      ENV[simple_server_env] = "production"
+      expect(env_prefix).to be_nil
     end
   end
 


### PR DESCRIPTION
Adds page titles to the report pages, as well as making the env name a shorter, more clear abbreviation for better tab readability.