### PR TITLE
Add deleted_at index to deduplication logs

### DIFF
--- a/db/migrate/20210622142216_add_deleted_at_index_to_deduplication_log.rb
+++ b/db/migrate/20210622142216_add_deleted_at_index_to_deduplication_log.rb
@@ -1,0 +1,7 @@
+class AddDeletedAtIndexToDeduplicationLog < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index "deduplication_logs", ["deduped_record_id", "deleted_at"], name: "index_deduplication_records_lookup"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_07_235412) do
+ActiveRecord::Schema.define(version: 2021_06_22_142216) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -159,6 +159,8 @@ ActiveRecord::Schema.define(version: 2021_06_07_235412) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
+    t.index ["deduped_record_id", "deleted_at"], name: "index_deduplication_records_lookup"
+    t.index ["deleted_at", "deleted_record_id"], name: "idx_deduplication_logs_lookup_tmp"
     t.index ["record_type", "deleted_record_id"], name: "idx_deduplication_logs_lookup_deleted_record", unique: true
     t.index ["user_id"], name: "index_deduplication_logs_on_user_id"
   end


### PR DESCRIPTION
**Story card:** - 

## Because

Deduplication logs are looked up in every sync request but the table doesn't have an index on `deleted_at` which makes syncs slower and eats up DB CPU.

## This addresses

Adds a `deleted_at` compound index.
