### PR TITLE
Disable net connections in regular suite:

### DIFF
--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -5,6 +5,8 @@ require "capybara/rails"
 
 Dir[Rails.root.join("spec/pages/**/*.rb")].sort.each { |f| require f }
 
+WebMock.allow_net_connect!
+
 RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :feature
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,8 @@ Dir[Rails.root.join("spec/**/shared_examples/**/*.rb")].sort.each { |f| require 
 
 ActiveRecord::Migration.maintain_test_schema!
 
+WebMock.disable_net_connect!
+
 RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,6 @@ require "sidekiq/testing"
 require "flipper_helper"
 require "reporting_helpers"
 
-WebMock.allow_net_connect!
-
 RSpec::Matchers.define_negated_matcher :not_change, :change
 
 RSpec.configure do |config|


### PR DESCRIPTION
and only allow them in our features suite for Webmock.

no story, just have noticed this when reviewing PRs and it would be good to have this safety.