### PR TITLE
4318: do not raise an error when experiment is not found

### DIFF
--- a/app/services/experiment_control_service.rb
+++ b/app/services/experiment_control_service.rb
@@ -38,7 +38,9 @@ class ExperimentControlService
     end
 
     def schedule_daily_stale_patient_notifications(name:, patients_per_day: PATIENTS_PER_DAY)
-      experiment = Experimentation::Experiment.find_by!(name: name, experiment_type: "stale_patients", state: [:new, :running])
+      experiment = Experimentation::Experiment.find_by(name: name, experiment_type: "stale_patients", state: [:new, :running])
+      return unless experiment
+
       today = Date.current
       return if experiment.start_date > today
       if experiment.end_date < today

--- a/app/services/experiment_control_service.rb
+++ b/app/services/experiment_control_service.rb
@@ -5,7 +5,9 @@ class ExperimentControlService
 
   class << self
     def start_current_patient_experiment(name:, days_til_start:, days_til_end:, percentage_of_patients: 100)
-      experiment = Experimentation::Experiment.find_by!(name: name, experiment_type: "current_patients", state: :new)
+      experiment = Experimentation::Experiment.find_by(name: name, experiment_type: "current_patients", state: :new)
+      return unless experiment
+
       experiment_start = days_til_start.days.from_now.beginning_of_day
       experiment_end = days_til_end.days.from_now.end_of_day
 

--- a/spec/services/experiment_control_service_spec.rb
+++ b/spec/services/experiment_control_service_spec.rb
@@ -333,7 +333,7 @@ describe ExperimentControlService, type: :model do
     end
 
     it "does nothing if it the experiment is not in 'new' or 'running' state" do
-      experiment = create(:experiment, :with_treatment_group ,experiment_type: "stale_patients", state: "complete")
+      experiment = create(:experiment, :with_treatment_group, experiment_type: "stale_patients", state: "complete")
       group = experiment.treatment_groups.first
       create(:reminder_template, treatment_group: group, message: "come today", remind_on_in_days: 0)
       patient1 = create(:patient, age: 80)


### PR DESCRIPTION
**Story card:** [ch4318](https://app.clubhouse.io/simpledotorg/story/4318/release-plan-for-first-full-ab-experiment)

## Because

This allows us to start current patient experiments without manual steps. We can add it to the schedule to start the experiment and remove the schedule code at our leisure. 