### PR TITLE
Add Gujarat drug stock coefficients

### DIFF
--- a/config/data/drug_stock_config.yml
+++ b/config/data/drug_stock_config.yml
@@ -46,6 +46,7 @@ Goa:
       '331132': 2
 Gujarat:
   load_coefficient: 1
+  drug_categories:
     hypertension_ccb:
       new_patient_coefficient: 1.12
       '329528': 1

--- a/config/data/drug_stock_config.yml
+++ b/config/data/drug_stock_config.yml
@@ -44,6 +44,19 @@ Goa:
       new_patient_coefficient: 0.06
       'Chlor6.25': 1
       '331132': 2
+Gujarat:
+  load_coefficient: 1
+    hypertension_ccb:
+      new_patient_coefficient: 1.12
+      '329528': 1
+      '329526': 2
+    hypertension_arb:
+      new_patient_coefficient: 0.65
+      '316764': 1
+      '316765': 2
+    hypertension_diuretic:
+      new_patient_coefficient: 0.06
+      '331132': 1
 Jharkhand:
   load_coefficient: 1
   drug_categories:


### PR DESCRIPTION
**Story card:** [ch4803](https://app.clubhouse.io/simpledotorg/story/4803/enable-drug-stock-tracking-for-gujarat)

## Because

We want to enable drug stock tracking in Gujarat

## This addresses

Adds the drug stock coefficients for Gujarat 