### PR TITLE
Track metrics about Twilio errors

### DIFF
--- a/app/jobs/appointment_notification/worker.rb
+++ b/app/jobs/appointment_notification/worker.rb
@@ -41,9 +41,9 @@ class AppointmentNotification::Worker
     notification_service = if communication_type == "imo"
       ImoApiService.new
     elsif notification.experiment&.experiment_type == "medication_reminder" && medication_reminder_sms_sender
-      TwilioApiService.new(sms_sender: medication_reminder_sms_sender)
+      TwilioApiService.new(sms_sender: medication_reminder_sms_sender, communication_type: communication_type)
     else
-      TwilioApiService.new
+      TwilioApiService.new(communication_type: communication_type)
     end
 
     context = {

--- a/app/jobs/request_otp_sms_job.rb
+++ b/app/jobs/request_otp_sms_job.rb
@@ -5,7 +5,7 @@ class RequestOtpSmsJob < ApplicationJob
       user_id: user.id,
       communication_type: :sms
     }
-    TwilioApiService.new.send_sms(recipient_number: user.localized_phone_number, message: otp_message(user), context: context)
+    TwilioApiService.new(communication_type: "sms").send_sms(recipient_number: user.localized_phone_number, message: otp_message(user), context: context)
   end
 
   private

--- a/app/jobs/send_patient_otp_sms_job.rb
+++ b/app/jobs/send_patient_otp_sms_job.rb
@@ -8,7 +8,7 @@ class SendPatientOtpSmsJob < ApplicationJob
       patient_id: passport_authentication.patient&.id,
       communication_type: :sms
     }
-    TwilioApiService.new.send_sms(
+    TwilioApiService.new(communication_type: "sms").send_sms(
       recipient_number: phone_number,
       message: otp_message(passport_authentication),
       context: context

--- a/app/services/twilio_api_service.rb
+++ b/app/services/twilio_api_service.rb
@@ -31,7 +31,7 @@ class TwilioApiService
     end
   end
 
-  def initialize(sms_sender: nil, communication_type:)
+  def initialize(communication_type:, sms_sender: nil)
     @test_mode = if ENV["TWILIO_PRODUCTION_OVERRIDE"]
       false
     else

--- a/lib/tasks/scripts/message_patients.rb
+++ b/lib/tasks/scripts/message_patients.rb
@@ -41,7 +41,7 @@ class MessagePatients
       phone_number = phone_number_for(patient)
 
       next unless phone_number
-      notification_service = TwilioApiService.new
+      notification_service = TwilioApiService.new(communication_type: channel)
       context = {
         calling_class: self.class.name,
         patient_id: patient.id,

--- a/spec/jobs/appointment_notification/worker_spec.rb
+++ b/spec/jobs/appointment_notification/worker_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe AppointmentNotification::Worker, type: :job do
         allow_any_instance_of(Notification).to receive(:next_communication_type).and_return("sms")
         allow_any_instance_of(Notification).to receive(:experiment).and_return(experiment)
 
-        expect(TwilioApiService).to receive(:new).with(sms_sender: /testnumber/).and_call_original
+        expect(TwilioApiService).to receive(:new).with(sms_sender: /testnumber/, communication_type: "sms").and_call_original
         expect_any_instance_of(TwilioApiService).to receive(:send_sms)
         described_class.perform_async(notification.id)
         described_class.drain
@@ -254,7 +254,7 @@ RSpec.describe AppointmentNotification::Worker, type: :job do
         allow_any_instance_of(Notification).to receive(:next_communication_type).and_return("sms")
         allow_any_instance_of(Notification).to receive(:experiment).and_return(experiment)
 
-        expect(TwilioApiService).to receive(:new).with(no_args).and_call_original
+        expect(TwilioApiService).to receive(:new).with(communication_type: "sms").and_call_original
         expect_any_instance_of(TwilioApiService).to receive(:send_sms)
         described_class.perform_async(notification.id)
         described_class.drain
@@ -266,7 +266,7 @@ RSpec.describe AppointmentNotification::Worker, type: :job do
         allow_any_instance_of(Notification).to receive(:next_communication_type).and_return("sms")
         allow_any_instance_of(Notification).to receive(:experiment).and_return(experiment)
 
-        expect(TwilioApiService).to receive(:new).with(no_args).and_call_original
+        expect(TwilioApiService).to receive(:new).with(communication_type: "sms").and_call_original
         expect_any_instance_of(TwilioApiService).to receive(:send_sms)
         described_class.perform_async(notification.id)
         described_class.drain
@@ -277,7 +277,7 @@ RSpec.describe AppointmentNotification::Worker, type: :job do
         allow_any_instance_of(Notification).to receive(:next_communication_type).and_return("sms")
         allow_any_instance_of(Notification).to receive(:experiment).and_return(nil)
 
-        expect(TwilioApiService).to receive(:new).with(no_args).and_call_original
+        expect(TwilioApiService).to receive(:new).with(communication_type: "sms").and_call_original
         expect_any_instance_of(TwilioApiService).to receive(:send_sms)
         described_class.perform_async(notification.id)
         described_class.drain

--- a/spec/services/twilio_api_service_spec.rb
+++ b/spec/services/twilio_api_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TwilioApiService do
   let(:sender_sms_phone_number) { described_class::TWILIO_TEST_SMS_NUMBER }
   let(:sender_whatsapp_phone_number) { described_class::TWILIO_TEST_WHATSAPP_NUMBER }
 
-  subject(:notification_service) { TwilioApiService.new }
+  subject(:notification_service) { TwilioApiService.new(communication_type: :whatsapp) }
   let(:recipient_phone_number) { "+918585858585" }
   let(:invalid_phone_number) { "+15005550001" } # this is twilio's hard-coded "invalid phone number"
 
@@ -48,12 +48,12 @@ RSpec.describe TwilioApiService do
   describe "specifying an SMS sender" do
     it "uses the provided SMS sender number in production" do
       stub_const("SIMPLE_SERVER_ENV", "production")
-      notification_service = TwilioApiService.new(sms_sender: "1234567890")
+      notification_service = described_class.new(sms_sender: "1234567890", communication_type: :sms)
       expect(notification_service.twilio_sender_sms_number).to eq("1234567890")
     end
 
     it "uses the test number in test environments" do
-      notification_service = TwilioApiService.new(sms_sender: "1234567890")
+      notification_service = described_class.new(sms_sender: "1234567890", communication_type: :sms)
       expect(notification_service.twilio_sender_sms_number).to eq(TwilioApiService::TWILIO_TEST_SMS_NUMBER)
     end
 


### PR DESCRIPTION
Part of [ch2943](https://app.clubhouse.io/simpledotorg/story/2943/as-a-developer-i-want-to-be-able-monitor-existing-experiments-and-reminders?vc_group_by=day&ct_workflow=all&cf_workflow=500000005)

We want to be able to track errors in addition to the attempted notification sends in one place (a Datadog dashboard).

This wires up the Twilio API client so it tracks metrics as well.