### PR TITLE
Remove deprecated bundler flags

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,8 +33,6 @@ blocks:
           commands:
             - checkout
             - script/semaphore_setup
-            - 'bundle exec rake db:setup'
-            - 'bundle exec rake db:test:prepare'
             - rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT
 promotions:
   - name: Deploy

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -14,5 +14,7 @@ sudo dpkg -i /tmp/libpng12.deb
 gem install semaphore_test_boosters
 cache restore
 yarn install
-bundle install --deployment --path vendor/bundle
+bundle config set deployment 'true'
+bundle config set path 'vendor/bundle'
+bundle install
 cache store

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -17,4 +17,6 @@ yarn install
 bundle config set deployment 'true'
 bundle config set path 'vendor/bundle'
 bundle install
+bundle exec rake db:setup
+bundle exec rake db:test:prepare
 cache store


### PR DESCRIPTION
bundler complains about these flags, and wants to use the config set
approach from here on out

clean up for new bundler: 
**Story card:** [ch3875](https://app.shortcut.com/simpledotorg/story/3875/upgrade-bundler-across-all-environments)
