### PR TITLE
Add ACE drug category

### DIFF
--- a/app/helpers/my_facilities_helper.rb
+++ b/app/helpers/my_facilities_helper.rb
@@ -34,6 +34,7 @@ module MyFacilitiesHelper
     {hypertension_ccb: {full: "CCB Tablets", short: "CCB"},
      hypertension_arb: {full: "ARB Tablets", short: "ARB"},
      hypertension_diuretic: {full: "Diuretic Tablets", short: "Diuretic"},
+     hypertension_ace: {full: "ACE Tablets", short: "ACE"},
      hypertension_other: {full: "Other Tablets", short: "Other(H)"},
      diabetes: {full: "Diabetes Tablets", short: "Diabetes"},
      other: {full: "Other Tablets", short: "Other"}}.with_indifferent_access

--- a/app/models/protocol_drug.rb
+++ b/app/models/protocol_drug.rb
@@ -11,6 +11,7 @@ class ProtocolDrug < ApplicationRecord
     hypertension_ccb: "Hypertension: CCB",
     hypertension_arb: "Hypertension: ARB",
     hypertension_diuretic: "Hypertension: Diuretic",
+    hypertension_ace: "Hypertension: ACE",
     hypertension_other: "Hypertension: Other",
     diabetes: "Diabetes",
     other: "Other"


### PR DESCRIPTION
**Story card:** [ch5462](https://app.shortcut.com/simpledotorg/story/5462/add-hypertension-ace-drug-category)

## Because

We want to add ACE Inhibitors as a drug category

## This addresses

Adds ACE drug category, and labels