### PR TITLE
Add custom Datadog spans for Sync API (sync_to_user)

### DIFF
--- a/app/controllers/api/manifests_controller.rb
+++ b/app/controllers/api/manifests_controller.rb
@@ -1,6 +1,6 @@
 class Api::ManifestsController < ApplicationController
   def show
-    if ENV["SIMPLE_SERVER_ENV"].in?(%w[development review])
+    if ENV["SIMPLE_SERVER_ENV"].in?(%w[development profiling review])
       @countries = %w[IN BD ET US UK]
     else
       manifest_file = "public/manifest/#{ENV["SIMPLE_SERVER_ENV"]}.json"

--- a/app/controllers/api/v3/facilities_controller.rb
+++ b/app/controllers/api/v3/facilities_controller.rb
@@ -13,11 +13,9 @@ class Api::V3::FacilitiesController < Api::V3::SyncController
   end
 
   def other_facility_records
-    time(__method__) do
-      Facility
-        .with_discarded
-        .updated_on_server_since(other_facilities_processed_since, limit)
-    end
+    Facility
+      .with_discarded
+      .updated_on_server_since(other_facilities_processed_since, limit)
   end
 
   def disable_audit_logs?
@@ -42,12 +40,10 @@ class Api::V3::FacilitiesController < Api::V3::SyncController
   end
 
   def records_to_sync
-    time(__method__) do
-      other_facility_records
-        .with_block_region_id
-        .includes(:facility_group)
-        .where.not(facility_group: nil)
-    end
+    other_facility_records
+      .with_block_region_id
+      .includes(:facility_group)
+      .where.not(facility_group: nil)
   end
 
   memoize def district_level_sync?

--- a/app/controllers/api/v3/protocols_controller.rb
+++ b/app/controllers/api/v3/protocols_controller.rb
@@ -12,11 +12,9 @@ class Api::V3::ProtocolsController < Api::V3::SyncController
   end
 
   def other_facility_records
-    time(__method__) do
-      Protocol
-        .with_discarded
-        .updated_on_server_since(other_facilities_processed_since, limit)
-    end
+    Protocol
+      .with_discarded
+      .updated_on_server_since(other_facilities_processed_since, limit)
   end
 
   def disable_audit_logs?

--- a/app/controllers/api/v3/sync_controller.rb
+++ b/app/controllers/api/v3/sync_controller.rb
@@ -35,9 +35,13 @@ class Api::V3::SyncController < APIController
   private
 
   def trace(name)
-    Datadog.tracer.trace(name, resource: model.to_s) do
+    Datadog.tracer.trace(name, resource: datadog_resource) do |span|
       yield
     end
+  end
+
+  def datadog_resource
+    @datadog_resource ||= "#{self.class}##{action_name}"
   end
 
   def model

--- a/app/controllers/api/v3/sync_controller.rb
+++ b/app/controllers/api/v3/sync_controller.rb
@@ -15,7 +15,7 @@ class Api::V3::SyncController < APIController
 
     AuditLog.create_logs_async(current_user, records, "fetch", Time.current) unless disable_audit_logs?
 
-    transformed_records = Datadog.tracer.trace("api.tranform", resource: model.to_s) do
+    transformed_records = Datadog.tracer.trace("api.transform", resource: model.to_s) do
       records.map { |record| transform_to_response(record) }
     end
     json = Datadog.tracer.trace("api.to_json", resource: model.to_s) do

--- a/app/controllers/api/v4/medications_controller.rb
+++ b/app/controllers/api/v4/medications_controller.rb
@@ -12,9 +12,7 @@ class Api::V4::MedicationsController < Api::V4::SyncController
   end
 
   def other_facility_records
-    time(__method__) do
-      Medication.all
-    end
+    Medication.all
   end
 
   def disable_audit_logs?
@@ -39,8 +37,6 @@ class Api::V4::MedicationsController < Api::V4::SyncController
   end
 
   def records_to_sync
-    time(__method__) do
-      other_facility_records
-    end
+    other_facility_records
   end
 end

--- a/app/controllers/concerns/api/v3/sync_to_user.rb
+++ b/app/controllers/concerns/api/v3/sync_to_user.rb
@@ -37,7 +37,7 @@ module Api::V3::SyncToUser
     end
 
     def records_to_sync
-      time(__method__) do
+      Datadog.tracer.trace("api.records_to_sync", resource: model) do
         current_facility_records + other_facility_records
       end
     end

--- a/app/controllers/concerns/api/v3/sync_to_user.rb
+++ b/app/controllers/concerns/api/v3/sync_to_user.rb
@@ -33,9 +33,7 @@ module Api::V3::SyncToUser
     end
 
     def records_to_sync
-      Datadog.tracer.trace("api.records_to_sync", resource: model.to_s) do
-        current_facility_records + other_facility_records
-      end
+      current_facility_records + other_facility_records
     end
 
     def processed_until(records)

--- a/app/controllers/concerns/api/v3/sync_to_user.rb
+++ b/app/controllers/concerns/api/v3/sync_to_user.rb
@@ -37,7 +37,7 @@ module Api::V3::SyncToUser
     end
 
     def records_to_sync
-      Datadog.tracer.trace("api.records_to_sync", resource: model) do
+      Datadog.tracer.trace("api.records_to_sync", resource: model.to_s) do
         current_facility_records + other_facility_records
       end
     end

--- a/app/controllers/concerns/api/v3/sync_to_user.rb
+++ b/app/controllers/concerns/api/v3/sync_to_user.rb
@@ -32,10 +32,6 @@ module Api::V3::SyncToUser
       model.for_sync
     end
 
-    def model
-      controller_name.classify.constantize
-    end
-
     def records_to_sync
       Datadog.tracer.trace("api.records_to_sync", resource: model.to_s) do
         current_facility_records + other_facility_records

--- a/lib/seed/runner.rb
+++ b/lib/seed/runner.rb
@@ -57,7 +57,8 @@ module Seed
       [
         :drug_stocks,
         :notifications,
-        (:auto_approve_users if SimpleServer.env.android_review?)
+        (:auto_approve_users if SimpleServer.env.android_review?),
+        (:fixed_otp if SimpleServer.env.android_review?)
       ].compact
     end
 


### PR DESCRIPTION
Add custom spans to our sync API so we can see these parts of the sync process on their own in Datadog.


See https://docs.datadoghq.com/tracing/setup_overview/custom_instrumentation/ruby/?tab=activespan#adding-spans for an overview on how this works.

Going to only add to `sync_to_user` to verify this works before adding elsewhere.
**Story card:** [ch4964](https://app.clubhouse.io/simpledotorg/story/4964/add-spans-around-key-parts-of-sync-api)


<img width="1603" alt="image" src="https://user-images.githubusercontent.com/69/133170483-8cf8b9e8-e3a0-4124-a7cf-4e25f3170e1d.png">

<img width="1743" alt="image" src="https://user-images.githubusercontent.com/69/133170719-c0703c3f-c1fe-4ac4-b63f-eca71257427c.png">

