### PR TITLE
Ensure we get back all values in month_date order

### DIFF
--- a/app/models/reports/region_summary.rb
+++ b/app/models/reports/region_summary.rb
@@ -55,7 +55,7 @@ module Reports
     def call
       query = for_regions
       query = query.where(month_date: range) if range
-      facility_states = query.group(:month_date, slug_field).select("month_date", slug_field, SUMS, CALCULATIONS)
+      facility_states = query.group(:month_date, slug_field).select("month_date", slug_field, SUMS, CALCULATIONS).order(:month_date)
       facility_states.each { |facility_state|
         @results[facility_state.send(slug_field)][facility_state.period] = facility_state.attributes
       }


### PR DESCRIPTION
**Story card:** [ch5735](https://app.shortcut.com/simpledotorg/story/5735/registration-months-are-out-of-order-in-report-card)

I wasn't able to reproduce this in a test, which is why there are no corresponding specs to verify this behavior.  This may be some postgresql platform / version difference at work here.