### PR TITLE
Facility search on Overdue page

### DIFF
--- a/app/views/layouts/overdue.html.erb
+++ b/app/views/layouts/overdue.html.erb
@@ -5,23 +5,13 @@
   <p>
     Patients that are overdue for a follow-up visit<% if current_admin.accessible_facilities(:manage_overdue_list) %>. If you select a facility, you can download a patient list.<% end %>
   </p>
-  <% if current_admin.accessible_facilities(:manage_overdue_list) %>
-    <%= render('shared/paginate_and_filter_by_facility',
-               form_url: appointments_path,
-               current_admin: current_admin,
-               facility_id: @facility_id,
-               per_page: @per_page,
-               form_id: "search-filters",
-               scope_namespace: current_admin.accessible_facilities(:manage_overdue_list)) %>
-  <% else %>
-    <%= render('shared/paginate_and_filter_by_facility',
-               form_url: appointments_path,
-               current_admin: current_admin,
-               facility_id: @facility_id,
-               per_page: @per_page,
-               form_id: "search-filters",
-               scope_namespace: [:overdue_list, Facility]) %>
-  <% end %>
+  <%= render('shared/paginate_and_filter_by_facility',
+             form_url: appointments_path,
+             current_admin: current_admin,
+             facility_id: @facility_id,
+             per_page: @per_page,
+             form_id: "search-filters",
+             scope_namespace: current_admin.accessible_facilities(:manage_overdue_list)) %>
   <section class="secondary-nav-filters">
     <h4 class="mt-2">
       Filters

--- a/app/views/shared/_paginate_and_filter_by_facility.html.erb
+++ b/app/views/shared/_paginate_and_filter_by_facility.html.erb
@@ -1,7 +1,7 @@
 <%= bootstrap_form_with(url: form_url, method: :get, layout: :horizontal, class: "mt-4") do |form| %>
   <% form_id = local_assigns[:form_id]
-     html_options = { onchange: "this.form.submit();" }
-     html_options.merge!(form: form_id) if form_id.present?
+     facility_html_options = { form: form_id, onchange: "this.form.submit();", class: "selectpicker", data: {live_search: true} }.compact
+     page_html_options = { form: form_id, onchange: "this.form.submit();" }.compact
   %>
   <div class="form-row">
     <div id="facility-selector" class="form-group col-md-6">
@@ -13,7 +13,7 @@
                           selected: facility_id,
                           wrapper: false
                       },
-                      html_options
+                      facility_html_options
       %>
     </div>
     <div id="limit-selector" class="form-group col-md-3">
@@ -23,7 +23,7 @@
                           hide_label: true,
                           selected: per_page,
                       },
-                      html_options
+                      page_html_options
       %>
     </div>
   </div>

--- a/spec/features/appointments/index_spec.rb
+++ b/spec/features/appointments/index_spec.rb
@@ -28,7 +28,6 @@ RSpec.feature "To test overdue appointment functionality", type: :feature do
     it "landing page -Facility and page dropdown " do
       create_list(:facility, 2, facility_group: ihmi_facility_group)
       nav_page.click_main_menu_tab("Overdue")
-      appoint_page.select_facility_drop_down
       expect(appoint_page.get_all_facility_count).to eq(2)
 
       appoint_page.select_page_dropdown

--- a/spec/pages/appointments/index.rb
+++ b/spec/pages/appointments/index.rb
@@ -21,12 +21,12 @@ module AppointmentsPage
     end
 
     def select_facility_drop_down
-      click(FACILITY_DROPDOWN)
+      find(:xpath, "//select[@name='facility_id']/following-sibling::button").click
     end
 
     def get_all_facility_count
-      click(FACILITY_DROPDOWN)
-      all_option = find(:css, "select[name='facility_id']").all("option").collect(&:text)
+      select_facility_drop_down
+      all_option = find(:css, "select[name='facility_id'] ~ .dropdown-menu").all("li").collect(&:text)
       # We subtract 1 to exclude the value of "All Facilities"
       all_option.length - 1
     end


### PR DESCRIPTION
Follow-up to #2864 

**Story card:** [ch3936](https://app.clubhouse.io/simpledotorg/story/3936/facility-search-bar)

## Because

The overdue page also has a giant facility list dropdown

## This addresses

Making it searchable so that a list of 10k facilities can be managed.

<img width="1175" alt="Screen Shot 2021-08-20 at 3 37 00 PM" src="https://user-images.githubusercontent.com/4241399/130217682-b42cb063-82b0-434e-bb4e-3b2a577355ad.png">
