### PR TITLE
Initialize region service with a region

### DIFF
--- a/app/controllers/my_facilities/facility_performance_controller.rb
+++ b/app/controllers/my_facilities/facility_performance_controller.rb
@@ -28,7 +28,7 @@ class MyFacilities::FacilityPerformanceController < AdminController
 
     @facilities.each do |facility|
       slug = facility.region.slug
-      @data_for_facility[slug] = Reports::RegionService.new(region: facility,
+      @data_for_facility[slug] = Reports::RegionService.new(region: facility.region,
                                                             period: @period).call
 
       @scores_for_facility[slug] = Reports::PerformanceScore.new(region: facility,

--- a/app/controllers/my_facilities_controller.rb
+++ b/app/controllers/my_facilities_controller.rb
@@ -77,7 +77,7 @@ class MyFacilitiesController < AdminController
 
     facilities.each do |facility|
       @data_for_facility[facility.name] = Reports::RegionService.new(
-        region: facility, period: @period, months: 6
+        region: facility.region, period: @period, months: 6
       ).call
     end
     sizes = @data_for_facility.map { |_, facility| facility.region.source.facility_size }.uniq


### PR DESCRIPTION
**Story card:** [ch4413](https://app.clubhouse.io/simpledotorg/story/4413/my-facilities-bug)

Quick-fix for latest My Facilities bug. The problem surfaces when a facility and its region have different slugs (which is common). This makes everyone happy by initializing the `RegionService` with region records for now.

The follow-up robust fix would be to teach the `RegionService` to convert whatever it receives into region records as soon as possible, similar to how the `Repository` does today.