### PR TITLE
Fix flaky drug stock spec

### DIFF
--- a/spec/factories/drug_stocks.rb
+++ b/spec/factories/drug_stocks.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :drug_stock do
     id { SecureRandom.uuid }
-    association :facility, strategy: :create
+    association :facility
     region { facility.region }
-    association :user, strategy: :create
-    association :protocol_drug, strategy: :create
+    association :user
+    association :protocol_drug
     for_end_of_month { Date.today.end_of_month }
     in_stock { rand(1..1000) }
     received { rand(1..1000) }

--- a/spec/factories/protocol_drugs.rb
+++ b/spec/factories/protocol_drugs.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     rxnorm_code { Faker::Code.npi }
     stock_tracked { false }
     drug_category { "other" }
-    association :protocol, strategy: :build
+    association :protocol
   end
 end

--- a/spec/models/reports/drug_stock_calculation_spec.rb
+++ b/spec/models/reports/drug_stock_calculation_spec.rb
@@ -9,16 +9,16 @@ RSpec.describe Reports::DrugStockCalculation, type: :model do
   let(:user) { create(:admin) }
   let(:drug_category) { "hypertension_ccb" }
   let(:drug_stocks) {
-    [build(:drug_stock, in_stock: 10000, received: 5000, redistributed: 1000, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "329528")),
-      build(:drug_stock, in_stock: 20000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "329526")),
-      build(:drug_stock, in_stock: 10000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "316764")),
-      build(:drug_stock, in_stock: 20000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "316765")),
-      build(:drug_stock, in_stock: 10000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "979467")),
-      build(:drug_stock, in_stock: 10000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "316049")),
-      build(:drug_stock, in_stock: 10000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "331132"))]
+    [build(:drug_stock, in_stock: 10000, received: 5000, redistributed: 1000, facility: facility, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "329528")),
+      build(:drug_stock, in_stock: 20000, redistributed: 0, facility: facility, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "329526")),
+      build(:drug_stock, in_stock: 10000, redistributed: 0, facility: facility, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "316764")),
+      build(:drug_stock, in_stock: 20000, redistributed: 0, facility: facility, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "316765")),
+      build(:drug_stock, in_stock: 10000, redistributed: 0, facility: facility, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "979467")),
+      build(:drug_stock, in_stock: 10000, redistributed: 0, facility: facility, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "316049")),
+      build(:drug_stock, in_stock: 10000, redistributed: 0, facility: facility, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "331132"))]
   }
   let(:previous_month_drug_stocks) {
-    [build(:drug_stock, in_stock: 10000, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "329528"))]
+    [build(:drug_stock, in_stock: 10000, facility: facility, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "329528"))]
   }
 
   let(:punjab_drug_stock_config) {
@@ -45,11 +45,11 @@ RSpec.describe Reports::DrugStockCalculation, type: :model do
       ).stocks_on_hand
 
       expect(result).to match_array [
-        {protocol_drug: protocol.protocol_drugs.find_by(rxnorm_code: "329528"),
+        {protocol_drug: protocol_drugs.find_by(rxnorm_code: "329528"),
          in_stock: 10000,
          coefficient: 1.2,
          stock_on_hand: 12000},
-        {protocol_drug: protocol.protocol_drugs.find_by(rxnorm_code: "329526"),
+        {protocol_drug: protocol_drugs.find_by(rxnorm_code: "329526"),
          in_stock: 20000,
          coefficient: 2,
          stock_on_hand: 40000}

--- a/spec/models/reports/drug_stock_calculation_spec.rb
+++ b/spec/models/reports/drug_stock_calculation_spec.rb
@@ -9,16 +9,16 @@ RSpec.describe Reports::DrugStockCalculation, type: :model do
   let(:user) { create(:admin) }
   let(:drug_category) { "hypertension_ccb" }
   let(:drug_stocks) {
-    [build(:drug_stock, in_stock: 10000, received: 5000, redistributed: 1000, facility_id: facility.id, user: user, protocol_drug: ProtocolDrug.find_by(rxnorm_code: "329528")),
-      build(:drug_stock, in_stock: 20000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: ProtocolDrug.find_by(rxnorm_code: "329526")),
-      build(:drug_stock, in_stock: 10000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: ProtocolDrug.find_by(rxnorm_code: "316764")),
-      build(:drug_stock, in_stock: 20000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: ProtocolDrug.find_by(rxnorm_code: "316765")),
-      build(:drug_stock, in_stock: 10000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: ProtocolDrug.find_by(rxnorm_code: "979467")),
-      build(:drug_stock, in_stock: 10000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: ProtocolDrug.find_by(rxnorm_code: "316049")),
-      build(:drug_stock, in_stock: 10000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: ProtocolDrug.find_by(rxnorm_code: "331132"))]
+    [build(:drug_stock, in_stock: 10000, received: 5000, redistributed: 1000, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "329528")),
+      build(:drug_stock, in_stock: 20000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "329526")),
+      build(:drug_stock, in_stock: 10000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "316764")),
+      build(:drug_stock, in_stock: 20000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "316765")),
+      build(:drug_stock, in_stock: 10000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "979467")),
+      build(:drug_stock, in_stock: 10000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "316049")),
+      build(:drug_stock, in_stock: 10000, redistributed: 0, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "331132"))]
   }
   let(:previous_month_drug_stocks) {
-    [build(:drug_stock, in_stock: 10000, facility_id: facility.id, user: user, protocol_drug: ProtocolDrug.find_by(rxnorm_code: "329528"))]
+    [build(:drug_stock, in_stock: 10000, facility_id: facility.id, user: user, protocol_drug: protocol_drugs.find_by(rxnorm_code: "329528"))]
   }
 
   let(:punjab_drug_stock_config) {
@@ -238,7 +238,7 @@ RSpec.describe Reports::DrugStockCalculation, type: :model do
         previous_drug_stocks: previous_month_drug_stocks,
         patient_count: patient_count
       ).consumption
-      drug = ProtocolDrug.find_by(rxnorm_code: "329528")
+      drug = protocol_drugs.find_by(rxnorm_code: "329528")
 
       expect(result[drug][:consumed]).to eq(4000)
       expect(result[drug][:received]).to eq(5000)


### PR DESCRIPTION
**Story card:** n/a

## Because

We introduced a flaky spec in #2719 

The flakiness has two underlying causes:
- The `drug_stock` factory was creating unnecessary `protocol_drug` and `protocol` records, even when the association was provided.
- We were looking up `ProtocolDrug`s by `rxnorm_code`, which would occasionally find the extra record created above.

## This addresses

Prevent creation of these extra records, and also lookup drugs in the protocol we explicitly create.  
