### PR TITLE
Fix Sri Lanka manifest typo

### DIFF
--- a/public/manifest/qa.json
+++ b/public/manifest/qa.json
@@ -19,7 +19,7 @@
       "isd_code": "251"
     },
     {
-      "country_code": "SL",
+      "country_code": "LK",
       "endpoint": "https://api-qa.simple.org/api/",
       "display_name": "Sri Lanka",
       "isd_code": "94"

--- a/public/manifest/sandbox.json
+++ b/public/manifest/sandbox.json
@@ -19,7 +19,7 @@
       "isd_code": "251"
     },
     {
-      "country_code": "SL",
+      "country_code": "LK",
       "endpoint": "https://api-sandbox.simple.org/api/",
       "display_name": "Sri Lanka",
       "isd_code": "94"


### PR DESCRIPTION
**Story card:** -

## Because

The country code is LK, not SL.

## This addresses

Fixes the country code.
