### PR TITLE
Extract FlipperInfo; send feature flags to DataDog as tags

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,7 +1,10 @@
 class AdminController < ApplicationController
   include BustCache
+  include FlipperInfo
+
   before_action :authenticate_email_authentication!
   before_action :set_bust_cache
+  before_action :set_enabled_features_as_datadog_tags
 
   after_action :verify_authorization_attempted, except: [:root]
 
@@ -29,7 +32,6 @@ class AdminController < ApplicationController
   end
 
   helper_method :current_admin
-  helper_method :current_enabled_features
 
   private
 
@@ -38,10 +40,6 @@ class AdminController < ApplicationController
     admin = current_email_authentication.user
     admin.email_authentications.load
     @current_admin = admin
-  end
-
-  def current_enabled_features
-    Flipper.features.select { |feature| feature.enabled?(current_admin) }.map(&:name)
   end
 
   def pundit_user

--- a/app/controllers/email_authentications/invitations_controller.rb
+++ b/app/controllers/email_authentications/invitations_controller.rb
@@ -1,7 +1,7 @@
 class EmailAuthentications::InvitationsController < Devise::InvitationsController
+  include FlipperInfo
   before_action :verify_params, only: [:create]
   helper_method :current_admin
-  helper_method :current_enabled_features
 
   rescue_from UserAccess::NotAuthorizedError, with: :user_not_authorized
 
@@ -86,9 +86,5 @@ class EmailAuthentications::InvitationsController < Devise::InvitationsControlle
   def user_not_authorized
     flash[:alert] = "You are not authorized to perform this action."
     redirect_to(request.referrer || root_path)
-  end
-
-  def current_enabled_features
-    Flipper.features.select { |feature| feature.enabled?(current_admin) }.map(&:name)
   end
 end

--- a/app/controllers/flipper_info.rb
+++ b/app/controllers/flipper_info.rb
@@ -11,6 +11,6 @@ module FlipperInfo
   def set_enabled_features_as_datadog_tags
     current_span = Datadog.tracer.active_span
     return if current_span.nil?
-    current_span.set_tag(:enabled_features, current_enabled_features)
+    current_span.set_tag(:enabled_features, current_enabled_features.map(&:to_s))
   end
 end

--- a/app/controllers/flipper_info.rb
+++ b/app/controllers/flipper_info.rb
@@ -1,0 +1,16 @@
+# Expose currently enabled features from Flipper for admin / dashboard requests
+module FlipperInfo
+  def self.included(base)
+    base.helper_method :current_enabled_features
+  end
+
+  def current_enabled_features
+    @current_enabled_features ||= Flipper.features.select { |feature| feature.enabled?(current_admin) }.map(&:name)
+  end
+
+  def set_enabled_features_as_datadog_tags
+    current_span = Datadog.tracer.active_span
+    return if current_span.nil?
+    current_span.set_tag(:enabled_features, current_enabled_features)
+  end
+end

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -86,6 +86,20 @@ RSpec.describe AdminController, type: :controller do
     end
   end
 
+  context "flipper info" do
+    it "sends enabled features as datadog tag" do
+      Flipper.enable(:enabled_1)
+      Flipper.enable(:enabled_2)
+      Flipper.disable(:disabled)
+      span_double = instance_double("Datadog::Span")
+
+      expect(span_double).to receive(:set_tag).with(:enabled_features, ["enabled_1", "enabled_2"])
+      expect(Datadog.tracer).to receive(:active_span).and_return(span_double)
+      routes.draw { get "authorized" => "admin#authorized" }
+      get :authorized
+    end
+  end
+
   context "#verify_authorization_attempted" do
     it "raises an error if authorize is not called but required" do
       routes.draw { get "authorization_not_attempted" => "admin#authorization_not_attempted" }


### PR DESCRIPTION
**Story card:** [ch4811](https://app.clubhouse.io/simpledotorg/story/4811/get-feature-flag-info-into-datadog)

We need to send current features to datadog inside the scope of a request, as it will help us better see changes in perf between feature toggles.

docs https://docs.datadoghq.com/tracing/guide/add_span_md_and_graph_it/