### PR TITLE
Admin access form performance

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -139,6 +139,6 @@ class AdminsController < AdminController
   end
 
   def set_facilities_pre_checks(user)
-    user.visible_facilities.map(&:id).product([true]).to_h
+    @facilities_pre_checks = user.visible_facilities.map(&:id).product([true]).to_h
   end
 end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -28,8 +28,12 @@ class AdminsController < AdminController
         head(:not_found) && return
       end
 
-    user_being_edited = page_for_access_tree.eql?(:edit) ? AdminAccessPresenter.new(@admin) : nil
-    @facilities_pre_checks = user_being_edited && user_being_edited.visible_facilities.map(&:id).product([true]).to_h
+    if page_for_access_tree.eql?(:edit)
+      user_being_edited = AdminAccessPresenter.new(@admin)
+      set_facilities_pre_checks(user_being_edited)
+    else
+      user_being_edited = nil
+    end
 
     render partial: access_tree[:render_partial],
            locals: {
@@ -132,5 +136,9 @@ class AdminsController < AdminController
 
   def validate_selected_facilities?
     selected_facilities.blank? && user_params[:access_level] != User.access_levels[:power_user]
+  end
+
+  def set_facilities_pre_checks(user)
+    user.visible_facilities.map(&:id).product([true]).to_h
   end
 end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -29,6 +29,7 @@ class AdminsController < AdminController
       end
 
     user_being_edited = page_for_access_tree.eql?(:edit) ? AdminAccessPresenter.new(@admin) : nil
+    @facilities_pre_checks = user_being_edited && user_being_edited.visible_facilities.map(&:id).product([true]).to_h
 
     render partial: access_tree[:render_partial],
            locals: {

--- a/app/models/user_access.rb
+++ b/app/models/user_access.rb
@@ -84,7 +84,7 @@ class UserAccess
   end
 
   def accessible_facilities(action)
-    return Facility.all.includes(:region) if power_user?
+    return Facility.all.includes(:region, facility_group: :organization) if power_user?
     resources_for(Facility, action)
       .union(Facility.where(facility_group: accessible_facility_groups(action)))
       .includes(:region, facility_group: :organization)

--- a/app/views/email_authentications/invitations/_facility_access_tree.html.erb
+++ b/app/views/email_authentications/invitations/_facility_access_tree.html.erb
@@ -13,7 +13,7 @@
         <div class="form-check <%= "show" if page.eql?(:show) %>">
 
           <% unless page.eql?(:show) %>
-            <% pre_checked = page.eql?(:edit) && user_being_edited.visible_facilities.include?(facility) %>
+            <% pre_checked = page.eql?(:edit) && @facilities_pre_checks[facility.id] %>
             <%= access_checkbox(:facilities, facility, checked: pre_checked) %>
           <% end %>
 


### PR DESCRIPTION
**Story card:** [ch4550](https://app.clubhouse.io/simpledotorg/story/4550)

## Because

We received reports of timeout errors on the admin access page on IHCI. This was likely happening because of the large number of facilities added recently.

## This addresses

- Adds a missing `includes` that speeds up the `visible_access_tree` method. This is a regression that got introduced in https://github.com/simpledotorg/simple-server/pull/2841. On a data set half the size of prod, this cuts down the request time from 28s to 13s.
- Use a hash to calculate if a facility's checkbox should be checked. We were checking with an `include?` on every facility, which is `O(n^2)` (for 5k facilities = 25M operations). The hash lookup is `O(n)`. This brings the time down from 13s to ~3 seconds.
- (investigating) The time for a full page render is currently at ~15s of which the DOM paint takes ~10s, only ~5s is AJAX. 
From some preliminary digging, it looks we are spending the majority of this time in the function [nodeListToArray](https://github.com/simpledotorg/simple-server/blob/9f7decab010743015335312de38d4a4804455abc/app/assets/javascripts/common/admins.js#L324)
![image](https://user-images.githubusercontent.com/16774200/129535753-b4176f1a-09a4-4e40-bce4-37ec09981a38.png).


This PR fixes the timeout issue. The JS can be addressed in a follow up PR.