### PR TITLE
Cache regions index w/ same key for power users

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -14,7 +14,7 @@ class Reports::RegionsController < AdminController
   def index
     accessible_facility_regions = authorize { current_admin.accessible_facility_regions(:view_reports) }
 
-    cache_key = "#{current_admin.cache_key}/regions/index"
+    cache_key = current_admin.regions_access_cache_key
     cache_version = "#{accessible_facility_regions.cache_key} / v2"
     @accessible_regions = cache.fetch(cache_key, version: cache_version, expires_in: 7.days) {
       accessible_facility_regions.each_with_object({}) { |facility, result|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -246,6 +246,10 @@ class User < ApplicationRecord
     true
   end
 
+  def regions_access_cache_key
+    power_user? ? "users/power_user_region_access" : cache_key
+  end
+
   def power_user?
     power_user_access? && email_authentication.present?
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -420,4 +420,16 @@ RSpec.describe User, type: :model do
       expect(admin.drug_stocks_enabled?).to be false
     end
   end
+
+  describe "regions_access_cache_key" do
+    it "is cache key for non power users" do
+      admin = create(:admin, :viewer_all)
+      expect(admin.regions_access_cache_key).to eq("users/#{admin.id}")
+    end
+
+    it "is constant cache key for power users" do
+      admin = create(:admin, :power_user)
+      expect(admin.regions_access_cache_key).to eq("users/power_user_region_access")
+    end
+  end
 end


### PR DESCRIPTION
No need to cache under different keys for power users, as they will have
access to every region

**Story card:** [ch5562](https://app.shortcut.com/simpledotorg/story/5562/speed-up-regions-index)

Note that the cache key will be shared across all power users, which will increase the cache hit rate:

### Top level cache key (before)

```
 :missed_keys => [
            [  0] "users/6ec26921-b838-4a0f-acd0-a6b5f6240a97/regions/index",
```

### Top level cache key (after)
```
    :missed_keys => [
            [0] "users/power_user_region_access"
        ]
```