### PR TITLE
Switch some reporting related BP factories to with_encounter

### DIFF
--- a/spec/controllers/my_facilities_controller_spec.rb
+++ b/spec/controllers/my_facilities_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe MyFacilitiesController, type: :controller do
         create_list(:patient, 2, full_name: "controlled", assigned_facility: facility, registration_user: supervisor)
       }
       Timecop.freeze("September 20th 2020") do
-        controlled.each { |patient| create(:blood_pressure, :under_control, patient: patient, facility: facility, user: supervisor) }
+        controlled.each { |patient| create(:bp_with_encounter, :under_control, patient: patient, facility: facility, user: supervisor) }
       end
       Timecop.freeze("January 15th 2021") do
         refresh_views
@@ -87,7 +87,7 @@ RSpec.describe MyFacilitiesController, type: :controller do
         create_list(:patient, 2, full_name: "uncontrolled", assigned_facility: facility, registration_user: supervisor)
       }
       Timecop.freeze("September 20th 2020") do
-        controlled.each { |patient| create(:blood_pressure, :hypertensive, patient: patient, facility: facility, user: supervisor) }
+        controlled.each { |patient| create(:bp_with_encounter, :hypertensive, patient: patient, facility: facility, user: supervisor) }
       end
 
       Timecop.freeze("January 15th 2021") do
@@ -110,7 +110,7 @@ RSpec.describe MyFacilitiesController, type: :controller do
         create_list(:patient, 2, full_name: "controlled", assigned_facility: facility, registration_user: supervisor)
       }
       Timecop.freeze("September 20th 2020") do
-        controlled.each { |patient| create(:blood_pressure, :under_control, patient: patient, facility: facility, user: supervisor) }
+        controlled.each { |patient| create(:bp_with_encounter, :under_control, patient: patient, facility: facility, user: supervisor) }
       end
 
       Timecop.freeze("January 15th 2021") do

--- a/spec/queries/cohort_analytics_query_spec.rb
+++ b/spec/queries/cohort_analytics_query_spec.rb
@@ -98,12 +98,12 @@ RSpec.describe CohortAnalyticsQuery do
       it "calculates return and control patient counts in Q2 for patients registered in Q1" do
         travel_to(april) do
           # Facility 1: 2 patients under control, 3 not controlled
-          jan_patients_1[0..1].each { |patient| create(:blood_pressure, :under_control, patient: patient, facility: facility1) }
-          jan_patients_1[2..4].each { |patient| create(:blood_pressure, :hypertensive, patient: patient, facility: facility2) }
+          jan_patients_1[0..1].each { |patient| create(:bp_with_encounter, :under_control, patient: patient, facility: facility1) }
+          jan_patients_1[2..4].each { |patient| create(:bp_with_encounter, :hypertensive, patient: patient, facility: facility2) }
 
           # Facility 2: 3 patients under control, 1 not controlled
-          jan_patients_2[0..2].each { |patient| create(:blood_pressure, :under_control, patient: patient, facility: facility1) }
-          jan_patients_2[3..3].each { |patient| create(:blood_pressure, :hypertensive, patient: patient, facility: facility2) }
+          jan_patients_2[0..2].each { |patient| create(:bp_with_encounter, :under_control, patient: patient, facility: facility1) }
+          jan_patients_2[3..3].each { |patient| create(:bp_with_encounter, :hypertensive, patient: patient, facility: facility2) }
         end
 
         expected_result = {
@@ -142,8 +142,8 @@ RSpec.describe CohortAnalyticsQuery do
       context "when a patient makes multiple follow-up visits" do
         it "only counts the patient once in the registration facility" do
           travel_to(april) do
-            jan_patients_1[0].tap { |patient| create(:blood_pressure, :under_control, patient: patient, facility: facility1) }
-            jan_patients_1[0].tap { |patient| create(:blood_pressure, :under_control, patient: patient, facility: facility2) }
+            jan_patients_1[0].tap { |patient| create(:bp_with_encounter, :under_control, patient: patient, facility: facility1) }
+            jan_patients_1[0].tap { |patient| create(:bp_with_encounter, :under_control, patient: patient, facility: facility2) }
           end
 
           expected_follow_ups = {
@@ -158,10 +158,10 @@ RSpec.describe CohortAnalyticsQuery do
 
         it "marks patient uncontrolled if most recent bp is hypertensive" do
           travel_to(april) do
-            jan_patients_1[0].tap { |patient| create(:blood_pressure, :under_control, patient: patient, facility: facility1) }
+            jan_patients_1[0].tap { |patient| create(:bp_with_encounter, :under_control, patient: patient, facility: facility1) }
           end
           travel_to(may) do
-            jan_patients_1[0].tap { |patient| create(:blood_pressure, :hypertensive, patient: patient, facility: facility2) }
+            jan_patients_1[0].tap { |patient| create(:bp_with_encounter, :hypertensive, patient: patient, facility: facility2) }
           end
 
           analytics = CohortAnalyticsQuery.new(facility_group, period: :quarter, prev_periods: 3, from_time: report_end)
@@ -172,10 +172,10 @@ RSpec.describe CohortAnalyticsQuery do
 
         it "marks patient controlled if most recent bp is under control" do
           travel_to(april) do
-            jan_patients_1[0].tap { |patient| create(:blood_pressure, :hypertensive, patient: patient, facility: facility1) }
+            jan_patients_1[0].tap { |patient| create(:bp_with_encounter, :hypertensive, patient: patient, facility: facility1) }
           end
           travel_to(may) do
-            jan_patients_1[0].tap { |patient| create(:blood_pressure, :under_control, patient: patient, facility: facility2) }
+            jan_patients_1[0].tap { |patient| create(:bp_with_encounter, :under_control, patient: patient, facility: facility2) }
           end
 
           analytics = CohortAnalyticsQuery.new(facility_group, period: :quarter, prev_periods: 3, from_time: report_end)
@@ -202,13 +202,13 @@ RSpec.describe CohortAnalyticsQuery do
       it "calculates return and control patient counts in Feb-Mar for patients registered in Jan" do
         travel_to(march) do
           # Facility 1: 2 patients under control, 3 not controlled
-          jan_patients_1[0..1].each { |patient| create(:blood_pressure, :under_control, patient: patient, facility: facility1) }
-          jan_patients_1[2..4].each { |patient| create(:blood_pressure, :hypertensive, patient: patient, facility: facility2) }
+          jan_patients_1[0..1].each { |patient| create(:bp_with_encounter, :under_control, patient: patient, facility: facility1) }
+          jan_patients_1[2..4].each { |patient| create(:bp_with_encounter, :hypertensive, patient: patient, facility: facility2) }
 
           # Facility 2: 3 patients under control, 3 not controlled
-          jan_patients_2[0..2].each { |patient| create(:blood_pressure, :under_control, patient: patient, facility: facility1) }
-          jan_patients_2[3..3].each { |patient| create(:blood_pressure, :hypertensive, patient: patient, facility: facility2) }
-          jan_patients_3.each { |patient| create(:blood_pressure, :hypertensive, patient: patient, facility: facility2) }
+          jan_patients_2[0..2].each { |patient| create(:bp_with_encounter, :under_control, patient: patient, facility: facility1) }
+          jan_patients_2[3..3].each { |patient| create(:bp_with_encounter, :hypertensive, patient: patient, facility: facility2) }
+          jan_patients_3.each { |patient| create(:bp_with_encounter, :hypertensive, patient: patient, facility: facility2) }
         end
 
         expected_result = {

--- a/spec/queries/district_analytics_query_spec.rb
+++ b/spec/queries/district_analytics_query_spec.rb
@@ -64,11 +64,11 @@ RSpec.describe DistrictAnalyticsQuery do
         #
         Timecop.travel(month + 1.month) do
           patients_1.each do |patient|
-            create(:blood_pressure, patient: patient, facility: facility_1, user: user)
+            create(:bp_with_encounter, patient: patient, facility: facility_1, user: user)
           end
 
           patients_2.each do |patient|
-            create(:blood_pressure, patient: patient, facility: facility_2, user: user)
+            create(:bp_with_encounter, patient: patient, facility: facility_2, user: user)
           end
         end
 
@@ -77,11 +77,11 @@ RSpec.describe DistrictAnalyticsQuery do
         #
         Timecop.travel(month + 2.months) do
           patients_1.each do |patient|
-            create(:blood_pressure, patient: patient, facility: facility_1, user: user)
+            create(:bp_with_encounter, patient: patient, facility: facility_1, user: user)
           end
 
           patients_2.each do |patient|
-            create(:blood_pressure, patient: patient, facility: facility_2, user: user)
+            create(:bp_with_encounter, patient: patient, facility: facility_2, user: user)
           end
         end
       end
@@ -193,7 +193,7 @@ RSpec.describe DistrictAnalyticsQuery do
 
     context "facilities in the same district but belonging to different organizations" do
       let!(:facility_in_another_org) { create(:facility) }
-      let!(:bp_in_another_org) { create(:blood_pressure, facility: facility_in_another_org) }
+      let!(:bp_in_another_org) { create(:bp_with_encounter, facility: facility_in_another_org) }
 
       it "does not contain data from a different organization" do
         expect(analytics.registered_patients_by_period.keys).not_to include(facility_in_another_org.id)
@@ -224,8 +224,8 @@ RSpec.describe DistrictAnalyticsQuery do
 
     before do
       Timecop.travel(three_months_back) do
-        create(:blood_pressure, patient: patients.first, facility: facility_2, user: user)
-        create(:blood_pressure, patient: patients.second, facility: facility_2, user: user)
+        create(:bp_with_encounter, patient: patients.first, facility: facility_2, user: user)
+        create(:bp_with_encounter, patient: patients.second, facility: facility_2, user: user)
       end
 
       patients.first.discard_data

--- a/spec/services/activity_service_spec.rb
+++ b/spec/services/activity_service_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_1)
@@ -224,7 +224,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       [
@@ -233,7 +233,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_2, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_2, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_group)
@@ -250,7 +250,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       [
@@ -259,7 +259,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_2, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_2, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_group, group: BloodPressure.arel_table[:facility_id])
@@ -285,7 +285,7 @@ RSpec.describe ActivityService do
         aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_1, period: :day)
@@ -312,7 +312,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_1, include_current_period: false)
@@ -329,7 +329,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_1, last: 2)
@@ -347,11 +347,11 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         htn_patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: htn_patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: htn_patient, facility: facility_1, recorded_at: date)
         create(:blood_sugar, patient: htn_patient, facility: facility_1, recorded_at: date)
 
         dm_patient_with_bp = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: dm_patient_with_bp, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: dm_patient_with_bp, facility: facility_1, recorded_at: date)
       end
 
       # Included patients
@@ -379,7 +379,7 @@ RSpec.describe ActivityService do
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
         # We need encounters for these BPs since the generic follow up scope traverses Encounter records
-        create(:blood_pressure, :with_encounter, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       [
@@ -406,7 +406,7 @@ RSpec.describe ActivityService do
         june_1, june_2, june_3,
         july_1
       ].each do |date|
-        create(:blood_pressure, patient: multi_visit_patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: multi_visit_patient, facility: facility_1, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_1)
@@ -422,7 +422,7 @@ RSpec.describe ActivityService do
       [
         june_1, june_2, june_3
       ].each do |date|
-        create(:blood_pressure, patient: multi_visit_patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: multi_visit_patient, facility: facility_1, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_1, period: :day)
@@ -439,7 +439,7 @@ RSpec.describe ActivityService do
         june_1, june_1, june_1,
         june_2
       ].each do |date|
-        create(:blood_pressure, patient: multi_visit_patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: multi_visit_patient, facility: facility_1, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_1, period: :day)
@@ -458,7 +458,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_1)
@@ -475,7 +475,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       [
@@ -484,7 +484,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_2, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_2, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_group)
@@ -501,7 +501,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       [
@@ -510,7 +510,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_2, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_2, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_group, group: BloodPressure.arel_table[:facility_id])
@@ -536,7 +536,7 @@ RSpec.describe ActivityService do
         aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_1, period: :day)
@@ -563,7 +563,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_1, include_current_period: false)
@@ -580,7 +580,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_1, last: 2)
@@ -598,7 +598,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         htn_patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: htn_patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: htn_patient, facility: facility_1, recorded_at: date)
         create(:blood_sugar, patient: htn_patient, facility: facility_1, recorded_at: date)
 
         dm_patient_with_blood_sugar = create(:patient, :diabetes, recorded_at: long_ago)
@@ -612,7 +612,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         dm_patient_with_bp = create(:patient, :diabetes, recorded_at: long_ago)
-        create(:blood_pressure, patient: dm_patient_with_bp, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: dm_patient_with_bp, facility: facility_1, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_1, diagnosis: :diabetes)
@@ -629,7 +629,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :hypertension, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       [
@@ -638,7 +638,7 @@ RSpec.describe ActivityService do
         aug_1, aug_2
       ].each do |date|
         patient = create(:patient, :diabetes, recorded_at: long_ago)
-        create(:blood_pressure, patient: patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: patient, facility: facility_1, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_1, diagnosis: :all)
@@ -655,7 +655,7 @@ RSpec.describe ActivityService do
         june_1, june_2, june_3,
         july_1
       ].each do |date|
-        create(:blood_pressure, patient: multi_visit_patient, facility: facility_1, recorded_at: date)
+        create(:bp_with_encounter, patient: multi_visit_patient, facility: facility_1, recorded_at: date)
       end
 
       activity_service = ActivityService.new(facility_1)

--- a/spec/services/facility_stats_service_spec.rb
+++ b/spec/services/facility_stats_service_spec.rb
@@ -50,11 +50,11 @@ RSpec.describe FacilityStatsService do
       small_controlled.each do |patient|
         logger.info "--- start"
         create(:bp_with_encounter, :under_control, patient: patient, facility: patient.assigned_facility,
-                                                recorded_at: december - 4.months, user: user)
+                                                   recorded_at: december - 4.months, user: user)
         logger.info "--- end"
       end
       create(:bp_with_encounter, :hypertensive, patient: small_uncontrolled, facility: small_uncontrolled.assigned_facility,
-                                             recorded_at: december - 4.months, user: user)
+                                                recorded_at: december - 4.months, user: user)
 
       medium_facility1 = create(:facility, name: "medium_1", facility_size: "medium", facility_group: facility_group)
       medium_facility2 = create(:facility, name: "medium_2", facility_size: "medium", facility_group: facility_group)
@@ -63,9 +63,9 @@ RSpec.describe FacilityStatsService do
       medium_uncontrolled = create(:patient, full_name: "medium_uncontrolled", registration_facility: medium_facility2,
                                              recorded_at: december - 4.months, registration_user: user)
       create(:bp_with_encounter, :under_control, patient: medium_controlled, user: user,
-                                              facility: medium_controlled.assigned_facility, recorded_at: december - 3.months)
+                                                 facility: medium_controlled.assigned_facility, recorded_at: december - 3.months)
       create(:bp_with_encounter, :hypertensive, patient: medium_uncontrolled, user: user,
-                                             facility: medium_controlled.assigned_facility, recorded_at: december - 3.months)
+                                                facility: medium_controlled.assigned_facility, recorded_at: december - 3.months)
 
       large_facility1 = create(:facility, name: "large_1", facility_size: "large", facility_group: facility_group)
       large_facility2 = create(:facility, name: "large_2", facility_size: "large", facility_group: facility_group)
@@ -75,10 +75,10 @@ RSpec.describe FacilityStatsService do
       large_uncontrolled = create_list(:patient, 2, full_name: "large_uncontrolled", registration_user: user,
                                                     registration_facility: large_facility2, recorded_at: december - 3.months)
       create(:bp_with_encounter, :under_control, patient: large_controlled, user: user,
-                                              facility: large_controlled.assigned_facility, recorded_at: december - 2.months)
+                                                 facility: large_controlled.assigned_facility, recorded_at: december - 2.months)
       large_uncontrolled.each do |patient|
         create(:bp_with_encounter, :hypertensive, patient: patient, user: user,
-                                               facility: patient.assigned_facility, recorded_at: december - 2.months)
+                                                  facility: patient.assigned_facility, recorded_at: december - 2.months)
       end
 
       all_facilities = [small_facility1, small_facility2, medium_facility1,

--- a/spec/services/facility_stats_service_spec.rb
+++ b/spec/services/facility_stats_service_spec.rb
@@ -49,11 +49,11 @@ RSpec.describe FacilityStatsService do
       # recorded_at needs to be in a month after registration in order to appear in control rate data
       small_controlled.each do |patient|
         logger.info "--- start"
-        create(:blood_pressure, :under_control, patient: patient, facility: patient.assigned_facility,
+        create(:bp_with_encounter, :under_control, patient: patient, facility: patient.assigned_facility,
                                                 recorded_at: december - 4.months, user: user)
         logger.info "--- end"
       end
-      create(:blood_pressure, :hypertensive, patient: small_uncontrolled, facility: small_uncontrolled.assigned_facility,
+      create(:bp_with_encounter, :hypertensive, patient: small_uncontrolled, facility: small_uncontrolled.assigned_facility,
                                              recorded_at: december - 4.months, user: user)
 
       medium_facility1 = create(:facility, name: "medium_1", facility_size: "medium", facility_group: facility_group)
@@ -62,9 +62,9 @@ RSpec.describe FacilityStatsService do
                                            recorded_at: december - 4.months, registration_user: user)
       medium_uncontrolled = create(:patient, full_name: "medium_uncontrolled", registration_facility: medium_facility2,
                                              recorded_at: december - 4.months, registration_user: user)
-      create(:blood_pressure, :under_control, patient: medium_controlled, user: user,
+      create(:bp_with_encounter, :under_control, patient: medium_controlled, user: user,
                                               facility: medium_controlled.assigned_facility, recorded_at: december - 3.months)
-      create(:blood_pressure, :hypertensive, patient: medium_uncontrolled, user: user,
+      create(:bp_with_encounter, :hypertensive, patient: medium_uncontrolled, user: user,
                                              facility: medium_controlled.assigned_facility, recorded_at: december - 3.months)
 
       large_facility1 = create(:facility, name: "large_1", facility_size: "large", facility_group: facility_group)
@@ -74,10 +74,10 @@ RSpec.describe FacilityStatsService do
       expect(large_controlled.registration_facility).to eq(large_controlled.assigned_facility)
       large_uncontrolled = create_list(:patient, 2, full_name: "large_uncontrolled", registration_user: user,
                                                     registration_facility: large_facility2, recorded_at: december - 3.months)
-      create(:blood_pressure, :under_control, patient: large_controlled, user: user,
+      create(:bp_with_encounter, :under_control, patient: large_controlled, user: user,
                                               facility: large_controlled.assigned_facility, recorded_at: december - 2.months)
       large_uncontrolled.each do |patient|
-        create(:blood_pressure, :hypertensive, patient: patient, user: user,
+        create(:bp_with_encounter, :hypertensive, patient: patient, user: user,
                                                facility: patient.assigned_facility, recorded_at: december - 2.months)
       end
 

--- a/spec/services/monthly_district_data_service_spec.rb
+++ b/spec/services/monthly_district_data_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe MonthlyDistrictDataService do
   let(:follow_up_patient) do
     patient = create(:patient, :hypertension, recorded_at: 3.months.ago, assigned_facility: facility2, registration_facility: facility2)
     create(:appointment, creation_facility: facility2, scheduled_date: 2.month.ago, patient: patient)
-    create(:blood_pressure, facility: facility2, patient: patient, recorded_at: 2.months.ago)
+    create(:bp_with_encounter, facility: facility2, patient: patient, recorded_at: 2.months.ago)
     patient
   end
   let(:patient_without_hypertension) do


### PR DESCRIPTION
[ch5738](https://app.shortcut.com/simpledotorg/story/5738/switch-all-reports-data-access-to-v2)


Cherry picking some spec only changes from https://github.com/simpledotorg/simple-server/pull/3022

## Because

For all reporting pipeline related queries, BPs need to have encounters created for the pipeline to work correctly. This updates some reporting related specs to use `bp_with_encounter` so that as we make the pipeline the main source of reporting truth, things will work correctly.

## This addresses

updating specs

## Test instructions

Run tests