### PR TITLE
4330: Better Twilio error handling

### DIFF
--- a/app/services/twilio_api_service.rb
+++ b/app/services/twilio_api_service.rb
@@ -21,12 +21,6 @@ class TwilioApiService
   delegate :logger, to: Rails
 
   class Error < StandardError
-    attr_reader :exception_message, :context
-    def initialize(message, exception_message:, context:)
-      super(message)
-      @exception_message = exception_message
-      @context = context
-    end
   end
 
   def initialize(sms_sender: nil)
@@ -86,6 +80,7 @@ class TwilioApiService
   private
 
   def send_twilio_message(sender_number, recipient_number, message, callback_url, context)
+    Sentry.set_tags(context)
     client.messages.create(
       from: sender_number,
       to: recipient_number,
@@ -93,6 +88,6 @@ class TwilioApiService
       body: message
     )
   rescue Twilio::REST::TwilioError => exception
-    raise Error.new("Error while calling Twilio API", exception_message: exception.to_s, context: context)
+    raise Error.new("Error while calling Twilio API: #{exception.message}")
   end
 end

--- a/app/services/twilio_api_service.rb
+++ b/app/services/twilio_api_service.rb
@@ -93,21 +93,6 @@ class TwilioApiService
       body: message
     )
   rescue Twilio::REST::TwilioError => exception
-    if exception.respond_to?(:code)
-      log_error(exception, sender_number, recipient_number, context)
-      nil
-    else
-      raise Error.new("Error while calling Twilio API", exception_message: exception.to_s, context: context)
-    end
-  end
-
-  def log_error(e, sender_number, recipient_number, context)
-    logger.info({
-      class: self.class.name,
-      error: e,
-      sender: sender_number,
-      recipient: recipient_number,
-      **context
-    })
+    raise Error.new("Error while calling Twilio API", exception_message: exception.to_s, context: context)
   end
 end

--- a/app/services/twilio_api_service.rb
+++ b/app/services/twilio_api_service.rb
@@ -88,13 +88,14 @@ class TwilioApiService
 
   def send_twilio_message(sender_number, recipient_number, message, callback_url, context)
     Sentry.set_tags(context)
-    client.messages.create(
+    response = client.messages.create(
       from: sender_number,
       to: recipient_number,
       status_callback: callback_url,
       body: message
     )
     metrics.increment("#{communication_type}.sent")
+    response
   rescue Twilio::REST::TwilioError => exception
     metrics.increment("#{communication_type}.errors")
     raise Error.new("Error while calling Twilio API: #{exception.message}")

--- a/lib/tasks/scripts/message_patients.rb
+++ b/lib/tasks/scripts/message_patients.rb
@@ -56,12 +56,9 @@ class MessagePatients
         end
       rescue TwilioApiService::Error
         update_report(:exception, patient: patient)
+        next
       end
-      if response
-        update_report(:responses, response: response, patient: patient)
-      else
-        update_report(:exception, patient: patient)
-      end
+      update_report(:responses, response: response, patient: patient)
     end
   end
 

--- a/spec/services/twilio_api_service_spec.rb
+++ b/spec/services/twilio_api_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe TwilioApiService do
       )
     end
 
-    it "raises a custom error on twilio error that does not specify an error code" do
+    it "raises a custom error on twilio error" do
       stub_client
       allow(twilio_client).to receive_message_chain("messages.create").and_raise(Twilio::REST::TwilioError)
       expect {
@@ -90,15 +90,6 @@ RSpec.describe TwilioApiService do
           callback_url: fake_callback_url
         )
       }.to raise_error(TwilioApiService::Error)
-    end
-
-    it "logs when twilio specifies an error code" do
-      expect(Rails).to receive_message_chain(:logger, :info)
-      notification_service.send_sms(
-        recipient_number: invalid_phone_number,
-        message: "test sms message",
-        callback_url: fake_callback_url
-      )
     end
   end
 
@@ -120,7 +111,7 @@ RSpec.describe TwilioApiService do
       )
     end
 
-    it "raises a custom error on twilio error that does not specify an error code" do
+    it "raises a custom error on twilio error" do
       stub_client
       allow(twilio_client).to receive_message_chain("messages.create").and_raise(Twilio::REST::TwilioError)
 
@@ -131,16 +122,6 @@ RSpec.describe TwilioApiService do
           callback_url: fake_callback_url
         )
       }.to raise_error(TwilioApiService::Error)
-    end
-
-    it "logs when twilio specifies an error code" do
-      expect(Rails).to receive_message_chain(:logger, :info)
-
-      notification_service.send_whatsapp(
-        recipient_number: invalid_phone_number,
-        message: "test whatsapp message",
-        callback_url: fake_callback_url
-      )
     end
   end
 end


### PR DESCRIPTION
**Story card:** [ch4330](https://app.clubhouse.io/simpledotorg/story/4330/stop-rescuing-twilio-errors) and 
[ch2943](https://app.clubhouse.io/simpledotorg/story/2943/as-a-developer-i-want-to-be-able-monitor-existing-experiments-and-reminders)
## Because

This is undoing a change I made because I had looked at a list of twilio errors and none of them looked like they should merit a retry. However, that list was incomplete and most of the errors we encounter are for things like rate limiting, which we do want to know about. This ensures that all twilio errors will be reported to sentry. 