### PR TITLE
Show user typo fix

### DIFF
--- a/app/views/shared/_recent_bp_log.html.erb
+++ b/app/views/shared/_recent_bp_log.html.erb
@@ -7,7 +7,7 @@
     <% if display_model == :facility %>
       by healthcare workers at <%= @region.name %>
     <% elsif display_model == :user %>
-      by this healthecare workers.
+      by this healthecare worker
     <% end %>
   </p>
   <% if blood_pressures.any? %>

--- a/app/views/shared/_recent_bp_log.html.erb
+++ b/app/views/shared/_recent_bp_log.html.erb
@@ -7,7 +7,7 @@
     <% if display_model == :facility %>
       by healthcare workers at <%= @region.name %>
     <% elsif display_model == :user %>
-      by this healthecare worker
+      by this healthcare worker
     <% end %>
   </p>
   <% if blood_pressures.any? %>


### PR DESCRIPTION
**Story card:** [ch4057](https://app.clubhouse.io/simpledotorg/story/4057/show-user-page-typo-fix)

## Because

There's a typo in the SHOW USER page "Recent BPs" subtitle.

## This addresses

Replaces `healthecare workers` with `healthcare worker`

## Test instructions

Check subtitle :)