### PR TITLE
Remove duplicate drug stock index migration

### DIFF
--- a/db/migrate/20210721120744_add_facility_id_index_on_drug_stocks.rb
+++ b/db/migrate/20210721120744_add_facility_id_index_on_drug_stocks.rb
@@ -1,5 +1,0 @@
-class AddFacilityIdIndexOnDrugStocks < ActiveRecord::Migration[5.2]
-  def change
-    add_index :drug_stocks, :facility_id
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,8 +9,8 @@
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
 # It's strongly recommended that you check this file into your version control system.
+ActiveRecord::Schema.define(version: 2021_07_15_120731) do
 
-ActiveRecord::Schema.define(version: 2021_07_21_120744) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
   enable_extension "pgcrypto"


### PR DESCRIPTION
**Story card:** -

## Because

We added a migration that added an index that already existed on drug stocks. This happened because locally we ran `db:schema:load` on a fresh DB which didn't have this index and we assumed this index didn't exist.

## This addresses

Removes the migration file and reverts the schema timestamp to the previous migration.