### PR TITLE
Make assigned_patients private

### DIFF
--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -350,7 +350,7 @@ module Reports
       ((numerator.to_f / denominator) * 100).round(PERCENTAGE_PRECISION)
     end
 
-    # Returns assigned patients for a Region. NOTE: We grab and cache ALL the counts for a particular region with one SQL query
+    # Returns monthly assigned patients for a Region. NOTE: We grab and cache ALL the counts for a particular region with one SQL query
     # because it is easier and fast enough to do so. We still return _just_ the periods the Repository was created with
     # to conform to the same interface as all the other queries here.
 

--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -59,22 +59,6 @@ module Reports
       earliest_patient_recorded_at.each_with_object({}) { |(slug, time), hsh| hsh[slug] = Period.new(value: time, type: @period_type) if time }
     end
 
-    # Returns assigned patients for a Region. NOTE: We grab and cache ALL the counts for a particular region with one SQL query
-    # because it is easier and fast enough to do so. We still return _just_ the periods the Repository was created with
-    # to conform to the same interface as all the other queries here.
-
-    # Returns a Hash in the shape of:
-    # {
-    #    region_slug: { period: value, period: value },
-    #    region_slug: { period: value, period: value }
-    # }
-    memoize def assigned_patients
-      complete_monthly_assigned_patients.each_with_object({}) do |(entry, result), results|
-        values = periods.each_with_object(Hash.new(0)) { |period, region_result| region_result[period] = result[period] if result[period] }
-        results[entry.region.slug] = values
-      end
-    end
-
     # Adjusted patient counts are the patient counts from three months ago (the adjusted period) that
     # are the basis for control rates. These counts DO include lost to follow up.
     memoize def adjusted_patients_with_ltfu
@@ -365,5 +349,22 @@ module Reports
       return 0 if denominator == 0 || numerator == 0
       ((numerator.to_f / denominator) * 100).round(PERCENTAGE_PRECISION)
     end
+
+    # Returns assigned patients for a Region. NOTE: We grab and cache ALL the counts for a particular region with one SQL query
+    # because it is easier and fast enough to do so. We still return _just_ the periods the Repository was created with
+    # to conform to the same interface as all the other queries here.
+
+    # Returns a Hash in the shape of:
+    # {
+    #    region_slug: { period: value, period: value },
+    #    region_slug: { period: value, period: value }
+    # }
+    memoize def assigned_patients
+      complete_monthly_assigned_patients.each_with_object({}) do |(entry, result), results|
+        values = periods.each_with_object(Hash.new(0)) { |period, region_result| region_result[period] = result[period] if result[period] }
+        results[entry.region.slug] = values
+      end
+    end
   end
+
 end

--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -366,5 +366,4 @@ module Reports
       end
     end
   end
-
 end

--- a/app/services/reports/region_service.rb
+++ b/app/services/reports/region_service.rb
@@ -29,7 +29,6 @@ module Reports
       result.earliest_registration_period = repository.earliest_patient_recorded_at_period[slug]
       result.adjusted_patient_counts = repository.adjusted_patients_without_ltfu[slug]
       result.adjusted_patient_counts_with_ltfu = repository.adjusted_patients_with_ltfu[slug]
-      result.assigned_patients = repository.assigned_patients[slug]
       result.controlled_patients = repository.controlled[slug]
       result.controlled_patients_rate = repository.controlled_rates[slug]
       result.controlled_patients_with_ltfu_rate = repository.controlled_rates(with_ltfu: true)[slug]

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Reports::Repository, type: :model do
   end
 
   context "counts and rates" do
-    it "gets assigned and registration counts for single region" do
+    it "gets registration counts for single region" do
       facilities = FactoryBot.create_list(:facility, 2, facility_group: facility_group_1).sort_by(&:slug)
       facility_1, facility_2 = facilities.take(2)
 
@@ -59,7 +59,6 @@ RSpec.describe Reports::Repository, type: :model do
           jan_2019.to_period => 2
         }
       }
-      expect(repo.assigned_patients).to eq(expected)
       expect(repo.monthly_registrations).to eq(expected)
     end
 
@@ -77,11 +76,8 @@ RSpec.describe Reports::Repository, type: :model do
       slug = facility_1.slug
       repo = Reports::Repository.new(facility_1.region, periods: (july_2018.to_period..july_2020.to_period))
 
-      expect(repo.assigned_patients[slug][Period.month("August 2018")]).to eq(2)
-      expect(repo.assigned_patients[slug][Period.month("Jan 2019")]).to eq(2)
       expect(repo.cumulative_assigned_patients[slug][Period.month("August 2018")]).to eq(2)
       expect(repo.cumulative_assigned_patients[slug][Period.month("Jan 2019")]).to eq(4)
-      expect(repo.assigned_patients[slug][july_2020]).to eq(0)
       expect(repo.monthly_registrations[slug][Period.month("August 2018")]).to eq(2)
       expect(repo.monthly_registrations[slug][Period.month("Jan 2019")]).to eq(2)
       expect(repo.monthly_registrations[slug][july_2020.to_period]).to eq(0)

--- a/spec/services/reports/region_service_spec.rb
+++ b/spec/services/reports/region_service_spec.rb
@@ -69,19 +69,15 @@ RSpec.describe Reports::RegionService, type: :model do
     may_period = Date.parse("May 1 2020").to_period
     june_period = Date.parse("June 1 2020").to_period
     expect(result[:registrations][june_1_2018.to_date.to_period]).to eq(2)
-    expect(result[:assigned_patients][june_1_2018.to_date.to_period]).to eq(2)
     expect(result[:cumulative_registrations][june_1_2018.to_date.to_period]).to eq(6)
     expect(result[:cumulative_assigned_patients][june_1_2018.to_date.to_period]).to eq(6)
     expect(result[:registrations][april_period]).to eq(2)
-    expect(result[:assigned_patients][april_period]).to eq(2)
     expect(result[:cumulative_registrations][april_period]).to eq(8)
     expect(result[:cumulative_assigned_patients][april_period]).to eq(8)
     expect(result[:registrations][may_period]).to eq(4)
-    expect(result[:assigned_patients][may_period]).to eq(3)
     expect(result[:cumulative_registrations][may_period]).to eq(12)
     expect(result[:cumulative_assigned_patients][may_period]).to eq(11)
     expect(result[:registrations][june_period]).to eq(4)
-    expect(result[:assigned_patients][june_period]).to eq(4)
     expect(result[:cumulative_registrations][june_period]).to eq(16)
     expect(result[:cumulative_assigned_patients][june_period]).to eq(15)
   end
@@ -234,7 +230,6 @@ RSpec.describe Reports::RegionService, type: :model do
     end
 
     expect(result[:registrations][Period.month(jan_2019)]).to eq(5)
-    expect(result[:assigned_patients][Period.month(jan_2019)]).to eq(5)
     expect(result[:cumulative_registrations][Period.month(jan_2019)]).to eq(5)
     expect(result[:cumulative_assigned_patients][Period.month(jan_2019)]).to eq(5)
     expect(result[:adjusted_patient_counts][Period.month(jan_2019)]).to eq(0)
@@ -251,7 +246,6 @@ RSpec.describe Reports::RegionService, type: :model do
     expect(result[:cumulative_registrations][Period.month(june_1_2020)]).to eq(10)
     expect(result[:cumulative_assigned_patients][Period.month(june_1_2020)]).to eq(10)
     expect(result[:registrations][Period.month(june_1_2020)]).to eq(0)
-    expect(result[:assigned_patients][Period.month(june_1_2020)]).to eq(0)
     expect(result[:controlled_patients][Period.month(june_1_2020)]).to eq(3)
     expect(result[:controlled_patients_rate][Period.month(june_1_2020)]).to eq(30.0)
     expect(result[:uncontrolled_patients][Period.month(june_1_2020)]).to eq(5)


### PR DESCRIPTION
Trying to reduce the surface area of Repository a bit, which will make it easier to move the public API to the new pipeline.

breaking this from #2734 
