### PR TITLE
4322: fix schedule syntax for scheduling notifications

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -58,7 +58,7 @@ end
 
 every :day, at: local("08:30 am"), roles: [:cron] do
   if CountryConfig.current_country?("India")
-    AppointmentNotification::ScheduleExperimentReminders.perform_now
+    runner "AppointmentNotification::ScheduleExperimentReminders.perform_now"
   end
 end
 


### PR DESCRIPTION
**Story card:** [ch4322](https://app.clubhouse.io/simpledotorg/story/4322/add-both-active-and-stale-experiments-to-scheduler)

## Because

I made a mistake setting up the scheduler.