### PR TITLE
Sync API - Eager load teleconsultation_medical_officers phone numbers also

### DIFF
--- a/app/controllers/api/v4/facility_medical_officers_controller.rb
+++ b/app/controllers/api/v4/facility_medical_officers_controller.rb
@@ -1,8 +1,8 @@
 class Api::V4::FacilityMedicalOfficersController < APIController
   def sync_to_user
-    medical_officers = current_facility_group.facilities.eager_load(:teleconsultation_medical_officers).map { |facility|
-      facility_medical_officers(facility)
-    }
+    medical_officers = current_facility_group.facilities
+      .eager_load(teleconsultation_medical_officers: :phone_number_authentications)
+      .map { |facility| facility_medical_officers(facility) }
     render json: to_response(medical_officers)
   end
 

--- a/app/controllers/api/v4/facility_medical_officers_controller.rb
+++ b/app/controllers/api/v4/facility_medical_officers_controller.rb
@@ -1,6 +1,6 @@
 class Api::V4::FacilityMedicalOfficersController < APIController
   def sync_to_user
-    medical_officers = current_facility_group.facilities.map { |facility|
+    medical_officers = current_facility_group.facilities.eager_load(:teleconsultation_medical_officers).map { |facility|
       facility_medical_officers(facility)
     }
     render json: to_response(medical_officers)

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -4,6 +4,7 @@ set -ex
 # See https://github.com/semaphoreci/toolbox for more details on the "sem-" commands
 source ~/.toolbox/toolbox
 
+cache clear
 sem-version ruby 2.6.6
 sem-service start postgres 10
 wget -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -4,7 +4,9 @@ set -ex
 # See https://github.com/semaphoreci/toolbox for more details on the "sem-" commands
 source ~/.toolbox/toolbox
 
-cache clear
+# Temporarily turn on cache clear if Semaphore has weird bunlding issues
+# cache clear
+
 sem-version ruby 2.6.6
 sem-service start postgres 10
 wget -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     full_name { Faker::Name.name }
     device_created_at { Time.current }
     device_updated_at { Time.current }
-    teleconsultation_phone_number { Faker::PhoneNumber.phone_number }
+    teleconsultation_phone_number { rand > 0.50 ? Faker::PhoneNumber.phone_number : nil }
     teleconsultation_isd_code { "+91" }
 
     sync_allowed

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -276,8 +276,8 @@ RSpec.describe User, type: :model do
       include_examples "full_name search", :teleconsult_search
 
       context "searches against phone_number and teleconsultation_phone_number" do
-        let!(:user_1) { create(:user, full_name: "Sri Priyanka John") }
-        let!(:user_2) { create(:user, full_name: "Priya Sri Gupta") }
+        let!(:user_1) { create(:user, full_name: "Sri Priyanka John", teleconsultation_phone_number: Faker::PhoneNumber.phone_number) }
+        let!(:user_2) { create(:user, full_name: "Priya Sri Gupta", teleconsultation_phone_number: Faker::PhoneNumber.phone_number) }
 
         it "matches a user with a phone number" do
           expect(User.search_by_name_or_phone(user_1.phone_number)).to match_array(user_1)


### PR DESCRIPTION
**Story card:** [ch4947](https://app.clubhouse.io/simpledotorg/story/4947/improve-performance-of-facilitymedicalofficerscontroller-sync-endpoint?vc_group_by=day&ct_workflow=all&cf_workflow=500000005)

Follow up to https://github.com/simpledotorg/simple-server/pull/2903
## Because

This end point is way slower than it should be

## This addresses

adding eager loading to the medical officers' phone number as well to improve perf

## Test instructions

Ship this PR, and revisit the [datadog reporting](https://app.clubhouse.io/simpledotorg/story/4947/improve-performance-of-facilitymedicalofficerscontroller-sync-endpoint?vc_group_by=day&ct_workflow=all&cf_workflow=500000005) to see how it improves.

I added better test data locally to better see how this end point performs and why we are loading all sorts of PhoneNumberAuthentications, hence the added eager loading here.