### PR TITLE
Don't try to serialize if patient is missing an address

### DIFF
--- a/spec/transformers/api/v3/patient_transformer_spec.rb
+++ b/spec/transformers/api/v3/patient_transformer_spec.rb
@@ -41,5 +41,12 @@ RSpec.describe Api::V3::PatientTransformer do
       transformed_nested_patient = Api::V3::PatientTransformer.to_nested_response(patient)
       expect(transformed_nested_patient["registration_facility_id"]).to eq(patient.registration_facility.id)
     end
+
+    it "patient does not have an existing address" do
+      patient.address_id = nil
+      patient.save!
+      transformed_nested_patient = Api::V3::PatientTransformer.to_nested_response(patient)
+      expect(transformed_nested_patient["address"]).to eq({})
+    end
   end
 end

--- a/spec/transformers/api/v3/patient_transformer_spec.rb
+++ b/spec/transformers/api/v3/patient_transformer_spec.rb
@@ -42,7 +42,14 @@ RSpec.describe Api::V3::PatientTransformer do
       expect(transformed_nested_patient["registration_facility_id"]).to eq(patient.registration_facility.id)
     end
 
-    it "patient does not have an existing address" do
+    it "patient does not have an associated existing address" do
+      transformed_nested_patient = Api::V3::PatientTransformer.to_nested_response(patient)
+      expected_hsh = Api::V3::Transformer.to_response(patient.address)
+
+      expect(transformed_nested_patient["address"]).to eq(expected_hsh)
+    end
+
+    it "patient does not have an associated existing address" do
       patient.address_id = nil
       patient.save!
       transformed_nested_patient = Api::V3::PatientTransformer.to_nested_response(patient)


### PR DESCRIPTION
**Story card:** [ch4632](https://app.clubhouse.io/simpledotorg/story/4632/undefined-method-attributes-for-nil-nilclass-in-sync-api-when-patient-does-not-have-address)

