### PR TITLE
4084: render error page when user is not found by reset token

### DIFF
--- a/app/controllers/email_authentications/passwords_controller.rb
+++ b/app/controllers/email_authentications/passwords_controller.rb
@@ -1,7 +1,7 @@
 class EmailAuthentications::PasswordsController < Devise::PasswordsController
   def edit
     users_email_authentication = resource_class.with_reset_password_token(params["reset_password_token"])
-    return render "expired_reset_token" unless users_email_authentication.reset_password_period_valid?
+    return render "expired_reset_token" unless users_email_authentication&.reset_password_period_valid?
     super
   end
 end

--- a/spec/controllers/email_authentications/passwords_controller_spec.rb
+++ b/spec/controllers/email_authentications/passwords_controller_spec.rb
@@ -21,5 +21,13 @@ RSpec.describe EmailAuthentications::PasswordsController, type: :controller do
       put :edit, params: {reset_password_token: token}
       expect(response).to render_template "expired_reset_token"
     end
+
+    it "renders the expired reset token page when devise does not find the user by token" do
+      auth = build(:email_authentication)
+      auth.send_reset_password_instructions
+
+      put :edit, params: {reset_password_token: "heyheyhey"}
+      expect(response).to render_template "expired_reset_token"
+    end
   end
 end


### PR DESCRIPTION
**Story card:** [ch4084](https://app.clubhouse.io/simpledotorg/story/4084/error-when-login-token-is-not-found)

## Because
This fixes a sentry error we've recently seen: https://sentry.io/organizations/simple-ethiopia/issues/2499060149/?project=5496145&referrer=slack

Without digging too deeply into how Devise works, my best guess is that the token is very old and has been cleared from devise's cache. That's pure speculation. Regardless, showing the error page on whatever is going on here seems appropriate. If there's a deeper problem, hopefully it will be reported and we can fix it with more information. 