### PR TITLE
prevent gsub failing on empty an string in the duplicate facility check

### DIFF
--- a/app/validators/csv/facilities_validator.rb
+++ b/app/validators/csv/facilities_validator.rb
@@ -31,7 +31,7 @@ class Csv::FacilitiesValidator
   def duplicate_rows
     fields = facilities
       .map do |facility|
-        {name: facility[:name].gsub(/\s+/, ""),
+        {name: facility[:name]&.gsub(/\s+/, ""),
          organization_name: facility[:organization_name],
          facility_group_name: facility[:facility_group_name]}
       end


### PR DESCRIPTION
**Story card:** none

## Because

https://sentry.io/organizations/resolve-to-save-lives/issues/2574085855

Uploading a facilities CSV where a facility row is missing a name fails in the duplicate check. It should actually fail in the per facility validation step instead, this will give the user actionable error messages

## This addresses

Allows the duplicate check to pass through facilities without a name