### PR TITLE
Progress tab cache bug fix

### DIFF
--- a/app/controllers/api/v3/analytics/user_analytics_controller.rb
+++ b/app/controllers/api/v3/analytics/user_analytics_controller.rb
@@ -2,6 +2,7 @@ class Api::V3::Analytics::UserAnalyticsController < Api::V3::AnalyticsController
   include ApplicationHelper
   include SetForEndOfMonth
   before_action :set_for_end_of_month
+  before_action :set_bust_cache
 
   layout false
 
@@ -20,5 +21,9 @@ class Api::V3::Analytics::UserAnalyticsController < Api::V3::AnalyticsController
       format.html { render :show }
       format.json { render json: stats }
     end
+  end
+
+  def set_bust_cache
+    RequestStore.store[:bust_cache] = true if params[:bust_cache].present?
   end
 end

--- a/app/presenters/user_analytics_presenter.rb
+++ b/app/presenters/user_analytics_presenter.rb
@@ -4,6 +4,7 @@ class UserAnalyticsPresenter
   include PeriodHelper
   include DashboardHelper
   include ActionView::Helpers::NumberHelper
+  include BustCache
 
   def initialize(current_facility)
     @current_facility = current_facility
@@ -146,7 +147,7 @@ class UserAnalyticsPresenter
 
   def statistics
     @statistics ||=
-      Rails.cache.fetch(statistics_cache_key, expires_in: EXPIRE_STATISTICS_CACHE_IN) {
+      Rails.cache.fetch(statistics_cache_key, expires_in: EXPIRE_STATISTICS_CACHE_IN, force: bust_cache?) {
         {
           daily: daily_stats,
           monthly: monthly_stats,

--- a/app/presenters/user_analytics_presenter.rb
+++ b/app/presenters/user_analytics_presenter.rb
@@ -371,7 +371,7 @@ class UserAnalyticsPresenter
   end
 
   def statistics_cache_key
-    "user_analytics/#{current_facility.id}/#{CACHE_VERSION}"
+    "user_analytics/#{current_facility.id}/#{diabetes_enabled?}/#{CACHE_VERSION}"
   end
 
   def sum_by_gender(data)


### PR DESCRIPTION
**Story card:** [chXXXX](URL)

## Because

When DM is enabled for a facility, the cached progress tab results cause an error because they don't have any diabetes related information but the view expects it. Sentry: https://sentry.io/organizations/resolve-to-save-lives/issues/2598315876/?referrer=slack

## This addresses
Adds `diabetes_enabled?` to the cache key so the cache is updated when the DM status of a facility is changed.
