### PR TITLE
Allow changing Twilio test mode from ENV var

### DIFF
--- a/app/services/twilio_api_service.rb
+++ b/app/services/twilio_api_service.rb
@@ -30,7 +30,11 @@ class TwilioApiService
   end
 
   def initialize(sms_sender: nil)
-    @test_mode = ENV["TWILIO_TEST_MODE"] || !SimpleServer.env.production?
+    @test_mode = if ENV["TWILIO_PRODUCTION_OVERRIDE"]
+      false
+    else
+      !SimpleServer.env.production?
+    end
 
     @twilio_account_sid = ENV.fetch("TWILIO_ACCOUNT_SID")
     @twilio_auth_token = ENV.fetch("TWILIO_AUTH_TOKEN")

--- a/app/services/twilio_api_service.rb
+++ b/app/services/twilio_api_service.rb
@@ -30,7 +30,7 @@ class TwilioApiService
   end
 
   def initialize(sms_sender: nil)
-    @test_mode = !SimpleServer.env.production?
+    @test_mode = ENV["TWILIO_TEST_MODE"] || !SimpleServer.env.production?
 
     @twilio_account_sid = ENV.fetch("TWILIO_ACCOUNT_SID")
     @twilio_auth_token = ENV.fetch("TWILIO_AUTH_TOKEN")

--- a/spec/services/twilio_api_service_spec.rb
+++ b/spec/services/twilio_api_service_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe TwilioApiService do
       expect(notification_service.client).to be_instance_of(Twilio::REST::Client)
       expect(notification_service.test_mode?).to be_falsey
     end
+
+    it "uses the production twilio creds when TWILIO_PRODUCTION_OVERRIDE is set" do
+      stub_const("SIMPLE_SERVER_ENV", "sandbox")
+      ENV["TWILIO_PRODUCTION_OVERRIDE"] = "true"
+      twilio_account_sid = ENV.fetch("TWILIO_ACCOUNT_SID")
+      twilio_auth_token = ENV.fetch("TWILIO_AUTH_TOKEN")
+      expect(Twilio::REST::Client).to receive(:new).with(twilio_account_sid, twilio_auth_token).and_call_original
+      expect(notification_service.client).to be_instance_of(Twilio::REST::Client)
+      expect(notification_service.test_mode?).to be_falsey
+    ensure
+      ENV.delete("TWILIO_PRODUCTION_OVERRIDE")
+    end
   end
 
   describe "specifying an SMS sender" do


### PR DESCRIPTION
This would allow us to flip to the prod client for real end to end
testing on prod...via a script run manually from SBX for example.

