### PR TITLE
Fix overdue list download button

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -45,7 +45,7 @@ class AppointmentsController < AdminController
   private
 
   def index_params
-    @index_params ||= params.permit(:facility_id, :per_page, search_filters: [])
+    @index_params ||= params.permit(:district_slug, :facility_id, :per_page, search_filters: [])
   end
 
   def set_appointment


### PR DESCRIPTION
**Story card:** -

## Because

Due to a bad merge on https://github.com/simpledotorg/simple-server/pull/2876, the `Download overdue list` button doesn't submit the district slug, which is causing the default district's (first district) list to be downloaded always.

## This addresses

Fixes the permitted params on the controller.