### PR TITLE
Facility search on user edit page

### DIFF
--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -24,7 +24,9 @@
       <%= form.password_field :password_confirmation, id: :user_password_confirmation, pattern: "[0-9]{4}", label: "PIN confirmation", optional: true %>
       <%= form.select :registration_facility_id, current_admin.accessible_facilities(:manage) \
         .sort_by { |facility| facility.name.sub /^Dr(.?)(\s*)/, '' } \
-        .collect { |facility| [facility.name, facility.id] } %>
+        .collect { |facility| [facility.name, facility.id] },
+        {},
+        {class: "selectpicker", data: {live_search: true, size: 5}} %>
       <%= form.primary %>
     <% end %>
   </div>

--- a/spec/pages/admin/users/edit.rb
+++ b/spec/pages/admin/users/edit.rb
@@ -13,7 +13,8 @@ module AdminPage
       end
 
       def edit_registration_facility(name)
-        find(:xpath, "//select[@name='user[registration_facility_id]']").find(:option, name).select_option
+        find(:xpath, "//select[@name='user[registration_facility_id]']/following-sibling::button").click
+        find("ul.dropdown-menu.inner > li", text: name).click
         click(UPDATE_USER)
       end
     end


### PR DESCRIPTION
**Story card:** [ch3936](https://app.clubhouse.io/simpledotorg/story/3936/facility-search-bar)

## Because

It's hard for power users to scroll through a dropdown of 10000 facilities to assign a user's facility

## This addresses

Adding a search-bar-powered dropdown using standard `bootstrap-select` tools.

### Desktop gif

![desktop](http://g.recordit.co/AKSf2TODc2.gif)

### Mobile screenshot

<img src="https://user-images.githubusercontent.com/4241399/130176976-334f29cd-a441-4131-8bbf-deccbf1aa32a.jpeg" width=500>
