### PR TITLE
Don't allow duplicate block names in FG

### DIFF
--- a/app/models/facility_group_region_sync.rb
+++ b/app/models/facility_group_region_sync.rb
@@ -30,7 +30,7 @@ class FacilityGroupRegionSync < SimpleDelegator
   def create_block_regions
     return if new_block_names.blank?
 
-    new_block_names.map { |name|
+    new_block_names.uniq.map { |name|
       Region.block_regions.create!(name: name, reparent_to: region)
     }
   end

--- a/spec/models/facility_group_spec.rb
+++ b/spec/models/facility_group_spec.rb
@@ -87,6 +87,15 @@ RSpec.describe FacilityGroup, type: :model do
   end
 
   describe "keeps block regions in sync" do
+    it "creates blocks from new_block_names" do
+      facility_group = create(:facility_group, name: "FG", state: "Punjab")
+
+      facility_group.new_block_names = ["Block 1", "Block 1", "Block 2"]
+      facility_group.sync_block_regions
+
+      expect(facility_group.region.block_regions.map(&:name)).to contain_exactly("Block 1", "Block 2")
+    end
+
     it "deletes blocks from remove_block_ids" do
       facility_group = create(:facility_group, name: "FG", state: "Punjab")
       district_region = facility_group.region


### PR DESCRIPTION
**Story card:** [ch4397](https://app.clubhouse.io/simpledotorg/story/4397/regions-integrity-failure-in-production)

## Because

We found some blocks with the same name in a district. This is not a valid state and we received a Region Integrity alert.

## This addresses

Blocks are created from the `Create District` form. The form uniques blocks by name with Javascript but we don't unique them on the backend. We suspect a user managed to submit the form with the same block name twice somehow.

This uniques block names in the model callback.

The integrity failure was fixed manually by deleting the duplicate blocks (these were all created recently and had no facilities).
