### PR TITLE
Reorganise Chennai hierarchy in IHCI

### DIFF
--- a/lib/tasks/scripts/chennai_hierarchy_cleanup.rb
+++ b/lib/tasks/scripts/chennai_hierarchy_cleanup.rb
@@ -1,0 +1,22 @@
+class ChennaiHierarchyCleanup
+  def self.run
+    raise "Cannot run this outside India production" unless CountryConfig.current[:name] == "India" && SimpleServer.env.production?
+
+    state = Region.state_regions.find_by_name("Tamil Nadu")
+    new_district = Region.find_by_name("Chennai")
+    raise "Create Chennai district before running" if new_district.blank?
+
+    old_districts = state.district_regions.where.not(name: new_district.name)
+
+    ActiveRecord::Base.transaction do
+      state.block_regions.each do |block|
+        block.reparent_to = new_district
+        block.save!
+      end
+
+      state.facilities.update_all(facility_group_id: new_district.source.id)
+
+      FacilityGroup.where(id: old_districts.pluck(:source_id)).discard_all
+    end
+  end
+end

--- a/lib/tasks/scripts/chennai_hierarchy_cleanup.rb
+++ b/lib/tasks/scripts/chennai_hierarchy_cleanup.rb
@@ -16,6 +16,7 @@ class ChennaiHierarchyCleanup
 
       state.facilities.update_all(facility_group_id: new_district.source.id)
 
+      # make sure facility gropus are empty before deleting
       FacilityGroup.where(id: old_districts.pluck(:source_id)).discard_all
     end
   end

--- a/spec/tasks/scripts/chennai_hierarchy_cleanup_spec.rb
+++ b/spec/tasks/scripts/chennai_hierarchy_cleanup_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "tasks/scripts/chennai_hierarchy_cleanup"
 
-describe 'ChennaiHierarchyCleanup' do
+describe "ChennaiHierarchyCleanup" do
   it "doesn't run outside india prod" do
     expect { ChennaiHierarchyCleanup.run }.to raise_error "Cannot run this outside India production"
   end
@@ -24,5 +24,12 @@ describe 'ChennaiHierarchyCleanup' do
     expect(block.reload.district_region).to eq(new_district.region)
     expect(old_district.reload.deleted_at).to be_present
     expect(old_district.region).to be_nil
+  end
+
+  it "sync region ID of any facility remains unchanged" do
+  end
+
+  it "only one district remains in Tamil Nadu after the cleanup" do
+
   end
 end

--- a/spec/tasks/scripts/chennai_hierarchy_cleanup_spec.rb
+++ b/spec/tasks/scripts/chennai_hierarchy_cleanup_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+require "tasks/scripts/chennai_hierarchy_cleanup"
+
+describe 'ChennaiHierarchyCleanup' do
+  it "doesn't run outside india prod" do
+    expect { ChennaiHierarchyCleanup.run }.to raise_error "Cannot run this outside India production"
+  end
+
+  it "doesn't run if Chennai district hasn't been created on dashboard" do
+    stub_const("SIMPLE_SERVER_ENV", "production")
+
+    expect { ChennaiHierarchyCleanup.run }.to raise_error "Create Chennai district before running"
+  end
+
+  it "reparents old blocks to the new district" do
+    stub_const("SIMPLE_SERVER_ENV", "production")
+
+    new_district = create(:facility_group, name: "Chennai", state: "Tamil Nadu")
+    old_district = create(:facility_group, name: "Chennai old", state: "Tamil Nadu")
+    block = create(:region, :block, name: "Chennai old - block", reparent_to: old_district.region)
+
+    ChennaiHierarchyCleanup.run
+
+    expect(block.reload.district_region).to eq(new_district.region)
+    expect(old_district.reload.deleted_at).to be_present
+    expect(old_district.region).to be_nil
+  end
+end

--- a/spec/tasks/scripts/chennai_hierarchy_cleanup_spec.rb
+++ b/spec/tasks/scripts/chennai_hierarchy_cleanup_spec.rb
@@ -30,6 +30,5 @@ describe "ChennaiHierarchyCleanup" do
   end
 
   it "only one district remains in Tamil Nadu after the cleanup" do
-
   end
 end


### PR DESCRIPTION
**Story card:** [ch4249](https://app.shortcut.com/simpledotorg/story/4249/fix-chennai-region-hierarchy)

## Because

We created an FG per block in Chennai to mitigate performance concerns before we had block level sync. Since we are able to block sync now, we can do away with these and combine them into a single FG called Chennai.

## This addresses

Adds a rake task to reorganize . This should . The mechanism is:
- Create a district called `Chennai` in `Tamil Nadu` from the dashboard
- All blocks are reparented to the new district, all old districts are deleted
