### PR TITLE
Update LK patient address labels 

### DIFF
--- a/config/locales/en_LK.yml
+++ b/config/locales/en_LK.yml
@@ -14,12 +14,11 @@ en_LK:
       facility_group:
         state: "Province"
       address:
-        street_address: "House and street number"
-        village_or_colony: "Village or colony"
-        zone: "Town *"
+        street_address: "House and road number"
+        village_or_colony: "Town/Area"
         district: "District"
-        state: "Province *"
-        country: "Country *"
+        state: "Province"
+        country: "Country"
         pin: "Postal Code"
       drug:
         frequency:


### PR DESCRIPTION
**Story card:** [ch4944](https://app.shortcut.com/simpledotorg/story/4944/we-ll-need-to-fix-the-mapping-on-the-server-side-not-a-big-deal-just-a-labeling-change)

## Because

The patient address labels are different from the facility address labels. `Zone` is not used by the app.

## This addresses

Fixes the patient address labels