### PR TITLE
Use SRI to improve cross domain security

### DIFF
--- a/app/views/layouts/reports.html.erb
+++ b/app/views/layouts/reports.html.erb
@@ -36,7 +36,7 @@
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, shrink-to-fit=no"/>
     <meta name="apple-mobile-web-app-capable" content="yes"/>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0/dist/Chart.min.js" integrity="sha256-Uv9BNBucvCPipKQ2NS9wYpJmi8DTOEfTA/nH2aoJALw=" crossorigin="anonymous"></script>
   </head>
   <body class="bg-grey-100">
     <%= render "shared/nav_bar_v2" %>
@@ -44,6 +44,6 @@
     <div id="data-json" style="display: none;">
       <%= raw @data.to_json %>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0/dist/Chart.min.js" integrity="sha256-Uv9BNBucvCPipKQ2NS9wYpJmi8DTOEfTA/nH2aoJALw=" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/app/views/my_facilities/bp_controlled.html.erb
+++ b/app/views/my_facilities/bp_controlled.html.erb
@@ -172,4 +172,4 @@
     </div>
   </div>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0/dist/Chart.min.js" integrity="sha256-Uv9BNBucvCPipKQ2NS9wYpJmi8DTOEfTA/nH2aoJALw=" crossorigin="anonymous"></script>

--- a/app/views/my_facilities/bp_not_controlled.html.erb
+++ b/app/views/my_facilities/bp_not_controlled.html.erb
@@ -171,4 +171,4 @@
     </div>
   </div>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0/dist/Chart.min.js" integrity="sha256-Uv9BNBucvCPipKQ2NS9wYpJmi8DTOEfTA/nH2aoJALw=" crossorigin="anonymous"></script>

--- a/app/views/my_facilities/missed_visits.html.erb
+++ b/app/views/my_facilities/missed_visits.html.erb
@@ -171,4 +171,4 @@
     </div>
   </div>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0/dist/Chart.min.js" integrity="sha256-Uv9BNBucvCPipKQ2NS9wYpJmi8DTOEfTA/nH2aoJALw=" crossorigin="anonymous"></script>

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -134,5 +134,5 @@
   });
 </script>
 
-<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
-<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-piechart-outlabels"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0/dist/Chart.min.js" integrity="sha256-Uv9BNBucvCPipKQ2NS9wYpJmi8DTOEfTA/nH2aoJALw=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-piechart-outlabels@0.1.4/dist/chartjs-plugin-piechart-outlabels.min.js" integrity="sha256-yVxLw9A3MN0xzvzu6ByJRFAGgGH1ALIfgfuMURm3Bnc=" crossorigin="anonymous"></script>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -217,7 +217,7 @@
 <div id="data-json" style="display: none;">
   <%= raw @data.to_json %>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0/dist/Chart.min.js" integrity="sha256-Uv9BNBucvCPipKQ2NS9wYpJmi8DTOEfTA/nH2aoJALw=" crossorigin="anonymous"></script>
 <script>
   window.addEventListener("DOMContentLoaded", () => {
     new Reports(<%= @with_ltfu %>).initialize();


### PR DESCRIPTION
- Add integrity fields where possible: chart.js, chart plugin, etc
- Google fonts generates different assets based on the browser, so it's not possible to add SRI: https://github.com/google/fonts/issues/473
- The asset for redoc is generated server side, and the asset is also dynamic: https://www.jsdelivr.com/using-sri-with-dynamic-files

**Story card:** [ch5026](https://app.shortcut.com/simpledotorg/story/5026/medium-cross-domain-script-include)
