### PR TITLE
Fix SMS otp job

### DIFF
--- a/app/jobs/request_otp_sms_job.rb
+++ b/app/jobs/request_otp_sms_job.rb
@@ -5,7 +5,7 @@ class RequestOtpSmsJob < ApplicationJob
       user_id: user.id,
       communication_type: :sms
     }
-    TwilioApiService.new.send_sms(recipient_number: user.phone_number, message: otp_message(user), context: context)
+    TwilioApiService.new.send_sms(recipient_number: user.localized_phone_number, message: otp_message(user), context: context)
   end
 
   private

--- a/app/models/phone_number_authentication.rb
+++ b/app/models/phone_number_authentication.rb
@@ -23,6 +23,12 @@ class PhoneNumberAuthentication < ApplicationRecord
 
   alias_method :registration_facility, :facility
 
+  def localized_phone_number
+    parsed_number = Phonelib.parse(phone_number, Rails.application.config.country[:abbreviation]).raw_national
+    default_country_code = Rails.application.config.country[:sms_country_code]
+    default_country_code + parsed_number
+  end
+
   def presence_of_password
     unless password_digest.present? || password.present?
       errors.add(:password, "Either password_digest or password should be present")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,6 +100,7 @@ class User < ApplicationRecord
     :has_never_logged_in?,
     :mark_as_logged_in,
     :phone_number,
+    :localized_phone_number,
     :otp,
     :otp_valid?,
     :facility_group,

--- a/spec/jobs/request_otp_sms_job_spec.rb
+++ b/spec/jobs/request_otp_sms_job_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RequestOtpSmsJob, type: :job do
       communication_type: :sms
     }
     expect_any_instance_of(TwilioApiService).to receive(:send_sms).with(
-      recipient_number: user.phone_number, message: otp_message, context: context
+      recipient_number: user.localized_phone_number, message: otp_message, context: context
     )
 
     described_class.perform_now(user)


### PR DESCRIPTION
**Story card:** [ch4199](https://app.clubhouse.io/simpledotorg/story/4199/ensure-that-all-phone-numbers-use-the-country-code)

## Because

We introduced a regression in #2735 where calls to twilio for OTPs were being sent the non-localized phone number.

## This addresses

This fixes `RequestSmsOtpJob` to send the user's localized phone number.
