### PR TITLE
Check if index exists before creating it

### DIFF
--- a/db/migrate/20210721120744_add_facility_id_index_on_drug_stocks.rb
+++ b/db/migrate/20210721120744_add_facility_id_index_on_drug_stocks.rb
@@ -1,5 +1,5 @@
 class AddFacilityIdIndexOnDrugStocks < ActiveRecord::Migration[5.2]
   def change
-    add_index :drug_stocks, :facility_id
+    add_index :drug_stocks, :facility_id unless index_exists?(:drug_stocks, :facilities)
   end
 end


### PR DESCRIPTION
**Story card:** none

## Because

The index creation fails if the index already exists

## This addresses

Check to see if there is already an index on the facilities column before attempting creation