### PR TITLE
Add user id to v4 login error exception reports

### DIFF
--- a/app/controllers/api/v4/users_controller.rb
+++ b/app/controllers/api/v4/users_controller.rb
@@ -63,7 +63,7 @@ class Api::V4::UsersController < APIController
     if error_string.present?
       Sentry.capture_message("Login Error",
         extra: {activate_params: activate_params, errors: error_string},
-        tags: {type: "login"})
+        tags: {type: "login", user_id: activate_params[:id]})
       {user: [error_string]}
     end
   end


### PR DESCRIPTION
**Story card:** [ch5161](https://app.shortcut.com/simpledotorg/story/5161/add-user-id-to-login-error-exception-reports)

## Because

We get this error a lot: https://sentry.io/organizations/resolve-to-save-lives/issues/2651979117/?referrer=slack

And we can't tell why this is happening. Is it bad PIN entries? Is it a deleted user account? Is it a bot crawling?

## This addresses

Adds `user_id` from params into this exception's tags.