### PR TITLE
Add index on blood_pressures/facility_id

### DIFF
--- a/db/migrate/20210924102745_add_index_on_blood_pressures_facility_id.rb
+++ b/db/migrate/20210924102745_add_index_on_blood_pressures_facility_id.rb
@@ -1,0 +1,7 @@
+class AddIndexOnBloodPressuresFacilityId < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :blood_pressures, [:facility_id], name: :index_blood_pressures_on_facility_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_15_134540) do
+ActiveRecord::Schema.define(version: 2021_09_24_102745) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 2021_09_15_134540) do
     t.datetime "deleted_at"
     t.datetime "recorded_at"
     t.index ["deleted_at"], name: "index_blood_pressures_on_deleted_at"
+    t.index ["facility_id"], name: "index_blood_pressures_on_facility_id"
     t.index ["patient_id", "recorded_at"], name: "index_blood_pressures_on_patient_id_and_recorded_at", order: { recorded_at: :desc }
     t.index ["patient_id", "updated_at"], name: "index_blood_pressures_on_patient_id_and_updated_at"
     t.index ["patient_id"], name: "index_blood_pressures_on_patient_id"


### PR DESCRIPTION
- This addresses some critical performance issues seen in production
- The queries run for the progress-tab/user-analytics API need this to run quickly
- See more in the incident report: https://docs.google.com/document/d/1v9mtcW1UN1FSGXOGLoK-YFNS3VWbFMuWi7p_8I_YnRY