### PR TITLE
Drug stock improvements 2

### DIFF
--- a/app/controllers/concerns/my_facilities_filtering.rb
+++ b/app/controllers/concerns/my_facilities_filtering.rb
@@ -85,7 +85,7 @@ module MyFacilitiesFiltering
         .select { |district| district.feature_enabled?(:drug_stocks) }
         .pluck(:source_id)
 
-      FacilityGroup.where(id: facility_group_ids)
+      FacilityGroup.where(id: facility_group_ids).order(:name)
     end
   end
 end

--- a/app/controllers/my_facilities/drug_stocks_controller.rb
+++ b/app/controllers/my_facilities/drug_stocks_controller.rb
@@ -92,10 +92,10 @@ class MyFacilities::DrugStocksController < AdminController
   end
 
   def blocks_to_display
-    if @selected_facility_sizes != @facility_sizes || @selected_zones != @zones
-      Region.none
-    else
+    if @selected_facility_sizes == @facility_sizes && @selected_zones == @zones
       @query.blocks.order(:name)
+    else
+      Region.none
     end
   end
 

--- a/app/views/my_facilities/drug_stocks/_drug_consumption_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_consumption_table.html.erb
@@ -177,7 +177,7 @@
       <% end %>
     <% end %>
     <% @drugs_by_category.map do |drug_category, _drugs| %>
-      <% total = @report.dig(:all_drug_consumption, drug_category, :base_doses, :total) %>
+      <% total = @report.dig(:facilities_total_drug_consumption, drug_category, :base_doses, :total) %>
       <% if total.nil? || total == "error" %>
         <td class="type-blank"><span>?</span></td>
       <% else %>

--- a/app/views/my_facilities/drug_stocks/new.html.erb
+++ b/app/views/my_facilities/drug_stocks/new.html.erb
@@ -56,6 +56,7 @@
 
   <script type="text/javascript" charset="utf-8">
     $(document).ready(function () {
+      const urlParams = new URLSearchParams(window.location.search);
       $('#for_end_of_month').datepicker({
         format: "M-yyyy",
         startView: "months",
@@ -65,7 +66,9 @@
         window.location.href = location.origin
             + location.pathname
             + '?for_end_of_month='
-            + encodeURIComponent(e.format());
+            + encodeURIComponent(e.format())
+            + '&region_type='
+            + urlParams.get('region_type');
       });
     })
   </script>

--- a/config/initializers/country_config.rb
+++ b/config/initializers/country_config.rb
@@ -13,7 +13,7 @@ class CountryConfig
       sms_country_code: ENV["SMS_COUNTRY_CODE"] || "+91",
       supported_genders: %w[male female transgender],
       patient_line_list_show_zone: false,
-      custom_drug_category_order: %w[hypertension_ccb,hypertension_arb,hypertension_diuretic]
+      custom_drug_category_order: %w[hypertension_ccb hypertension_arb hypertension_diuretic]
     },
     BD: {
       abbreviation: "BD",

--- a/spec/exporters/drug_consumption_report_exporter_spec.rb
+++ b/spec/exporters/drug_consumption_report_exporter_spec.rb
@@ -7,127 +7,211 @@ RSpec.describe DrugConsumptionReportExporter do
     end
   end
 
-  it "renders the csv" do
+  context "exports the csv" do
     Timecop.freeze do
-      protocol = create(:protocol, :with_tracked_drugs)
-      facility_group = create(:facility_group, protocol: protocol, state: "Punjab")
-      facilities = create_list(:facility, 2, facility_group: facility_group)
-      query = DrugStocksQuery.new(facilities: facilities,
-                                  for_end_of_month: Date.current.end_of_month)
+      let(:protocol) { create(:protocol, :with_tracked_drugs) }
+      let(:facility_group) { create(:facility_group, protocol: protocol, state: "Punjab") }
+      let(:facilities) { create_list(:facility, 2, facility_group: facility_group) }
+      let(:query) { DrugStocksQuery.new(facilities: facilities,
+                                        for_end_of_month: Date.current.end_of_month) }
 
-      stocks_by_rxnorm = {
-        "329528" => {in_stock: 10000, received: 2000, redistributed: 0},
-        "329526" => {in_stock: 20000, received: 2000, redistributed: 0},
-        "316764" => {in_stock: 10000, received: 2000, redistributed: 0},
-        "316765" => {in_stock: 20000, received: 2000, redistributed: nil},
-        "979467" => {in_stock: 10000, received: 2000, redistributed: nil}
+      let(:stocks_by_rxnorm) {
+        {
+          "329528" => { in_stock: 10000, received: 2000, redistributed: 0 },
+          "329526" => { in_stock: 20000, received: 2000, redistributed: 0 },
+          "316764" => { in_stock: 10000, received: 2000, redistributed: 0 },
+          "316765" => { in_stock: 20000, received: 2000, redistributed: nil },
+          "979467" => { in_stock: 10000, received: 2000, redistributed: nil }
+        }
       }
 
-      previous_month_stocks_by_rxnorm =
-        {"329528" => {in_stock: 8000},
-         "329526" => {in_stock: 15000},
-         "316764" => {in_stock: 8000},
-         "316765" => {in_stock: 17000},
-         "979467" => {in_stock: 9000}}
+      let(:previous_month_stocks_by_rxnorm) {
+        {
+          "329528" => { in_stock: 8000 },
+          "329526" => { in_stock: 15000 },
+          "316764" => { in_stock: 8000 },
+          "316765" => { in_stock: 17000 },
+          "979467" => { in_stock: 9000 }
+        }
+      }
 
-      stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
-        protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
-        create(:drug_stock,
-          region: facility_group.region,
-          protocol_drug: protocol_drug,
-          in_stock: drug_stock[:in_stock],
-          received: drug_stock[:received],
-          redistributed: drug_stock[:redistributed])
-        create(:drug_stock,
-          facility: facilities.first,
-          protocol_drug: protocol_drug,
-          in_stock: drug_stock[:in_stock],
-          received: drug_stock[:received],
-          redistributed: drug_stock[:redistributed])
+      let(:timestamp) { ["Report last updated at:", Time.now] }
+
+      before do
+        stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
+          protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
+          create(:drug_stock,
+                 region: facility_group.region,
+                 protocol_drug: protocol_drug,
+                 in_stock: drug_stock[:in_stock],
+                 received: drug_stock[:received],
+                 redistributed: drug_stock[:redistributed])
+          create(:drug_stock,
+                 facility: facilities.first,
+                 protocol_drug: protocol_drug,
+                 in_stock: drug_stock[:in_stock],
+                 received: drug_stock[:received],
+                 redistributed: drug_stock[:redistributed])
+        end
+
+        previous_month_stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
+          protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
+          create(:drug_stock,
+                 region: facility_group.region,
+                 protocol_drug: protocol_drug,
+                 in_stock: drug_stock[:in_stock],
+                 for_end_of_month: (Date.today - 1.month).end_of_month)
+          create(:drug_stock,
+                 facility: facilities.first,
+                 protocol_drug: protocol_drug,
+                 in_stock: drug_stock[:in_stock],
+                 for_end_of_month: (Date.today - 1.month).end_of_month)
+        end
       end
 
-      previous_month_stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
-        protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
-        create(:drug_stock,
-          region: facility_group.region,
-          protocol_drug: protocol_drug,
-          in_stock: drug_stock[:in_stock],
-          for_end_of_month: (Date.today - 1.month).end_of_month)
-        create(:drug_stock,
-          facility: facilities.first,
-          protocol_drug: protocol_drug,
-          in_stock: drug_stock[:in_stock],
-          for_end_of_month: (Date.today - 1.month).end_of_month)
-      end
+      it "renders the csv" do
+        allow(CountryConfig.current).to receive(:fetch).with(:custom_drug_category_order, []).and_return([])
 
-      timestamp = ["Report last updated at:", Time.now]
+        headers_row_1 = [
+          nil, nil,
+          "ARB Tablets", nil, nil,
+          "CCB Tablets", nil,
+          "Diuretic Tablets", nil,
+          "Overall in base doses", nil, nil
+        ]
 
-      headers_row_1 = [
-        nil, nil,
-        "ARB Tablets", nil, nil,
-        "CCB Tablets", nil,
-        "Diuretic Tablets", nil,
-        "Overall in base doses", nil, nil
-      ]
+        headers_row_2 = [
+          "Facilities",
+          "Block",
+          "Losartan 50 mg",
+          "Telmisartan 40 mg",
+          "Telmisartan 80 mg",
+          "Amlodipine 5 mg",
+          "Amlodipine 10 mg",
+          "Chlorthalidone 12.5 mg",
+          "Hydrochlorothiazide 25 mg",
+          "ARB base doses",
+          "CCB base doses",
+          "Diuretic base doses"
+        ]
 
-      headers_row_2 = [
-        "Facilities",
-        "Block",
-        "Losartan 50 mg",
-        "Telmisartan 40 mg",
-        "Telmisartan 80 mg",
-        "Amlodipine 5 mg",
-        "Amlodipine 10 mg",
-        "Chlorthalidone 12.5 mg",
-        "Hydrochlorothiazide 25 mg",
-        "ARB base doses",
-        "CCB base doses",
-        "Diuretic base doses"
-      ]
+        totals_row = [
+          "All", "",
+          2000, 0, -2000,
+          0, -6000,
+          "?", "?",
+          -2000, -12000, "?"
+        ]
 
-      totals_row = [
-        "All", "",
-        2000, 0, -2000,
-        0, -6000,
-        "?", "?",
-        -2000, -12000, "?"
-      ]
-
-      district_warehouse_row = [
-        "District Warehouse", "",
-        1000, 0, -1000,
-        0, -3000,
-        "?", "?",
-        -1000, -6000, "?"
-      ]
-
-      facility_1_row =
-        [facilities.first.name,
-          facilities.first.zone,
+        district_warehouse_row = [
+          "District Warehouse", "",
           1000, 0, -1000,
           0, -3000,
           "?", "?",
-          -1000, -6000, "?"]
+          -1000, -6000, "?"
+        ]
 
-      facility_2_row =
-        [facilities.second.name,
-          facilities.second.zone,
-          "?", "?", "?", "?",
+        facility_1_row =
+          [facilities.first.name,
+           facilities.first.zone,
+           1000, 0, -1000,
+           0, -3000,
+           "?", "?",
+           -1000, -6000, "?"]
+
+        facility_2_row =
+          [facilities.second.name,
+           facilities.second.zone,
+           "?", "?", "?", "?",
+           "?", "?",
+           "?", "?",
+           "?", "?"]
+
+        csv = described_class.csv(query)
+        expected_csv =
+          timestamp.to_csv +
+            headers_row_1.to_csv +
+            headers_row_2.to_csv +
+            totals_row.to_csv +
+            district_warehouse_row.to_csv +
+            facility_1_row.to_csv +
+            facility_2_row.to_csv
+
+        expect(csv).to eq(expected_csv)
+      end
+
+      it "renders the csv in custom category order" do
+        allow(CountryConfig.current).to receive(:fetch)
+                                          .with(:custom_drug_category_order, [])
+                                          .and_return(["hypertension_ccb", "hypertension_arb", "hypertension_diuretic"])
+
+        headers_row_1 = [
+          nil, nil,
+          "CCB Tablets", nil,
+          "ARB Tablets", nil, nil,
+          "Diuretic Tablets", nil,
+          "Overall in base doses", nil, nil
+        ]
+
+        headers_row_2 = [
+          "Facilities",
+          "Block",
+          "Amlodipine 5 mg",
+          "Amlodipine 10 mg",
+          "Losartan 50 mg",
+          "Telmisartan 40 mg",
+          "Telmisartan 80 mg",
+          "Chlorthalidone 12.5 mg",
+          "Hydrochlorothiazide 25 mg",
+          "CCB base doses",
+          "ARB base doses",
+          "Diuretic base doses"
+        ]
+
+        totals_row = [
+          "All", "",
+          0, -6000,
+          2000, 0, -2000,
           "?", "?",
+          -12000, -2000, "?"
+        ]
+
+        district_warehouse_row = [
+          "District Warehouse", "",
+          0, -3000,
+          1000, 0, -1000,
           "?", "?",
-          "?", "?"]
+          -6000, -1000, "?"
+        ]
 
-      csv = described_class.csv(query)
-      expected_csv =
-        timestamp.to_csv +
-        headers_row_1.to_csv +
-        headers_row_2.to_csv +
-        totals_row.to_csv +
-        district_warehouse_row.to_csv +
-        facility_1_row.to_csv +
-        facility_2_row.to_csv
+        facility_1_row =
+          [facilities.first.name,
+           facilities.first.zone,
+           0, -3000,
+           1000, 0, -1000,
+           "?", "?",
+           -6000, -1000, "?"]
 
-      expect(csv).to eq(expected_csv)
+        facility_2_row =
+          [facilities.second.name,
+           facilities.second.zone,
+           "?", "?", "?", "?",
+           "?", "?",
+           "?", "?",
+           "?", "?"]
+
+        csv = described_class.csv(query)
+        expected_csv =
+          timestamp.to_csv +
+            headers_row_1.to_csv +
+            headers_row_2.to_csv +
+            totals_row.to_csv +
+            district_warehouse_row.to_csv +
+            facility_1_row.to_csv +
+            facility_2_row.to_csv
+
+        expect(csv).to eq(expected_csv)
+      end
     end
   end
 end

--- a/spec/exporters/drug_consumption_report_exporter_spec.rb
+++ b/spec/exporters/drug_consumption_report_exporter_spec.rb
@@ -12,26 +12,28 @@ RSpec.describe DrugConsumptionReportExporter do
       let(:protocol) { create(:protocol, :with_tracked_drugs) }
       let(:facility_group) { create(:facility_group, protocol: protocol, state: "Punjab") }
       let(:facilities) { create_list(:facility, 2, facility_group: facility_group) }
-      let(:query) { DrugStocksQuery.new(facilities: facilities,
-                                        for_end_of_month: Date.current.end_of_month) }
+      let(:query) {
+        DrugStocksQuery.new(facilities: facilities,
+                            for_end_of_month: Date.current.end_of_month)
+      }
 
       let(:stocks_by_rxnorm) {
         {
-          "329528" => { in_stock: 10000, received: 2000, redistributed: 0 },
-          "329526" => { in_stock: 20000, received: 2000, redistributed: 0 },
-          "316764" => { in_stock: 10000, received: 2000, redistributed: 0 },
-          "316765" => { in_stock: 20000, received: 2000, redistributed: nil },
-          "979467" => { in_stock: 10000, received: 2000, redistributed: nil }
+          "329528" => {in_stock: 10000, received: 2000, redistributed: 0},
+          "329526" => {in_stock: 20000, received: 2000, redistributed: 0},
+          "316764" => {in_stock: 10000, received: 2000, redistributed: 0},
+          "316765" => {in_stock: 20000, received: 2000, redistributed: nil},
+          "979467" => {in_stock: 10000, received: 2000, redistributed: nil}
         }
       }
 
       let(:previous_month_stocks_by_rxnorm) {
         {
-          "329528" => { in_stock: 8000 },
-          "329526" => { in_stock: 15000 },
-          "316764" => { in_stock: 8000 },
-          "316765" => { in_stock: 17000 },
-          "979467" => { in_stock: 9000 }
+          "329528" => {in_stock: 8000},
+          "329526" => {in_stock: 15000},
+          "316764" => {in_stock: 8000},
+          "316765" => {in_stock: 17000},
+          "979467" => {in_stock: 9000}
         }
       }
 
@@ -41,31 +43,31 @@ RSpec.describe DrugConsumptionReportExporter do
         stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
           protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
           create(:drug_stock,
-                 region: facility_group.region,
-                 protocol_drug: protocol_drug,
-                 in_stock: drug_stock[:in_stock],
-                 received: drug_stock[:received],
-                 redistributed: drug_stock[:redistributed])
+            region: facility_group.region,
+            protocol_drug: protocol_drug,
+            in_stock: drug_stock[:in_stock],
+            received: drug_stock[:received],
+            redistributed: drug_stock[:redistributed])
           create(:drug_stock,
-                 facility: facilities.first,
-                 protocol_drug: protocol_drug,
-                 in_stock: drug_stock[:in_stock],
-                 received: drug_stock[:received],
-                 redistributed: drug_stock[:redistributed])
+            facility: facilities.first,
+            protocol_drug: protocol_drug,
+            in_stock: drug_stock[:in_stock],
+            received: drug_stock[:received],
+            redistributed: drug_stock[:redistributed])
         end
 
         previous_month_stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
           protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
           create(:drug_stock,
-                 region: facility_group.region,
-                 protocol_drug: protocol_drug,
-                 in_stock: drug_stock[:in_stock],
-                 for_end_of_month: (Date.today - 1.month).end_of_month)
+            region: facility_group.region,
+            protocol_drug: protocol_drug,
+            in_stock: drug_stock[:in_stock],
+            for_end_of_month: (Date.today - 1.month).end_of_month)
           create(:drug_stock,
-                 facility: facilities.first,
-                 protocol_drug: protocol_drug,
-                 in_stock: drug_stock[:in_stock],
-                 for_end_of_month: (Date.today - 1.month).end_of_month)
+            facility: facilities.first,
+            protocol_drug: protocol_drug,
+            in_stock: drug_stock[:in_stock],
+            for_end_of_month: (Date.today - 1.month).end_of_month)
         end
       end
 
@@ -113,37 +115,37 @@ RSpec.describe DrugConsumptionReportExporter do
 
         facility_1_row =
           [facilities.first.name,
-           facilities.first.zone,
-           1000, 0, -1000,
-           0, -3000,
-           "?", "?",
-           -1000, -6000, "?"]
+            facilities.first.zone,
+            1000, 0, -1000,
+            0, -3000,
+            "?", "?",
+            -1000, -6000, "?"]
 
         facility_2_row =
           [facilities.second.name,
-           facilities.second.zone,
-           "?", "?", "?", "?",
-           "?", "?",
-           "?", "?",
-           "?", "?"]
+            facilities.second.zone,
+            "?", "?", "?", "?",
+            "?", "?",
+            "?", "?",
+            "?", "?"]
 
         csv = described_class.csv(query)
         expected_csv =
           timestamp.to_csv +
-            headers_row_1.to_csv +
-            headers_row_2.to_csv +
-            totals_row.to_csv +
-            district_warehouse_row.to_csv +
-            facility_1_row.to_csv +
-            facility_2_row.to_csv
+          headers_row_1.to_csv +
+          headers_row_2.to_csv +
+          totals_row.to_csv +
+          district_warehouse_row.to_csv +
+          facility_1_row.to_csv +
+          facility_2_row.to_csv
 
         expect(csv).to eq(expected_csv)
       end
 
       it "renders the csv in custom category order" do
         allow(CountryConfig.current).to receive(:fetch)
-                                          .with(:custom_drug_category_order, [])
-                                          .and_return(["hypertension_ccb", "hypertension_arb", "hypertension_diuretic"])
+          .with(:custom_drug_category_order, [])
+          .and_return(["hypertension_ccb", "hypertension_arb", "hypertension_diuretic"])
 
         headers_row_1 = [
           nil, nil,
@@ -186,29 +188,29 @@ RSpec.describe DrugConsumptionReportExporter do
 
         facility_1_row =
           [facilities.first.name,
-           facilities.first.zone,
-           0, -3000,
-           1000, 0, -1000,
-           "?", "?",
-           -6000, -1000, "?"]
+            facilities.first.zone,
+            0, -3000,
+            1000, 0, -1000,
+            "?", "?",
+            -6000, -1000, "?"]
 
         facility_2_row =
           [facilities.second.name,
-           facilities.second.zone,
-           "?", "?", "?", "?",
-           "?", "?",
-           "?", "?",
-           "?", "?"]
+            facilities.second.zone,
+            "?", "?", "?", "?",
+            "?", "?",
+            "?", "?",
+            "?", "?"]
 
         csv = described_class.csv(query)
         expected_csv =
           timestamp.to_csv +
-            headers_row_1.to_csv +
-            headers_row_2.to_csv +
-            totals_row.to_csv +
-            district_warehouse_row.to_csv +
-            facility_1_row.to_csv +
-            facility_2_row.to_csv
+          headers_row_1.to_csv +
+          headers_row_2.to_csv +
+          totals_row.to_csv +
+          district_warehouse_row.to_csv +
+          facility_1_row.to_csv +
+          facility_2_row.to_csv
 
         expect(csv).to eq(expected_csv)
       end

--- a/spec/exporters/drug_stocks_report_exporter_spec.rb
+++ b/spec/exporters/drug_stocks_report_exporter_spec.rb
@@ -12,16 +12,18 @@ RSpec.describe DrugStocksReportExporter do
       let(:protocol) { create(:protocol, :with_tracked_drugs) }
       let(:facility_group) { create(:facility_group, protocol: protocol, state: "Punjab") }
       let(:facilities) { create_list(:facility, 2, facility_group: facility_group) }
-      let(:query) { DrugStocksQuery.new(facilities: facilities,
-                                        for_end_of_month: Date.current.end_of_month) }
+      let(:query) {
+        DrugStocksQuery.new(facilities: facilities,
+                            for_end_of_month: Date.current.end_of_month)
+      }
 
       let(:stocks_by_rxnorm) {
         {
-          "329528" => { in_stock: 10000, received: 2000, redistributed: 0 },
-          "329526" => { in_stock: 20000, received: 2000, redistributed: 0 },
-          "316764" => { in_stock: 10000, received: 2000, redistributed: 0 },
-          "316765" => { in_stock: 20000, received: 2000, redistributed: nil },
-          "979467" => { in_stock: 10000, received: 2000, redistributed: nil }
+          "329528" => {in_stock: 10000, received: 2000, redistributed: 0},
+          "329526" => {in_stock: 20000, received: 2000, redistributed: 0},
+          "316764" => {in_stock: 10000, received: 2000, redistributed: 0},
+          "316765" => {in_stock: 20000, received: 2000, redistributed: nil},
+          "979467" => {in_stock: 10000, received: 2000, redistributed: nil}
         }
       }
 
@@ -32,10 +34,10 @@ RSpec.describe DrugStocksReportExporter do
           stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
             protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
             create(:drug_stock,
-                   facility: facility,
-                   protocol_drug: protocol_drug,
-                   in_stock: drug_stock[:in_stock],
-                   received: drug_stock[:received])
+              facility: facility,
+              protocol_drug: protocol_drug,
+              in_stock: drug_stock[:in_stock],
+              received: drug_stock[:received])
           end
           create_list(:patient, 2, assigned_facility: facility)
         end
@@ -43,10 +45,10 @@ RSpec.describe DrugStocksReportExporter do
         stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
           protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
           create(:drug_stock,
-                 region: facility_group.region,
-                 protocol_drug: protocol_drug,
-                 in_stock: drug_stock[:in_stock],
-                 received: drug_stock[:received])
+            region: facility_group.region,
+            protocol_drug: protocol_drug,
+            in_stock: drug_stock[:in_stock],
+            received: drug_stock[:received])
         end
       end
 
@@ -94,34 +96,34 @@ RSpec.describe DrugStocksReportExporter do
 
         facility_1_row =
           [facilities.first.name,
-           facilities.first.zone,
-           10000, 10000, 20000, 81081,
-           10000, 20000, 17857,
-           nil, nil, nil]
+            facilities.first.zone,
+            10000, 10000, 20000, 81081,
+            10000, 20000, 17857,
+            nil, nil, nil]
 
         facility_2_row =
           [facilities.second.name,
-           facilities.second.zone,
-           10000, 10000, 20000, 81081,
-           10000, 20000, 17857,
-           nil, nil, nil]
+            facilities.second.zone,
+            10000, 10000, 20000, 81081,
+            10000, 20000, 17857,
+            nil, nil, nil]
 
         csv = described_class.csv(query)
         expected_csv =
           timestamp.to_csv +
-            headers_row_1.to_csv +
-            headers_row_2.to_csv +
-            totals_row.to_csv +
-            district_warehouse_row.to_csv +
-            facility_1_row.to_csv +
-            facility_2_row.to_csv
+          headers_row_1.to_csv +
+          headers_row_2.to_csv +
+          totals_row.to_csv +
+          district_warehouse_row.to_csv +
+          facility_1_row.to_csv +
+          facility_2_row.to_csv
 
         expect(csv).to eq(expected_csv)
       end
       it "renders the csv in custom category order" do
         allow(CountryConfig.current).to receive(:fetch)
-                                          .with(:custom_drug_category_order, [])
-                                          .and_return(["hypertension_ccb", "hypertension_arb", "hypertension_diuretic"])
+          .with(:custom_drug_category_order, [])
+          .and_return(["hypertension_ccb", "hypertension_arb", "hypertension_diuretic"])
         headers_row_1 = [
           nil, nil,
           "CCB Tablets",
@@ -163,31 +165,30 @@ RSpec.describe DrugStocksReportExporter do
 
         facility_1_row =
           [facilities.first.name,
-           facilities.first.zone,
-           10000, 20000, 17857,
-           10000, 10000, 20000, 81081,
-           nil, nil, nil]
+            facilities.first.zone,
+            10000, 20000, 17857,
+            10000, 10000, 20000, 81081,
+            nil, nil, nil]
 
         facility_2_row =
           [facilities.second.name,
-           facilities.second.zone,
-           10000, 20000, 17857,
-           10000, 10000, 20000, 81081,
-           nil, nil, nil]
+            facilities.second.zone,
+            10000, 20000, 17857,
+            10000, 10000, 20000, 81081,
+            nil, nil, nil]
 
         csv = described_class.csv(query)
         expected_csv =
           timestamp.to_csv +
-            headers_row_1.to_csv +
-            headers_row_2.to_csv +
-            totals_row.to_csv +
-            district_warehouse_row.to_csv +
-            facility_1_row.to_csv +
-            facility_2_row.to_csv
+          headers_row_1.to_csv +
+          headers_row_2.to_csv +
+          totals_row.to_csv +
+          district_warehouse_row.to_csv +
+          facility_1_row.to_csv +
+          facility_2_row.to_csv
 
         expect(csv).to eq(expected_csv)
       end
     end
   end
 end
-

--- a/spec/exporters/drug_stocks_report_exporter_spec.rb
+++ b/spec/exporters/drug_stocks_report_exporter_spec.rb
@@ -7,108 +7,187 @@ RSpec.describe DrugStocksReportExporter do
     end
   end
 
-  it "renders the csv" do
+  context "exports the csv" do
     Timecop.freeze do
-      protocol = create(:protocol, :with_tracked_drugs)
-      facility_group = create(:facility_group, protocol: protocol, state: "Punjab")
-      facilities = create_list(:facility, 2, facility_group: facility_group)
-      query = DrugStocksQuery.new(facilities: facilities,
-                                  for_end_of_month: Time.current.end_of_month)
+      let(:protocol) { create(:protocol, :with_tracked_drugs) }
+      let(:facility_group) { create(:facility_group, protocol: protocol, state: "Punjab") }
+      let(:facilities) { create_list(:facility, 2, facility_group: facility_group) }
+      let(:query) { DrugStocksQuery.new(facilities: facilities,
+                                        for_end_of_month: Date.current.end_of_month) }
 
-      stocks_by_rxnorm = {
-        "329528" => {in_stock: 10000, received: 2000},
-        "329526" => {in_stock: 20000, received: 2000},
-        "316764" => {in_stock: 10000, received: 2000},
-        "316765" => {in_stock: 20000, received: 2000},
-        "979467" => {in_stock: 10000, received: 2000}
+      let(:stocks_by_rxnorm) {
+        {
+          "329528" => { in_stock: 10000, received: 2000, redistributed: 0 },
+          "329526" => { in_stock: 20000, received: 2000, redistributed: 0 },
+          "316764" => { in_stock: 10000, received: 2000, redistributed: 0 },
+          "316765" => { in_stock: 20000, received: 2000, redistributed: nil },
+          "979467" => { in_stock: 10000, received: 2000, redistributed: nil }
+        }
       }
 
-      facilities.each do |facility|
+      let(:timestamp) { ["Report last updated at:", Time.now] }
+
+      before do
+        facilities.each do |facility|
+          stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
+            protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
+            create(:drug_stock,
+                   facility: facility,
+                   protocol_drug: protocol_drug,
+                   in_stock: drug_stock[:in_stock],
+                   received: drug_stock[:received])
+          end
+          create_list(:patient, 2, assigned_facility: facility)
+        end
+
         stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
           protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
           create(:drug_stock,
-            facility: facility,
-            protocol_drug: protocol_drug,
-            in_stock: drug_stock[:in_stock],
-            received: drug_stock[:received])
+                 region: facility_group.region,
+                 protocol_drug: protocol_drug,
+                 in_stock: drug_stock[:in_stock],
+                 received: drug_stock[:received])
         end
-        create_list(:patient, 2, assigned_facility: facility)
       end
 
-      stocks_by_rxnorm.map do |(rxnorm_code, drug_stock)|
-        protocol_drug = protocol.protocol_drugs.find_by(rxnorm_code: rxnorm_code)
-        create(:drug_stock,
-          region: facility_group.region,
-          protocol_drug: protocol_drug,
-          in_stock: drug_stock[:in_stock],
-          received: drug_stock[:received])
+      it "renders the csv" do
+        allow(CountryConfig.current).to receive(:fetch).with(:custom_drug_category_order, []).and_return([])
+
+        headers_row_1 = [
+          nil, nil,
+          "ARB Tablets",
+          nil, nil, nil,
+          "CCB Tablets",
+          nil, nil,
+          "Diuretic Tablets",
+          nil, nil
+        ]
+
+        headers_row_2 = [
+          "Facilities",
+          "Block",
+          "Losartan 50 mg",
+          "Telmisartan 40 mg",
+          "Telmisartan 80 mg",
+          "Patient days",
+          "Amlodipine 5 mg",
+          "Amlodipine 10 mg",
+          "Patient days",
+          "Chlorthalidone 12.5 mg",
+          "Hydrochlorothiazide 25 mg",
+          "Patient days"
+        ]
+
+        totals_row = [
+          "All", "",
+          30000, 30000, 60000, 121621,
+          30000, 60000, 26785,
+          nil, nil, nil
+        ]
+
+        district_warehouse_row = [
+          "District Warehouse", "",
+          10000, 10000, 20000, 40540,
+          10000, 20000, 8928,
+          nil, nil, nil
+        ]
+
+        facility_1_row =
+          [facilities.first.name,
+           facilities.first.zone,
+           10000, 10000, 20000, 81081,
+           10000, 20000, 17857,
+           nil, nil, nil]
+
+        facility_2_row =
+          [facilities.second.name,
+           facilities.second.zone,
+           10000, 10000, 20000, 81081,
+           10000, 20000, 17857,
+           nil, nil, nil]
+
+        csv = described_class.csv(query)
+        expected_csv =
+          timestamp.to_csv +
+            headers_row_1.to_csv +
+            headers_row_2.to_csv +
+            totals_row.to_csv +
+            district_warehouse_row.to_csv +
+            facility_1_row.to_csv +
+            facility_2_row.to_csv
+
+        expect(csv).to eq(expected_csv)
       end
+      it "renders the csv in custom category order" do
+        allow(CountryConfig.current).to receive(:fetch)
+                                          .with(:custom_drug_category_order, [])
+                                          .and_return(["hypertension_ccb", "hypertension_arb", "hypertension_diuretic"])
+        headers_row_1 = [
+          nil, nil,
+          "CCB Tablets",
+          nil, nil,
+          "ARB Tablets",
+          nil, nil, nil,
+          "Diuretic Tablets",
+          nil, nil
+        ]
 
-      timestamp = ["Report last updated at:", Time.now]
-      headers_row_1 = [
-        nil, nil,
-        "ARB Tablets",
-        nil, nil, nil,
-        "CCB Tablets",
-        nil, nil,
-        "Diuretic Tablets",
-        nil, nil
-      ]
+        headers_row_2 = [
+          "Facilities",
+          "Block",
+          "Amlodipine 5 mg",
+          "Amlodipine 10 mg",
+          "Patient days",
+          "Losartan 50 mg",
+          "Telmisartan 40 mg",
+          "Telmisartan 80 mg",
+          "Patient days",
+          "Chlorthalidone 12.5 mg",
+          "Hydrochlorothiazide 25 mg",
+          "Patient days"
+        ]
 
-      headers_row_2 = [
-        "Facilities",
-        "Block",
-        "Losartan 50 mg",
-        "Telmisartan 40 mg",
-        "Telmisartan 80 mg",
-        "Patient days",
-        "Amlodipine 5 mg",
-        "Amlodipine 10 mg",
-        "Patient days",
-        "Chlorthalidone 12.5 mg",
-        "Hydrochlorothiazide 25 mg",
-        "Patient days"
-      ]
+        totals_row = [
+          "All", "",
+          30000, 60000, 26785,
+          30000, 30000, 60000, 121621,
+          nil, nil, nil
+        ]
 
-      totals_row = [
-        "All", "",
-        30000, 30000, 60000, 121621,
-        30000, 60000, 26785,
-        nil, nil, nil
-      ]
+        district_warehouse_row = [
+          "District Warehouse", "",
+          10000, 20000, 8928,
+          10000, 10000, 20000, 40540,
+          nil, nil, nil
+        ]
 
-      district_warehouse_row = [
-        "District Warehouse", "",
-        10000, 10000, 20000, 40540,
-        10000, 20000, 8928,
-        nil, nil, nil
-      ]
+        facility_1_row =
+          [facilities.first.name,
+           facilities.first.zone,
+           10000, 20000, 17857,
+           10000, 10000, 20000, 81081,
+           nil, nil, nil]
 
-      facility_1_row =
-        [facilities.first.name,
-          facilities.first.zone,
-          10000, 10000, 20000, 81081,
-          10000, 20000, 17857,
-          nil, nil, nil]
+        facility_2_row =
+          [facilities.second.name,
+           facilities.second.zone,
+           10000, 20000, 17857,
+           10000, 10000, 20000, 81081,
+           nil, nil, nil]
 
-      facility_2_row =
-        [facilities.second.name,
-          facilities.second.zone,
-          10000, 10000, 20000, 81081,
-          10000, 20000, 17857,
-          nil, nil, nil]
+        csv = described_class.csv(query)
+        expected_csv =
+          timestamp.to_csv +
+            headers_row_1.to_csv +
+            headers_row_2.to_csv +
+            totals_row.to_csv +
+            district_warehouse_row.to_csv +
+            facility_1_row.to_csv +
+            facility_2_row.to_csv
 
-      csv = described_class.csv(query)
-      expected_csv =
-        timestamp.to_csv +
-        headers_row_1.to_csv +
-        headers_row_2.to_csv +
-        totals_row.to_csv +
-        district_warehouse_row.to_csv +
-        facility_1_row.to_csv +
-        facility_2_row.to_csv
-
-      expect(csv).to eq(expected_csv)
+        expect(csv).to eq(expected_csv)
+      end
     end
   end
 end
+


### PR DESCRIPTION
**Story card:** [ch4365](https://app.clubhouse.io/simpledotorg/story/4365/drug-stock-improvements)

## Because

Some additional Drug Stock improvements

## This addresses

- Order drug stock districts by name in the selector
- Simplify boolean logic to show/hide block rows
- Bugfix: the facilities subtotal base doses consumption was looking up a non-existent key
- Bugfix: the new drug stock form was not preserving region type when the month selector is used
- Custom drug category order config was incorrectly formatted, remove commas