### PR TITLE
Updating Docker configs for issue #2108

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM ruby:2.5.1
-
-RUN curl https://deb.nodesource.com/setup_12.x | bash
-RUN curl https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+FROM ruby:2.6.6
 
 RUN apt-get update && apt-get install -y yarn redis-server postgresql-client nodejs jq
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,18 @@ If you encounter issues with this script, please open [a new issue with details]
 For quick development and testing, the server can be run locally using Docker Compose and the command:
 
 ```
-docker-compose up
+docker compose up
 ```
 
 The Dockerfile and docker-compose.yml files replicate the steps detailed below for manual installation, including the running of ngrok for local android development.
 
 Once the Docker Compose server is running, the logs should provide the ngrok URL. For example: `SIMPLE_SERVER_HOST=91a705dde8c1.ngrok.io`. This is the value that should be used when setting up the Android app as described in the section below.
 
+To remove the server and clear the volumes of database data, run the command:
+
+```
+docker compose down --volumes
+```
 
 #### Manual Setup
 
@@ -97,14 +102,15 @@ ngrok http 3000
 The output of the ngrok command is HTTP and HTTPS URLs that can be used to access your local server. The HTTP URL cannot
 be used since HTTP traffic will not be supported by the emulator. Configure the following places with the HTTPS URL.
 
-In the `gradle.properties` file in the `simple-android` repository,
+In the `gradle.properties` file in the `simple-android` repository, set:
 ```
-qaManifestEndpoint=<HTTPS URL>
+manifestEndpoint=<HTTPS URL>/api/
+fallbackApiEndpoint=<HTTPS URL>/api/
 ```
 
 In the `.env.development.local` (you can create this file if it doesn't exist),
 ```
-SIMPLE_SERVER_HOST=<HTTPS URL>
+SIMPLE_SERVER_HOST=<URL>  # i.e. without https://
 SIMPLE_SERVER_HOST_PROTOCOL=https
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - SIMPLE_SERVER_DATABASE_PASSWORD=root
       - SIMPLE_SERVER_HOST_PROTOCOL=https
       - CALL_SESSION_REDIS_HOST=redis
-      - RAILS_CACHE_REDIS_URL=redis
+      - RAILS_CACHE_REDIS_URL=redis://
       - SIDEKIQ_REDIS_HOST=redis
 
 volumes:


### PR DESCRIPTION
**Story card:** https://github.com/simpledotorg/simple-server/issues/2108

## Because

As mentioned in the issue, the Dockerfile was out out date with the required Ruby version, and when the Ruby version was updated there was a Redis error.

Issue details: https://github.com/simpledotorg/simple-server/issues/2108

## This addresses

The Ruby version was updated in the Dockerfile, and the Redis bug fixed by updating the Docker Compose config. The README was updated with details on removing the volumes used by docker compose, and how to test with the Android App. 

## Test instructions

- Run the server with 'docker compose up'
- Capture the ngrok url from the logs
- Configure the Android App to use the ngrok URL
- Build and test the app