### PR TITLE
Prevent parallel deploys via semaphore

### DIFF
--- a/.semaphore/bangladesh_demo_deployment.yml
+++ b/.semaphore/bangladesh_demo_deployment.yml
@@ -15,7 +15,7 @@ blocks:
             - yarn install
             - bundle install --deployment --path vendor/bundle
             - cache store
-            - 'BRANCH=$SEMAPHORE_GIT_BRANCH bundle exec cap bangladesh:demo deploy'
+            - 'BRANCH=$SEMAPHORE_GIT_SHA bundle exec cap bangladesh:demo deploy'
       prologue:
         commands:
           - chmod 600 ~/.ssh/semaphore_id_rsa

--- a/.semaphore/bangladesh_production_deployment.yml
+++ b/.semaphore/bangladesh_production_deployment.yml
@@ -15,7 +15,7 @@ blocks:
             - yarn install
             - bundle install --deployment --path vendor/bundle
             - cache store
-            - 'BRANCH=$SEMAPHORE_GIT_BRANCH bundle exec cap bangladesh:production deploy'
+            - 'BRANCH=$SEMAPHORE_GIT_SHA bundle exec cap bangladesh:production deploy'
       prologue:
         commands:
           - chmod 600 ~/.ssh/semaphore_id_rsa

--- a/.semaphore/deploy.yml
+++ b/.semaphore/deploy.yml
@@ -15,7 +15,7 @@ blocks:
             - yarn install
             - bundle install --deployment --path vendor/bundle
             - cache store
-            - BRANCH=$SEMAPHORE_GIT_BRANCH bundle exec cap sandbox deploy
+            - BRANCH=$SEMAPHORE_GIT_SHA bundle exec cap sandbox deploy
       prologue:
         commands:
           - chmod 600 ~/.ssh/semaphore_id_rsa
@@ -40,7 +40,7 @@ blocks:
             - yarn install
             - bundle install --deployment --path vendor/bundle
             - cache store
-            - BRANCH=$SEMAPHORE_GIT_BRANCH bundle exec cap qa deploy
+            - BRANCH=$SEMAPHORE_GIT_SHA bundle exec cap qa deploy
 agent:
   machine:
     type: e1-standard-2

--- a/.semaphore/deploy.yml
+++ b/.semaphore/deploy.yml
@@ -41,6 +41,9 @@ blocks:
             - bundle install --deployment --path vendor/bundle
             - cache store
             - BRANCH=$SEMAPHORE_GIT_SHA bundle exec cap qa deploy
+queue:
+  name: Deployment queue
+  scope: project
 agent:
   machine:
     type: e1-standard-2

--- a/.semaphore/ethiopia_demo_deployment.yml
+++ b/.semaphore/ethiopia_demo_deployment.yml
@@ -9,7 +9,7 @@ blocks:
             - git clone https://github.com/simpledotorg/deployment
             - cd deployment/standalone
             - make init
-            - "make deploy hosts=ethiopia/demo password_file=~/.ansible/vault_password_et branch=$SEMAPHORE_GIT_BRANCH"
+            - "make deploy hosts=ethiopia/demo password_file=~/.ansible/vault_password_et branch=$SEMAPHORE_GIT_SHA"
       secrets:
         - name: ansible ethiopia
         - name: semaphore-deploy-key

--- a/.semaphore/ethiopia_production_deployment.yml
+++ b/.semaphore/ethiopia_production_deployment.yml
@@ -9,7 +9,7 @@ blocks:
             - git clone https://github.com/simpledotorg/deployment
             - cd deployment/standalone
             - make init
-            - "make deploy hosts=ethiopia/production password_file=~/.ansible/vault_password_et branch=$SEMAPHORE_GIT_BRANCH"
+            - "make deploy hosts=ethiopia/production password_file=~/.ansible/vault_password_et branch=$SEMAPHORE_GIT_SHA"
       secrets:
         - name: ansible ethiopia
         - name: semaphore-deploy-key

--- a/.semaphore/india_demo_deployment.yml
+++ b/.semaphore/india_demo_deployment.yml
@@ -15,7 +15,7 @@ blocks:
             - yarn install
             - bundle install --deployment --path vendor/bundle
             - cache store
-            - 'BRANCH=$SEMAPHORE_GIT_BRANCH bundle exec cap india:staging deploy'
+            - 'BRANCH=$SEMAPHORE_GIT_SHA bundle exec cap india:staging deploy'
       prologue:
         commands:
           - chmod 600 ~/.ssh/semaphore_id_rsa

--- a/.semaphore/india_production_deployment.yml
+++ b/.semaphore/india_production_deployment.yml
@@ -15,7 +15,7 @@ blocks:
             - yarn install
             - bundle install --deployment --path vendor/bundle
             - cache store
-            - 'BRANCH=$SEMAPHORE_GIT_BRANCH bundle exec cap india:production deploy'
+            - 'BRANCH=$SEMAPHORE_GIT_SHA bundle exec cap india:production deploy'
       prologue:
         commands:
           - chmod 600 ~/.ssh/semaphore_id_rsa


### PR DESCRIPTION
**Story card:** -

## Because

Our semaphore pipeline always picks up the latest master to deploy irresepective of the tag it was triggered from.

Also if multiple deploys are triggered in parallel, we can have a race condition where an older deploy can end up overwriting a newer deploy.

## This addresses

- Fixes `semaphore.yml` to pickup the git SHA instead of the branch name (which was always `master`).
- Puts the deploy pipeline in a [queue](https://docs.semaphoreci.com/essentials/pipeline-queues) so there's only one deploy running at a time.