### PR TITLE
5123: add country codes to phone numbers

### DIFF
--- a/app/models/concerns/phone_number_helpers.rb
+++ b/app/models/concerns/phone_number_helpers.rb
@@ -1,0 +1,11 @@
+module PhoneNumberHelpers
+  def localize_phone_number(number, country_code)
+    if country_code
+      country_code + number
+    else
+      parsed_number = Phonelib.parse(number, Rails.application.config.country[:abbreviation]).raw_national
+      default_country_code = Rails.application.config.country[:sms_country_code]
+      default_country_code + parsed_number
+    end
+  end
+end

--- a/app/models/patient_phone_number.rb
+++ b/app/models/patient_phone_number.rb
@@ -1,5 +1,6 @@
 class PatientPhoneNumber < ApplicationRecord
   include Mergeable
+  include PhoneNumberHelpers
 
   enum phone_type: {
     mobile: "mobile",
@@ -56,8 +57,6 @@ class PatientPhoneNumber < ApplicationRecord
   end
 
   def number_with_country_code
-    parsed_number = Phonelib.parse(number, Rails.application.config.country[:abbreviation]).raw_national
-    default_country_code = Rails.application.config.country[:sms_country_code]
-    default_country_code + parsed_number
+    localize_phone_number(number, country_code)
   end
 end

--- a/app/models/phone_number_authentication.rb
+++ b/app/models/phone_number_authentication.rb
@@ -1,5 +1,6 @@
 class PhoneNumberAuthentication < ApplicationRecord
   include PgSearch::Model
+  include PhoneNumberHelpers
 
   USER_AUTH_MAX_FAILED_ATTEMPTS = Integer(ENV["USER_AUTH_MAX_FAILED_ATTEMPTS"] || 5).freeze
   USER_AUTH_LOCKOUT_IN_MINUTES = Integer(ENV["USER_AUTH_LOCKOUT_IN_MINUTES"] || 20).freeze
@@ -24,9 +25,7 @@ class PhoneNumberAuthentication < ApplicationRecord
   alias_method :registration_facility, :facility
 
   def localized_phone_number
-    parsed_number = Phonelib.parse(phone_number, Rails.application.config.country[:abbreviation]).raw_national
-    default_country_code = Rails.application.config.country[:sms_country_code]
-    default_country_code + parsed_number
+    localize_phone_number(phone_number, country_code)
   end
 
   def presence_of_password

--- a/db/migrate/20211013160516_add_country_code_to_patient_phone_number.rb
+++ b/db/migrate/20211013160516_add_country_code_to_patient_phone_number.rb
@@ -1,0 +1,5 @@
+class AddCountryCodeToPatientPhoneNumber < ActiveRecord::Migration[5.2]
+  def change
+    add_column :patient_phone_numbers, :country_code, :string, null: true
+  end
+end

--- a/db/migrate/20211013161109_add_country_code_to_phone_number_authentication.rb
+++ b/db/migrate/20211013161109_add_country_code_to_phone_number_authentication.rb
@@ -1,0 +1,5 @@
+class AddCountryCodeToPhoneNumberAuthentication < ActiveRecord::Migration[5.2]
+  def change
+    add_column :phone_number_authentications, :country_code, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_07_075808) do
+ActiveRecord::Schema.define(version: 2021_10_13_161109) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -466,6 +466,7 @@ ActiveRecord::Schema.define(version: 2021_10_07_075808) do
     t.datetime "device_updated_at", null: false
     t.datetime "deleted_at"
     t.boolean "dnd_status", default: true, null: false
+    t.string "country_code"
     t.index ["deleted_at"], name: "index_patient_phone_numbers_on_deleted_at"
     t.index ["dnd_status"], name: "index_patient_phone_numbers_on_dnd_status"
     t.index ["patient_id"], name: "index_patient_phone_numbers_on_patient_id"
@@ -517,6 +518,7 @@ ActiveRecord::Schema.define(version: 2021_10_07_075808) do
     t.datetime "deleted_at"
     t.integer "failed_attempts", default: 0, null: false
     t.datetime "locked_at"
+    t.string "country_code"
     t.index "to_tsvector('simple'::regconfig, COALESCE((phone_number)::text, ''::text))", name: "index_gin_phone_number_authentications_on_phone_number", using: :gin
     t.index ["deleted_at"], name: "index_phone_number_authentications_on_deleted_at"
   end

--- a/spec/factories/patient_phone_numbers.rb
+++ b/spec/factories/patient_phone_numbers.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :patient_phone_number do
     id { SecureRandom.uuid }
     number { Faker::PhoneNumber.phone_number }
+    country_code {}
     phone_type { "mobile" }
     active { [true, false].sample }
     device_created_at { Time.current }

--- a/spec/models/patient_phone_number_spec.rb
+++ b/spec/models/patient_phone_number_spec.rb
@@ -159,6 +159,11 @@ RSpec.describe PatientPhoneNumber, type: :model do
         phone_number = create(:patient_phone_number, number: "+911234567890")
         expect(phone_number.number_with_country_code).to eq("+11234567890")
       end
+
+      it "overrides the default country code with country_code if provided" do
+        phone_number = create(:patient_phone_number, number: "1234567890", country_code: "+999")
+        expect(phone_number.number_with_country_code).to eq("+9991234567890")
+      end
     end
   end
 end

--- a/spec/models/phone_number_authentication_spec.rb
+++ b/spec/models/phone_number_authentication_spec.rb
@@ -71,4 +71,16 @@ RSpec.describe PhoneNumberAuthentication, type: :model do
       expect(authentication.otp_expires_at.to_i).to eq(0)
     end
   end
+
+  describe "#localized_phone_number" do
+    it "works with only a phone number" do
+      auth = create(:phone_number_authentication, phone_number: "+91123456790")
+      expect(auth.localized_phone_number).to eq(auth.phone_number)
+    end
+
+    it "works with a country code" do
+      auth = create(:phone_number_authentication, phone_number: "1234567890", country_code: "+999")
+      expect(auth.localized_phone_number).to eq(auth.country_code + auth.phone_number)
+    end
+  end
 end


### PR DESCRIPTION
**Story card:** [chXXXX](URL)

## Because
This is a "light touch" draft of how we can bypass our current limitations around phone country codes. It would allow us to set up patient and user phone numbers with a country code override for testing purposes. This approach would also allow us to later migrate all users to this approach if we see the need. 

This covers three tickets:
https://app.shortcut.com/simpledotorg/story/4389/move-number-with-country-code-into-module
https://app.shortcut.com/simpledotorg/story/5123/make-patient-phone-numbers-country-code-configurable
https://app.shortcut.com/simpledotorg/story/5127/make-user-phone-numbers-country-code-configurable
