### PR TITLE
Fix sync loop for telemed MOs

### DIFF
--- a/app/controllers/api/v3/facilities_controller.rb
+++ b/app/controllers/api/v3/facilities_controller.rb
@@ -26,7 +26,7 @@ class Api::V3::FacilitiesController < Api::V3::SyncController
   def transform_to_response(facility)
     Api::V3::FacilityTransformer
       .to_response(facility)
-      .merge(sync_region_id: facility.block_region_id)
+      .merge(sync_region_id: sync_region_id(facility))
   end
 
   def response_process_token
@@ -46,6 +46,18 @@ class Api::V3::FacilitiesController < Api::V3::SyncController
         .with_block_region_id
         .includes(:facility_group)
         .where.not(facility_group: nil)
+    end
+  end
+
+  memoize def district_level_sync?
+    current_user&.district_level_sync?
+  end
+
+  def sync_region_id(facility)
+    if district_level_sync?
+      facility.facility_group_id
+    else
+      facility.block_region_id
     end
   end
 end

--- a/app/controllers/api/v3/facilities_controller.rb
+++ b/app/controllers/api/v3/facilities_controller.rb
@@ -1,5 +1,6 @@
 class Api::V3::FacilitiesController < Api::V3::SyncController
   include Api::V3::PublicApi
+  include Memery
 
   def sync_to_user
     __sync_to_user__("facilities")

--- a/app/controllers/concerns/api/v3/sync_to_user.rb
+++ b/app/controllers/concerns/api/v3/sync_to_user.rb
@@ -87,9 +87,8 @@ module Api::V3::SyncToUser
     end
 
     def sync_region_modified?
-      return if requested_sync_region_id.blank?
       return if process_token[:sync_region_id].blank?
-      process_token[:sync_region_id] != requested_sync_region_id
+      process_token[:sync_region_id] != current_sync_region.id
     end
 
     def time(method_name, &block)

--- a/app/controllers/concerns/api/v3/sync_to_user.rb
+++ b/app/controllers/concerns/api/v3/sync_to_user.rb
@@ -87,6 +87,8 @@ module Api::V3::SyncToUser
     end
 
     def sync_region_modified?
+      # If the user has been syncing a different region than
+      # what we think the user's sync region should be, we resync.
       return if process_token[:sync_region_id].blank?
       process_token[:sync_region_id] != current_sync_region.id
     end

--- a/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
+++ b/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
@@ -424,6 +424,8 @@ RSpec.shared_examples "a working sync controller that supports region level sync
         reset_controller
 
         # 1 current facility record, 2 other facility records
+        # The last record in the first request is repeated as the first record in the second request.
+        # This happens because of the >= comparison in the updated_on_server_since method.
         get :sync_to_user, params: {process_token: JSON(response.body)["process_token"], limit: 3}
         response_record_ids += JSON(response.body)[response_key].map { |r| r["id"] }
 
@@ -486,6 +488,8 @@ RSpec.shared_examples "a working sync controller that supports region level sync
           reset_controller
 
           # 1 current facility record, 2 other facility records
+          # The last record in the first request is repeated as the first record in the second request.
+          # This happens because of the >= comparison in the updated_on_server_since method.
           get :sync_to_user, params: {process_token: JSON(response.body)["process_token"], limit: 3}
           response_record_ids += JSON(response.body)[response_key].map { |r| r["id"] }
 

--- a/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
+++ b/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
@@ -457,17 +457,17 @@ RSpec.shared_examples "a working sync controller that supports region level sync
         it "sync facility group records when user is a teleconsult MO" do
           allow_any_instance_of(User).to receive(:can_teleconsult?).and_return true
           block_records = Timecop.travel(15.minutes.ago) {
-            create_record_list(5, patient: patient_in_same_block, facility: facility_in_same_block)
+            create_record_list(2, patient: patient_in_same_block, facility: facility_in_same_block)
           }
-          non_block_records = Timecop.travel(15.minutes.ago) { create_record_list(5, facility: facility_in_other_block) }
+          non_block_records = Timecop.travel(15.minutes.ago) { create_record_list(2, facility: facility_in_other_block) }
 
-          # 5 current facility records
-          get :sync_to_user, params: {limit: 5}
+          # 2 current facility records
+          get :sync_to_user, params: {limit: 2}
           response_record_ids = JSON(response.body)[response_key].map { |r| r["id"] }
           reset_controller
 
-          # 1 current facility record, 5 other facility records
-          get :sync_to_user, params: {process_token: JSON(response.body)["process_token"], limit: 6}
+          # 1 current facility record, 2 other facility records
+          get :sync_to_user, params: {process_token: JSON(response.body)["process_token"], limit: 3}
           response_record_ids += JSON(response.body)[response_key].map { |r| r["id"] }
 
           expect(response_record_ids.uniq).to match_array (block_records + non_block_records).map(&:id).uniq

--- a/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
+++ b/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
@@ -410,6 +410,25 @@ RSpec.shared_examples "a working sync controller that supports region level sync
           expect(response_record_ids).to match_array model.pluck(:id)
         end
       end
+
+      it "syncs facility group records when user is a teleconsult MO" do
+        allow_any_instance_of(User).to receive(:can_teleconsult?).and_return true
+        block_records = Timecop.travel(15.minutes.ago) {
+          create_record_list(2, patient: patient_in_same_block, facility: facility_in_same_block)
+        }
+        non_block_records = Timecop.travel(15.minutes.ago) { create_record_list(2, facility: facility_in_other_block) }
+
+        # 2 current facility records
+        get :sync_to_user, params: {limit: 2}
+        response_record_ids = JSON(response.body)[response_key].map { |r| r["id"] }
+        reset_controller
+
+        # 1 current facility record, 2 other facility records
+        get :sync_to_user, params: {process_token: JSON(response.body)["process_token"], limit: 3}
+        response_record_ids += JSON(response.body)[response_key].map { |r| r["id"] }
+
+        expect(response_record_ids.uniq).to match_array (block_records + non_block_records).map(&:id).uniq
+      end
     end
 
     context "when X_SYNC_REGION_ID is block_id" do


### PR DESCRIPTION
**Story card:** [ch3701](https://app.clubhouse.io/simpledotorg/story/3701/sync-is-not-finishing-and-sync-indicator-is-not-responding)

## Because

We have a sync loop bug that affects Telemed MO's. Telemed MOs are stuck resyncing the first 1000 records from the beginning in each request.

### Root cause

1. In https://github.com/simpledotorg/simple-server/pull/2430 we started to set block id as the `sync_region_id` for all users. This is not true for MOs because they need to sync the entire district's records.

2. We sync the entire district's records to Telemed MO's as a special case. We determine if a user is switching from an old app to a new app based on a mismatch between process token's `sync_region_id` and `X-SYNC-REGION-ID`. We use this mismatch to force a resync. In the case of MOs however, these region id's never match. The `current_sync_region` is forcibly set to district and doesn't match the `X-SYNC-REGION-ID` which is the user's block. 
We failed to account for this in the `force_resync?` check, which meant `force_resync?` was always evaluating to true for MOs.

### Impact

Telemed MOs have been in a sync loop since block level sync was released to them. This means they can't lookup the latest patients. They would only be able to lookup pre-block sync patients from their block. Patients outside their block would have been purged and not synced again.

## This addresses

Starts using `current_sync_region` to determine if a resync needs to be happen. 

`current_sync_region` is responsible for figuring out which region's data should be synced to the user. We used `requested_sync_region_id` in `sync_region_modified?` because we transparently synced the region the user the asked for through `X-SYNC-REGION-ID`. In an MO's case however, we disregard that request and instead always sync district records. We should rely on the more intelligent `current_sync_region` to evaluate `sync_region_modified?`.

## Test instructions

In a block with more than 1000 records
- [x] Test sync as non-MO user on review app
- [x] Test sync as MO user on review app, number of records should be > 1000