### PR TITLE
Draft of stale patient notifications per day formula

### DIFF
--- a/script/stale_patient_notifications_per_day.rb
+++ b/script/stale_patient_notifications_per_day.rb
@@ -1,0 +1,10 @@
+#!/bin/ruby
+
+# We are in Tier 2 for WhatsApp, which limits us to 10_000 unique recipients per day
+WHATSAPP_LIMIT_PER_DAY = 10_000
+# TBD - this is dependant upon how much margin we want to build in per day for stale patient reminders
+# to ensure we stay under the WhatsApp rate limit
+STALE_EXPERIMENT_BUFFER = 0.5
+
+active_notifications_sent_via_whats_app_per_day = active_notifications_scheduled_per_day * .50
+(WHATSAPP_LIMIT_PER_DAY - active_notifications_sent_via_whats_app_per_day) * STALE_EXPERIMENT_BUFFER

--- a/script/stale_patient_notifications_per_day.rb
+++ b/script/stale_patient_notifications_per_day.rb
@@ -2,11 +2,16 @@
 
 # We are in Tier 2 for WhatsApp, which limits us to 10_000 unique recipients per day
 WHATSAPP_LIMIT_PER_DAY = 10_000
+# An estimate of how many notifications succeed using WhatsApp
+WHATSAPP_SUCCESS_RATE = 0.5
 # TBD - this is dependant upon how much margin we want to build in per day for stale patient reminders
 # to ensure we stay under the WhatsApp rate limit
 STALE_EXPERIMENT_BUFFER = 0.5
 
+active_notifications_scheduled_per_day = Notification.group(:remind_on).count
+active_notifications_sent_via_whats_app_per_day = active_notifications_scheduled_per_day * WHATSAPP_SUCCESS_RATE
+stale_patients_per_day = (WHATSAPP_LIMIT_PER_DAY - active_notifications_sent_via_whats_app_per_day) * STALE_EXPERIMENT_BUFFER
 
-active_notifications_scheduled_per_day = Notification.group(:schedule_date).count
-active_notifications_sent_via_whats_app_per_day = active_notifications_scheduled_per_day * .50
-(WHATSAPP_LIMIT_PER_DAY - active_notifications_sent_via_whats_app_per_day) * STALE_EXPERIMENT_BUFFER
+puts "Estimated amount of patients per day for the stale patient experiment:"
+puts stale_patients_per_day
+puts

--- a/script/stale_patient_notifications_per_day.rb
+++ b/script/stale_patient_notifications_per_day.rb
@@ -6,5 +6,7 @@ WHATSAPP_LIMIT_PER_DAY = 10_000
 # to ensure we stay under the WhatsApp rate limit
 STALE_EXPERIMENT_BUFFER = 0.5
 
+
+active_notifications_scheduled_per_day = Notification.group(:schedule_date).count
 active_notifications_sent_via_whats_app_per_day = active_notifications_scheduled_per_day * .50
 (WHATSAPP_LIMIT_PER_DAY - active_notifications_sent_via_whats_app_per_day) * STALE_EXPERIMENT_BUFFER


### PR DESCRIPTION
**Story card:** [ch4373](https://app.clubhouse.io/simpledotorg/story/4373/calculate-how-many-patients-we-can-send-to-per-day-for-the-stale-patient-experiment)

## Because

We want to have a number of patients per day that we add to the 'stale patient experiment' such that we stay under the WhatsApp rate limit. This script is an attempt at a formula for that.
