### PR TITLE
Drop sentry async job submission - use Sentry's builtin background worker

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,2 +1,3 @@
 Sentry.init do |config|
+  config.tracing_enabled = false
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,2 @@
 Sentry.init do |config|
-  config.tracing_enabled = false
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,2 @@
 Sentry.init do |config|
-  config.async = lambda do |event, hint|
-    Sentry::SendEventJob.perform_later(event, hint)
-  end
 end


### PR DESCRIPTION
Sentry has had its own backgrounb job submissions done via [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby) since version 4.1.  We have been using the `async` config option for a long time to send jobs through Sidekiq, which has quite a bit overhead and also introduces another point of failure for error submission.

This PR removes the `async` option so that Sentry will just use its own background thread for job processing.

See https://github.com/getsentry/sentry-ruby/issues/1522 for more details about this and why we want to do this change, as its possible the `async` option may be removed entirely in sentry-ruby version 5.

We suspect this also may be a cause of https://app.shortcut.com/simpledotorg/story/5282/redis-down-in-production

**Story card:** [ch5288](https://app.shortcut.com/simpledotorg/story/5288/change-sentry-to-use-its-own-built-in-async-job-submission-instead-of-sidekiq)
