### PR TITLE
Add a metric to track number of online lookups

### DIFF
--- a/app/controllers/api/v4/patients_controller.rb
+++ b/app/controllers/api/v4/patients_controller.rb
@@ -17,8 +17,8 @@ class Api::V4::PatientsController < APIController
       json: Oj.dump({
         patients: patients.map do |patient|
           retention = retention(patient)
-          Api::V4::PatientLookupTransformer.to_response(patient, retention)
           Statsd.instance.increment("OnlineLookup.#{retention[:type]}", tags: [current_state.name, current_user.id])
+          Api::V4::PatientLookupTransformer.to_response(patient, retention)
         end
       }, mode: :compat),
       status: :ok

--- a/spec/controllers/api/v4/patients_controller_spec.rb
+++ b/spec/controllers/api/v4/patients_controller_spec.rb
@@ -144,5 +144,12 @@ RSpec.describe Api::V4::PatientsController, type: :controller do
       ))
       post :lookup, params: {identifier: patient.business_identifiers.first.identifier}, as: :json
     end
+
+    it "increments a statsd metric" do
+      patient = create(:patient)
+      set_headers(patient.registration_user, patient.registration_facility)
+      expect(Statsd.instance).to receive(:increment).with("OnlineLookup.temporary", {tags: [patient.registration_facility.state, patient.registration_user.id]})
+      post :lookup, params: {identifier: patient.business_identifiers.first.identifier}, as: :json
+    end
   end
 end


### PR DESCRIPTION
**Story card:** [ch4211](https://app.clubhouse.io/simpledotorg/story/4211/create-a-dashboard-to-monitor-metrics-relating-to-performance-of-the-online-lookup-feature)

- Increment a metric for every patient looked up
- Add the retention type in the metric name
- Add state and user-id in tags as metadata