### PR TITLE
Prevent the gh bot closing stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,3 +14,4 @@ jobs:
         stale-pr-message: 'This PR is stale. Please review/update it or close it.'
         stale-pr-label: 'stale-pr'
         days-before-stale: 10
+        days-before-pr-close: -1


### PR DESCRIPTION
**Story card:** [ch4362](https://app.clubhouse.io/simpledotorg/story/4362/allow-the-github-stale-action-to-close-stale-prs)

## Because

We want to prevent the gh stale action from closing stale PRs

## This addresses

Setting `days-before-pr-close: -1` means the action will no longer close stale PRs. It will still mark stale PRs.
We can turn this back on once the audit is completed