### PR TITLE
Fix BD state data migration

### DIFF
--- a/db/data/20210804072005_rename_dhaka_north_to_dhaka.rb
+++ b/db/data/20210804072005_rename_dhaka_north_to_dhaka.rb
@@ -1,6 +1,6 @@
 class RenameDhakaNorthToDhaka < ActiveRecord::Migration[5.2]
   def up
-    return unless CountryConfig.current_country?("Bangladesh")
+    return unless (CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?)
 
     Region.state_regions.find_by(name: "Dhaka North").update!(name: "Dhaka")
     Facility.where(state: "Dhaka North").update_all(state: "Dhaka")

--- a/db/data/20210804072005_rename_dhaka_north_to_dhaka.rb
+++ b/db/data/20210804072005_rename_dhaka_north_to_dhaka.rb
@@ -1,6 +1,6 @@
 class RenameDhakaNorthToDhaka < ActiveRecord::Migration[5.2]
   def up
-    return unless (CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?)
+    return unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
 
     Region.state_regions.find_by(name: "Dhaka North").update!(name: "Dhaka")
     Facility.where(state: "Dhaka North").update_all(state: "Dhaka")


### PR DESCRIPTION
**Story card:** [chXXXX](URL)

## Because
There was a bad guard clause in the migration added in https://github.com/simpledotorg/simple-server/pull/2779.

## This addresses

Fixes the guard clause. This migration should only run in BD prod.
