### PR TITLE
Data migration to discard the offending BPs

### DIFF
--- a/db/data/20210804083620_delete_zero_bps.rb
+++ b/db/data/20210804083620_delete_zero_bps.rb
@@ -1,0 +1,16 @@
+class DeleteZeroBps < ActiveRecord::Migration[5.2]
+  def up
+    return unless CountryConfig.current[:abbreviation] == "ET"
+
+    zero_bps = BloodPressure.where(systolic: 0, diastolic: 0)
+
+    zero_bps.find_each do |blood_pressure|
+      blood_pressure.observation&.discard
+      blood_pressure.discard
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20210730185818)
+DataMigrate::Data.define(version: 20210804083620)


### PR DESCRIPTION
**Story card:** [ch4415](https://app.clubhouse.io/simpledotorg/story/4415/et-0-0-bps)

## Because

The ET data import process imported some rows with no BP information and created "blank" BPs (sys: 0, dia: 0)

## This addresses

This PR adds a data migration to discard the offending BPs, and their associated observations.

## Test instructions

Here's how I'll be testing this:
* [x] Pull ET data locally
* [x] Run the data migration
* [x] Ensure the dashboard is working (My Facilities, user activity log, reports)
* [x] Ensure the app can sync after the data migration