### PR TITLE
A/B enhancements: Make experiment limits configurable

### DIFF
--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -1,7 +1,6 @@
 module Experimentation
   class NotificationsExperiment < Experiment
     include Memery
-    MAX_PATIENTS_PER_DAY = 2000
     BATCH_SIZE = 1000
 
     default_scope { where(experiment_type: %w[current_patients stale_patients]) }
@@ -41,7 +40,7 @@ module Experimentation
                                              .having("count(patient_id) > 1"))
     end
 
-    def enroll_patients(date, limit = MAX_PATIENTS_PER_DAY)
+    def enroll_patients(date, limit = max_patients_per_day)
       eligible_patients(date)
         .limit([remaining_enrollments_allowed(date), limit].min)
         .includes(:assigned_facility, :registration_facility, :medical_history)
@@ -127,7 +126,7 @@ module Experimentation
     private
 
     def remaining_enrollments_allowed(date)
-      MAX_PATIENTS_PER_DAY - treatment_group_memberships.where(experiment_inclusion_date: date).count
+      max_patients_per_day - treatment_group_memberships.where(experiment_inclusion_date: date).count
     end
 
     def reporting_data(patient, date)

--- a/db/migrate/20211105065243_add_max_patients_per_day_to_experiment.rb
+++ b/db/migrate/20211105065243_add_max_patients_per_day_to_experiment.rb
@@ -1,0 +1,5 @@
+class AddMaxPatientsPerDayToExperiment < ActiveRecord::Migration[5.2]
+  def change
+    add_column :experiments, :max_patients_per_day, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_29_070915) do
+ActiveRecord::Schema.define(version: 2021_11_05_065243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -261,6 +261,7 @@ ActiveRecord::Schema.define(version: 2021_10_29_070915) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
+    t.integer "max_patients_per_day", default: 0
     t.index ["name"], name: "index_experiments_on_name", unique: true
   end
 

--- a/spec/factories/experimentation/experiments.rb
+++ b/spec/factories/experimentation/experiments.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     experiment_type { "current_patients" }
     start_time { 1.week.ago }
     end_time { 1.week.from_now }
+    max_patients_per_day { 10 }
   end
 
   trait :with_treatment_group do

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -192,10 +192,9 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
     it "enrolls max patients per day only even if called multiple times" do
       patients = create_list(:patient, 2, age: 18)
       patients.each { |patient| create(:appointment, scheduled_date: Date.today, patient: patient) }
-      experiment = create(:experiment, experiment_type: "current_patients")
+      experiment = create(:experiment, experiment_type: "current_patients", max_patients_per_day: 1)
       treatment_group = create(:treatment_group, experiment: experiment)
       create(:reminder_template, message: "1", treatment_group: treatment_group, remind_on_in_days: 0)
-      stub_const("#{Experimentation::NotificationsExperiment}::MAX_PATIENTS_PER_DAY", 1)
 
       expect(Experimentation::CurrentPatientExperiment.first.eligible_patients(Date.today).count).to eq(2)
       Experimentation::CurrentPatientExperiment.first.enroll_patients(Date.today, 1)


### PR DESCRIPTION
**Story card:** [ch5755](https://app.shortcut.com/simpledotorg/story/5755/make-experiment-enrollment-limit-configurable-per-experiment)

## Because

As we run experiments in different countries, we will want to run experiments with different bucket sizes depending on the registrations there. We also want to select different numbers of patients because of twilio limits in the IHCI experiment. [Slack ref](https://simpledotorg.slack.com/archives/C01FMV58MEC/p1635935947041600)

## This addresses

This moves the experiment limits from a class constant to the database. We will set these limits while seeding the experiment each time.
