### PR TITLE
Turn on rake integration for Datadog

### DIFF
--- a/config/initializers/00_datadog.rb
+++ b/config/initializers/00_datadog.rb
@@ -13,8 +13,9 @@ Datadog.configure do |c|
   c.tracer.enabled = DATADOG_ENABLED
   c.profiling.enabled = ENABLE_DD_PROFILING
   c.version = SimpleServer.git_ref(short: true)
-  c.use :rails, analytics_enabled: true
   c.use :rack, headers: {request: %w[X-USER-ID X-FACILITY-ID X-SYNC-REGION-ID], response: %w[Content-Type X-Request-ID]}
+  c.use :rake
+  c.use :rails, analytics_enabled: true
   c.use :sidekiq, analytics_enabled: true
 end
 


### PR DESCRIPTION
Missed this during initial setup - we definitely want this for rake
tasks that are run from cron.

Possible fix for: **Story card:** [ch4314](https://app.shortcut.com/simpledotorg/story/4314/not-getting-metrics-for-matview-refresh-times-for-v2)

