### PR TITLE
Log user information for identical records

### DIFF
--- a/app/controllers/api/v3/patients_controller.rb
+++ b/app/controllers/api/v3/patients_controller.rb
@@ -57,14 +57,18 @@ class Api::V3::PatientsController < Api::V3::SyncController
     else
       transformed_params = Api::V3::PatientTransformer.from_nested_request(single_patient_params)
       patient = MergePatientService.new(transformed_params, request_metadata: request_metadata).merge
-      if patient.merge_status == :identical
-        logger.info(event: "identical patient record synced",
-                    user_id: current_user.id,
-                    patient_id: patient.id,
-                    sync_region_id: current_sync_region.id)
-      end
+      log_identical_record_info(patient) if patient.merge_status == :identical
       {record: patient}
     end
+  end
+
+  def log_identical_record_info(patient)
+    # This is to investigate large number of identical records being synced by the app.
+    # Remove once we figure it out.
+    logger.info(event: "identical patient record synced",
+                user_id: current_user.id,
+                patient_id: patient.id,
+                sync_region_id: current_sync_region.id)
   end
 
   def transform_to_response(patient)

--- a/app/controllers/api/v3/patients_controller.rb
+++ b/app/controllers/api/v3/patients_controller.rb
@@ -57,6 +57,12 @@ class Api::V3::PatientsController < Api::V3::SyncController
     else
       transformed_params = Api::V3::PatientTransformer.from_nested_request(single_patient_params)
       patient = MergePatientService.new(transformed_params, request_metadata: request_metadata).merge
+      if patient.merge_status == :identical
+        logger.info(event: "identical patient record synced",
+                    user_id: current_user.id,
+                    patient_id: patient.id,
+                    sync_region_id: current_sync_region.id)
+      end
       {record: patient}
     end
   end


### PR DESCRIPTION
**Story card:** [ch4055](https://app.clubhouse.io/simpledotorg/story/4055/investigate-ec2-cpu-spikes)

## Because

The recent EC2 spikes correlate with spikes in `identical` patient payloads being synced to the server. 
![image](https://user-images.githubusercontent.com/16774200/124767871-d002f100-df55-11eb-9148-353ee32330b6.png). 
![image](https://user-images.githubusercontent.com/16774200/124768631-751dc980-df56-11eb-9d1c-73d43bac839f.png)
![image](https://user-images.githubusercontent.com/16774200/124768553-633c2680-df56-11eb-8b58-609e9b8232d1.png)
![image](https://user-images.githubusercontent.com/16774200/124779975-db5b1a00-df5f-11eb-867c-5d54ff6cb4d1.png)


These spikes correspond to the alerts on [Jul 3rd](https://simpledotorg.slack.com/archives/C012BDG130D/p1625302798000200), [Jul 5th](https://simpledotorg.slack.com/archives/C012BDG130D/p1625472178000100), [Jul 7th](https://simpledotorg.slack.com/archives/C012BDG130D/p1625647198002100).

We need more information to find why these records are being sent to us by the apps. 

Related: https://app.clubhouse.io/simpledotorg/story/3843/high-database-load-around-10-am-ist-time-june-16-17th

## This addresses

Log some extra information for identical records.