### PR TITLE
Prevent the gh bot stale action killing #2660

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,4 +14,4 @@ jobs:
         stale-pr-message: 'This PR is stale. Please review/update it or close it.'
         stale-pr-label: 'stale-pr'
         days-before-stale: 10
-        days-before-pr-close: -1
+        exempt-pr-labels: 'keep-alive'


### PR DESCRIPTION
**Story card:** [ch4362](https://app.clubhouse.io/simpledotorg/story/4362/allow-the-github-stale-action-to-close-stale-prs)

## Because

We tried this earlier with https://github.com/simpledotorg/simple-server/pull/2768, but that doesn't seem to have worked. Trying a different approach.

## This addresses

Use an exempt-pr-label to keep the PR around