### PR TITLE
A/B enhancements: Schedule daily notifications

### DIFF
--- a/app/models/experimentation/current_patient_experiment.rb
+++ b/app/models/experimentation/current_patient_experiment.rb
@@ -14,10 +14,12 @@ module Experimentation
 
     # Patients whose expected return date falls on
     # one of the reminder template's remind_on days since `date`.
-    def memberships_to_notify(reminder_template, date)
-      treatment_group_memberships.status_enrolled.where(
-        expected_return_date: date - reminder_template.remind_on_in_days.days
-      )
+    def memberships_to_notify(date)
+      treatment_group_memberships
+        .status_enrolled
+        .joins(treatment_group: :reminder_templates)
+        .where("expected_return_date::timestamp + make_interval(days := reminder_templates.remind_on_in_days) = ?", date)
+        .select("treatment_group_memberships.*, reminder_templates.id template_id, reminder_templates.message message")
     end
 
     private

--- a/app/models/experimentation/current_patient_experiment.rb
+++ b/app/models/experimentation/current_patient_experiment.rb
@@ -12,14 +12,13 @@ module Experimentation
         .distinct
     end
 
-    # Patients whose expected return date falls on
+    # Memberships where the expected return date falls on
     # one of the reminder template's remind_on days since `date`.
     def memberships_to_notify(date)
       treatment_group_memberships
         .status_enrolled
         .joins(treatment_group: :reminder_templates)
         .where("expected_return_date::timestamp + make_interval(days := reminder_templates.remind_on_in_days) = ?", date)
-        .select("treatment_group_memberships.*, reminder_templates.id template_id, reminder_templates.message message")
     end
 
     private

--- a/app/models/experimentation/current_patient_experiment.rb
+++ b/app/models/experimentation/current_patient_experiment.rb
@@ -12,9 +12,12 @@ module Experimentation
         .distinct
     end
 
-    def memberships_to_notify(date)
-      # Patients where `date` equals one of their reminder template's remind_on.
-      # To be implemented in a follow up PR.
+    # Patients whose expected return date falls on
+    # one of the reminder template's remind_on days since `date`.
+    def memberships_to_notify(reminder_template, date)
+      treatment_group_memberships.status_enrolled.where(
+        expected_return_date: date - reminder_template.remind_on_in_days.days
+      )
     end
 
     private

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -107,11 +107,11 @@ module Experimentation
         registration_facility_state: registration_facility&.state
       }
     end
-  end
 
-  def mark_visits
-  end
+    def mark_visits
+    end
 
-  def evict_patients
+    def evict_patients
+    end
   end
 end

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -41,9 +41,9 @@ module Experimentation
                                              .having("count(patient_id) > 1"))
     end
 
-    def enroll_patients(date)
+    def enroll_patients(date, limit = MAX_PATIENTS_PER_DAY)
       eligible_patients(date)
-        .limit(MAX_PATIENTS_PER_DAY)
+        .limit(limit)
         .includes(:assigned_facility, :registration_facility, :medical_history)
         .includes(latest_scheduled_appointments: [:facility, :creation_facility])
         .in_batches(of: MEMBERSHIPS_BATCH_SIZE)

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -65,6 +65,8 @@ module Experimentation
     end
 
     def schedule_notification(membership, template, date)
+      return if Notification.find_by(reminder_template: template, experiment: self, patient_id: membership.patient_id)
+
       Notification.create!(
         experiment: self,
         message: template.message,

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -58,6 +58,8 @@ module Experimentation
 
     def schedule_notifications(date)
       memberships_to_notify(date)
+        .select("reminder_templates.id reminder_template_id")
+        .select("reminder_templates.message message, treatment_group_memberships.*")
         .in_batches(of: MEMBERSHIPS_BATCH_SIZE)
         .each_record { |membership| schedule_notification(membership, date) }
     end
@@ -126,7 +128,7 @@ module Experimentation
     def schedule_notification(membership, date)
       Notification.where(
         experiment: self,
-        reminder_template_id: membership.template_id,
+        reminder_template_id: membership.reminder_template_id,
         patient_id: membership.patient_id
       ).exists? ||
         Notification.create!(
@@ -135,7 +137,7 @@ module Experimentation
           patient_id: membership.patient_id,
           purpose: :experimental_appointment_reminder,
           remind_on: date,
-          reminder_template_id: membership.template_id,
+          reminder_template_id: membership.reminder_template_id,
           status: "pending"
         )
     end

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -57,26 +57,26 @@ module Experimentation
     end
 
     def schedule_notifications(date)
-      reminder_templates.each do |template|
-        memberships_to_notify(template, date)
-          .in_batches(of: MEMBERSHIPS_BATCH_SIZE)
-          .each_record { |membership| schedule_notification(membership, template, date) }
+      memberships_to_notify(date)
+        .in_batches(of: MEMBERSHIPS_BATCH_SIZE)
+        .each_record do |membership|
+        schedule_notification(membership.patient_id, membership.template_id, membership.message, date)
       end
     end
 
-    def schedule_notification(membership, template, date)
+    def schedule_notification(patient_id, template_id, message, date)
       Notification.where(
         experiment: self,
-        reminder_template: template,
-        patient_id: membership.patient_id
+        reminder_template_id: template_id,
+        patient_id: patient_id
       ).exists? ||
         Notification.create!(
           experiment: self,
-          message: template.message,
-          patient_id: membership.patient_id,
+          message: message,
+          patient_id: patient_id,
           purpose: :experimental_appointment_reminder,
           remind_on: date,
-          reminder_template: template,
+          reminder_template_id: template_id,
           status: "pending"
         )
     end

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -58,9 +58,9 @@ module Experimentation
 
     def schedule_notifications(date)
       reminder_templates.each do |template|
-        memberships_to_notify(template, date).in_batches(of: MEMBERSHIPS_BATCH_SIZE).each_record do |membership|
-          schedule_notification(membership, template, date)
-        end
+        memberships_to_notify(template, date)
+          .in_batches(of: MEMBERSHIPS_BATCH_SIZE)
+          .each_record { |membership| schedule_notification(membership, template, date) }
       end
     end
 

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -65,7 +65,11 @@ module Experimentation
     end
 
     def schedule_notification(membership, template, date)
-      return if Notification.find_by(reminder_template: template, experiment: self, patient_id: membership.patient_id)
+      return if Notification.find_by(
+        reminder_template: template,
+        experiment: self,
+        patient_id: membership.patient_id
+      )
 
       Notification.create!(
         experiment: self,

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -65,21 +65,20 @@ module Experimentation
     end
 
     def schedule_notification(membership, template, date)
-      return if Notification.find_by(
-        reminder_template: template,
+      Notification.where(
         experiment: self,
+        reminder_template: template,
         patient_id: membership.patient_id
-      )
-
-      Notification.create!(
-        experiment: self,
-        message: template.message,
-        patient_id: membership.patient_id,
-        purpose: :experimental_appointment_reminder,
-        remind_on: date,
-        reminder_template: template,
-        status: "pending"
-      )
+      ).exists? ||
+        Notification.create!(
+          experiment: self,
+          message: template.message,
+          patient_id: membership.patient_id,
+          purpose: :experimental_appointment_reminder,
+          remind_on: date,
+          reminder_template: template,
+          status: "pending"
+        )
     end
 
     def cancel

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -43,7 +43,7 @@ module Experimentation
 
     def enroll_patients(date, limit = MAX_PATIENTS_PER_DAY)
       eligible_patients(date)
-        .limit(limit)
+        .limit([remaining_enrollments_allowed(date), limit].min)
         .includes(:assigned_facility, :registration_facility, :medical_history)
         .includes(latest_scheduled_appointments: [:facility, :creation_facility])
         .in_batches(of: MEMBERSHIPS_BATCH_SIZE)
@@ -90,6 +90,14 @@ module Experimentation
     end
 
     private
+
+    def remaining_enrollments_allowed(date)
+      MAX_PATIENTS_PER_DAY - enrolled_patients(date).count
+    end
+
+    def enrolled_patients(date)
+      treatment_group_memberships.where(experiment_inclusion_date: date)
+    end
 
     def reporting_data(patient, date)
       medical_history = patient.medical_history

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -91,11 +91,7 @@ module Experimentation
     private
 
     def remaining_enrollments_allowed(date)
-      MAX_PATIENTS_PER_DAY - enrolled_patients(date).count
-    end
-
-    def enrolled_patients(date)
-      treatment_group_memberships.where(experiment_inclusion_date: date)
+      MAX_PATIENTS_PER_DAY - treatment_group_memberships.where(experiment_inclusion_date: date).count
     end
 
     def reporting_data(patient, date)

--- a/app/models/experimentation/reminder_template.rb
+++ b/app/models/experimentation/reminder_template.rb
@@ -5,13 +5,6 @@ module Experimentation
 
     validates :message, presence: true
     validates :remind_on_in_days, presence: true, numericality: {only_integer: true}
-
-    validate :unique_message_per_group
-
-    def unique_message_per_group
-      if self.class.find_by(message: message, treatment_group: treatment_group)
-        errors.add(:message, "already exists in this treatment group")
-      end
-    end
+    validates :message, uniqueness: {scope: :treatment_group, message: "already exists in this treatment group"}
   end
 end

--- a/app/models/experimentation/reminder_template.rb
+++ b/app/models/experimentation/reminder_template.rb
@@ -5,5 +5,13 @@ module Experimentation
 
     validates :message, presence: true
     validates :remind_on_in_days, presence: true, numericality: {only_integer: true}
+
+    validate :unique_message_per_group
+
+    def unique_message_per_group
+      if self.class.find_by(message: message, treatment_group: treatment_group)
+        errors.add(:message, "already exists in this treatment group")
+      end
+    end
   end
 end

--- a/app/models/experimentation/stale_patient_experiment.rb
+++ b/app/models/experimentation/stale_patient_experiment.rb
@@ -41,9 +41,12 @@ module Experimentation
       self.class.superclass.eligible_patients.where(id: sql.values)
     end
 
-    def memberships_to_notify(date)
-      # Patients who were enrolled on the `date`.
-      # To be implemented in a follow up PR.
+    # Patients who were enrollment date falls on
+    # one of the reminder template's remind_on days since `date`.
+    def memberships_to_notify(reminder_template, date)
+      treatment_group_memberships.status_enrolled.where(
+        experiment_inclusion_date: date - reminder_template.remind_on_in_days.days
+      )
     end
   end
 end

--- a/app/models/experimentation/stale_patient_experiment.rb
+++ b/app/models/experimentation/stale_patient_experiment.rb
@@ -41,14 +41,13 @@ module Experimentation
       self.class.superclass.eligible_patients.where(id: sql.values)
     end
 
-    # Patients who were enrollment date falls on
+    # Memberships where enrollment date falls on
     # one of the reminder template's remind_on days since `date`.
     def memberships_to_notify(date)
       treatment_group_memberships
         .status_enrolled
         .joins(treatment_group: :reminder_templates)
         .where("experiment_inclusion_date::timestamp + make_interval(days := reminder_templates.remind_on_in_days) = ?", date)
-        .select("treatment_group_memberships.*, reminder_templates.id template_id, reminder_templates.message message")
     end
   end
 end

--- a/app/models/experimentation/stale_patient_experiment.rb
+++ b/app/models/experimentation/stale_patient_experiment.rb
@@ -43,10 +43,12 @@ module Experimentation
 
     # Patients who were enrollment date falls on
     # one of the reminder template's remind_on days since `date`.
-    def memberships_to_notify(reminder_template, date)
-      treatment_group_memberships.status_enrolled.where(
-        experiment_inclusion_date: date - reminder_template.remind_on_in_days.days
-      )
+    def memberships_to_notify(date)
+      treatment_group_memberships
+        .status_enrolled
+        .joins(treatment_group: :reminder_templates)
+        .where("experiment_inclusion_date::timestamp + make_interval(days := reminder_templates.remind_on_in_days) = ?", date)
+        .select("treatment_group_memberships.*, reminder_templates.id template_id, reminder_templates.message message")
     end
   end
 end

--- a/spec/models/experimentation/current_patient_experiment_spec.rb
+++ b/spec/models/experimentation/current_patient_experiment_spec.rb
@@ -29,31 +29,31 @@ RSpec.describe Experimentation::CurrentPatientExperiment do
   end
 
   describe "#memberships_to_notify" do
-    context "for a reminder_template in an experiment" do
-      it "returns treatment_group_memberships whose expected visit is in the future and need to be reminded `remind_on_in_days` before" do
-        experiment = create(:experiment, experiment_type: "current_patients")
-        treatment_group = create(:treatment_group, experiment: experiment)
-        patient_1 = create(:patient)
-        patient_2 = create(:patient)
+    it "returns treatment_group_memberships whose expected visit is in the future and need to be reminded `remind_on_in_days` before" do
+      experiment = create(:experiment, experiment_type: "current_patients")
+      treatment_group = create(:treatment_group, experiment: experiment)
+      patient_1 = create(:patient)
+      patient_2 = create(:patient)
 
-        membership_1 = treatment_group.enroll(patient_1, expected_return_date: 2.days.from_now.to_date)
-        membership_2 = treatment_group.enroll(patient_2, expected_return_date: 3.days.from_now.to_date)
+      membership_1 = treatment_group.enroll(patient_1, expected_return_date: 2.days.from_now.to_date)
+      membership_2 = treatment_group.enroll(patient_2, expected_return_date: 3.days.from_now.to_date)
 
-        template_1 = create(:reminder_template, message: "1", treatment_group: treatment_group, remind_on_in_days: -2)
-        template_2 = create(:reminder_template, message: "2", treatment_group: treatment_group, remind_on_in_days: -3)
+      create(:reminder_template, message: "1", treatment_group: treatment_group, remind_on_in_days: -2)
+      create(:reminder_template, message: "2", treatment_group: treatment_group, remind_on_in_days: -3)
+      create(:reminder_template, message: "3", treatment_group: treatment_group, remind_on_in_days: 0)
 
-        expect(described_class.first.memberships_to_notify(template_1, Date.today)).to contain_exactly(membership_1)
-        expect(described_class.first.memberships_to_notify(template_2, Date.today)).to contain_exactly(membership_2)
-      end
+      expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership_1, membership_2)
+      expect(described_class.first.memberships_to_notify(Date.today).map(&:message)).to contain_exactly("1", "2")
+    end
 
       it "returns treatment_group_memberships whose expected visit is today and need to be reminded `remind_on_in_days` today" do
         experiment = create(:experiment, experiment_type: "current_patients")
         treatment_group = create(:treatment_group, experiment: experiment)
         patient = create(:patient)
         membership = treatment_group.enroll(patient, expected_return_date: Date.today)
-        template = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
+        create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
 
-        expect(described_class.first.memberships_to_notify(template, Date.today)).to contain_exactly(membership)
+        expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership)
       end
 
       it "returns treatment_group_memberships whose expected visit date has passed by `remind_on_in_days` days away" do
@@ -65,11 +65,12 @@ RSpec.describe Experimentation::CurrentPatientExperiment do
         membership_1 = treatment_group.enroll(patient_1, expected_return_date: 1.days.from_now.to_date)
         membership_2 = treatment_group.enroll(patient_2, expected_return_date: 10.days.from_now.to_date)
 
-        template_1 = create(:reminder_template, message: "1", treatment_group: treatment_group, remind_on_in_days: -1)
-        template_2 = create(:reminder_template, message: "2", treatment_group: treatment_group, remind_on_in_days: -10)
+        create(:reminder_template, message: "1", treatment_group: treatment_group, remind_on_in_days: -1)
+        create(:reminder_template, message: "2", treatment_group: treatment_group, remind_on_in_days: -10)
+        create(:reminder_template, message: "3", treatment_group: treatment_group, remind_on_in_days: 1)
 
-        expect(described_class.first.memberships_to_notify(template_1, Date.today)).to contain_exactly(membership_1)
-        expect(described_class.first.memberships_to_notify(template_2, Date.today)).to contain_exactly(membership_2)
+        expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership_1, membership_2)
+        expect(described_class.first.memberships_to_notify(Date.today).map(&:message)).to contain_exactly("1", "2")
       end
 
       it "only picks patients who are still enrolled in the experiment" do
@@ -80,10 +81,9 @@ RSpec.describe Experimentation::CurrentPatientExperiment do
 
         membership_1 = treatment_group.enroll(patient_1, expected_return_date: Date.today, status: :enrolled)
         _membership_2 = treatment_group.enroll(patient_2, expected_return_date: Date.today, status: :evicted)
-        template_1 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
+        create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
 
-        expect(described_class.first.memberships_to_notify(template_1, Date.today)).to contain_exactly(membership_1)
+        expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership_1)
       end
-    end
   end
 end

--- a/spec/models/experimentation/current_patient_experiment_spec.rb
+++ b/spec/models/experimentation/current_patient_experiment_spec.rb
@@ -27,4 +27,63 @@ RSpec.describe Experimentation::CurrentPatientExperiment do
       expect(described_class.first.eligible_patients(scheduled_appointment_date + 1.days)).not_to include(patient)
     end
   end
+
+  describe "#memberships_to_notify" do
+    context "for a reminder_template in an experiment" do
+      it "returns treatment_group_memberships whose expected visit is in the future and need to be reminded `remind_on_in_days` before" do
+        experiment = create(:experiment, experiment_type: "current_patients")
+        treatment_group = create(:treatment_group, experiment: experiment)
+        patient_1 = create(:patient)
+        patient_2 = create(:patient)
+
+        membership_1 = treatment_group.enroll(patient_1, expected_return_date: 2.days.from_now.to_date)
+        membership_2 = treatment_group.enroll(patient_2, expected_return_date: 3.days.from_now.to_date)
+
+        template_1 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: -2)
+        template_2 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: -3)
+
+        expect(described_class.first.memberships_to_notify(template_1, Date.today)).to contain_exactly(membership_1)
+        expect(described_class.first.memberships_to_notify(template_2, Date.today)).to contain_exactly(membership_2)
+      end
+
+      it "returns treatment_group_memberships whose expected visit is today and need to be reminded `remind_on_in_days` today" do
+        experiment = create(:experiment, experiment_type: "current_patients")
+        treatment_group = create(:treatment_group, experiment: experiment)
+        patient = create(:patient)
+        membership = treatment_group.enroll(patient, expected_return_date: Date.today)
+        template = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
+
+        expect(described_class.first.memberships_to_notify(template, Date.today)).to contain_exactly(membership)
+      end
+
+      it "returns treatment_group_memberships whose expected visit date has passed by `remind_on_in_days` days away" do
+        experiment = create(:experiment, experiment_type: "current_patients")
+        treatment_group = create(:treatment_group, experiment: experiment)
+        patient_1 = create(:patient)
+        patient_2 = create(:patient)
+
+        membership_1 = treatment_group.enroll(patient_1, expected_return_date: 1.days.from_now.to_date)
+        membership_2 = treatment_group.enroll(patient_2, expected_return_date: 10.days.from_now.to_date)
+
+        template_1 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: -1)
+        template_2 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: -10)
+
+        expect(described_class.first.memberships_to_notify(template_1, Date.today)).to contain_exactly(membership_1)
+        expect(described_class.first.memberships_to_notify(template_2, Date.today)).to contain_exactly(membership_2)
+      end
+
+      it "only picks patients who are still enrolled in the experiment" do
+        experiment = create(:experiment, experiment_type: "current_patients")
+        treatment_group = create(:treatment_group, experiment: experiment)
+        patient_1 = create(:patient)
+        patient_2 = create(:patient)
+
+        membership_1 = treatment_group.enroll(patient_1, expected_return_date: Date.today, status: :enrolled)
+        _membership_2 = treatment_group.enroll(patient_2, expected_return_date: Date.today, status: :evicted)
+        template_1 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
+
+        expect(described_class.first.memberships_to_notify(template_1, Date.today)).to contain_exactly(membership_1)
+      end
+    end
+  end
 end

--- a/spec/models/experimentation/current_patient_experiment_spec.rb
+++ b/spec/models/experimentation/current_patient_experiment_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Experimentation::CurrentPatientExperiment do
       experiment = create(:experiment, experiment_type: "current_patients")
       group = create(:treatment_group, experiment: experiment)
 
-      earliest_reminder = create(:reminder_template, treatment_group: group, remind_on_in_days: -1)
-      create(:reminder_template, treatment_group: group, remind_on_in_days: 0)
+      earliest_reminder = create(:reminder_template, message: "1", treatment_group: group, remind_on_in_days: -1)
+      create(:reminder_template, message: "2", treatment_group: group, remind_on_in_days: 0)
 
       expect(described_class.first.eligible_patients(scheduled_appointment_date - 3.days)).not_to include(patient)
       expect(described_class.first.eligible_patients(scheduled_appointment_date - 2.days)).not_to include(patient)
@@ -39,8 +39,8 @@ RSpec.describe Experimentation::CurrentPatientExperiment do
         membership_1 = treatment_group.enroll(patient_1, expected_return_date: 2.days.from_now.to_date)
         membership_2 = treatment_group.enroll(patient_2, expected_return_date: 3.days.from_now.to_date)
 
-        template_1 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: -2)
-        template_2 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: -3)
+        template_1 = create(:reminder_template, message: "1", treatment_group: treatment_group, remind_on_in_days: -2)
+        template_2 = create(:reminder_template, message: "2", treatment_group: treatment_group, remind_on_in_days: -3)
 
         expect(described_class.first.memberships_to_notify(template_1, Date.today)).to contain_exactly(membership_1)
         expect(described_class.first.memberships_to_notify(template_2, Date.today)).to contain_exactly(membership_2)
@@ -65,8 +65,8 @@ RSpec.describe Experimentation::CurrentPatientExperiment do
         membership_1 = treatment_group.enroll(patient_1, expected_return_date: 1.days.from_now.to_date)
         membership_2 = treatment_group.enroll(patient_2, expected_return_date: 10.days.from_now.to_date)
 
-        template_1 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: -1)
-        template_2 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: -10)
+        template_1 = create(:reminder_template, message: "1", treatment_group: treatment_group, remind_on_in_days: -1)
+        template_2 = create(:reminder_template, message: "2", treatment_group: treatment_group, remind_on_in_days: -10)
 
         expect(described_class.first.memberships_to_notify(template_1, Date.today)).to contain_exactly(membership_1)
         expect(described_class.first.memberships_to_notify(template_2, Date.today)).to contain_exactly(membership_2)

--- a/spec/models/experimentation/current_patient_experiment_spec.rb
+++ b/spec/models/experimentation/current_patient_experiment_spec.rb
@@ -46,44 +46,44 @@ RSpec.describe Experimentation::CurrentPatientExperiment do
       expect(described_class.first.memberships_to_notify(Date.today).map(&:message)).to contain_exactly("1", "2")
     end
 
-      it "returns treatment_group_memberships whose expected visit is today and need to be reminded `remind_on_in_days` today" do
-        experiment = create(:experiment, experiment_type: "current_patients")
-        treatment_group = create(:treatment_group, experiment: experiment)
-        patient = create(:patient)
-        membership = treatment_group.enroll(patient, expected_return_date: Date.today)
-        create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
+    it "returns treatment_group_memberships whose expected visit is today and need to be reminded `remind_on_in_days` today" do
+      experiment = create(:experiment, experiment_type: "current_patients")
+      treatment_group = create(:treatment_group, experiment: experiment)
+      patient = create(:patient)
+      membership = treatment_group.enroll(patient, expected_return_date: Date.today)
+      create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
 
-        expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership)
-      end
+      expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership)
+    end
 
-      it "returns treatment_group_memberships whose expected visit date has passed by `remind_on_in_days` days away" do
-        experiment = create(:experiment, experiment_type: "current_patients")
-        treatment_group = create(:treatment_group, experiment: experiment)
-        patient_1 = create(:patient)
-        patient_2 = create(:patient)
+    it "returns treatment_group_memberships whose expected visit date has passed by `remind_on_in_days` days away" do
+      experiment = create(:experiment, experiment_type: "current_patients")
+      treatment_group = create(:treatment_group, experiment: experiment)
+      patient_1 = create(:patient)
+      patient_2 = create(:patient)
 
-        membership_1 = treatment_group.enroll(patient_1, expected_return_date: 1.days.from_now.to_date)
-        membership_2 = treatment_group.enroll(patient_2, expected_return_date: 10.days.from_now.to_date)
+      membership_1 = treatment_group.enroll(patient_1, expected_return_date: 1.days.from_now.to_date)
+      membership_2 = treatment_group.enroll(patient_2, expected_return_date: 10.days.from_now.to_date)
 
-        create(:reminder_template, message: "1", treatment_group: treatment_group, remind_on_in_days: -1)
-        create(:reminder_template, message: "2", treatment_group: treatment_group, remind_on_in_days: -10)
-        create(:reminder_template, message: "3", treatment_group: treatment_group, remind_on_in_days: 1)
+      create(:reminder_template, message: "1", treatment_group: treatment_group, remind_on_in_days: -1)
+      create(:reminder_template, message: "2", treatment_group: treatment_group, remind_on_in_days: -10)
+      create(:reminder_template, message: "3", treatment_group: treatment_group, remind_on_in_days: 1)
 
-        expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership_1, membership_2)
-        expect(described_class.first.memberships_to_notify(Date.today).map(&:message)).to contain_exactly("1", "2")
-      end
+      expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership_1, membership_2)
+      expect(described_class.first.memberships_to_notify(Date.today).map(&:message)).to contain_exactly("1", "2")
+    end
 
-      it "only picks patients who are still enrolled in the experiment" do
-        experiment = create(:experiment, experiment_type: "current_patients")
-        treatment_group = create(:treatment_group, experiment: experiment)
-        patient_1 = create(:patient)
-        patient_2 = create(:patient)
+    it "only picks patients who are still enrolled in the experiment" do
+      experiment = create(:experiment, experiment_type: "current_patients")
+      treatment_group = create(:treatment_group, experiment: experiment)
+      patient_1 = create(:patient)
+      patient_2 = create(:patient)
 
-        membership_1 = treatment_group.enroll(patient_1, expected_return_date: Date.today, status: :enrolled)
-        _membership_2 = treatment_group.enroll(patient_2, expected_return_date: Date.today, status: :evicted)
-        create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
+      membership_1 = treatment_group.enroll(patient_1, expected_return_date: Date.today, status: :enrolled)
+      _membership_2 = treatment_group.enroll(patient_2, expected_return_date: Date.today, status: :evicted)
+      create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
 
-        expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership_1)
-      end
+      expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership_1)
+    end
   end
 end

--- a/spec/models/experimentation/current_patient_experiment_spec.rb
+++ b/spec/models/experimentation/current_patient_experiment_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Experimentation::CurrentPatientExperiment do
       create(:reminder_template, message: "3", treatment_group: treatment_group, remind_on_in_days: 0)
 
       expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership_1, membership_2)
-      expect(described_class.first.memberships_to_notify(Date.today).map(&:message)).to contain_exactly("1", "2")
+      expect(described_class.first.memberships_to_notify(Date.today).select(:message).pluck(:message)).to contain_exactly("1", "2")
     end
 
     it "returns treatment_group_memberships whose expected visit is today and need to be reminded `remind_on_in_days` today" do
@@ -70,7 +70,7 @@ RSpec.describe Experimentation::CurrentPatientExperiment do
       create(:reminder_template, message: "3", treatment_group: treatment_group, remind_on_in_days: 1)
 
       expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership_1, membership_2)
-      expect(described_class.first.memberships_to_notify(Date.today).map(&:message)).to contain_exactly("1", "2")
+      expect(described_class.first.memberships_to_notify(Date.today).select(:message).pluck(:message)).to contain_exactly("1", "2")
     end
 
     it "only picks patients who are still enrolled in the experiment" do

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -188,6 +188,21 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
       expect(Experimentation::CurrentPatientExperiment.first.treatment_group_memberships.first.registration_facility_name).to be_nil
       expect(Experimentation::CurrentPatientExperiment.first.treatment_group_memberships.first.expected_return_date).to be_nil
     end
+
+    it "enrolls max patients per day only even if called multiple times" do
+      patients = create_list(:patient, 2, age: 18)
+      patients.each { |patient| create(:appointment, scheduled_date: Date.today, patient: patient) }
+      experiment = create(:experiment, experiment_type: "current_patients")
+      treatment_group = create(:treatment_group, experiment: experiment)
+      create(:reminder_template, message: "1", treatment_group: treatment_group, remind_on_in_days: 0)
+      stub_const("#{Experimentation::NotificationsExperiment}::MAX_PATIENTS_PER_DAY", 1)
+
+      expect(Experimentation::CurrentPatientExperiment.first.eligible_patients(Date.today).count).to eq(2)
+      Experimentation::CurrentPatientExperiment.first.enroll_patients(Date.today, 1)
+      expect(Experimentation::TreatmentGroupMembership.count).to eq(1)
+      Experimentation::CurrentPatientExperiment.first.enroll_patients(Date.today, 1)
+      expect(Experimentation::TreatmentGroupMembership.count).to eq(1)
+    end
   end
 
   describe "#schedule_notifications" do

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
       expect(Notification.pluck(:patient_id)).to contain_exactly(patient.id, patient.id) # Once for each reminder template
     end
 
-    it "doesn't create duplicate notifications if it is called twice" do
+    it "doesn't create duplicate notifications if a notification has already been created" do
       create(:experiment, experiment_type: "current_patients")
       experiment = Experimentation::CurrentPatientExperiment.first
       treatment_group = create(:treatment_group, experiment: experiment)

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -22,16 +22,16 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
         create(:experiment, :with_treatment_group_and_template, :cancelled, start_time: 5.months.ago, end_time: 4.months.ago)
         notifying_experiment = create(:experiment, start_time: 3.day.ago, end_time: 1.day.ago, experiment_type: "current_patients")
 
-        treatment_group = create(:treatment_group, experiment: notifying_experiment)
-        create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
-        create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 2)
-        create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 3)
+        treatment_group_1 = create(:treatment_group, experiment: notifying_experiment)
+        create(:reminder_template, message: "1", treatment_group: treatment_group_1, remind_on_in_days: 0)
+        create(:reminder_template, message: "2", treatment_group: treatment_group_1, remind_on_in_days: 2)
+        create(:reminder_template, message: "3", treatment_group: treatment_group_1, remind_on_in_days: 3)
 
         not_notifying_experiment = create(:experiment, start_time: 3.day.ago, end_time: 1.day.ago, experiment_type: "stale_patients")
-        treatment_group = create(:treatment_group, experiment: not_notifying_experiment)
+        treatment_group_2 = create(:treatment_group, experiment: not_notifying_experiment)
 
-        create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 1)
-        create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
+        create(:reminder_template, message: "1", treatment_group: treatment_group_2, remind_on_in_days: 1)
+        create(:reminder_template, message: "2", treatment_group: treatment_group_2, remind_on_in_days: 0)
 
         expect(described_class.notifying.pluck(:id)).to contain_exactly(notifying_experiment.id)
       end
@@ -195,7 +195,8 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
       create(:experiment, experiment_type: "current_patients")
       experiment = Experimentation::CurrentPatientExperiment.first
       treatment_group = create(:treatment_group, experiment: experiment)
-      create_list(:reminder_template, 2, treatment_group: treatment_group)
+      create(:reminder_template, message: "1", treatment_group: treatment_group)
+      create(:reminder_template, message: "2", treatment_group: treatment_group)
       patient = create(:patient)
       membership = treatment_group.enroll(patient)
 

--- a/spec/models/experimentation/reminder_template_spec.rb
+++ b/spec/models/experimentation/reminder_template_spec.rb
@@ -10,5 +10,18 @@ RSpec.describe Experimentation::ReminderTemplate, type: :model do
     it { should validate_presence_of(:message) }
     it { should validate_presence_of(:remind_on_in_days) }
     it { should validate_numericality_of(:remind_on_in_days) }
+
+    describe "#unique_message_per_group" do
+      it "allows only one template with a message in a group" do
+        treatment_group = create(:treatment_group)
+        message = "Hello please visit the clinic."
+        create(:reminder_template, treatment_group: treatment_group, message: message)
+
+        new_reminder_template = build(:reminder_template, treatment_group: treatment_group, message: message)
+        new_reminder_template.validate
+
+        expect(new_reminder_template.errors[:message]).to be_present
+      end
+    end
   end
 end

--- a/spec/models/experimentation/reminder_template_spec.rb
+++ b/spec/models/experimentation/reminder_template_spec.rb
@@ -11,17 +11,27 @@ RSpec.describe Experimentation::ReminderTemplate, type: :model do
     it { should validate_presence_of(:remind_on_in_days) }
     it { should validate_numericality_of(:remind_on_in_days) }
 
-    describe "#unique_message_per_group" do
-      it "allows only one template with a message in a group" do
-        treatment_group = create(:treatment_group)
-        message = "Hello please visit the clinic."
-        create(:reminder_template, treatment_group: treatment_group, message: message)
+    it "allows only one template with a message in a group" do
+      treatment_group = create(:treatment_group)
+      message = "Hello please visit the clinic."
+      create(:reminder_template, treatment_group: treatment_group, message: message)
 
-        new_reminder_template = build(:reminder_template, treatment_group: treatment_group, message: message)
-        new_reminder_template.validate
+      new_reminder_template = build(:reminder_template, treatment_group: treatment_group, message: message)
+      new_reminder_template.validate
 
-        expect(new_reminder_template.errors[:message]).to be_present
-      end
+      expect(new_reminder_template.errors[:message]).to be_present
+    end
+
+    it "allows same message in another group" do
+      treatment_group = create(:treatment_group, experiment: create(:experiment, experiment_type: "current_patients"))
+      other_treatment_group = create(:treatment_group, experiment: create(:experiment, experiment_type: "stale_patients"))
+      message = "Hello please visit the clinic."
+      create(:reminder_template, treatment_group: treatment_group, message: message)
+
+      other_group_reminder_template = build(:reminder_template, treatment_group: other_treatment_group, message: message)
+      other_group_reminder_template.validate
+
+      expect(other_group_reminder_template.errors[:message]).not_to be_present
     end
   end
 end

--- a/spec/models/experimentation/stale_patient_experiment_spec.rb
+++ b/spec/models/experimentation/stale_patient_experiment_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe Experimentation::StalePatientExperiment do
         membership_1 = treatment_group.enroll(patient_1, experiment_inclusion_date: 1.days.ago.to_date)
         membership_2 = treatment_group.enroll(patient_2, experiment_inclusion_date: 10.days.ago.to_date)
 
-        template_1 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 1)
-        template_2 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 10)
+        template_1 = create(:reminder_template, message: "1", treatment_group: treatment_group, remind_on_in_days: 1)
+        template_2 = create(:reminder_template, message: "2", treatment_group: treatment_group, remind_on_in_days: 10)
 
         expect(described_class.first.memberships_to_notify(template_1, Date.today)).to contain_exactly(membership_1)
         expect(described_class.first.memberships_to_notify(template_2, Date.today)).to contain_exactly(membership_2)

--- a/spec/models/experimentation/stale_patient_experiment_spec.rb
+++ b/spec/models/experimentation/stale_patient_experiment_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Experimentation::StalePatientExperiment do
       create(:reminder_template, message: "3", treatment_group: treatment_group, remind_on_in_days: 0)
 
       expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership_1, membership_2)
-      expect(described_class.first.memberships_to_notify(Date.today).map(&:message)).to contain_exactly("1", "2")
+      expect(described_class.first.memberships_to_notify(Date.today).select(:message).pluck(:message)).to contain_exactly("1", "2")
     end
 
     it "only picks patients who are still enrolled in the experiment" do

--- a/spec/models/experimentation/stale_patient_experiment_spec.rb
+++ b/spec/models/experimentation/stale_patient_experiment_spec.rb
@@ -94,45 +94,44 @@ RSpec.describe Experimentation::StalePatientExperiment do
   end
 
   describe "#memberships_to_notify" do
-    context "for a reminder_template in an experiment" do
-      it "returns treatment_group_memberships who were enrolled today and need to be reminded today" do
-        experiment = create(:experiment, experiment_type: "stale_patients")
-        treatment_group = create(:treatment_group, experiment: experiment)
-        patient = create(:patient)
-        membership = treatment_group.enroll(patient, experiment_inclusion_date: Date.today)
-        template = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
+    it "returns treatment_group_memberships who were enrolled today and need to be reminded today" do
+      experiment = create(:experiment, experiment_type: "stale_patients")
+      treatment_group = create(:treatment_group, experiment: experiment)
+      patient = create(:patient)
+      membership = treatment_group.enroll(patient, experiment_inclusion_date: Date.today)
+      create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
 
-        expect(described_class.first.memberships_to_notify(template, Date.today)).to contain_exactly(membership)
-      end
+      expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership)
+    end
 
-      it "returns treatment_group_memberships whose were enrolled in the past `remind_on_in_days` days ago" do
-        experiment = create(:experiment, experiment_type: "stale_patients")
-        treatment_group = create(:treatment_group, experiment: experiment)
-        patient_1 = create(:patient)
-        patient_2 = create(:patient)
+    it "returns treatment_group_memberships whose were enrolled in the past `remind_on_in_days` days ago" do
+      experiment = create(:experiment, experiment_type: "stale_patients")
+      treatment_group = create(:treatment_group, experiment: experiment)
+      patient_1 = create(:patient)
+      patient_2 = create(:patient)
 
-        membership_1 = treatment_group.enroll(patient_1, experiment_inclusion_date: 1.days.ago.to_date)
-        membership_2 = treatment_group.enroll(patient_2, experiment_inclusion_date: 10.days.ago.to_date)
+      membership_1 = treatment_group.enroll(patient_1, experiment_inclusion_date: 1.days.ago.to_date)
+      membership_2 = treatment_group.enroll(patient_2, experiment_inclusion_date: 10.days.ago.to_date)
 
-        template_1 = create(:reminder_template, message: "1", treatment_group: treatment_group, remind_on_in_days: 1)
-        template_2 = create(:reminder_template, message: "2", treatment_group: treatment_group, remind_on_in_days: 10)
+      create(:reminder_template, message: "1", treatment_group: treatment_group, remind_on_in_days: 1)
+      create(:reminder_template, message: "2", treatment_group: treatment_group, remind_on_in_days: 10)
+      create(:reminder_template, message: "3", treatment_group: treatment_group, remind_on_in_days: 0)
 
-        expect(described_class.first.memberships_to_notify(template_1, Date.today)).to contain_exactly(membership_1)
-        expect(described_class.first.memberships_to_notify(template_2, Date.today)).to contain_exactly(membership_2)
-      end
+      expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership_1, membership_2)
+      expect(described_class.first.memberships_to_notify(Date.today).map(&:message)).to contain_exactly("1", "2")
+    end
 
-      it "only picks patients who are still enrolled in the experiment" do
-        experiment = create(:experiment, experiment_type: "stale_patients")
-        treatment_group = create(:treatment_group, experiment: experiment)
-        patient_1 = create(:patient)
-        patient_2 = create(:patient)
+    it "only picks patients who are still enrolled in the experiment" do
+      experiment = create(:experiment, experiment_type: "stale_patients")
+      treatment_group = create(:treatment_group, experiment: experiment)
+      patient_1 = create(:patient)
+      patient_2 = create(:patient)
 
-        membership_1 = treatment_group.enroll(patient_1, experiment_inclusion_date: Date.today, status: :enrolled)
-        _membership_2 = treatment_group.enroll(patient_2, experiment_inclusion_date: Date.today, status: :evicted)
-        template_1 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
+      membership_1 = treatment_group.enroll(patient_1, experiment_inclusion_date: Date.today, status: :enrolled)
+      _membership_2 = treatment_group.enroll(patient_2, experiment_inclusion_date: Date.today, status: :evicted)
+      create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
 
-        expect(described_class.first.memberships_to_notify(template_1, Date.today)).to contain_exactly(membership_1)
-      end
+      expect(described_class.first.memberships_to_notify(Date.today)).to contain_exactly(membership_1)
     end
   end
 end

--- a/spec/models/experimentation/stale_patient_experiment_spec.rb
+++ b/spec/models/experimentation/stale_patient_experiment_spec.rb
@@ -92,4 +92,47 @@ RSpec.describe Experimentation::StalePatientExperiment do
       expect(result).to contain_exactly(patient)
     end
   end
+
+  describe "#memberships_to_notify" do
+    context "for a reminder_template in an experiment" do
+      it "returns treatment_group_memberships who were enrolled today and need to be reminded today" do
+        experiment = create(:experiment, experiment_type: "stale_patients")
+        treatment_group = create(:treatment_group, experiment: experiment)
+        patient = create(:patient)
+        membership = treatment_group.enroll(patient, experiment_inclusion_date: Date.today)
+        template = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
+
+        expect(described_class.first.memberships_to_notify(template, Date.today)).to contain_exactly(membership)
+      end
+
+      it "returns treatment_group_memberships whose were enrolled in the past `remind_on_in_days` days ago" do
+        experiment = create(:experiment, experiment_type: "stale_patients")
+        treatment_group = create(:treatment_group, experiment: experiment)
+        patient_1 = create(:patient)
+        patient_2 = create(:patient)
+
+        membership_1 = treatment_group.enroll(patient_1, experiment_inclusion_date: 1.days.ago.to_date)
+        membership_2 = treatment_group.enroll(patient_2, experiment_inclusion_date: 10.days.ago.to_date)
+
+        template_1 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 1)
+        template_2 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 10)
+
+        expect(described_class.first.memberships_to_notify(template_1, Date.today)).to contain_exactly(membership_1)
+        expect(described_class.first.memberships_to_notify(template_2, Date.today)).to contain_exactly(membership_2)
+      end
+
+      it "only picks patients who are still enrolled in the experiment" do
+        experiment = create(:experiment, experiment_type: "stale_patients")
+        treatment_group = create(:treatment_group, experiment: experiment)
+        patient_1 = create(:patient)
+        patient_2 = create(:patient)
+
+        membership_1 = treatment_group.enroll(patient_1, experiment_inclusion_date: Date.today, status: :enrolled)
+        _membership_2 = treatment_group.enroll(patient_2, experiment_inclusion_date: Date.today, status: :evicted)
+        template_1 = create(:reminder_template, treatment_group: treatment_group, remind_on_in_days: 0)
+
+        expect(described_class.first.memberships_to_notify(template_1, Date.today)).to contain_exactly(membership_1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Story card:** [ch5676](https://app.shortcut.com/simpledotorg/story/5676/schedule-notifications-for-the-same-day-as-part-of-daily-runner)

## Because
The existing runner schedules notifications for a patient ahead of time. We want to send messages to patients without scheduling to minimise room for erroneous notifications being sent out.

## This addresses

This implements the `Send messages` section in the experiment [flow](https://docs.google.com/document/d/1IMXu_ca9xKU8Xox_3v403ZdvNGQzczLWljy7LQ6RQ6A/edit#). 
> **Current patients**
> - For patients in control: Do nothing
> - For patients in single notification group: Send “your appt. is tomorrow” message
> - For patients in cascade group: 
>   - For patients expected tomorrow: Send “your appt. is tomorrow” message 
>   - For patients expected today: Send “your appt. is today” message
>   - For patients expected 3 days ago: Send “your appt. was 3 days ago” message
> 
> **Stale patients:**
> - For patients in control: Do nothing
> - For patients who were enrolled today: Send “you are late for your BP” notification

The "number of days" are determined from the reminder templates in the experiment at that point in time. Note that the notifications are "scheduled" for the same day, until the `AppointmentNotification::Worker` picks it up during the messaging window.

