### PR TITLE
Generate manifests for android_review app

### DIFF
--- a/app/controllers/api/manifests_controller.rb
+++ b/app/controllers/api/manifests_controller.rb
@@ -1,6 +1,6 @@
 class Api::ManifestsController < ApplicationController
   def show
-    if ENV["SIMPLE_SERVER_ENV"].in?(%w[development profiling review])
+    if ENV["SIMPLE_SERVER_ENV"].in?(%w[development profiling review android_review])
       @countries = %w[IN BD ET US UK]
     else
       manifest_file = "public/manifest/#{ENV["SIMPLE_SERVER_ENV"]}.json"

--- a/spec/controllers/api/manifests_controller_spec.rb
+++ b/spec/controllers/api/manifests_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Api::ManifestsController, type: :controller do
     end
 
     context "in non-production environments" do
-      environments = %w[development review]
+      environments = %w[development review android_review]
 
       environments.each do |env|
         it "returns a dynamic manifest for #{env}" do


### PR DESCRIPTION
**Story card:** -

## Because
The android CI creates a heroku instance with `android_review` as the `SIMPLE_SERVER_ENV` (Android PR: https://github.com/simpledotorg/simple-android/pull/3137)

## This addresses

Creates a manifest for the `android_review` env. [Slack ref](https://simpledotorg.slack.com/archives/CFK2PHJ1L/p1631768178281500)
