### PR TITLE
Cherry pick spec changes to support new matviews

### DIFF
--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "is successful for an organization" do
       patient = create(:patient, registration_facility: @facility, recorded_at: jan_2020.advance(months: -1))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
+      create(:bp_with_encounter, :hypertensive, recorded_at: jan_2020, facility: @facility)
       refresh_views
 
       org = @facility_group.organization
@@ -66,8 +66,8 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "is successful for a district" do
       patient = create(:patient, registration_facility: @facility, recorded_at: jan_2020.advance(months: -1))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
+      create(:bp_with_encounter, :hypertensive, recorded_at: jan_2020, facility: @facility)
       refresh_views
 
       Timecop.freeze("June 1 2020") do
@@ -79,11 +79,11 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "is successful for a block" do
       patient_2 = create(:patient, registration_facility: @facility, recorded_at: "June 01 2019 00:00:00 UTC", registration_user: cvho)
-      create(:blood_pressure, :hypertensive, recorded_at: "Feb 2020", facility: @facility, patient: patient_2, user: cvho)
+      create(:bp_with_encounter, :hypertensive, recorded_at: "Feb 2020", facility: @facility, patient: patient_2, user: cvho)
 
       patient_1 = create(:patient, registration_facility: @facility, recorded_at: "September 01 2019 00:00:00 UTC", registration_user: cvho)
-      create(:blood_pressure, :under_control, recorded_at: "December 10th 2019", patient: patient_1, facility: @facility, user: cvho)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility, user: cvho)
+      create(:bp_with_encounter, :under_control, recorded_at: "December 10th 2019", patient: patient_1, facility: @facility, user: cvho)
+      create(:bp_with_encounter, :hypertensive, recorded_at: jan_2020, facility: @facility, user: cvho)
 
       refresh_views
 
@@ -98,8 +98,8 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "is successful for a facility" do
       patient = create(:patient, registration_facility: @facility, recorded_at: jan_2020.advance(months: -1))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
+      create(:bp_with_encounter, :hypertensive, recorded_at: jan_2020, facility: @facility)
       refresh_views
 
       Timecop.freeze("June 1 2020") do
@@ -111,8 +111,8 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "renders period hash info" do
       patient = create(:patient, registration_facility: @facility, recorded_at: jan_2020.advance(months: -1))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
+      create(:bp_with_encounter, :hypertensive, recorded_at: jan_2020, facility: @facility)
       refresh_views
 
       Timecop.freeze("June 1 2020") do
@@ -137,8 +137,8 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "retrieves monthly cohort data by default" do
       patient = create(:patient, registration_facility: @facility, registration_user: cvho, recorded_at: jan_2020.advance(months: -1))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
+      create(:bp_with_encounter, :hypertensive, recorded_at: jan_2020, facility: @facility)
       refresh_views
 
       Timecop.freeze("June 1 2020") do
@@ -153,7 +153,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "can retrieve quarterly cohort data" do
       patient = create(:patient, registration_facility: @facility, registration_user: cvho, recorded_at: jan_2020.advance(months: -2))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020 + 1.day, patient: patient, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020 + 1.day, patient: patient, facility: @facility)
       refresh_views
 
       Timecop.freeze("June 1 2020") do
@@ -294,8 +294,8 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "retrieves district data" do
       patient = create(:patient, registration_facility: @facility, recorded_at: jan_2020.advance(months: -4))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
+      create(:bp_with_encounter, :hypertensive, recorded_at: jan_2020, facility: @facility)
       refresh_views
 
       Timecop.freeze("June 1 2020") do
@@ -311,8 +311,8 @@ RSpec.describe Reports::RegionsController, type: :controller do
     it "retrieves facility data" do
       Time.parse("January 1 2020")
       patient = create(:patient, registration_facility: @facility, recorded_at: jan_2020.advance(months: -4))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
+      create(:bp_with_encounter, :hypertensive, recorded_at: jan_2020, facility: @facility)
       refresh_views
 
       Timecop.freeze("June 1 2020") do
@@ -328,8 +328,8 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "retrieves facility district data" do
       patient = create(:patient, registration_facility: @facility, recorded_at: jan_2020.advance(months: -4))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
+      create(:bp_with_encounter, :hypertensive, recorded_at: jan_2020, facility: @facility)
       refresh_views
 
       Timecop.freeze("June 1 2020") do
@@ -344,11 +344,11 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "retrieves block data" do
       patient_2 = create(:patient, registration_facility: @facility, recorded_at: "June 01 2019 00:00:00 UTC", registration_user: cvho)
-      create(:blood_pressure, :hypertensive, recorded_at: "Feb 2020", facility: @facility, patient: patient_2, user: cvho)
+      create(:bp_with_encounter, :hypertensive, recorded_at: "Feb 2020", facility: @facility, patient: patient_2, user: cvho)
 
       patient_1 = create(:patient, registration_facility: @facility, recorded_at: "September 01 2019 00:00:00 UTC", registration_user: cvho)
-      create(:blood_pressure, :under_control, recorded_at: "December 10th 2019", patient: patient_1, facility: @facility, user: cvho)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility, user: cvho)
+      create(:bp_with_encounter, :under_control, recorded_at: "December 10th 2019", patient: patient_1, facility: @facility, user: cvho)
+      create(:bp_with_encounter, :hypertensive, recorded_at: jan_2020, facility: @facility, user: cvho)
 
       refresh_views
 
@@ -371,8 +371,8 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "works when a user requests data just before the earliest registration date" do
       patient = create(:patient, registration_facility: @facility, recorded_at: jan_2020.advance(months: -4))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
+      create(:bp_with_encounter, :hypertensive, recorded_at: jan_2020, facility: @facility)
       refresh_views
       one_month_before = patient.recorded_at.advance(months: -1)
 
@@ -387,7 +387,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "works for very old dates" do
       patient = create(:patient, registration_facility: @facility, recorded_at: jan_2020.advance(months: -4))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
       refresh_views
       ten_years_ago = patient.recorded_at.advance(years: -10)
 
@@ -402,7 +402,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "works for far future dates" do
       patient = create(:patient, registration_facility: @facility, recorded_at: jan_2020.advance(months: -4))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
       refresh_views
       ten_years_from_now = patient.recorded_at.advance(years: -10)
 
@@ -426,8 +426,8 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "retrieves cohort data for a facility" do
       patient = create(:patient, registration_facility: @facility, recorded_at: jan_2020.advance(months: -1))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
+      create(:bp_with_encounter, :hypertensive, recorded_at: jan_2020, facility: @facility)
       refresh_views
 
       result = nil
@@ -444,8 +444,8 @@ RSpec.describe Reports::RegionsController, type: :controller do
     it "retrieves cohort data for a facility group" do
       facility_group = @facility.facility_group
       patient = create(:patient, registration_facility: @facility, recorded_at: jan_2020.advance(months: -1))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
+      create(:bp_with_encounter, :hypertensive, recorded_at: jan_2020, facility: @facility)
       refresh_views
 
       result = nil
@@ -461,8 +461,8 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     it "retrieves cohort data for a facility district" do
       patient = create(:patient, registration_facility: @facility, recorded_at: jan_2020.advance(months: -1))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
-      create(:blood_pressure, :hypertensive, recorded_at: jan_2020, facility: @facility)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: @facility)
+      create(:bp_with_encounter, :hypertensive, recorded_at: jan_2020, facility: @facility)
       refresh_views
 
       result = nil

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -258,8 +258,8 @@ RSpec.describe Reports::RegionsController, type: :controller do
     it "returns period info for current month" do
       today = Date.current
       Timecop.freeze(today) do
-        patient = create(:patient, registration_facility: @facility, recorded_at: today)
-        create(:blood_pressure, :under_control, recorded_at: today, patient: patient, facility: @facility)
+        patient = create(:patient, registration_facility: @facility, recorded_at: 2.months.ago)
+        create(:bp_with_encounter, :under_control, recorded_at: Time.current.yesterday, patient: patient, facility: @facility)
         refresh_views
         sign_in(cvho.email_authentication)
         get :show, params: {id: @facility.facility_group.slug, report_scope: "district"}

--- a/spec/models/blood_pressure_spec.rb
+++ b/spec/models/blood_pressure_spec.rb
@@ -15,6 +15,21 @@ RSpec.describe BloodPressure, type: :model do
     it_behaves_like "a record that is deletable"
   end
 
+  it "has a valid encounter / observation for bp_with_encounter factory" do
+    user = create(:user)
+    patient = create(:patient)
+    bp = create(:bp_with_encounter, user: user, patient: patient)
+    bp.reload
+    expect(bp.observation).to_not be nil
+    expect(bp.encounter).to_not be nil
+    expect(bp.observation.user).to eq(bp.user)
+    expect(bp.observation.observable).to eq(bp)
+    expect(bp.encounter.patient).to eq(bp.patient)
+    expect(bp.encounter.observations).to contain_exactly(bp.observation)
+    # This behavior is a bit confusing, but this matches what we do in Encounter#generated_encountered_on
+    expect(bp.encounter.encountered_on).to eq(bp.recorded_at.in_time_zone(Period::REPORTING_TIME_ZONE).to_date)
+  end
+
   describe "Scopes" do
     describe ".hypertensive" do
       it "only includes hypertensive BPs" do

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe Reports::Repository, type: :model do
     end
   end
 
-  context "caching", skip: "not worrying about caching specs for now" do
+  context "caching" do
     let(:facility_1) { create(:facility, name: "facility-1") }
 
     it "creates cache keys" do

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -77,9 +77,6 @@ RSpec.describe Reports::Repository, type: :model do
       slug = facility_1.slug
       repo = Reports::Repository.new(facility_1.region, periods: (july_2018.to_period..july_2020.to_period))
 
-      region = facility_1.region
-      region_field = "#{region.region_type}_region_id"
-
       expect(repo.assigned_patients[slug][Period.month("August 2018")]).to eq(2)
       expect(repo.assigned_patients[slug][Period.month("Jan 2019")]).to eq(2)
       expect(repo.cumulative_assigned_patients[slug][Period.month("August 2018")]).to eq(2)

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Reports::Repository, type: :model do
           create(:bp_with_encounter, :hypertensive, facility: facility_1, patient: patient, recorded_at: 3.days.from_now, user: user)
           create(:bp_with_encounter, :under_control, facility: facility_1, patient: patient, recorded_at: 4.days.from_now, user: user)
         end
-        uncontrolled_in_jan.map { |patient| create(:blood_pressure, :hypertensive, facility: facility_2, patient: patient, recorded_at: 4.days.from_now) }
+        uncontrolled_in_jan.map { |patient| create(:bp_with_encounter, :hypertensive, facility: facility_2, patient: patient, recorded_at: 4.days.from_now) }
         create(:bp_with_encounter, :under_control, facility: patient_from_other_facility.assigned_facility, patient: patient_from_other_facility, recorded_at: 4.days.from_now)
       end
 
@@ -274,7 +274,7 @@ RSpec.describe Reports::Repository, type: :model do
       Timecop.freeze(jan_2020) do
         create(:appointment, patient: visit_with_no_bp_and_ltfu, facility: facility_1, user: user)
         create(:blood_sugar, patient: visit_with_no_bp_and_not_ltfu, facility: facility_1, user: user)
-        create(:blood_pressure, :under_control, facility: facility_1, patient: visit_with_bp, user: user)
+        create(:bp_with_encounter, :under_control, facility: facility_1, patient: visit_with_bp, user: user)
       end
 
       refresh_views
@@ -295,10 +295,10 @@ RSpec.describe Reports::Repository, type: :model do
         user_1 = create(:user)
         user_2 = create(:user)
 
-        create(:blood_pressure, recorded_at: 3.months.ago, facility: facility_1, patient: patient_1, user: user_1)
-        create(:blood_pressure, recorded_at: 3.months.ago, facility: facility_1, patient: patient_2, user: user_2)
-        create(:blood_pressure, recorded_at: 2.months.ago, facility: facility_1, patient: patient_2, user: user_2)
-        create(:blood_pressure, recorded_at: 1.month.ago, facility: facility_2, patient: patient_1)
+        create(:bp_with_encounter, recorded_at: 3.months.ago, facility: facility_1, patient: patient_1, user: user_1)
+        create(:bp_with_encounter, recorded_at: 3.months.ago, facility: facility_1, patient: patient_2, user: user_2)
+        create(:bp_with_encounter, recorded_at: 2.months.ago, facility: facility_1, patient: patient_2, user: user_2)
+        create(:bp_with_encounter, recorded_at: 1.month.ago, facility: facility_2, patient: patient_1)
 
         repo = Reports::Repository.new(regions, periods: periods)
         repo_2 = Reports::Repository.new(regions, periods: periods)
@@ -339,7 +339,7 @@ RSpec.describe Reports::Repository, type: :model do
       controlled_in_jan = create_list(:patient, 2, full_name: "controlled", recorded_at: jan_2019, assigned_facility: facility_1, registration_user: user)
       Timecop.freeze(jan_2020) do
         controlled_in_jan.map do |patient|
-          create(:blood_pressure, :under_control, facility: facility_1, patient: patient, recorded_at: 4.days.from_now, user: user)
+          create(:bp_with_encounter, :under_control, facility: facility_1, patient: patient, recorded_at: 4.days.from_now, user: user)
         end
       end
       refresh_views
@@ -367,7 +367,7 @@ RSpec.describe Reports::Repository, type: :model do
       controlled_in_jan = create_list(:patient, 2, full_name: "controlled", recorded_at: jan_2019, assigned_facility: facility_1, registration_user: user)
       Timecop.freeze(jan_2020) do
         controlled_in_jan.map do |patient|
-          create(:blood_pressure, :under_control, facility: facility_1, patient: patient, recorded_at: 4.days.from_now, user: user)
+          create(:bp_with_encounter, :under_control, facility: facility_1, patient: patient, recorded_at: 4.days.from_now, user: user)
         end
       end
       refresh_views
@@ -384,7 +384,7 @@ RSpec.describe Reports::Repository, type: :model do
     it "works for very old dates" do
       facility_1 = create(:facility)
       patient = create(:patient, registration_facility: facility_1, recorded_at: jan_2020.advance(months: -4))
-      create(:blood_pressure, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: facility_1)
+      create(:bp_with_encounter, :under_control, recorded_at: jan_2020.advance(months: -1), patient: patient, facility: facility_1)
       refresh_views
 
       ten_years_ago = patient.recorded_at.advance(years: -10).to_period
@@ -407,7 +407,7 @@ RSpec.describe Reports::Repository, type: :model do
       patient_with_appt_visit = FactoryBot.create(:patient, assigned_facility: facility, recorded_at: jan_2020, registration_user: user)
       patient_with_bp_visit = FactoryBot.create(:patient, assigned_facility: facility, recorded_at: jan_2020, registration_user: user)
       create(:appointment, creation_facility: facility, scheduled_date: may_1_2020, device_created_at: may_1_2020, patient: patient_with_appt_visit)
-      create(:blood_pressure, :under_control, facility: facility, patient: patient_with_bp_visit, recorded_at: may_15_2020)
+      create(:bp_with_encounter, :under_control, facility: facility, patient: patient_with_bp_visit, recorded_at: may_15_2020)
 
       service = Reports::RegionService.new(region: facility, period: july_2020.to_period)
       repo = Reports::Repository.new(facility.region, periods: service.range)


### PR DESCRIPTION
Grabbing some spec only changes from the reporting pipeline changes in #2734 to get that diff smaller, and also to make sure these changes don't disrupt mainline specs.

Most of this is changing BP factories to `bp_with_encounter`, which ensures we always have the backing encounter / observation.  New matviews depend on encounters for much of the visit calculations, so we should really be creating fixtures that way.

