### PR TITLE
Dial down Sentry perf tracing

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,13 +5,19 @@ Sentry.init do |config|
 
   config.traces_sampler = lambda do |sampling_context|
     transaction_context = sampling_context[:transaction_context]
+    transaction_name = transaction_context[:name]
     op = transaction_context[:op]
 
     case op
     when /request/ # web requests
-      0.20
+      case transaction_name
+      when /ping/
+        0.0
+      else
+        0.10
+      end
     when /sidekiq/i # background jobs
-      0.01
+      0.005
     else
       0.0
     end


### PR DESCRIPTION
Seeing lots of Sentry Events in our logs ...we can dial down how many transaction samples we are making.

We don't need to trace the health check, and we can trace less in general.

Some context - https://docs.sentry.io/platforms/ruby/configuration/sampling/#configuring-the-transaction-sample-rate