### PR TITLE
Add region id to drug stocks

### DIFF
--- a/app/controllers/my_facilities/drug_stocks_controller.rb
+++ b/app/controllers/my_facilities/drug_stocks_controller.rb
@@ -42,7 +42,7 @@ class MyFacilities::DrugStocksController < AdminController
   end
 
   def create
-    DrugStocksCreator.call(current_admin, @facility, @for_end_of_month, drug_stocks_params[:drug_stocks])
+    DrugStocksCreator.call(user: current_admin, facility: @facility, month: @for_end_of_month, drug_stocks_params: drug_stocks_params[:drug_stocks])
     redirect_to redirect_url, notice: "Saved drug stocks"
   rescue ActiveRecord::RecordInvalid
     redirect_to redirect_url, alert: "Something went wrong, Drug Stocks were not saved."

--- a/app/controllers/my_facilities/drug_stocks_controller.rb
+++ b/app/controllers/my_facilities/drug_stocks_controller.rb
@@ -42,7 +42,10 @@ class MyFacilities::DrugStocksController < AdminController
   end
 
   def create
-    DrugStocksCreator.call(user: current_admin, facility: @facility, month: @for_end_of_month, drug_stocks_params: drug_stocks_params[:drug_stocks])
+    DrugStocksCreator.call(user: current_admin,
+                           month: @for_end_of_month,
+                           drug_stocks_params: drug_stocks_params[:drug_stocks],
+                           region: @facility.region)
     redirect_to redirect_url, notice: "Saved drug stocks"
   rescue ActiveRecord::RecordInvalid
     redirect_to redirect_url, alert: "Something went wrong, Drug Stocks were not saved."

--- a/app/controllers/my_facilities/drug_stocks_controller.rb
+++ b/app/controllers/my_facilities/drug_stocks_controller.rb
@@ -45,7 +45,7 @@ class MyFacilities::DrugStocksController < AdminController
     DrugStocksCreator.call(user: current_admin,
                            month: @for_end_of_month,
                            drug_stocks_params: drug_stocks_params[:drug_stocks],
-                           region: @facility.region)
+                           facility: @facility)
     redirect_to redirect_url, notice: "Saved drug stocks"
   rescue ActiveRecord::RecordInvalid
     redirect_to redirect_url, alert: "Something went wrong, Drug Stocks were not saved."

--- a/app/controllers/my_facilities/drug_stocks_controller.rb
+++ b/app/controllers/my_facilities/drug_stocks_controller.rb
@@ -43,7 +43,7 @@ class MyFacilities::DrugStocksController < AdminController
 
   def create
     DrugStocksCreator.call(user: current_admin,
-                           month: @for_end_of_month,
+                           for_end_of_month: @for_end_of_month,
                            drug_stocks_params: drug_stocks_params[:drug_stocks],
                            facility: @facility)
     redirect_to redirect_url, notice: "Saved drug stocks"

--- a/app/controllers/webview/drug_stocks_controller.rb
+++ b/app/controllers/webview/drug_stocks_controller.rb
@@ -7,7 +7,7 @@ class Webview::DrugStocksController < ApplicationController
   skip_before_action :verify_authenticity_token
   around_action :set_reporting_time_zone
   before_action :authenticate
-  before_action :find_current_facility
+  before_action :set_current_facility
   before_action :set_for_end_of_month
   before_action :set_bust_cache
   layout false
@@ -18,7 +18,10 @@ class Webview::DrugStocksController < ApplicationController
   end
 
   def create
-    DrugStocksCreator.call(user: current_user, facility: current_facility, month: @for_end_of_month, drug_stocks_params: safe_params[:drug_stocks])
+    DrugStocksCreator.call(user: current_user,
+                           region: @current_facility.region,
+                           month: @for_end_of_month,
+                           drug_stocks_params: safe_params[:drug_stocks])
     redirect_to webview_drug_stocks_url(for_end_of_month: @for_end_of_month,
                                         facility_id: current_facility.id,
                                         user_id: current_user.id,
@@ -63,7 +66,7 @@ class Webview::DrugStocksController < ApplicationController
     @current_user = user
   end
 
-  def find_current_facility
+  def set_current_facility
     @current_facility = Facility.find(safe_params[:facility_id])
     if @current_facility.community?
       logger.error "Cannot create DrugStocks for community facility #{@current_facility.slug}"

--- a/app/controllers/webview/drug_stocks_controller.rb
+++ b/app/controllers/webview/drug_stocks_controller.rb
@@ -20,7 +20,7 @@ class Webview::DrugStocksController < ApplicationController
   def create
     DrugStocksCreator.call(user: current_user,
                            facility: @current_facility,
-                           month: @for_end_of_month,
+                           for_end_of_month: @for_end_of_month,
                            drug_stocks_params: safe_params[:drug_stocks])
     redirect_to webview_drug_stocks_url(for_end_of_month: @for_end_of_month,
                                         facility_id: current_facility.id,

--- a/app/controllers/webview/drug_stocks_controller.rb
+++ b/app/controllers/webview/drug_stocks_controller.rb
@@ -18,7 +18,7 @@ class Webview::DrugStocksController < ApplicationController
   end
 
   def create
-    DrugStocksCreator.call(current_user, current_facility, @for_end_of_month, safe_params[:drug_stocks])
+    DrugStocksCreator.call(user: current_user, facility: current_facility, month: @for_end_of_month, drug_stocks_params: safe_params[:drug_stocks])
     redirect_to webview_drug_stocks_url(for_end_of_month: @for_end_of_month,
                                         facility_id: current_facility.id,
                                         user_id: current_user.id,

--- a/app/controllers/webview/drug_stocks_controller.rb
+++ b/app/controllers/webview/drug_stocks_controller.rb
@@ -19,7 +19,7 @@ class Webview::DrugStocksController < ApplicationController
 
   def create
     DrugStocksCreator.call(user: current_user,
-                           region: @current_facility.region,
+                           facility: @current_facility,
                            month: @for_end_of_month,
                            drug_stocks_params: safe_params[:drug_stocks])
     redirect_to webview_drug_stocks_url(for_end_of_month: @for_end_of_month,

--- a/app/models/drug_stock.rb
+++ b/app/models/drug_stock.rb
@@ -1,5 +1,6 @@
 class DrugStock < ApplicationRecord
   belongs_to :facility
+  belongs_to :region
   belongs_to :user
   belongs_to :protocol_drug
 

--- a/app/models/drug_stock.rb
+++ b/app/models/drug_stock.rb
@@ -1,6 +1,6 @@
 class DrugStock < ApplicationRecord
   belongs_to :facility
-  belongs_to :region
+  belongs_to :region, optional: true
   belongs_to :user
   belongs_to :protocol_drug
 

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -14,6 +14,7 @@ class Region < ApplicationRecord
   belongs_to :source, polymorphic: true, optional: true
   auto_strip_attributes :name, squish: true, upcase_first: true
 
+  has_many :drug_stocks
   # To set a new path for a Region, assign the parent region via `reparent_to`, and the before_validation
   # callback will assign the new path.
   attr_accessor :reparent_to

--- a/app/services/drug_stocks_creator.rb
+++ b/app/services/drug_stocks_creator.rb
@@ -3,11 +3,10 @@ class DrugStocksCreator
     new(*args).call
   end
 
-  def initialize(user:, facility:, month:, drug_stocks_params:, region: nil)
+  def initialize(user:, facility:, for_end_of_month:, drug_stocks_params:, region: nil)
     @user = user
     @facility = facility
-    @month = month
-    @for_end_of_month = @month.end_of_month
+    @for_end_of_month = for_end_of_month
     @drug_stocks_params = drug_stocks_params || []
     @region = region || facility.region
   end

--- a/app/services/drug_stocks_creator.rb
+++ b/app/services/drug_stocks_creator.rb
@@ -3,12 +3,13 @@ class DrugStocksCreator
     new(*args).call
   end
 
-  def initialize(user, facility, month, drug_stock_params)
+  def initialize(user:, facility:, month:, drug_stock_params:, region:)
     @user = user
     @facility = facility
     @month = month
     @for_end_of_month = @month.end_of_month
     @drug_stock_params = drug_stock_params || []
+    @region = region || facility.region
   end
 
   def call
@@ -19,7 +20,8 @@ class DrugStocksCreator
                           protocol_drug_id: drug_stock[:protocol_drug_id],
                           received: drug_stock[:received].presence,
                           in_stock: drug_stock[:in_stock].presence,
-                          for_end_of_month: @for_end_of_month)
+                          for_end_of_month: @for_end_of_month,
+                          region: @region)
       end
     end
   end

--- a/app/services/drug_stocks_creator.rb
+++ b/app/services/drug_stocks_creator.rb
@@ -3,18 +3,18 @@ class DrugStocksCreator
     new(*args).call
   end
 
-  def initialize(user:, facility:, month:, drug_stock_params:, region:)
+  def initialize(user:, facility:, month:, drug_stocks_params:, region: nil)
     @user = user
     @facility = facility
     @month = month
     @for_end_of_month = @month.end_of_month
-    @drug_stock_params = drug_stock_params || []
+    @drug_stocks_params = drug_stocks_params || []
     @region = region || facility.region
   end
 
   def call
     DrugStock.transaction do
-      @drug_stock_params.map do |drug_stock|
+      @drug_stocks_params.map do |drug_stock|
         DrugStock.create!(facility: @facility,
                           user: @user,
                           protocol_drug_id: drug_stock[:protocol_drug_id],

--- a/db/data/20210708133536_populate_drug_stock_region_id.rb
+++ b/db/data/20210708133536_populate_drug_stock_region_id.rb
@@ -1,0 +1,11 @@
+class PopulateDrugStockRegionId < ActiveRecord::Migration[5.2]
+  def up
+    DrugStock.find_each do |drug_stock|
+      drug_stock.update!(region_id: drug_stock.facility.region.id)
+    end
+  end
+
+  def down
+    DrugStock.update_all(region_id: nil)
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20210521194339)
+DataMigrate::Data.define(version: 20210708133536)

--- a/db/migrate/20210708133404_add_region_id_to_drug_stock.rb
+++ b/db/migrate/20210708133404_add_region_id_to_drug_stock.rb
@@ -1,0 +1,5 @@
+class AddRegionIdToDrugStock < ActiveRecord::Migration[5.2]
+  def change
+    add_column :drug_stocks, :region_id, :uuid, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_07_014011) do
+ActiveRecord::Schema.define(version: 2021_07_08_133404) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -174,6 +174,7 @@ ActiveRecord::Schema.define(version: 2021_07_07_014011) do
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "region_id"
     t.index ["facility_id"], name: "index_drug_stocks_on_facility_id"
     t.index ["protocol_drug_id"], name: "index_drug_stocks_on_protocol_drug_id"
     t.index ["user_id"], name: "index_drug_stocks_on_user_id"

--- a/lib/seed/runner.rb
+++ b/lib/seed/runner.rb
@@ -83,7 +83,7 @@ module Seed
       Facility.all.each do |facility|
         user = facility.users.first
         facility.protocol.protocol_drugs.where(stock_tracked: true).each do |protocol_drug|
-          FactoryBot.create(:drug_stock, facility: facility, user: user, protocol_drug: protocol_drug)
+          FactoryBot.create(:drug_stock, facility: facility, region: facility.region, user: user, protocol_drug: protocol_drug)
         end
       end
     end

--- a/lib/seed/runner.rb
+++ b/lib/seed/runner.rb
@@ -83,7 +83,7 @@ module Seed
       Facility.all.each do |facility|
         user = facility.users.first
         facility.protocol.protocol_drugs.where(stock_tracked: true).each do |protocol_drug|
-          FactoryBot.create(:drug_stock, facility: facility, region: facility.region, user: user, protocol_drug: protocol_drug)
+          FactoryBot.create(:drug_stock, facility: facility, user: user, protocol_drug: protocol_drug)
         end
       end
     end


### PR DESCRIPTION
**Story card:** [ch4082](https://app.clubhouse.io/simpledotorg/story/4082/add-a-region-id-column-on-drug-stocks)

## Because

We need to be able to add `DrugStock`s to districts, we need a `region_id` column to support this

## This addresses

Adds a `region_id` column to `DrugStock`