### PR TITLE
Grab visited_without_bp_taken rates from repository

### DIFF
--- a/app/controllers/my_facilities/facility_performance_controller.rb
+++ b/app/controllers/my_facilities/facility_performance_controller.rb
@@ -27,15 +27,16 @@ class MyFacilities::FacilityPerformanceController < AdminController
     @scores_for_facility = {}
 
     @facilities.each do |facility|
-      @data_for_facility[facility.name] = Reports::RegionService.new(region: facility,
-                                                                     period: @period).call
+      slug = facility.region.slug
+      @data_for_facility[slug] = Reports::RegionService.new(region: facility,
+        period: @period).call
 
-      @scores_for_facility[facility.name] = Reports::PerformanceScore.new(region: facility,
-                                                                          reports_result: @data_for_facility[facility.name],
-                                                                          period: @period)
+      @scores_for_facility[slug] = Reports::PerformanceScore.new(region: facility,
+        reports_result: @data_for_facility[slug],
+        period: @period)
     end
 
-    @facilities = @facilities.sort_by { |facility| @scores_for_facility[facility.name].overall_score }
+    @facilities = @facilities.sort_by { |facility| @scores_for_facility[facility.region.slug].overall_score }
     @facilities_by_size = @facilities.group_by { |facility| facility.facility_size }
   end
 

--- a/app/controllers/my_facilities/facility_performance_controller.rb
+++ b/app/controllers/my_facilities/facility_performance_controller.rb
@@ -29,11 +29,11 @@ class MyFacilities::FacilityPerformanceController < AdminController
     @facilities.each do |facility|
       slug = facility.region.slug
       @data_for_facility[slug] = Reports::RegionService.new(region: facility,
-        period: @period).call
+                                                            period: @period).call
 
       @scores_for_facility[slug] = Reports::PerformanceScore.new(region: facility,
-        reports_result: @data_for_facility[slug],
-        period: @period)
+                                                                 reports_result: @data_for_facility[slug],
+                                                                 period: @period)
     end
 
     @facilities = @facilities.sort_by { |facility| @scores_for_facility[facility.region.slug].overall_score }

--- a/app/models/reports/performance_score.rb
+++ b/app/models/reports/performance_score.rb
@@ -40,7 +40,7 @@ module Reports
     end
 
     def control_rate
-      @reports_result.controlled_patients_rate_for(@period) || 0
+      @reports_result.controlled_patients_rate[@period] || 0
     end
 
     def visits_score
@@ -52,7 +52,7 @@ module Reports
     end
 
     def visits_rate
-      100 - (@reports_result.missed_visits_rate_for(@period) || 0)
+      100 - (@reports_result.missed_visits_rate[@period] || 0)
     end
 
     def registrations_score
@@ -73,7 +73,7 @@ module Reports
     end
 
     def registrations
-      @reports_result.registrations_for(@period) || 0
+      @reports_result.registrations[@period] || 0
     end
   end
 end

--- a/app/models/reports/result.rb
+++ b/app/models/reports/result.rb
@@ -1,7 +1,5 @@
 module Reports
   class Result
-    PERCENTAGE_PRECISION = 0
-
     def initialize(region:, period_type:, data: nil)
       @region = region
       @period_type = period_type
@@ -69,26 +67,8 @@ module Reports
       Result.new(region: region, period_type: period_type, data: report_data)
     end
 
-    # Return all periods for the entire set of data for a Region - from the first registrations until
-    # the most recent period
-    def full_data_range
-      if earliest_registration_period.nil?
-        (current_period..current_period)
-      else
-        (earliest_registration_period..current_period)
-      end
-    end
-
     def to_s
       "#{self.class} #{object_id} region=#{@region.name} period_type=#{period_type}"
-    end
-
-    def last_value(key)
-      self[key].values.last
-    end
-
-    def last_key(key)
-      self[key].keys.last
     end
 
     [:period_info, :earliest_registration_period,
@@ -117,17 +97,7 @@ module Reports
       define_method(setter) do |value|
         self[key] = value
       end
-
-      define_method("#{key}_for") do |period|
-        self[key][period]
-      end
-
-      define_method("#{key}_for!") do |period|
-        self[key].fetch(period) { raise ArgumentError, "no data found for #{period} for #{key}" }
-      end
     end
-
-    DATE_FORMAT = "%-d-%b-%Y"
 
     def quarterly_report?
       @quarterly_report

--- a/app/models/reports/result.rb
+++ b/app/models/reports/result.rb
@@ -128,65 +128,6 @@ module Reports
     end
 
     DATE_FORMAT = "%-d-%b-%Y"
-    QUARTELY_DENOMINATORS = {
-      controlled_patients: :assigned_patients,
-      uncontrolled_patients: :assigned_patients,
-      visited_without_bp_taken: :assigned_patients,
-      ltfu_patients: :cumulative_registrations
-    }
-    MONTHLY_DENOMINATORS = {
-      with_ltfu: {
-        controlled_patients: :adjusted_patient_counts_with_ltfu,
-        uncontrolled_patients: :adjusted_patient_counts_with_ltfu,
-        visited_without_bp_taken: :adjusted_patient_counts_with_ltfu,
-        ltfu_patients: :cumulative_registrations
-      },
-      excluding_lftu: {
-        controlled_patients: :adjusted_patient_counts,
-        uncontrolled_patients: :adjusted_patient_counts,
-        visited_without_bp_taken: :adjusted_patient_counts,
-        ltfu_patients: :cumulative_registrations
-      }
-    }
-
-    def quarterly_denominator(numerator)
-      self[QUARTELY_DENOMINATORS[numerator]]
-    end
-
-    def monthly_denominator(numerator, with_ltfu:)
-      ltfu_key = if with_ltfu
-        :with_ltfu
-      else
-        :excluding_lftu
-      end
-
-      self[MONTHLY_DENOMINATORS[ltfu_key][numerator]]
-    end
-
-    def denominator_for_percentage_calculation(period, key, with_ltfu:)
-      if quarterly_report?
-        quarterly_denominator(key)[period.previous] || 0
-      else
-        monthly_denominator(key, with_ltfu: with_ltfu)[period]
-      end
-    end
-
-    def calculate_percentages(key, with_ltfu: false)
-      key_for_percentage_data = if with_ltfu
-        "#{key}_with_ltfu_rate"
-      else
-        "#{key}_rate"
-      end
-
-      self[key_for_percentage_data] = self[key].each_with_object(Hash.new(0)) { |(period, value), hsh|
-        hsh[period] = percentage(value, denominator_for_percentage_calculation(period, key, with_ltfu: with_ltfu))
-      }
-    end
-
-    def percentage(numerator, denominator)
-      return 0 if denominator == 0 || numerator == 0
-      ((numerator.to_f / denominator) * 100).round(PERCENTAGE_PRECISION)
-    end
 
     def quarterly_report?
       @quarterly_report

--- a/app/services/reports/region_service.rb
+++ b/app/services/reports/region_service.rb
@@ -42,8 +42,8 @@ module Reports
       result.uncontrolled_patients_with_ltfu_rate = repository.uncontrolled_rates(with_ltfu: true)[slug]
 
       result.visited_without_bp_taken = repository.visited_without_bp_taken[region.slug]
-      result.calculate_percentages(:visited_without_bp_taken)
-      result.calculate_percentages(:visited_without_bp_taken, with_ltfu: true)
+      result.visited_without_bp_taken_rate = repository.visited_without_bp_taken_rate[region.slug]
+      result.visited_without_bp_taken_with_ltfu_rate = repository.visited_without_bp_taken_rate(with_ltfu: true)[region.slug]
 
       result.missed_visits = repository.missed_visits[region.slug]
       result.missed_visits_rate = repository.missed_visits_without_ltfu_rates[region.slug]

--- a/app/views/my_facilities/facility_performance/show.html.erb
+++ b/app/views/my_facilities/facility_performance/show.html.erb
@@ -70,14 +70,15 @@
           </thead>
           <tbody>
             <% @facilities_by_size[size].each do |facility| %>
-              <% overall_score = number_with_precision(@scores_for_facility[facility.name].overall_score, precision: 2) %>
+              <% slug = facility.region.slug %>
+              <% overall_score = number_with_precision(@scores_for_facility[slug].overall_score, precision: 2) %>
               <tr>
-                <td class="type-grade grade-<%= @scores_for_facility[facility.name].letter_grade.downcase %>"
+                <td class="type-grade grade-<%= @scores_for_facility[slug].letter_grade.downcase %>"
                     data-sort-column-key="rank"
                     data-sort="<%= overall_score %>"
                     data-toggle="tooltip"
                     title="Overall score: <%= overall_score %>">
-                  <%= @scores_for_facility[facility.name].letter_grade %>
+                  <%= @scores_for_facility[slug].letter_grade %>
                 </td>
                 <td class="type-title">
                   <%= link_to(reports_region_path(facility, report_scope: "facility"))do %>
@@ -85,27 +86,27 @@
                   <% end %>
                 </td>
                 <td class="type-number">
-                  <%= number_with_delimiter(@data_for_facility[facility.name]["controlled_patients"].values.last || 0) %>
+                  <%= number_with_delimiter(@data_for_facility[slug]["controlled_patients"].values.last || 0) %>
                 </td>
                 <td class="type-percent" data-sort-column-key="controlled_patients_rate">
                   <em>
-                    <%= number_to_percentage(@data_for_facility[facility.name]["controlled_patients_rate"].values.last || 0, precision: 0) %>
+                    <%= number_to_percentage(@data_for_facility[slug]["controlled_patients_rate"].values.last || 0, precision: 0) %>
                   </em>
                 </td>
                 <td class="type-number">
-                  <%= number_with_delimiter(@data_for_facility[facility.name]["missed_visits"].values.last || 0) %>
+                  <%= number_with_delimiter(@data_for_facility[slug]["missed_visits"].values.last || 0) %>
                 </td>
                 <td class="type-percent" data-sort-column-key="missed_visits_rate">
                   <em>
-                    <%= number_to_percentage(@data_for_facility[facility.name]["missed_visits_rate"].values.last || 0, precision: 0) %>
+                    <%= number_to_percentage(@data_for_facility[slug]["missed_visits_rate"].values.last || 0, precision: 0) %>
                   </em>
                 </td>
                 <td class="type-number" data-sort-column-key="monthly_registrations">
-                  <%= number_with_delimiter(@data_for_facility[facility.name]["registrations"].values.last || 0) %>
+                  <%= number_with_delimiter(@data_for_facility[slug]["registrations"].values.last || 0) %>
                 </td>
                 <td class="type-percent" data-sort-column-key="registration_rate">
                   <em>
-                    <%= number_to_percentage(@scores_for_facility[facility.name].registrations_rate, precision: 0) %>
+                    <%= number_to_percentage(@scores_for_facility[slug].registrations_rate, precision: 0) %>
                   </em>
                 </td>
                 <td class="type-number" data-sort-column-key="opd_load">

--- a/spec/models/reports/performance_score_spec.rb
+++ b/spec/models/reports/performance_score_spec.rb
@@ -81,12 +81,12 @@ describe Reports::PerformanceScore, type: :model do
 
   describe "#control_rate" do
     it "returns the control rate" do
-      allow(reports_result).to receive(:controlled_patients_rate_for).with(period).and_return(20)
+      allow(reports_result).to receive(:controlled_patients_rate).and_return({period => 20})
       expect(perf_score.control_rate).to eq(20)
     end
 
-    it "returns 0 when control rate is nil" do
-      allow(reports_result).to receive(:controlled_patients_rate_for).with(period).and_return(nil)
+    it "returns 0 when control rate is empty hash" do
+      allow(reports_result).to receive(:controlled_patients_rate).and_return({})
       expect(perf_score.control_rate).to eq(0)
     end
   end
@@ -122,17 +122,17 @@ describe Reports::PerformanceScore, type: :model do
 
   describe "#visits_rate" do
     it "returns the inverse of the missed visits rate" do
-      allow(reports_result).to receive(:missed_visits_rate_for).with(period).and_return(60)
+      allow(reports_result).to receive(:missed_visits_rate).and_return({period => 60})
       expect(perf_score.visits_rate).to eq(40)
     end
 
     it "returns 100 when missed visits rate is 0" do
-      allow(reports_result).to receive(:missed_visits_rate_for).with(period).and_return(0)
+      allow(reports_result).to receive(:missed_visits_rate).and_return({period => 0})
       expect(perf_score.visits_rate).to eq(100)
     end
 
-    it "returns 100 when missed visits rate is nil" do
-      allow(reports_result).to receive(:missed_visits_rate_for).with(period).and_return(nil)
+    it "returns 100 when missed visits rate is empty hash" do
+      allow(reports_result).to receive(:missed_visits_rate).and_return({})
       expect(perf_score.visits_rate).to eq(100)
     end
   end
@@ -187,12 +187,12 @@ describe Reports::PerformanceScore, type: :model do
 
   describe "#registrations" do
     it "returns the registrations count" do
-      allow(reports_result).to receive(:registrations_for).with(period).and_return(20)
+      allow(reports_result).to receive(:registrations).and_return(period => 20)
       expect(perf_score.registrations).to eq(20)
     end
 
-    it "returns 0 when registrations count is nil" do
-      allow(reports_result).to receive(:registrations_for).with(period).and_return(nil)
+    it "returns 0 when registrations count is empty hash" do
+      allow(reports_result).to receive(:registrations).and_return({})
       expect(perf_score.registrations).to eq(0)
     end
   end

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -152,10 +152,14 @@ RSpec.describe Reports::Repository, type: :model, v2_flag: true do
 
         it "gets registration and assigned patient counts for brand new regions with no data" do
           facility_1 = FactoryBot.create(:facility, facility_group: facility_group_1)
+          slug = facility_1.region.slug
           repo = Reports::Repository.new(facility_1.region, periods: july_2020_range)
           expect(repo.monthly_registrations).to eq({facility_1.slug => {}})
           expect(repo.controlled).to eq({facility_1.slug => {}})
           expect(repo.controlled_rates).to eq({facility_1.slug => {}})
+          expect(repo.visited_without_bp_taken).to eq({slug => {}})
+          expect(repo.visited_without_bp_taken_rate).to eq({slug => {}})
+          expect(repo.visited_without_bp_taken_rate(with_ltfu: true)).to eq({slug => {}})
         end
 
         it "gets controlled counts and rates for single region" do

--- a/spec/models/reports/result_spec.rb
+++ b/spec/models/reports/result_spec.rb
@@ -17,9 +17,7 @@ describe Reports::Result, type: :model do
     result = Reports::Result.new(region: region, period_type: :month)
     result[:uncontrolled_patients][june_2020] = 30
     result[:controlled_patients][june_2020] = 100
-    expect(result.uncontrolled_patients_for(june_2020)).to eq(30)
     expect(result.uncontrolled_patients).to be(result[:uncontrolled_patients])
-    expect(result.controlled_patients_for(june_2020)).to eq(100)
     expect(result.controlled_patients).to be(result[:controlled_patients])
   end
 
@@ -28,13 +26,6 @@ describe Reports::Result, type: :model do
     hsh = {june_2020 => 30}
     result.uncontrolled_patients = hsh
     expect(result.uncontrolled_patients).to eq(hsh)
-  end
-
-  it "can get last value for the data" do
-    result = Reports::Result.new(region: region, period_type: :month)
-    result[:uncontrolled_patients][may_2020] = 20
-    result[:uncontrolled_patients][june_2020] = 30
-    expect(result.last_value(:uncontrolled_patients)).to eq(30)
   end
 
   it "can return report data that limits results to the range requested" do

--- a/spec/services/reports/region_service_spec.rb
+++ b/spec/services/reports/region_service_spec.rb
@@ -350,11 +350,11 @@ RSpec.describe Reports::RegionService, type: :model do
 
       service = Reports::RegionService.new(region: facility_group_1, period: Period.month(june_1_2020))
       result = service.call
-      expect(result.adjusted_patient_counts_for(Period.month("Jan 2019"))).to eq(0)
-      expect(result.adjusted_patient_counts_for(Period.month("Feb 2019"))).to eq(0)
-      expect(result.adjusted_patient_counts_for(Period.month("Mar 2019"))).to eq(0)
-      expect(result.adjusted_patient_counts_for(Period.month("Apr 2019"))).to eq(2)
-      expect(result.adjusted_patient_counts_for(Period.month("May 2019"))).to eq(2)
+      expect(result.adjusted_patient_counts[Period.month("Jan 2019")]).to eq(0)
+      expect(result.adjusted_patient_counts[Period.month("Feb 2019")]).to eq(0)
+      expect(result.adjusted_patient_counts[Period.month("Mar 2019")]).to eq(0)
+      expect(result.adjusted_patient_counts[Period.month("Apr 2019")]).to eq(2)
+      expect(result.adjusted_patient_counts[Period.month("May 2019")]).to eq(2)
     end
 
     it "returns counts for last n months for controlled patients and registrations" do


### PR DESCRIPTION
No need to calculate these via result anymore...which should either fix the related Sentry error or at least make it easier to track down.

**Story card:** [ch4390](https://app.clubhouse.io/simpledotorg/story/4390/error-in-my-facilities-dashboard-undefined-method-each-with-object)

**Sentry** https://sentry.io/organizations/resolve-to-save-lives/issues/2540211592/?project=1217715&referrer=Clubhouse