### PR TITLE
Disable Sentry transaction sampling

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,24 +2,4 @@ Sentry.init do |config|
   config.async = lambda do |event, hint|
     Sentry::SendEventJob.perform_later(event, hint)
   end
-
-  config.traces_sampler = lambda do |sampling_context|
-    transaction_context = sampling_context[:transaction_context]
-    transaction_name = transaction_context[:name]
-    op = transaction_context[:op]
-
-    case op
-    when /request/ # web requests
-      case transaction_name
-      when /ping/
-        0.0
-      else
-        0.10
-      end
-    when /sidekiq/i # background jobs
-      0.005
-    else
-      0.0
-    end
-  end
 end


### PR DESCRIPTION
We already have Datadog for performance and tx sampling, so having
Sentry in the mix is not necessary and most likely adding performance
overhead that we don't need right now. Having two tools sampling and sending call stacks to external services is probably not a great idea.

Removing the configuration will turn it off:
https://github.com/getsentry/sentry-ruby/blob/f82a2c3555091a0cbe0580fddd1f802426b77f5c/sentry-ruby/lib/sentry/transaction.rb#L74..L91

This may help with [ch5139](https://app.shortcut.com/simpledotorg/story/5139/argumenterror-start-sender-first)
