### PR TITLE
Fix drug stock report in webview

### DIFF
--- a/app/controllers/webview/drug_stocks_controller.rb
+++ b/app/controllers/webview/drug_stocks_controller.rb
@@ -22,7 +22,7 @@ class Webview::DrugStocksController < ApplicationController
                            facility: @current_facility,
                            for_end_of_month: @for_end_of_month,
                            drug_stocks_params: safe_params[:drug_stocks])
-    redirect_to webview_drug_stocks_url(for_end_of_month: @for_end_of_month,
+    redirect_to webview_drug_stocks_url(for_end_of_month: @for_end_of_month.to_s(:mon_year),
                                         facility_id: current_facility.id,
                                         user_id: current_user.id,
                                         access_token: current_user.access_token)

--- a/app/views/webview/drug_stocks/index.html.erb
+++ b/app/views/webview/drug_stocks/index.html.erb
@@ -29,17 +29,15 @@
       </div>
 
       <div class="title-caps">Report for end of <%= @for_end_of_month.to_s(:mon_year) %></div>
-      <% facility_report = @report[:facilities][current_facility.id] %>
-
       <% @drugs_by_category.each do |category, drugs| %>
-        <% patient_days = facility_report.dig(category, :patient_days) || 0 %>
+        <% patient_days = @report.dig(:patient_days_by_facility_id, @current_facility.id, category, :patient_days) || 0 %>
 
         <div class="card">
           <h3 style="margin-bottom: 8px;"><%= protocol_drug_labels[category][:full] %></h3>
           <span class="<%= patient_days_css_class(patient_days, prefix: "text") %>"><%= patient_days %> days of drug stock</span>
 
           <% drugs.each do |drug| %>
-            <% drug_stock = facility_report.dig(category, :drug_stocks, drug.id) %>
+            <% drug_stock = @report.dig(:drugs_in_stock_by_facility_id, @current_facility.id, category, :drug_stocks, drug.id) %>
 
             <div class="card-row">
               <% if drug_stock.present? %>


### PR DESCRIPTION
**Story card:** -

## Because

We introduced a regression in #2668 that broke the webview drug stock report redirect.

## This addresses

This fixes the report lookup and the redirect.