### PR TITLE
Bugfix: invitations controller

### DIFF
--- a/app/controllers/email_authentications/invitations_controller.rb
+++ b/app/controllers/email_authentications/invitations_controller.rb
@@ -1,6 +1,7 @@
 class EmailAuthentications::InvitationsController < Devise::InvitationsController
   before_action :verify_params, only: [:create]
   helper_method :current_admin
+  helper_method :current_enabled_features
 
   rescue_from UserAccess::NotAuthorizedError, with: :user_not_authorized
 
@@ -85,5 +86,9 @@ class EmailAuthentications::InvitationsController < Devise::InvitationsControlle
   def user_not_authorized
     flash[:alert] = "You are not authorized to perform this action."
     redirect_to(request.referrer || root_path)
+  end
+
+  def current_enabled_features
+    Flipper.features.select { |feature| feature.enabled?(current_admin) }.map(&:name)
   end
 end


### PR DESCRIPTION
**Story card:** [chXXXX](URL)

## Because

A `current_enabled_features` helper method was added to `AdminController` in #2849. It's called from the application layout but the method is not defined for `InvitationsController`. Sentry: https://sentry.io/organizations/resolve-to-save-lives/issues/2584293498/?referrer=slack

## This addresses

Adds the method to `InvitationsController`