### PR TITLE
Fix flaky drug stock exporter spec

### DIFF
--- a/spec/exporters/drug_consumption_report_exporter_spec.rb
+++ b/spec/exporters/drug_consumption_report_exporter_spec.rb
@@ -8,123 +8,126 @@ RSpec.describe DrugConsumptionReportExporter do
   end
 
   it "renders the csv" do
-    protocol = create(:protocol, :with_tracked_drugs)
-    facility_group = create(:facility_group, protocol: protocol, state: "Punjab")
-    facilities = create_list(:facility, 2, facility_group: facility_group)
-    query = DrugStocksQuery.new(facilities: facilities,
-                                for_end_of_month: Date.current.end_of_month)
+    Timecop.freeze do
+      protocol = create(:protocol, :with_tracked_drugs)
+      facility_group = create(:facility_group, protocol: protocol, state: "Punjab")
+      facilities = create_list(:facility, 2, facility_group: facility_group)
+      query = DrugStocksQuery.new(facilities: facilities,
+                                  for_end_of_month: Date.current.end_of_month)
 
-    stocks_by_rxnorm = {
-      "329528" => {in_stock: 10000, received: 2000, redistributed: 0},
-      "329526" => {in_stock: 20000, received: 2000, redistributed: 0},
-      "316764" => {in_stock: 10000, received: 2000, redistributed: 0},
-      "316765" => {in_stock: 20000, received: 2000, redistributed: nil},
-      "979467" => {in_stock: 10000, received: 2000, redistributed: nil}
-    }
+      stocks_by_rxnorm = {
+        "329528" => {in_stock: 10000, received: 2000, redistributed: 0},
+        "329526" => {in_stock: 20000, received: 2000, redistributed: 0},
+        "316764" => {in_stock: 10000, received: 2000, redistributed: 0},
+        "316765" => {in_stock: 20000, received: 2000, redistributed: nil},
+        "979467" => {in_stock: 10000, received: 2000, redistributed: nil}
+      }
 
-    previous_month_stocks_by_rxnorm =
-      {"329528" => {in_stock: 8000},
-       "329526" => {in_stock: 15000},
-       "316764" => {in_stock: 8000},
-       "316765" => {in_stock: 17000},
-       "979467" => {in_stock: 9000}}
+      previous_month_stocks_by_rxnorm =
+        {"329528" => {in_stock: 8000},
+         "329526" => {in_stock: 15000},
+         "316764" => {in_stock: 8000},
+         "316765" => {in_stock: 17000},
+         "979467" => {in_stock: 9000}}
 
-    stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
-      protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
-      create(:drug_stock,
-        region: facility_group.region,
-        protocol_drug: protocol_drug,
-        in_stock: drug_stock[:in_stock],
-        received: drug_stock[:received],
-        redistributed: drug_stock[:redistributed])
-      create(:drug_stock,
-        facility: facilities.first,
-        protocol_drug: protocol_drug,
-        in_stock: drug_stock[:in_stock],
-        received: drug_stock[:received],
-        redistributed: drug_stock[:redistributed])
-    end
+      stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
+        protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
+        create(:drug_stock,
+          region: facility_group.region,
+          protocol_drug: protocol_drug,
+          in_stock: drug_stock[:in_stock],
+          received: drug_stock[:received],
+          redistributed: drug_stock[:redistributed])
+        create(:drug_stock,
+          facility: facilities.first,
+          protocol_drug: protocol_drug,
+          in_stock: drug_stock[:in_stock],
+          received: drug_stock[:received],
+          redistributed: drug_stock[:redistributed])
+      end
 
-    previous_month_stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
-      protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
-      create(:drug_stock,
-        region: facility_group.region,
-        protocol_drug: protocol_drug,
-        in_stock: drug_stock[:in_stock],
-        for_end_of_month: (Date.today - 1.month).end_of_month)
-      create(:drug_stock,
-        facility: facilities.first,
-        protocol_drug: protocol_drug,
-        in_stock: drug_stock[:in_stock],
-        for_end_of_month: (Date.today - 1.month).end_of_month)
-    end
+      previous_month_stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
+        protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
+        create(:drug_stock,
+          region: facility_group.region,
+          protocol_drug: protocol_drug,
+          in_stock: drug_stock[:in_stock],
+          for_end_of_month: (Date.today - 1.month).end_of_month)
+        create(:drug_stock,
+          facility: facilities.first,
+          protocol_drug: protocol_drug,
+          in_stock: drug_stock[:in_stock],
+          for_end_of_month: (Date.today - 1.month).end_of_month)
+      end
 
-    timestamp = ["Report last updated at:", query.drug_stocks_report.fetch(:last_updated_at)]
-    headers_row_1 = [
-      nil, nil,
-      "ARB Tablets", nil, nil,
-      "CCB Tablets", nil,
-      "Diuretic Tablets", nil,
-      "Overall in base doses", nil, nil
-    ]
+      timestamp = ["Report last updated at:", Time.now]
 
-    headers_row_2 = [
-      "Facilities",
-      "Block",
-      "Losartan 50 mg",
-      "Telmisartan 40 mg",
-      "Telmisartan 80 mg",
-      "Amlodipine 5 mg",
-      "Amlodipine 10 mg",
-      "Chlorthalidone 12.5 mg",
-      "Hydrochlorothiazide 25 mg",
-      "ARB base doses",
-      "CCB base doses",
-      "Diuretic base doses"
-    ]
+      headers_row_1 = [
+        nil, nil,
+        "ARB Tablets", nil, nil,
+        "CCB Tablets", nil,
+        "Diuretic Tablets", nil,
+        "Overall in base doses", nil, nil
+      ]
 
-    totals_row = [
-      "All", "",
-      2000, 0, -2000,
-      0, -6000,
-      "?", "?",
-      -2000, -12000, "?"
-    ]
+      headers_row_2 = [
+        "Facilities",
+        "Block",
+        "Losartan 50 mg",
+        "Telmisartan 40 mg",
+        "Telmisartan 80 mg",
+        "Amlodipine 5 mg",
+        "Amlodipine 10 mg",
+        "Chlorthalidone 12.5 mg",
+        "Hydrochlorothiazide 25 mg",
+        "ARB base doses",
+        "CCB base doses",
+        "Diuretic base doses"
+      ]
 
-    district_warehouse_row = [
-      "District Warehouse", "",
-      1000, 0, -1000,
-      0, -3000,
-      "?", "?",
-      -1000, -6000, "?"
-    ]
+      totals_row = [
+        "All", "",
+        2000, 0, -2000,
+        0, -6000,
+        "?", "?",
+        -2000, -12000, "?"
+      ]
 
-    facility_1_row =
-      [facilities.first.name,
-        facilities.first.zone,
+      district_warehouse_row = [
+        "District Warehouse", "",
         1000, 0, -1000,
         0, -3000,
         "?", "?",
-        -1000, -6000, "?"]
+        -1000, -6000, "?"
+      ]
 
-    facility_2_row =
-      [facilities.second.name,
-        facilities.second.zone,
-        "?", "?", "?", "?",
-        "?", "?",
-        "?", "?",
-        "?", "?"]
+      facility_1_row =
+        [facilities.first.name,
+          facilities.first.zone,
+          1000, 0, -1000,
+          0, -3000,
+          "?", "?",
+          -1000, -6000, "?"]
 
-    csv = described_class.csv(query)
-    expected_csv =
-      timestamp.to_csv +
-      headers_row_1.to_csv +
-      headers_row_2.to_csv +
-      totals_row.to_csv +
-      district_warehouse_row.to_csv +
-      facility_1_row.to_csv +
-      facility_2_row.to_csv
+      facility_2_row =
+        [facilities.second.name,
+          facilities.second.zone,
+          "?", "?", "?", "?",
+          "?", "?",
+          "?", "?",
+          "?", "?"]
 
-    expect(csv).to eq(expected_csv)
+      csv = described_class.csv(query)
+      expected_csv =
+        timestamp.to_csv +
+        headers_row_1.to_csv +
+        headers_row_2.to_csv +
+        totals_row.to_csv +
+        district_warehouse_row.to_csv +
+        facility_1_row.to_csv +
+        facility_2_row.to_csv
+
+      expect(csv).to eq(expected_csv)
+    end
   end
 end

--- a/spec/exporters/drug_stocks_report_exporter_spec.rb
+++ b/spec/exporters/drug_stocks_report_exporter_spec.rb
@@ -16,21 +16,21 @@ RSpec.describe DrugStocksReportExporter do
                                   for_end_of_month: Time.current.end_of_month)
 
       stocks_by_rxnorm = {
-        "329528" => { in_stock: 10000, received: 2000 },
-        "329526" => { in_stock: 20000, received: 2000 },
-        "316764" => { in_stock: 10000, received: 2000 },
-        "316765" => { in_stock: 20000, received: 2000 },
-        "979467" => { in_stock: 10000, received: 2000 }
+        "329528" => {in_stock: 10000, received: 2000},
+        "329526" => {in_stock: 20000, received: 2000},
+        "316764" => {in_stock: 10000, received: 2000},
+        "316765" => {in_stock: 20000, received: 2000},
+        "979467" => {in_stock: 10000, received: 2000}
       }
 
       facilities.each do |facility|
         stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
           protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
           create(:drug_stock,
-                 facility: facility,
-                 protocol_drug: protocol_drug,
-                 in_stock: drug_stock[:in_stock],
-                 received: drug_stock[:received])
+            facility: facility,
+            protocol_drug: protocol_drug,
+            in_stock: drug_stock[:in_stock],
+            received: drug_stock[:received])
         end
         create_list(:patient, 2, assigned_facility: facility)
       end
@@ -38,10 +38,10 @@ RSpec.describe DrugStocksReportExporter do
       stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
         protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
         create(:drug_stock,
-               region: facility_group.region,
-               protocol_drug: protocol_drug,
-               in_stock: drug_stock[:in_stock],
-               received: drug_stock[:received])
+          region: facility_group.region,
+          protocol_drug: protocol_drug,
+          in_stock: drug_stock[:in_stock],
+          received: drug_stock[:received])
       end
 
       timestamp = ["Report last updated at:", Time.now]
@@ -86,27 +86,27 @@ RSpec.describe DrugStocksReportExporter do
 
       facility_1_row =
         [facilities.first.name,
-         facilities.first.zone,
-         10000, 10000, 20000, 81081,
-         10000, 20000, 17857,
-         nil, nil, nil]
+          facilities.first.zone,
+          10000, 10000, 20000, 81081,
+          10000, 20000, 17857,
+          nil, nil, nil]
 
       facility_2_row =
         [facilities.second.name,
-         facilities.second.zone,
-         10000, 10000, 20000, 81081,
-         10000, 20000, 17857,
-         nil, nil, nil]
+          facilities.second.zone,
+          10000, 10000, 20000, 81081,
+          10000, 20000, 17857,
+          nil, nil, nil]
 
       csv = described_class.csv(query)
       expected_csv =
         timestamp.to_csv +
-          headers_row_1.to_csv +
-          headers_row_2.to_csv +
-          totals_row.to_csv +
-          district_warehouse_row.to_csv +
-          facility_1_row.to_csv +
-          facility_2_row.to_csv
+        headers_row_1.to_csv +
+        headers_row_2.to_csv +
+        totals_row.to_csv +
+        district_warehouse_row.to_csv +
+        facility_1_row.to_csv +
+        facility_2_row.to_csv
 
       expect(csv).to eq(expected_csv)
     end

--- a/spec/exporters/drug_stocks_report_exporter_spec.rb
+++ b/spec/exporters/drug_stocks_report_exporter_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe DrugStocksReportExporter do
                received: drug_stock[:received])
       end
 
-      timestamp = ["Report last updated at:", query.drug_stocks_report.fetch(:last_updated_at)]
+      timestamp = ["Report last updated at:", Time.now]
       headers_row_1 = [
         nil, nil,
         "ARB Tablets",

--- a/spec/exporters/drug_stocks_report_exporter_spec.rb
+++ b/spec/exporters/drug_stocks_report_exporter_spec.rb
@@ -8,105 +8,107 @@ RSpec.describe DrugStocksReportExporter do
   end
 
   it "renders the csv" do
-    protocol = create(:protocol, :with_tracked_drugs)
-    facility_group = create(:facility_group, protocol: protocol, state: "Punjab")
-    facilities = create_list(:facility, 2, facility_group: facility_group)
-    query = DrugStocksQuery.new(facilities: facilities,
-                                for_end_of_month: Time.current.end_of_month)
+    Timecop.freeze do
+      protocol = create(:protocol, :with_tracked_drugs)
+      facility_group = create(:facility_group, protocol: protocol, state: "Punjab")
+      facilities = create_list(:facility, 2, facility_group: facility_group)
+      query = DrugStocksQuery.new(facilities: facilities,
+                                  for_end_of_month: Time.current.end_of_month)
 
-    stocks_by_rxnorm = {
-      "329528" => {in_stock: 10000, received: 2000},
-      "329526" => {in_stock: 20000, received: 2000},
-      "316764" => {in_stock: 10000, received: 2000},
-      "316765" => {in_stock: 20000, received: 2000},
-      "979467" => {in_stock: 10000, received: 2000}
-    }
+      stocks_by_rxnorm = {
+        "329528" => { in_stock: 10000, received: 2000 },
+        "329526" => { in_stock: 20000, received: 2000 },
+        "316764" => { in_stock: 10000, received: 2000 },
+        "316765" => { in_stock: 20000, received: 2000 },
+        "979467" => { in_stock: 10000, received: 2000 }
+      }
 
-    facilities.each do |facility|
+      facilities.each do |facility|
+        stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
+          protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
+          create(:drug_stock,
+                 facility: facility,
+                 protocol_drug: protocol_drug,
+                 in_stock: drug_stock[:in_stock],
+                 received: drug_stock[:received])
+        end
+        create_list(:patient, 2, assigned_facility: facility)
+      end
+
       stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
         protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
         create(:drug_stock,
-          facility: facility,
-          protocol_drug: protocol_drug,
-          in_stock: drug_stock[:in_stock],
-          received: drug_stock[:received])
+               region: facility_group.region,
+               protocol_drug: protocol_drug,
+               in_stock: drug_stock[:in_stock],
+               received: drug_stock[:received])
       end
-      create_list(:patient, 2, assigned_facility: facility)
+
+      timestamp = ["Report last updated at:", query.drug_stocks_report.fetch(:last_updated_at)]
+      headers_row_1 = [
+        nil, nil,
+        "ARB Tablets",
+        nil, nil, nil,
+        "CCB Tablets",
+        nil, nil,
+        "Diuretic Tablets",
+        nil, nil
+      ]
+
+      headers_row_2 = [
+        "Facilities",
+        "Block",
+        "Losartan 50 mg",
+        "Telmisartan 40 mg",
+        "Telmisartan 80 mg",
+        "Patient days",
+        "Amlodipine 5 mg",
+        "Amlodipine 10 mg",
+        "Patient days",
+        "Chlorthalidone 12.5 mg",
+        "Hydrochlorothiazide 25 mg",
+        "Patient days"
+      ]
+
+      totals_row = [
+        "All", "",
+        30000, 30000, 60000, 121621,
+        30000, 60000, 26785,
+        nil, nil, nil
+      ]
+
+      district_warehouse_row = [
+        "District Warehouse", "",
+        10000, 10000, 20000, 40540,
+        10000, 20000, 8928,
+        nil, nil, nil
+      ]
+
+      facility_1_row =
+        [facilities.first.name,
+         facilities.first.zone,
+         10000, 10000, 20000, 81081,
+         10000, 20000, 17857,
+         nil, nil, nil]
+
+      facility_2_row =
+        [facilities.second.name,
+         facilities.second.zone,
+         10000, 10000, 20000, 81081,
+         10000, 20000, 17857,
+         nil, nil, nil]
+
+      csv = described_class.csv(query)
+      expected_csv =
+        timestamp.to_csv +
+          headers_row_1.to_csv +
+          headers_row_2.to_csv +
+          totals_row.to_csv +
+          district_warehouse_row.to_csv +
+          facility_1_row.to_csv +
+          facility_2_row.to_csv
+
+      expect(csv).to eq(expected_csv)
     end
-
-    stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
-      protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
-      create(:drug_stock,
-        region: facility_group.region,
-        protocol_drug: protocol_drug,
-        in_stock: drug_stock[:in_stock],
-        received: drug_stock[:received])
-    end
-
-    timestamp = ["Report last updated at:", query.drug_stocks_report.fetch(:last_updated_at)]
-    headers_row_1 = [
-      nil, nil,
-      "ARB Tablets",
-      nil, nil, nil,
-      "CCB Tablets",
-      nil, nil,
-      "Diuretic Tablets",
-      nil, nil
-    ]
-
-    headers_row_2 = [
-      "Facilities",
-      "Block",
-      "Losartan 50 mg",
-      "Telmisartan 40 mg",
-      "Telmisartan 80 mg",
-      "Patient days",
-      "Amlodipine 5 mg",
-      "Amlodipine 10 mg",
-      "Patient days",
-      "Chlorthalidone 12.5 mg",
-      "Hydrochlorothiazide 25 mg",
-      "Patient days"
-    ]
-
-    totals_row = [
-      "All", "",
-      30000, 30000, 60000, 121621,
-      30000, 60000, 26785,
-      nil, nil, nil
-    ]
-
-    district_warehouse_row = [
-      "District Warehouse", "",
-      10000, 10000, 20000, 40540,
-      10000, 20000, 8928,
-      nil, nil, nil
-    ]
-
-    facility_1_row =
-      [facilities.first.name,
-        facilities.first.zone,
-        10000, 10000, 20000, 81081,
-        10000, 20000, 17857,
-        nil, nil, nil]
-
-    facility_2_row =
-      [facilities.second.name,
-        facilities.second.zone,
-        10000, 10000, 20000, 81081,
-        10000, 20000, 17857,
-        nil, nil, nil]
-
-    csv = described_class.csv(query)
-    expected_csv =
-      timestamp.to_csv +
-      headers_row_1.to_csv +
-      headers_row_2.to_csv +
-      totals_row.to_csv +
-      district_warehouse_row.to_csv +
-      facility_1_row.to_csv +
-      facility_2_row.to_csv
-
-    expect(csv).to eq(expected_csv)
   end
 end


### PR DESCRIPTION
**Story card:** -

## Because

The exporter spec has a flaky timestamp match. https://simple.semaphoreci.com/jobs/a567870d-9e3f-4f8d-8d34-e074fd88bb31

## This addresses

Wraps the test in a `Timecop.freeze` so that the timestamp always matches.

Ignore whitespace while reviewing.