### PR TITLE
Update sidekiq-throttled so its compatible w/ latest sidekiq

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -547,7 +547,7 @@ GEM
     sidekiq-statsd (2.1.0)
       activesupport
       sidekiq (>= 3.3.1)
-    sidekiq-throttled (0.11.0)
+    sidekiq-throttled (0.14.1)
       concurrent-ruby
       redis-prescription
       sidekiq


### PR DESCRIPTION
See https://github.com/sensortower/sidekiq-throttled/pull/85 for details

This broken in a sentry gem update PR I just shipped, so trying to roll forward.

/cc https://github.com/simpledotorg/simple-server/pull/2929

### Verification

Ran some jobs locally.  Note the stack trace is to be expected, as thats our error tracing job.

```
[~/src/simpledotorg/simple-server (fix-sidekiq)⚡]> be sidekiq


               m,
               `$b
          .ss,  $$:         .,d$
          `$$P,d$P'    .,md$P"'
           ,$$$$$b/md$$$P^'
         .d$$$$$$/$$$P'
         $$^' `"/$$$'       ____  _     _      _    _
         $:     ,$$:       / ___|(_) __| | ___| | _(_) __ _
         `b     :$$        \___ \| |/ _` |/ _ \ |/ / |/ _` |
                $$:         ___) | | (_| |  __/   <| | (_| |
                $$         |____/|_|\__,_|\___|_|\_\_|\__, |
              .d$$                                       |_|


2021-09-22T19:40:35.995Z pid=47084 tid=ox2u1kd0k INFO: Booted Rails 5.2.6 application in development environment
2021-09-22T19:40:35.996Z pid=47084 tid=ox2u1kd0k INFO: Running in ruby 2.6.6p146 (2020-03-31 revision 67876) [x86_64-darwin18]
2021-09-22T19:40:35.996Z pid=47084 tid=ox2u1kd0k INFO: See LICENSE and the LGPL-3.0 for licensing details.
2021-09-22T19:40:35.996Z pid=47084 tid=ox2u1kd0k INFO: Upgrade to Sidekiq Pro for more features and support: https://sidekiq.org
2021-09-22T19:40:35.998Z pid=47084 tid=ox2u1kd0k INFO: Starting processing, hit Ctrl-C to stop
2021-09-22T19:43:47.165Z pid=47084 tid=ox2neijbk class=TracerJob jid=ffa8c1db8d2dbf8c488265c2 INFO: start
2021-09-22T19:43:47.225Z pid=47084 tid=ox2neijbk class=TracerJob jid=ffa8c1db8d2dbf8c488265c2 elapsed=0.06 INFO: fail
2021-09-22T19:43:47.226Z pid=47084 tid=ox2neijbk WARN: {"context":"Job raised exception","job":{"retry":false,"queue":"default","class":"TracerJob","args":["2021-09-22T19:43:47Z",true],"jid":"ffa8c1db8d2dbf8c488265c2","created_at":1632339827.1475909,"enqueued_at":1632339827.147816},"jobstr":"{\"retry\":false,\"queue\":\"default\",\"class\":\"TracerJob\",\"args\":[\"2021-09-22T19:43:47Z\",true],\"jid\":\"ffa8c1db8d2dbf8c488265c2\",\"created_at\":1632339827.1475909,\"enqueued_at\":1632339827.147816}"}
2021-09-22T19:43:47.226Z pid=47084 tid=ox2neijbk WARN: Admin::ErrorTracesController::Boom: Error trace triggered via sidekiq!
2021-09-22T19:43:47.226Z pid=47084 tid=ox2neijbk WARN: /Users/rsanheim/src/simpledotorg/simple-server/app/jobs/tracer_job.rb:8:in `perform'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/processor.rb:196:in `execute_job'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/processor.rb:164:in `block (2 levels) in process'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/middleware/chain.rb:138:in `block in invoke'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-throttled-0.14.1/lib/sidekiq/throttled/middleware.rb:14:in `call'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
/Users/rsanheim/src/simpledotorg/simple-server/lib/sidekiq_middleware/flush_metrics.rb:6:in `call'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
/Users/rsanheim/src/simpledotorg/simple-server/lib/sidekiq_middleware/set_local_time_zone.rb:4:in `block in call'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-5.2.6/lib/active_support/core_ext/time/zones.rb:66:in `use_zone'
/Users/rsanheim/src/simpledotorg/simple-server/lib/sidekiq_middleware/set_local_time_zone.rb:4:in `call'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-statsd-2.1.0/lib/sidekiq/statsd/server_middleware.rb:35:in `block (2 levels) in call'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/dogstatsd-ruby-5.2.0/lib/datadog/statsd.rb:247:in `time'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-statsd-2.1.0/lib/sidekiq/statsd/server_middleware.rb:34:in `block in call'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/dogstatsd-ruby-5.2.0/lib/datadog/statsd.rb:324:in `batch'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-statsd-2.1.0/lib/sidekiq/statsd/server_middleware.rb:29:in `call'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/ddtrace-0.52.0/lib/ddtrace/contrib/sidekiq/server_tracer.rb:43:in `block in call'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/ddtrace-0.52.0/lib/ddtrace/tracer.rb:283:in `trace'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/ddtrace-0.52.0/lib/ddtrace/contrib/sidekiq/server_tracer.rb:24:in `call'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/request_store-sidekiq-0.1.0/lib/request_store/sidekiq/server_middleware.rb:5:in `call'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sentry-sidekiq-4.7.2/lib/sentry/sidekiq/sentry_context_middleware.rb:23:in `call'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/middleware/chain.rb:143:in `invoke'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/processor.rb:163:in `block in process'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/processor.rb:136:in `block (6 levels) in dispatch'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/job_retry.rb:112:in `local'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/processor.rb:135:in `block (5 levels) in dispatch'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/rails.rb:14:in `block in call'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-5.2.6/lib/active_support/execution_wrapper.rb:87:in `wrap'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-5.2.6/lib/active_support/reloader.rb:73:in `block in wrap'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-5.2.6/lib/active_support/execution_wrapper.rb:87:in `wrap'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-5.2.6/lib/active_support/reloader.rb:72:in `wrap'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/rails.rb:13:in `call'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/processor.rb:131:in `block (4 levels) in dispatch'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/processor.rb:257:in `stats'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/processor.rb:126:in `block (3 levels) in dispatch'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/job_logger.rb:13:in `call'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/processor.rb:125:in `block (2 levels) in dispatch'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/job_retry.rb:79:in `global'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/processor.rb:124:in `block in dispatch'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/logger.rb:11:in `with'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/job_logger.rb:33:in `prepare'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/processor.rb:123:in `dispatch'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/processor.rb:162:in `process'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/processor.rb:78:in `process_one'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/processor.rb:68:in `run'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/util.rb:43:in `watchdog'
/Users/rsanheim/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/sidekiq-6.2.2/lib/sidekiq/util.rb:52:in `block in safe_thread'
2021-09-22T19:44:56.711Z pid=47084 tid=ox2nekwvk class=PatientListDownloadJob jid=4339e9fb8c4b5a44f0f544f1 INFO: start
2021-09-22T19:44:57.143Z pid=47084 tid=ox2nekwvk class=PatientListDownloadJob jid=4339e9fb8c4b5a44f0f544f1 elapsed=0.432 INFO: done
```