### PR TITLE
Ethiopia DHIS2 calendar conversion

### DIFF
--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -185,6 +185,14 @@ class Period
     end
   end
 
+  def to_dhis2
+    if quarter?
+      "#{value.year}Q#{value.number}"
+    else
+      value.to_s(:dhis2_mon_year)
+    end
+  end
+
   # Returns a Hash with various Period related dates for eash consumption by the view
   def to_hash
     {

--- a/app/services/ethiopia_calendar_utilities.rb
+++ b/app/services/ethiopia_calendar_utilities.rb
@@ -6,4 +6,8 @@ module EthiopiaCalendarUtilities
 
     Date.new(year, 1, 1) + days_offset.days
   end
+
+  def self.gregorian_month_period_to_ethiopian(period)
+    period.advance(years: -7, months: -8)
+  end
 end

--- a/config/initializers/time_and_date_formats.rb
+++ b/config/initializers/time_and_date_formats.rb
@@ -9,3 +9,6 @@ Date::DATE_FORMATS[:month_year] = "%B %Y"
 
 Time::DATE_FORMATS[:day_mon_year] = "%-d-%b-%Y"
 Date::DATE_FORMATS[:day_mon_year] = "%-d-%b-%Y"
+
+Time::DATE_FORMATS[:dhis2_mon_year] = "%Y%m"
+Date::DATE_FORMATS[:dhis2_mon_year] = "%Y%m"

--- a/spec/models/period_spec.rb
+++ b/spec/models/period_spec.rb
@@ -91,6 +91,11 @@ RSpec.describe Period, type: :model do
     expect(q1_2019_period.to_s).to eq("Q1-2019")
   end
 
+  it "has to_dhis2 in correct format" do
+    expect(jan_1_2019_month_period.to_dhis2).to eq("201901")
+    expect(q1_2019_period.to_dhis2).to eq("2019Q1")
+  end
+
   it "month periods take an optional arg for to_s formatting" do
     expect(jan_1_2019_month_period.to_s(:mon_year_multiline)).to eq("Jan\n2019")
   end

--- a/spec/services/ethiopia_calendar_utilities_spec.rb
+++ b/spec/services/ethiopia_calendar_utilities_spec.rb
@@ -23,4 +23,31 @@ RSpec.describe EthiopiaCalendarUtilities do
       end
     end
   end
+
+  describe ".gregorian_month_period_to_ethiopian" do
+    it "converts Gregorian monthly periods to Ethiopian monthly periods" do
+      conversions = {
+        [2021, 1, 1] => "2013-05",
+        [2021, 2, 1] => "2013-06",
+        [2021, 3, 1] => "2013-07",
+        [2021, 4, 1] => "2013-08",
+        [2021, 5, 1] => "2013-09",
+        [2021, 6, 1] => "2013-10",
+        [2021, 7, 1] => "2013-11",
+        [2021, 8, 1] => "2013-12",
+        [2021, 9, 1] => "2014-01",
+        [2021, 10, 1] => "2014-02",
+        [2021, 11, 1] => "2014-03",
+        [2021, 12, 1] => "2014-04",
+        [2022, 1, 1] => "2014-05"
+      }
+
+      conversions.each do |gregorian_month, ethiopian_month|
+        period = Period.month(Date.new(*gregorian_month))
+        converted_period = described_class.gregorian_month_period_to_ethiopian(period)
+
+        expect(converted_period.to_date.strftime("%Y-%m")).to eq(ethiopian_month)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Story card:** [ch4339](https://app.shortcut.com/simpledotorg/story/4339/add-ethiopian-calendar-conversion-library)

## Because

Ethiopia's DHIS2 servers use the Ethiopian calendar for monthly periods.

## This addresses

This standardizes the DHIS2 period format strings and converts to Ethiopian periods if needed.