### PR TITLE
Add monthly_registrations_by_user to cache warmer

### DIFF
--- a/app/services/reports/repository_cache_warmer.rb
+++ b/app/services/reports/repository_cache_warmer.rb
@@ -17,6 +17,7 @@ class Reports::RepositoryCacheWarmer
   # As we move away from RegionService, we can add more things to be explicitly cached here.
   def call
     repository.hypertension_follow_ups
+    # see regions/etails.html.erb for where these are used
     if region.facility_region?
       repository.bp_measures_by_user
       repository.hypertension_follow_ups(group_by: "blood_pressures.user_id")

--- a/app/services/reports/repository_cache_warmer.rb
+++ b/app/services/reports/repository_cache_warmer.rb
@@ -18,8 +18,9 @@ class Reports::RepositoryCacheWarmer
   def call
     repository.hypertension_follow_ups
     if region.facility_region?
-      repository.hypertension_follow_ups(group_by: "blood_pressures.user_id")
       repository.bp_measures_by_user
+      repository.hypertension_follow_ups(group_by: "blood_pressures.user_id")
+      repository.monthly_registrations_by_user
     end
   end
 end


### PR DESCRIPTION
**Story card:** [ch4416](https://app.clubhouse.io/simpledotorg/story/4416/registrations-mismatch-in-hwc-jitta-kalan)

## Because

I suspect the problem w/ registration counts per user is that we just aren't busting the cache.

This adds that specific call to the cache warmer.
