### PR TITLE
Fix semaphore cache; extract our sem CI setup to shell script

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,14 +25,12 @@ blocks:
       jobs:
         - name: StandardRB
           commands:
-            - cache clear
             - checkout
             - script/semaphore_setup
             - "bundle exec standardrb"
         - name: RSpec
           parallelism: 8
           commands:
-            - cache clear
             - checkout
             - script/semaphore_setup
             - 'bundle exec rake db:setup'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,9 +27,9 @@ blocks:
           commands:
             - checkout
             - sem-version ruby 2.6.6
+            - cache clean
             - cache restore
             - bundle install --deployment --path vendor/bundle
-            - cache store
             - "bundle exec standardrb"
         - name: RSpec
           parallelism: 8
@@ -40,6 +40,7 @@ blocks:
             - 'wget -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb'
             - sudo dpkg -i /tmp/libpng12.deb
             - gem install semaphore_test_boosters
+            - cache clean
             - cache restore
             - yarn install
             - bundle install --deployment --path vendor/bundle

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,14 +27,14 @@ blocks:
           commands:
             - cache clean
             - checkout
-            - ./script/semaphore_setup
+            - sudo script/semaphore_setup
             - "bundle exec standardrb"
         - name: RSpec
           parallelism: 8
           commands:
             - cache clean
             - checkout
-            - ./script/semaphore_setup
+            - sudo script/semaphore_setup
             - 'bundle exec rake db:setup'
             - 'bundle exec rake db:test:prepare'
             - rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,30 +25,16 @@ blocks:
       jobs:
         - name: StandardRB
           commands:
+            - cache clean
             - checkout
-            - sem-service start postgres 10
-            - sem-version ruby 2.6.6
-            - 'wget -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb'
-            - sudo dpkg -i /tmp/libpng12.deb
-            - gem install semaphore_test_boosters
-            - cache restore
-            - yarn install
-            - bundle install --deployment --path vendor/bundle
-            - cache store
+            - script/semaphore_setup
             - "bundle exec standardrb"
         - name: RSpec
           parallelism: 8
           commands:
+            - cache clean
             - checkout
-            - sem-service start postgres 10
-            - sem-version ruby 2.6.6
-            - 'wget -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb'
-            - sudo dpkg -i /tmp/libpng12.deb
-            - gem install semaphore_test_boosters
-            - cache restore
-            - yarn install
-            - bundle install --deployment --path vendor/bundle
-            - cache store
+            - script/semaphore_setup
             - 'bundle exec rake db:setup'
             - 'bundle exec rake db:test:prepare'
             - rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,14 +27,16 @@ blocks:
           commands:
             - cache clean
             - checkout
-            - sudo script/semaphore_setup
+            - sem-version ruby 2.6.6
+            - script/semaphore_setup
             - "bundle exec standardrb"
         - name: RSpec
           parallelism: 8
           commands:
             - cache clean
             - checkout
-            - sudo script/semaphore_setup
+            - sem-version ruby 2.6.6
+            - script/semaphore_setup
             - 'bundle exec rake db:setup'
             - 'bundle exec rake db:test:prepare'
             - rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,14 +25,14 @@ blocks:
       jobs:
         - name: StandardRB
           commands:
-            - cache clean
+            - cache clear
             - checkout
             - script/semaphore_setup
             - "bundle exec standardrb"
         - name: RSpec
           parallelism: 8
           commands:
-            - cache clean
+            - cache clear
             - checkout
             - script/semaphore_setup
             - 'bundle exec rake db:setup'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -26,10 +26,15 @@ blocks:
         - name: StandardRB
           commands:
             - checkout
+            - sem-service start postgres 10
             - sem-version ruby 2.6.6
-            - cache clean
+            - 'wget -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb'
+            - sudo dpkg -i /tmp/libpng12.deb
+            - gem install semaphore_test_boosters
             - cache restore
+            - yarn install
             - bundle install --deployment --path vendor/bundle
+            - cache store
             - "bundle exec standardrb"
         - name: RSpec
           parallelism: 8
@@ -40,7 +45,6 @@ blocks:
             - 'wget -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb'
             - sudo dpkg -i /tmp/libpng12.deb
             - gem install semaphore_test_boosters
-            - cache clean
             - cache restore
             - yarn install
             - bundle install --deployment --path vendor/bundle

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,14 +27,14 @@ blocks:
           commands:
             - cache clean
             - checkout
-            - script/semaphore_setup
+            - ./script/semaphore_setup
             - "bundle exec standardrb"
         - name: RSpec
           parallelism: 8
           commands:
             - cache clean
             - checkout
-            - script/semaphore_setup
+            - ./script/semaphore_setup
             - 'bundle exec rake db:setup'
             - 'bundle exec rake db:test:prepare'
             - rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,7 +27,6 @@ blocks:
           commands:
             - cache clean
             - checkout
-            - sem-version ruby 2.6.6
             - script/semaphore_setup
             - "bundle exec standardrb"
         - name: RSpec
@@ -35,7 +34,6 @@ blocks:
           commands:
             - cache clean
             - checkout
-            - sem-version ruby 2.6.6
             - script/semaphore_setup
             - 'bundle exec rake db:setup'
             - 'bundle exec rake db:test:prepare'

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -ex
+
+sem-service start postgres 10
+sem-version ruby 2.6.6
+wget -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb
+sudo dpkg -i /tmp/libpng12.deb
+gem install semaphore_test_boosters
+cache restore
+yarn install
+bundle install --deployment --path vendor/bundle
+cache store

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -ex
 
+source ~/.toolbox/toolbox
+
 sem-service start postgres 10
 wget -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb
 sudo dpkg -i /tmp/libpng12.deb

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -9,6 +9,7 @@ sem-service start postgres 10
 wget -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb
 sudo dpkg -i /tmp/libpng12.deb
 gem install semaphore_test_boosters
+gem install wkhtmltoimage-binary -v '0.12.5' --source 'https://rubygems.org/'
 cache restore
 yarn install
 bundle install --deployment --path vendor/bundle

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -9,7 +9,6 @@ sem-service start postgres 10
 wget -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb
 sudo dpkg -i /tmp/libpng12.deb
 gem install semaphore_test_boosters
-gem install wkhtmltoimage-binary -v '0.12.5' --source 'https://rubygems.org/'
 cache restore
 yarn install
 bundle install --deployment --path vendor/bundle

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -2,7 +2,6 @@
 set -ex
 
 sem-service start postgres 10
-sem-version ruby 2.6.6
 wget -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb
 sudo dpkg -i /tmp/libpng12.deb
 gem install semaphore_test_boosters

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -1,9 +1,10 @@
 #!/bin/bash
-
 set -ex
 
+# See https://github.com/semaphoreci/toolbox for more details on the "sem-" commands
 source ~/.toolbox/toolbox
 
+sem-version ruby 2.6.6
 sem-service start postgres 10
 wget -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb
 sudo dpkg -i /tmp/libpng12.deb

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+
 set -ex
 
 source ~/.toolbox/toolbox


### PR DESCRIPTION
Fixes CI and makes this stuff easier to handle in the future by extracting the main setup to a bash script.