### PR TITLE
Update deduplication log index

### DIFF
--- a/db/migrate/20210628154848_update_deduplication_log_indexes.rb
+++ b/db/migrate/20210628154848_update_deduplication_log_indexes.rb
@@ -1,0 +1,6 @@
+class UpdateDeduplicationLogIndexes < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :deduplication_logs, name: :index_deduplication_records_lookup
+    add_index :deduplication_logs, [:deleted_record_id, :deleted_at], name: :idx_deduplication_logs_lookup_deleted_at
+  end
+end

--- a/db/migrate/20210628154848_update_deduplication_log_indexes.rb
+++ b/db/migrate/20210628154848_update_deduplication_log_indexes.rb
@@ -1,6 +1,8 @@
 class UpdateDeduplicationLogIndexes < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
   def change
     remove_index :deduplication_logs, name: :index_deduplication_records_lookup
-    add_index :deduplication_logs, [:deleted_at, :deleted_record_id], name: :idx_deduplication_logs_lookup_deleted_at
+    add_index :deduplication_logs, [:deleted_at, :deleted_record_id], name: :idx_deduplication_logs_lookup_deleted_at, algorithm: :concurrently
   end
 end

--- a/db/migrate/20210628154848_update_deduplication_log_indexes.rb
+++ b/db/migrate/20210628154848_update_deduplication_log_indexes.rb
@@ -1,6 +1,6 @@
 class UpdateDeduplicationLogIndexes < ActiveRecord::Migration[5.2]
   def change
     remove_index :deduplication_logs, name: :index_deduplication_records_lookup
-    add_index :deduplication_logs, [:deleted_record_id, :deleted_at], name: :idx_deduplication_logs_lookup_deleted_at
+    add_index :deduplication_logs, [:deleted_at, :deleted_record_id], name: :idx_deduplication_logs_lookup_deleted_at
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_22_191111) do
+ActiveRecord::Schema.define(version: 2021_06_28_154848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -159,8 +159,8 @@ ActiveRecord::Schema.define(version: 2021_06_22_191111) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
-    t.index ["deduped_record_id", "deleted_at"], name: "index_deduplication_records_lookup"
     t.index ["deleted_at", "deleted_record_id"], name: "idx_deduplication_logs_lookup_tmp"
+    t.index ["deleted_record_id", "deleted_at"], name: "idx_deduplication_logs_lookup_deleted_at"
     t.index ["record_type", "deleted_record_id"], name: "idx_deduplication_logs_lookup_deleted_record", unique: true
     t.index ["user_id"], name: "index_deduplication_logs_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -159,7 +159,6 @@ ActiveRecord::Schema.define(version: 2021_06_28_154848) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
-    t.index ["deleted_at", "deleted_record_id"], name: "idx_deduplication_logs_lookup_tmp"
     t.index ["deleted_record_id", "deleted_at"], name: "idx_deduplication_logs_lookup_deleted_at"
     t.index ["record_type", "deleted_record_id"], name: "idx_deduplication_logs_lookup_deleted_record", unique: true
     t.index ["user_id"], name: "index_deduplication_logs_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -159,7 +159,7 @@ ActiveRecord::Schema.define(version: 2021_06_28_154848) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
-    t.index ["deleted_record_id", "deleted_at"], name: "idx_deduplication_logs_lookup_deleted_at"
+    t.index ["deleted_at", "deleted_record_id"], name: "idx_deduplication_logs_lookup_deleted_at"
     t.index ["record_type", "deleted_record_id"], name: "idx_deduplication_logs_lookup_deleted_record", unique: true
     t.index ["user_id"], name: "index_deduplication_logs_on_user_id"
   end


### PR DESCRIPTION
**Story card:** -

## Because
Follow up to #2616. We added an index on the wrong column.

## This addresses

Drops the index added in #2616. Adds the correct index. Removes the accidentally committed temporary index from schema.
