### PR TITLE
Improve facility deletion

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -408,7 +408,7 @@ h6.dropdown-header {
 
 .btn.disabled {
     background: $grey-lightest;
-    border-color: $grey-lightest;
+    border-color: $grey-mid;
     color: $grey-mid;
 }
 

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -210,8 +210,24 @@ class Facility < ApplicationRecord
     teleconsultation_medical_officers.map(&:full_teleconsultation_phone_number)
   end
 
+  def records_preventing_discard
+    {
+      "registered patients" => registered_patients,
+      "blood pressures" => blood_pressures,
+      "blood sugars" => blood_sugars,
+      "scheduled appointments" => appointments.status_scheduled,
+      "users" => users
+    }
+  end
+
   def discardable?
-    registered_patients.none? && blood_pressures.none? && blood_sugars.none? && appointments.status_scheduled.none? && users.none?
+    records_preventing_discard.values.all? { |records| records.none? }
+  end
+
+  def discard_prevention_reasons
+    records_preventing_discard.map do |record_name, records|
+      "#{records.count} #{record_name}" if records.any?
+    end.compact
   end
 
   def valid_block

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -212,11 +212,11 @@ class Facility < ApplicationRecord
 
   def records_preventing_discard
     {
-      "registered patients" => registered_patients,
-      "blood pressures" => blood_pressures,
-      "blood sugars" => blood_sugars,
-      "scheduled appointments" => appointments.status_scheduled,
-      "users" => users
+      "registered patient" => registered_patients,
+      "blood pressure" => blood_pressures,
+      "blood sugar" => blood_sugars,
+      "scheduled appointment" => appointments.status_scheduled,
+      "user" => users
     }
   end
 
@@ -226,7 +226,10 @@ class Facility < ApplicationRecord
 
   def discard_prevention_reasons
     records_preventing_discard.map do |record_name, records|
-      "#{records.count} #{record_name}" if records.any?
+      if records.any?
+        number_of_records = records.count
+        "#{number_of_records} #{record_name.pluralize(number_of_records)}"
+      end
     end.compact
   end
 

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -211,7 +211,7 @@ class Facility < ApplicationRecord
   end
 
   def discardable?
-    registered_patients.none? && blood_pressures.none? && blood_sugars.none? && appointments.none?
+    registered_patients.none? && blood_pressures.none? && blood_sugars.none? && appointments.status_scheduled.none? && users.none?
   end
 
   def valid_block

--- a/app/views/admin/facilities/edit.html.erb
+++ b/app/views/admin/facilities/edit.html.erb
@@ -2,9 +2,21 @@
   <h1 class="page-title">Edit facility</h1>
   <nav class="page-nav">
 
-    <% if current_admin.accessible_facilities(:manage).find_by_id(@facility) && @facility.discardable? %>
-      <%= link_to 'Delete facility', [:admin, @facility_group, @facility], method: :delete, data: {confirm: "Are you sure you want to delete #{@facility.name}?"}, class: "btn btn-outline-danger ml-4" %>
+    <% if current_admin.accessible_facilities(:manage).find_by_id(@facility) %>
+    <span class="d-inline-block"
+          tabindex="0"
+          data-toggle="tooltip"
+          data-placement="bottom"
+          title="<% unless @facility.discardable? %>
+                  This facility cannot be deleted because <%= @facility.discard_prevention_reasons.join(', ') %> are present.
+                 <% end %>">
+      <%= link_to 'Delete facility',
+                  [:admin, @facility_group, @facility],
+                  method: :delete,
+                  data: { confirm: "Are you sure you want to delete #{@facility.name}?" },
+                  class: "btn btn-outline-danger ml-4 #{'disabled' unless @facility.discardable?}" %>
     <% end %>
+    </span>
   </nav>
 </div>
 

--- a/app/views/admin/facilities/edit.html.erb
+++ b/app/views/admin/facilities/edit.html.erb
@@ -9,6 +9,7 @@
           data-placement="bottom"
           title="<% unless @facility.discardable? %>
                   This facility cannot be deleted because it contains <%= @facility.discard_prevention_reasons.to_sentence %>.
+                  Please transfer all data to a different facility to delete this facility.
                  <% end %>">
       <%= link_to 'Delete facility',
                   [:admin, @facility_group, @facility],

--- a/app/views/admin/facilities/edit.html.erb
+++ b/app/views/admin/facilities/edit.html.erb
@@ -8,7 +8,7 @@
           data-toggle="tooltip"
           data-placement="bottom"
           title="<% unless @facility.discardable? %>
-                  This facility cannot be deleted because <%= @facility.discard_prevention_reasons.join(', ') %> are present.
+                  This facility cannot be deleted because it contains <%= @facility.discard_prevention_reasons.to_sentence %>.
                  <% end %>">
       <%= link_to 'Delete facility',
                   [:admin, @facility_group, @facility],

--- a/app/views/admin/facilities/edit.html.erb
+++ b/app/views/admin/facilities/edit.html.erb
@@ -4,7 +4,6 @@
 
     <% if current_admin.accessible_facilities(:manage).find_by_id(@facility) %>
     <span class="d-inline-block"
-          tabindex="0"
           data-toggle="tooltip"
           data-placement="bottom"
           title="<% unless @facility.discardable? %>

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -418,8 +418,13 @@ RSpec.describe Facility, type: :model do
         expect(facility.discardable?).to be false
       end
 
-      it "has appointments" do
-        create(:appointment, facility: facility)
+      it "has scheduled appointments" do
+        create(:appointment, status: :scheduled, facility: facility)
+        expect(facility.discardable?).to be false
+      end
+
+      it "has registered users" do
+        create(:user, registration_facility: facility)
         expect(facility.discardable?).to be false
       end
     end


### PR DESCRIPTION
**Story card:** [ch3523](https://app.clubhouse.io/simpledotorg/story/3523/improve-facility-deletion-from-dashboard)

## Because

The `Delete facility` button on edit facility page does not have good messaging when it's disallowed.

## This addresses

- [X] Check if any registered users are present in the facility before allowing to delete
- [X] Check for the presence of only scheduled appointments
- [x] Display on the page why deletion is not allowed

### Display why deletion is not allowed

Currently the `Delete facility` button is hidden without any messaging. This disables the button if deletion is not allowed and adds a tooltip that shows the records that are preventing the deletion so an admin can fix them.

![image](https://user-images.githubusercontent.com/16774200/130781531-48fbd0dc-7fd7-4c42-9824-c91143124bc6.png)


