### PR TITLE
Refresh new matviews concurrently

### DIFF
--- a/app/models/reports/matview.rb
+++ b/app/models/reports/matview.rb
@@ -3,7 +3,7 @@ module Reports
     def self.refresh
       ActiveRecord::Base.transaction do
         ActiveRecord::Base.connection.execute("SET LOCAL TIME ZONE '#{Period::REPORTING_TIME_ZONE}'")
-        Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
+        Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
       end
     end
   end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -5,6 +5,8 @@ namespace :db do
     puts "Materialized views have been refreshed"
   end
 
+  task refresh_matviews: :refresh_materialized_views
+
   desc "Generate fake Patient data"
   task seed_patients: :environment do
     abort "Can't run this task in env:#{ENV["SIMPLE_SERVER_ENV"]}!" if ENV["SIMPLE_SERVER_ENV"] == "production"


### PR DESCRIPTION
This is so they don't block SELECTs while they are being refreshed.

**Story card:** [ch4174](https://app.clubhouse.io/simpledotorg/story/4174/refresh-matviews-concurrently)


Took some timings locally to see the impact on performance, because `CONCURRENT` does make the refresh take a bit longer.  The impact on my box with a large data set is only around ~3 minutes extra time doing the new matviews.


Before - Without concurrent

```
{"name":"rails","hostname":"imacPro.local","pid":88293,"level":30,"time":"2021-07-14T13:49:07.551-05:00","v":0,"msg":"refresh_matviews.Reports::PatientBloodPressure (281321.3ms)"}
{"name":"rails","hostname":"imacPro.local","pid":88293,"level":30,"time":"2021-07-14T13:52:32.172-05:00","v":0,"msg":"refresh_matviews.Reports::PatientVisit (204620.1ms)"}
{"name":"rails","hostname":"imacPro.local","pid":88293,"level":30,"time":"2021-07-14T13:57:38.165-05:00","v":0,"msg":"refresh_matviews.Reports::PatientState (305992.9ms)"}
{"name":"rails","hostname":"imacPro.local","pid":88293,"level":30,"time":"2021-07-14T13:57:38.166-05:00","v":0,"msg":"refresh_matviews.all_v2 (791935.9ms)"}
```

After - With concurrent
```
{"name":"rails","hostname":"imacPro.local","pid":86849,"level":30,"time":"2021-07-14T13:28:27.348-05:00","v":0,"msg":"refresh_matviews.Reports::PatientBloodPressure (418528.2ms)"}
{"name":"rails","hostname":"imacPro.local","pid":86849,"level":30,"time":"2021-07-14T13:31:59.639-05:00","v":0,"msg":"refresh_matviews.Reports::PatientVisit (212290.6ms)"}
{"name":"rails","hostname":"imacPro.local","pid":86849,"level":30,"time":"2021-07-14T13:37:35.210-05:00","v":0,"msg":"refresh_matviews.Reports::PatientState (335570.7ms)"}
{"name":"rails","hostname":"imacPro.local","pid":86849,"level":30,"time":"2021-07-14T13:37:35.211-05:00","v":0,"msg":"refresh_matviews.all_v2 (966391.2ms)"}
{"name":"rails","hostname":"imacPro.local","pid":86849,"level":30,"time":"2021-07-14T13:37:35.211-05:00","v":0,"msg":"Completed full materialized view refresh"}
Materialized views have been refreshed
```

