### PR TITLE
Fix patient lookup for discarded patients

### DIFF
--- a/spec/controllers/api/v4/patients_controller_spec.rb
+++ b/spec/controllers/api/v4/patients_controller_spec.rb
@@ -79,6 +79,30 @@ RSpec.describe Api::V4::PatientsController, type: :controller do
       expect(response_data[:patients].count).to eq 2
     end
 
+    it "returns nothing when an identifier is not discarded but patient is discarded" do
+      patient_1 = create(:patient)
+      patient_2 = create(:patient, registration_facility: patient_1.registration_facility)
+      b = patient_1.business_identifiers.first
+      patient_1.business_identifiers.first.update(
+        identifier_type: PatientBusinessIdentifier.identifier_types.values.first
+      )
+
+      patient_2.business_identifiers.first.update(
+        identifier: patient_1.business_identifiers.first.identifier,
+        identifier_type: PatientBusinessIdentifier.identifier_types.values.second
+      )
+
+      set_headers(patient_1.registration_user, patient_1.registration_facility)
+      patient_1.discard_data
+      b.reload
+      b.undiscard
+
+
+      post :lookup, params: {identifier: patient_1.business_identifiers.first.identifier}, as: :json
+      response_data = JSON.parse(response.body).with_indifferent_access
+      expect(response_data[:patients].count).to eq 1
+    end
+
     it "sets the retention as temporary and specifies the duration when patient is outside syncable region" do
       facility_group = create(:facility_group, name: "fg2", state: "State 1")
 


### PR DESCRIPTION
**Story card:** [ch5242](https://app.shortcut.com/simpledotorg/story/5242)

## Because

When a discarded patient has a remaining business identifier that has not been discarded, the lookup fails with a 500. [Sentry](https://sentry.io/organizations/resolve-to-save-lives/issues/2557456792/?referrer=slack)

## This addresses
[Sample datadog trace](https://app.datadoghq.com/logs?query=trace_id%3A19177855750868170&cols=host%2Cservice%2Cenv&event=AQAAAXwYWSHImemQqwAAAABBWHdZV1RZUEFBQnVVSnBkQ0c5bk5RQUI&index=&messageDisplay=inline&stream_sort=desc&from_ts=1632495066121&to_ts=1632497066271&live=false)

- [ ] Investigate why some discarded patients have undiscarded business identifiers
- [ ] Fix lookup logic to account for this scenario


