### PR TITLE
4309: only create notifications for scheduled appointments during cur…

### DIFF
--- a/app/services/experiment_control_service.rb
+++ b/app/services/experiment_control_service.rb
@@ -21,7 +21,7 @@ class ExperimentControlService
         patients = Patient
           .where(id: batch)
           .includes(:appointments)
-          .where(appointments: {scheduled_date: experiment_start..experiment_end})
+          .where(appointments: {scheduled_date: experiment_start..experiment_end, status: "scheduled"})
 
         patients.each do |patient|
           group = experiment.random_treatment_group

--- a/spec/services/experiment_control_service_spec.rb
+++ b/spec/services/experiment_control_service_spec.rb
@@ -163,7 +163,7 @@ describe ExperimentControlService, type: :model do
       scheduled_appointment = create(:appointment, patient: patient1, scheduled_date: 10.days.from_now, status: "scheduled")
       visited_appointment = create(:appointment, patient: patient1, scheduled_date: 10.days.from_now, status: "visited")
       experiment = create(:experiment, :with_treatment_group)
-      template = create(:reminder_template, treatment_group: experiment.treatment_groups.first, message: "come today", remind_on_in_days: 0)
+      create(:reminder_template, treatment_group: experiment.treatment_groups.first, message: "come today", remind_on_in_days: 0)
 
       ExperimentControlService.start_current_patient_experiment(name: experiment.name, days_til_start: 5, days_til_end: 35)
 

--- a/spec/services/experiment_control_service_spec.rb
+++ b/spec/services/experiment_control_service_spec.rb
@@ -158,6 +158,19 @@ describe ExperimentControlService, type: :model do
       expect(reminder3.remind_on).to eq(appointment_date + 3.days)
     end
 
+    it "only creates a notification for scheduled appointments during the window" do
+      patient1 = create(:patient, age: 80)
+      scheduled_appointment = create(:appointment, patient: patient1, scheduled_date: 10.days.from_now, status: "scheduled")
+      visited_appointment = create(:appointment, patient: patient1, scheduled_date: 10.days.from_now, status: "visited")
+      experiment = create(:experiment, :with_treatment_group)
+      template = create(:reminder_template, treatment_group: experiment.treatment_groups.first, message: "come today", remind_on_in_days: 0)
+
+      ExperimentControlService.start_current_patient_experiment(name: experiment.name, days_til_start: 5, days_til_end: 35)
+
+      expect(scheduled_appointment.notifications.count).to eq 1
+      expect(visited_appointment.notifications.count).to eq 0
+    end
+
     it "creates experimental reminder notifications with correct attributes" do
       patient1 = create(:patient, age: 80)
       appointment = create(:appointment, patient: patient1, scheduled_date: 10.days.from_now)


### PR DESCRIPTION
…rent patient experiment

**Story card:** [ch4309](https://app.clubhouse.io/simpledotorg/story/4309)

## Because

We found a bug in which notifications are being created for visited appointments during the current patient experiment. Only scheduled appointments should have notifications. 