### PR TITLE
Be fault tolerant in scheduling notifications, skipping ones that fail

### DIFF
--- a/app/jobs/appointment_notification/schedule_experiment_reminders.rb
+++ b/app/jobs/appointment_notification/schedule_experiment_reminders.rb
@@ -15,6 +15,14 @@ class AppointmentNotification::ScheduleExperimentReminders < ApplicationJob
     notifications.each do |notification|
       notification.status_scheduled!
       AppointmentNotification::Worker.perform_at(next_messaging_time, notification.id)
+    rescue => e
+      Sentry.capture_message("Scheduling notification for experiment failed",
+        extra: {
+          notification: notification.id,
+          next_messaging_time: next_messaging_time,
+          exception: e
+        },
+        tags: {type: "notifications"})
     end
     logger.info "scheduling experiment notifications complete"
   end

--- a/spec/jobs/appointment_notification/schedule_experiment_reminders_spec.rb
+++ b/spec/jobs/appointment_notification/schedule_experiment_reminders_spec.rb
@@ -45,5 +45,16 @@ RSpec.describe AppointmentNotification::ScheduleExperimentReminders, type: :job 
         described_class.perform_now
       }.to change { reminder.reload.status }.from("pending").to("scheduled")
     end
+
+    it "skips over reminders if there are failures, and sends other reminders" do
+      reminder_1 = create(:notification, subject: appointment, remind_on: today, status: "pending")
+      reminder_2 = create(:notification, subject: appointment, remind_on: today, status: "pending")
+
+      reminder_1.patient.discard
+
+      described_class.perform_now
+      expect(reminder_2.reload.status).to eq("scheduled")
+      expect(reminder_1.reload.status).to eq("pending")
+    end
   end
 end

--- a/spec/jobs/appointment_notification/schedule_experiment_reminders_spec.rb
+++ b/spec/jobs/appointment_notification/schedule_experiment_reminders_spec.rb
@@ -52,7 +52,9 @@ RSpec.describe AppointmentNotification::ScheduleExperimentReminders, type: :job 
 
       reminder_1.patient.discard
 
-      described_class.perform_now
+      expect {
+        described_class.perform_now
+      }.not_to raise_error
       expect(reminder_2.reload.status).to eq("scheduled")
       expect(reminder_1.reload.status).to eq("pending")
     end


### PR DESCRIPTION
**Story card:** [ch4452](https://app.clubhouse.io/simpledotorg/story/4452/notifications-are-not-deleted-when-a-patient-is-deleted)

## This addresses

- Fault tolerance in the scheduler job
- ~~Deduplication of notifications~~ This will be a different story, and PR
- ~~Deletion of notifications on deletion of the patient~~ Deletion is in a [different PR](https://github.com/simpledotorg/simple-server/pull/2825)
