### PR TITLE
Send total record counts to Datadog as a gauge

### DIFF
--- a/app/jobs/record_counter_job.rb
+++ b/app/jobs/record_counter_job.rb
@@ -1,0 +1,7 @@
+class RecordCounterJob
+  include Sidekiq::Worker
+
+  def perform
+    RecordCounter.call
+  end
+end

--- a/app/services/record_counter.rb
+++ b/app/services/record_counter.rb
@@ -10,13 +10,28 @@ class RecordCounter
     User
   ]
 
+  def self.call
+    new.call
+  end
+
+  attr_reader :metrics
+
+  def initialize
+    @metrics ||= Metrics.with_prefix("counts")
+  end
+
   def call
     MODELS_TO_COUNT.each do |model|
       metrics.gauge(model.to_s, model.count)
     end
+    Region.facility_regions.find_each do |facility|
+      count = facility.assigned_patients
+      metrics.histogram("assigned_patients_per_facility", count)
+    end
+    Region.block_regions.each do |block|
+      count = block.assigned_patients
+      metrics.histogram("assigned_patients_per_block", count)
+    end
   end
 
-  def metrics
-    @metrics ||= Metrics.with_prefix("total_counts")
-  end
 end

--- a/app/services/record_counter.rb
+++ b/app/services/record_counter.rb
@@ -3,8 +3,10 @@ class RecordCounter
     Appointment,
     BloodPressure,
     BloodSugar,
+    Encounter,
     Facility,
     FacilityGroup,
+    MedicalHistory,
     Notification,
     Patient,
     Region,
@@ -22,9 +24,19 @@ class RecordCounter
   end
 
   def call
+    count_totals
+    count_per_region_totals
+  end
+
+  private
+
+  def count_totals
     MODELS_TO_COUNT.each do |model|
       metrics.gauge(model.to_s, model.count)
     end
+  end
+
+  def count_per_region_totals
     Region.facility_regions.find_each do |facility|
       count = facility.assigned_patients.count
       metrics.histogram("assigned_patients_per_facility", count)

--- a/app/services/record_counter.rb
+++ b/app/services/record_counter.rb
@@ -25,13 +25,12 @@ class RecordCounter
       metrics.gauge(model.to_s, model.count)
     end
     Region.facility_regions.find_each do |facility|
-      count = facility.assigned_patients
+      count = facility.assigned_patients.count
       metrics.histogram("assigned_patients_per_facility", count)
     end
     Region.block_regions.each do |block|
-      count = block.assigned_patients
+      count = block.assigned_patients.count
       metrics.histogram("assigned_patients_per_block", count)
     end
   end
-
 end

--- a/app/services/record_counter.rb
+++ b/app/services/record_counter.rb
@@ -5,6 +5,7 @@ class RecordCounter
     BloodSugar,
     Facility,
     FacilityGroup,
+    Notification,
     Patient,
     Region,
     User

--- a/app/services/record_counter.rb
+++ b/app/services/record_counter.rb
@@ -28,7 +28,7 @@ class RecordCounter
       count = facility.assigned_patients.count
       metrics.histogram("assigned_patients_per_facility", count)
     end
-    Region.block_regions.each do |block|
+    Region.block_regions.find_each.each do |block|
       count = block.assigned_patients.count
       metrics.histogram("assigned_patients_per_block", count)
     end

--- a/app/services/record_counter.rb
+++ b/app/services/record_counter.rb
@@ -1,0 +1,22 @@
+class RecordCounter
+  MODELS_TO_COUNT = [
+    Appointment,
+    BloodPressure,
+    BloodSugar,
+    Facility,
+    FacilityGroup,
+    Patient,
+    Region,
+    User
+  ]
+
+  def call
+    MODELS_TO_COUNT.each do |model|
+      metrics.gauge(model.to_s, model.count)
+    end
+  end
+
+  def metrics
+    @metrics ||= Metrics.with_prefix("total_counts")
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -35,6 +35,10 @@ every :day, at: local("02:00 am"), roles: [:cron] do
   runner "PatientDeduplication::Runner.new(PatientDeduplication::Strategies.identifier_and_full_name_match).perform"
 end
 
+every :day, at: local("02:30 am"), roles: [:cron] do
+  runner "RecordCounter.call"
+end
+
 every :day, at: local("04:00 am"), roles: [:cron] do
   runner "Reports::RegionCacheWarmer.call"
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -31,12 +31,12 @@ every :day, at: local("01:00 am"), roles: [:cron] do
   runner "MarkPatientMobileNumbers.call"
 end
 
-every :day, at: local("02:00 am"), roles: [:cron] do
-  runner "PatientDeduplication::Runner.new(PatientDeduplication::Strategies.identifier_and_full_name_match).perform"
+every :day, at: local("01:50 am"), roles: [:cron] do
+  runner "RecordCounter.perform_async"
 end
 
-every :day, at: local("01:30 am"), roles: [:cron] do
-  runner "RecordCounter.perform_async"
+every :day, at: local("02:00 am"), roles: [:cron] do
+  runner "PatientDeduplication::Runner.new(PatientDeduplication::Strategies.identifier_and_full_name_match).perform"
 end
 
 every :day, at: local("04:00 am"), roles: [:cron] do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -36,7 +36,7 @@ every :day, at: local("02:00 am"), roles: [:cron] do
 end
 
 every :day, at: local("02:30 am"), roles: [:cron] do
-  runner "RecordCounter.call"
+  runner "RecordCounter.perform_async"
 end
 
 every :day, at: local("04:00 am"), roles: [:cron] do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -35,7 +35,7 @@ every :day, at: local("02:00 am"), roles: [:cron] do
   runner "PatientDeduplication::Runner.new(PatientDeduplication::Strategies.identifier_and_full_name_match).perform"
 end
 
-every :day, at: local("02:30 am"), roles: [:cron] do
+every :day, at: local("01:30 am"), roles: [:cron] do
   runner "RecordCounter.perform_async"
 end
 

--- a/lib/metrics.rb
+++ b/lib/metrics.rb
@@ -12,6 +12,11 @@ class Metrics
     @prefix = prefix
   end
 
+  def gauge(event, count)
+    name = "#{@prefix}.#{event}"
+    Statsd.instance.gauge(name, count)
+  end
+
   def increment(event)
     name = "#{@prefix}.#{event}"
     Statsd.instance.increment(name)

--- a/lib/metrics.rb
+++ b/lib/metrics.rb
@@ -21,4 +21,9 @@ class Metrics
     name = "#{@prefix}.#{event}"
     Statsd.instance.increment(name)
   end
+
+  def histogram(event, count)
+    name = "#{@prefix}.#{event}"
+    Statsd.instance.histogram(name, count)
+  end
 end

--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -20,6 +20,7 @@ class Statsd
     count
     flush
     gauge
+    histogram
     increment
     time
     timing

--- a/spec/jobs/record_counter_job_spec.rb
+++ b/spec/jobs/record_counter_job_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe RecordCounterJob, type: :job do
+  it "works" do
+    described_class.new.perform
+  end
+end

--- a/spec/services/record_counter_spec.rb
+++ b/spec/services/record_counter_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe RecordCounter do
     expect(Statsd.instance).to receive(:gauge).with("counts.BloodPressure", 1)
     expect(Statsd.instance).to receive(:gauge).with("counts.Facility", 2)
     expect(Statsd.instance).to receive(:gauge).with("counts.FacilityGroup", 2)
+    expect(Statsd.instance).to receive(:gauge).with("counts.MedicalHistory", 3)
     expect(Statsd.instance).to receive(:gauge).with("counts.Patient", 3)
     expect(Statsd.instance).to receive(:gauge).with("counts.Region", Region.count)
     expect(Statsd.instance).to receive(:gauge).with("counts.User", 1)

--- a/spec/services/record_counter_spec.rb
+++ b/spec/services/record_counter_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe RecordCounter do
     expect(Statsd.instance).to receive(:gauge).with("counts.Region", Region.count)
     expect(Statsd.instance).to receive(:gauge).with("counts.User", 1)
 
+    expect(Statsd.instance).to receive(:histogram)
+      .with("counts.assigned_patients_per_facility", kind_of(Numeric)).at_least(1).times
+    expect(Statsd.instance).to receive(:histogram)
+      .with("counts.assigned_patients_per_block", kind_of(Numeric)).at_least(1).times
     RecordCounter.new.call
   end
 end

--- a/spec/services/record_counter_spec.rb
+++ b/spec/services/record_counter_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe RecordCounter do
+  let(:user) { create(:user) }
+  let(:facility) { create(:facility) }
+
+  it "sends total counts as gauges to Statsd" do
+    patients = create_list(:patient, 3, registration_facility: facility, registration_user: user)
+    create(:appointment, patient: patients.first, facility: facility, user: user)
+    create(:blood_pressure, patient: patients.first, facility: facility, user: user)
+
+    expect(Statsd.instance).to receive(:gauge).with(anything, 0)
+    expect(Statsd.instance).to receive(:gauge).with("total_counts.Appointment", 1)
+    expect(Statsd.instance).to receive(:gauge).with("total_counts.BloodPressure", 1)
+    expect(Statsd.instance).to receive(:gauge).with("total_counts.Facility", 2)
+    expect(Statsd.instance).to receive(:gauge).with("total_counts.FacilityGroup", 2)
+    expect(Statsd.instance).to receive(:gauge).with("total_counts.Patient", 3)
+    expect(Statsd.instance).to receive(:gauge).with("total_counts.Region", Region.count)
+    expect(Statsd.instance).to receive(:gauge).with("total_counts.User", 1)
+
+    RecordCounter.new.call
+  end
+end

--- a/spec/services/record_counter_spec.rb
+++ b/spec/services/record_counter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RecordCounter do
     create(:appointment, patient: patients.first, facility: facility, user: user)
     create(:blood_pressure, patient: patients.first, facility: facility, user: user)
 
-    expect(Statsd.instance).to receive(:gauge).with(anything, 0)
+    expect(Statsd.instance).to receive(:gauge).with(anything, 0).at_least(1).times
     expect(Statsd.instance).to receive(:gauge).with("counts.Appointment", 1)
     expect(Statsd.instance).to receive(:gauge).with("counts.BloodPressure", 1)
     expect(Statsd.instance).to receive(:gauge).with("counts.Facility", 2)

--- a/spec/services/record_counter_spec.rb
+++ b/spec/services/record_counter_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe RecordCounter do
     create(:blood_pressure, patient: patients.first, facility: facility, user: user)
 
     expect(Statsd.instance).to receive(:gauge).with(anything, 0)
-    expect(Statsd.instance).to receive(:gauge).with("total_counts.Appointment", 1)
-    expect(Statsd.instance).to receive(:gauge).with("total_counts.BloodPressure", 1)
-    expect(Statsd.instance).to receive(:gauge).with("total_counts.Facility", 2)
-    expect(Statsd.instance).to receive(:gauge).with("total_counts.FacilityGroup", 2)
-    expect(Statsd.instance).to receive(:gauge).with("total_counts.Patient", 3)
-    expect(Statsd.instance).to receive(:gauge).with("total_counts.Region", Region.count)
-    expect(Statsd.instance).to receive(:gauge).with("total_counts.User", 1)
+    expect(Statsd.instance).to receive(:gauge).with("counts.Appointment", 1)
+    expect(Statsd.instance).to receive(:gauge).with("counts.BloodPressure", 1)
+    expect(Statsd.instance).to receive(:gauge).with("counts.Facility", 2)
+    expect(Statsd.instance).to receive(:gauge).with("counts.FacilityGroup", 2)
+    expect(Statsd.instance).to receive(:gauge).with("counts.Patient", 3)
+    expect(Statsd.instance).to receive(:gauge).with("counts.Region", Region.count)
+    expect(Statsd.instance).to receive(:gauge).with("counts.User", 1)
 
     RecordCounter.new.call
   end


### PR DESCRIPTION
**Story card:** [ch4864](https://app.clubhouse.io/simpledotorg/story/4864/create-a-dashboard-with-record-counts-so-we-can-measure-our-scale-and-growth-rate)

We want to be able to track the general size of our data and how fast things are growing, and this should be possible without logging into a console or admin account.

Lets track it in data 🐶 !