### PR TITLE
A/B enhancements: Monitor runner performance

### DIFF
--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -14,9 +14,9 @@ module Experimentation
     # The order of operations is important.
     # See https://docs.google.com/document/d/1IMXu_ca9xKU8Xox_3v403ZdvNGQzczLWljy7LQ6RQ6A for more details.
     def self.conduct_daily(date)
-      running.each { |experiment| time(:enroll_patients) { experiment.enroll_patients(date) } }
-      monitoring.each { |experiment| time(:monitor) { experiment.monitor } }
-      notifying.each { |experiment| time(:scheduled_notifications) { experiment.schedule_notifications(date) } }
+      running.each { |experiment| time("#{experiment.experiment_type}.enroll_patients") { experiment.enroll_patients(date) } }
+      monitoring.each { |experiment| time("#{experiment.experiment_type}.monitor") { experiment.monitor } }
+      notifying.each { |experiment| time("#{experiment.experiment_type}.scheduled_notifications") { experiment.schedule_notifications(date) } }
     end
 
     # Returns patients who are eligible for enrollment. These should be
@@ -50,9 +50,9 @@ module Experimentation
     end
 
     def monitor
-      time(:record_notification_results) { record_notification_results }
-      time(:mark_visits) { mark_visits }
-      time(:evict_patients) { evict_patients }
+      time("#{experiment_type}.record_notification_results") { record_notification_results }
+      time("#{experiment_type}.mark_visits") { mark_visits }
+      time("#{experiment_type}.evict_patients") { evict_patients }
     end
 
     def record_notification_results


### PR DESCRIPTION
**Story card:** [ch4929](https://app.shortcut.com/simpledotorg/epic/4929/a-b-testing-ihci-experiment-2?vc_group_by=day&ct_workflow=all&cf_workflow=500000031)

## Because

We need some basic performance metrics to see how long does it take to: enroll, notify, mark visit, evict.

## This addresses

This adds statsd timers to measure performance at a high level. We will add more metrics if we need as the test experiment runs.
