### PR TITLE
Add DB constraint to treatment group membership

### DIFF
--- a/db/migrate/20211029070915_add_treatment_group_membership_constraint.rb
+++ b/db/migrate/20211029070915_add_treatment_group_membership_constraint.rb
@@ -1,0 +1,19 @@
+class AddTreatmentGroupMembershipConstraint < ActiveRecord::Migration[5.2]
+  def up
+    patients_in_multiple_experiments =
+      Experimentation::TreatmentGroupMembership
+        .group(:patient_id, :experiment_id)
+        .having("count(*) > 1")
+        .select(:patient_id)
+
+    Experimentation::TreatmentGroupMembership
+      .where(patient_id: patients_in_multiple_experiments)
+      .destroy_all
+
+    add_index :treatment_group_memberships, [:patient_id, :experiment_id], unique: true, name: "index_tgm_patient_id_and_experiment_id"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_19_144905) do
+ActiveRecord::Schema.define(version: 2021_10_29_070915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -678,6 +678,7 @@ ActiveRecord::Schema.define(version: 2021_10_19_144905) do
     t.datetime "deleted_at"
     t.index ["appointment_id"], name: "index_treatment_group_memberships_on_appointment_id"
     t.index ["experiment_id"], name: "index_treatment_group_memberships_on_experiment_id"
+    t.index ["patient_id", "experiment_id"], name: "index_tgm_patient_id_and_experiment_id", unique: true
     t.index ["patient_id"], name: "index_treatment_group_memberships_on_patient_id"
     t.index ["treatment_group_id"], name: "index_treatment_group_memberships_on_treatment_group_id"
   end


### PR DESCRIPTION
**Story card:** [ch5384](https://app.shortcut.com/simpledotorg/story/5384/enforce-constraints-on-experiment)

## Because

This is a follow up to https://github.com/simpledotorg/simple-server/pull/2970. We need a DB constraint on experiment memberships that allows patients to be enrolled in an experiment only once.

## This addresses

This allows a patient to have only one membership in an experiment (irrespective of the treatment group). Adding this since the model constraint can be worked around and this is a more fundamental validation than just checking in `running` experiments.

There are ~3k offending memberships in IHCI production that are enrolled across multiple groups in the `Stale Patient Experiment`. This also deletes those memberships in order to apply the constraint. We can hard delete these since they are basically invalid data. We excluded these from all reporting as well.
