### PR TITLE
Sync API - Eager load teleconsultation_medical_officers

### DIFF
--- a/app/controllers/api/v4/facility_medical_officers_controller.rb
+++ b/app/controllers/api/v4/facility_medical_officers_controller.rb
@@ -1,6 +1,6 @@
 class Api::V4::FacilityMedicalOfficersController < APIController
   def sync_to_user
-    medical_officers = current_facility_group.facilities.map { |facility|
+    medical_officers = current_facility_group.facilities.eager_load(:teleconsultation_medical_officers).map { |facility|
       facility_medical_officers(facility)
     }
     render json: to_response(medical_officers)


### PR DESCRIPTION
**Story card:** [ch4947](https://app.clubhouse.io/simpledotorg/story/4947/improve-performance-of-facilitymedicalofficerscontroller-sync-endpoint?vc_group_by=day&ct_workflow=all&cf_workflow=500000005)

## Because

This end point is way slower than it should be

## This addresses

adding eager loading to improve perf

## Test instructions

Ship this PR, and revisit the [datadog reporting](https://app.clubhouse.io/simpledotorg/story/4947/improve-performance-of-facilitymedicalofficerscontroller-sync-endpoint?vc_group_by=day&ct_workflow=all&cf_workflow=500000005) to see how it improves.

Locally I saw this change from 300-500 ms to well under 100 ms in testing.