### PR TITLE
One more datadog client update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "bootstrap-datepicker-rails", "~> 1.9"
 gem "connection_pool"
 gem "data-anonymization", require: false
 gem "data_migrate"
-gem "ddtrace"
+gem "ddtrace", "~> 0.51"
 gem "devise", ">= 4.7.1"
 gem "devise_invitable", "~> 1.7.0"
 gem "dhis2", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       thor (~> 0.20.3)
     data_migrate (6.3.0)
       rails (>= 5.0)
-    ddtrace (0.50.0)
+    ddtrace (0.51.1)
       ffi (~> 1.0)
       msgpack
     devise (4.7.1)
@@ -646,7 +646,7 @@ DEPENDENCIES
   connection_pool
   data-anonymization
   data_migrate
-  ddtrace
+  ddtrace (~> 0.51)
   devise (>= 4.7.1)
   devise_invitable (~> 1.7.0)
   dhis2


### PR DESCRIPTION
Apparently we need to update ddtrace to match the statsd collector now.

These two gems should really have some sort of hard dependancy on each
other.

https://github.com/DataDog/dd-trace-rb/issues/1491

re: #2709 
