### PR TITLE
Point ET Demo to simple.org subdomain

### DIFF
--- a/public/manifest/demo.json
+++ b/public/manifest/demo.json
@@ -14,7 +14,7 @@
     },
     {
       "country_code": "ET",
-      "endpoint": "https://simple-demo.moh.gov.et/api/",
+      "endpoint": "https://api-demo.et.simple.org/api/",
       "display_name": "Ethiopia",
       "isd_code": "251"
     },


### PR DESCRIPTION
The moh.gov.in subdomain's ssl cert has expired, and we wish
to unblock a training session immediately

**Story card:** @harimohanraj89 will fill this stuff in later.