### PR TITLE
4070: add optional phone number argument to imo invitation to enable …

### DIFF
--- a/app/services/imo_api_service.rb
+++ b/app/services/imo_api_service.rb
@@ -20,15 +20,16 @@ class ImoApiService
     end
   end
 
-  def send_invitation(patient)
+  def send_invitation(patient, phone_number: nil)
     return unless Flipper.enabled?(:imo_messaging)
 
     Statsd.instance.increment("imo.invites.attempt")
 
+    phone = phone_number || patient.latest_mobile_number
     locale = patient.locale
     url = IMO_BASE_URL + "send_invite"
     request_body = JSON(
-      phone: patient.latest_mobile_number,
+      phone: phone,
       msg: I18n.t("notifications.imo.invitations.message", patient_name: patient.full_name, locale: locale),
       contents: [{
         key: I18n.t("notifications.imo.invitations.message_key", locale: locale),

--- a/spec/services/imo_api_service_spec.rb
+++ b/spec/services/imo_api_service_spec.rb
@@ -40,6 +40,19 @@ describe ImoApiService, type: :model do
       before { Flipper.enable(:imo_messaging) }
 
       it "creates an ImoAuthorization on 200 success" do
+        locale = "bn-BD"
+        request_body = JSON(
+          phone: patient.latest_mobile_number,
+          msg: I18n.t("notifications.imo.invitations.message", patient_name: patient.full_name, locale: locale),
+          contents: [{
+            key: I18n.t("notifications.imo.invitations.message_key", locale: locale),
+            value: I18n.t("notifications.imo.invitations.message", patient_name: patient.full_name, locale: locale)
+          }],
+          title: I18n.t("notifications.imo.invitations.title", locale: locale),
+          action: I18n.t("notifications.imo.invitations.action", locale: locale),
+          callback_url: "https://localhost/api/v3/patients/#{patient.id}/imo_authorization"
+        )
+
         stub_request(:post, request_url).with(headers: request_headers).to_return(status: 200, body: success_body)
 
         expect { service.send_invitation(patient) }.to change { patient.imo_authorization }.from(nil)
@@ -84,6 +97,29 @@ describe ImoApiService, type: :model do
         expect {
           service.send_invitation(patient)
         }.to raise_error(ImoApiService::Error)
+      end
+
+      it "overrides the patient's phone number with an optional phone number argument" do
+        phone_number = "+9991112223333"
+        locale = "bn-BD"
+        request_body = JSON(
+          phone: phone_number,
+          msg: I18n.t("notifications.imo.invitations.message", patient_name: patient.full_name, locale: locale),
+          contents: [{
+            key: I18n.t("notifications.imo.invitations.message_key", locale: locale),
+            value: I18n.t("notifications.imo.invitations.message", patient_name: patient.full_name, locale: locale)
+          }],
+          title: I18n.t("notifications.imo.invitations.title", locale: locale),
+          action: I18n.t("notifications.imo.invitations.action", locale: locale),
+          callback_url: "https://localhost/api/v3/patients/#{patient.id}/imo_authorization"
+        )
+
+        stub_request(:post, request_url).with(headers: request_headers, body: request_body).to_return(status: 200, body: success_body)
+
+        expect {
+          service.send_invitation(patient, phone_number: phone_number)
+        }.to change { patient.imo_authorization }.from(nil)
+        expect(patient.imo_authorization.status).to eq("invited")
       end
     end
   end

--- a/spec/services/imo_api_service_spec.rb
+++ b/spec/services/imo_api_service_spec.rb
@@ -53,10 +53,11 @@ describe ImoApiService, type: :model do
           callback_url: "https://localhost/api/v3/patients/#{patient.id}/imo_authorization"
         )
 
-        stub_request(:post, request_url).with(headers: request_headers).to_return(status: 200, body: success_body)
+        stub = stub_request(:post, request_url).with(headers: request_headers, body: request_body).to_return(status: 200, body: success_body)
 
         expect { service.send_invitation(patient) }.to change { patient.imo_authorization }.from(nil)
         expect(patient.imo_authorization.status).to eq("invited")
+        expect(stub).to have_been_requested
       end
 
       it "creates an ImoAuthorization and reports to sentry on any other 200 response" do
@@ -114,12 +115,13 @@ describe ImoApiService, type: :model do
           callback_url: "https://localhost/api/v3/patients/#{patient.id}/imo_authorization"
         )
 
-        stub_request(:post, request_url).with(headers: request_headers, body: request_body).to_return(status: 200, body: success_body)
+        stub = stub_request(:post, request_url).with(headers: request_headers, body: request_body).to_return(status: 200, body: success_body)
 
         expect {
           service.send_invitation(patient, phone_number: phone_number)
         }.to change { patient.imo_authorization }.from(nil)
         expect(patient.imo_authorization.status).to eq("invited")
+        expect(stub).to have_been_requested
       end
     end
   end


### PR DESCRIPTION
…easier testing

**Story card:** [ch4070](https://app.shortcut.com/simpledotorg/story/4070/test-imo-invitations)

## Because

This makes testing imo easier. 
