### PR TITLE
Add drug stock config for losartan 50 mg, goa protocol

### DIFF
--- a/config/data/drug_stock_config.yml
+++ b/config/data/drug_stock_config.yml
@@ -39,6 +39,7 @@ Goa:
       new_patient_coefficient: 0.65
       '316764': 1
       '316765': 2
+      '979467': 1
     hypertension_diuretic:
       new_patient_coefficient: 0.06
       'Chlor6.25': 1


### PR DESCRIPTION
**Story card:** [ch4601](https://app.clubhouse.io/simpledotorg/story/4601/add-drug-stock-factor-for-losartan-50mg-goa)

## Because

We want to start tracking drug stock for Losartan 50mg in Goa
