### PR TITLE
Hard lock webpacker to 6.0.0.rc.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ gem "twilio-ruby", "~> 5.10", ">= 5.10.3"
 gem "uglifier", ">= 1.3.0"
 gem "uuidtools", require: false
 gem "view_component", require: "view_component/engine"
-gem "webpacker", "~> 6.x"
+gem "webpacker", "6.0.0.rc.5"
 gem "whenever", require: false
 gem "wkhtmltoimage-binary"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -743,7 +743,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webdrivers
   webmock
-  webpacker (~> 6.x)
+  webpacker (= 6.0.0.rc.5)
   whenever
   wkhtmltoimage-binary
 

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -5,7 +5,7 @@ set -ex
 source ~/.toolbox/toolbox
 
 # Temporarily turn on cache clear if Semaphore has weird bunlding issues
-cache clear
+# cache clear
 
 sem-version ruby 2.6.6
 sem-service start postgres 10

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -5,7 +5,7 @@ set -ex
 source ~/.toolbox/toolbox
 
 # Temporarily turn on cache clear if Semaphore has weird bunlding issues
-# cache clear
+cache clear
 
 sem-version ruby 2.6.6
 sem-service start postgres 10


### PR DESCRIPTION
We want this locked to a specific version to avoid deployment issues or dev confusion.