### PR TITLE
HOTFIX: Restore DHIS2 API calls

### DIFF
--- a/lib/tasks/dhis2.rake
+++ b/lib/tasks/dhis2.rake
@@ -65,7 +65,7 @@ namespace :dhis2 do
         end
       end
 
-      # puts Dhis2.client.data_value_sets.bulk_create(data_values: facility_bulk_data)
+      pp Dhis2.client.data_value_sets.bulk_create(data_values: facility_bulk_data)
     end
   end
 end


### PR DESCRIPTION
## Because

The API call to DHIS2 was accidentally commented out for debugging and merged with `master`

## This addresses

This restores the API call