### PR TITLE
Enable DataDog code profiling in sandbox

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "flipper-ui"
 gem "flipper"
 gem "friendly_id", "~> 5.2.4"
 gem "github-ds"
-gem "google-protobuf", "~> 3.0", require: false
+gem "google-protobuf", "~> 3.0"
 gem "groupdate"
 gem "http_accept_language"
 gem "http"

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "flipper-ui"
 gem "flipper"
 gem "friendly_id", "~> 5.2.4"
 gem "github-ds"
+gem "google-protobuf", "~> 3.0", require: false
 gem "groupdate"
 gem "http_accept_language"
 gem "http"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,7 @@ GEM
       activerecord (>= 3.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    google-protobuf (3.17.3)
     groupdate (5.0.0)
       activesupport (>= 5)
     guard (2.16.2)
@@ -674,6 +675,7 @@ DEPENDENCIES
   friendly_id (~> 5.2.4)
   generator_spec
   github-ds
+  google-protobuf (~> 3.0)
   groupdate
   guard-rspec
   http

--- a/app/controllers/api/v4/facility_medical_officers_controller.rb
+++ b/app/controllers/api/v4/facility_medical_officers_controller.rb
@@ -1,6 +1,6 @@
 class Api::V4::FacilityMedicalOfficersController < APIController
   def sync_to_user
-    medical_officers = current_facility_group.facilities.map { |facility|
+    medical_officers = current_facility_group.facilities.eager_load(:teleconsultation_medical_officers).map { |facility|
       facility_medical_officers(facility)
     }
     render json: to_response(medical_officers)

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,9 @@
 # This file is used by Rack-based servers to start the application.
 
+if ENABLE_DD_PROFILING
+  require "ddtrace/profiling/preload"
+end
+
 require_relative "config/environment"
 
 if defined?(PhusionPassenger)

--- a/config.ru
+++ b/config.ru
@@ -1,10 +1,10 @@
 # This file is used by Rack-based servers to start the application.
 
+require_relative "config/environment"
+
 if ENABLE_DD_PROFILING
   require "ddtrace/profiling/preload"
 end
-
-require_relative "config/environment"
 
 if defined?(PhusionPassenger)
   PhusionPassenger.on_event(:starting_worker_process) do |forked|

--- a/config/initializers/00_datadog.rb
+++ b/config/initializers/00_datadog.rb
@@ -5,9 +5,15 @@ require "datadog/statsd"
 # We want Datadog to run everywhere, but we won't have the DD agent running
 # in dev, test, or on Heroku - so we don't want to send payloads there.
 SEND_DATA_TO_DD_AGENT = !(Rails.env.development? || Rails.env.test? || SimpleServer.env.review?)
+# Trying out Ruby code profiling in Sandbox
+ENABLE_DD_PROFILING = SimpleServer.env.sandbox?
+if ENABLE_DD_PROFILING
+  require "google-protobuf"
+end
 
 Datadog.configure do |c|
   c.tracer.enabled = SEND_DATA_TO_DD_AGENT
+  c.profiling.enabled = ENABLE_DD_PROFILING
   c.version = SimpleServer.git_ref(short: true)
   c.use :rails, analytics_enabled: true
   c.use :rack, headers: {request: %w[X-USER-ID X-FACILITY-ID X-SYNC-REGION-ID], response: %w[Content-Type X-Request-ID]}

--- a/config/initializers/00_datadog.rb
+++ b/config/initializers/00_datadog.rb
@@ -7,7 +7,7 @@ require "datadog/statsd"
 SEND_DATA_TO_DD_AGENT = !(Rails.env.development? || Rails.env.test? || SimpleServer.env.review?)
 
 # Trying out Ruby code profiling in selected environments
-ENABLE_DD_PROFILING = SimpleServer.env.sandbox? || SimpleServer.env.review?
+ENABLE_DD_PROFILING = SimpleServer.env.sandbox?
 
 Datadog.configure do |c|
   c.tracer.enabled = SEND_DATA_TO_DD_AGENT

--- a/config/initializers/00_datadog.rb
+++ b/config/initializers/00_datadog.rb
@@ -5,8 +5,8 @@ require "datadog/statsd"
 # We want Datadog to run everywhere, but we won't have the DD agent running
 # in dev, test, or on Heroku - so we don't want to send payloads there.
 SEND_DATA_TO_DD_AGENT = !(Rails.env.development? || Rails.env.test? || SimpleServer.env.review?)
-# Trying out Ruby code profiling in Sandbox
-ENABLE_DD_PROFILING = SimpleServer.env.sandbox?
+# Trying out Ruby code profiling in selected environments
+ENABLE_DD_PROFILING = SimpleServer.env.sandbox? || SimpleServer.env.review?
 if ENABLE_DD_PROFILING
   require "google-protobuf"
 end

--- a/config/initializers/00_datadog.rb
+++ b/config/initializers/00_datadog.rb
@@ -5,11 +5,9 @@ require "datadog/statsd"
 # We want Datadog to run everywhere, but we won't have the DD agent running
 # in dev, test, or on Heroku - so we don't want to send payloads there.
 SEND_DATA_TO_DD_AGENT = !(Rails.env.development? || Rails.env.test? || SimpleServer.env.review?)
+
 # Trying out Ruby code profiling in selected environments
 ENABLE_DD_PROFILING = SimpleServer.env.sandbox? || SimpleServer.env.review?
-if ENABLE_DD_PROFILING
-  require "google-protobuf"
-end
 
 Datadog.configure do |c|
   c.tracer.enabled = SEND_DATA_TO_DD_AGENT


### PR DESCRIPTION
This is in public beta, so they recommend starting in a non prod
enviornment to start

I don't know how useful it will be, but we can get a sense of if it works and what we can see in Sandbox.  See https://docs.datadoghq.com/tracing/profiler/enabling/ruby/ for some docs.

**Story card:** [ch4951](https://app.clubhouse.io/simpledotorg/story/4951/enable-datadog-code-level-profiling?vc_group_by=day&ct_workflow=all&cf_workflow=500000005)
