### PR TITLE
A/B experiments: Create small test experiment in IHCI

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -53,6 +53,12 @@ every :monday, at: local("6:00 am"), roles: [:cron] do
   end
 end
 
+every :day, at: local("07:30 am"), roles: [:cron] do
+  if CountryConfig.current_country?("India")
+    runner "Experimentation::Runner.call"
+  end
+end
+
 every :day, at: local("08:30 am"), roles: [:cron] do
   if CountryConfig.current_country?("India")
     runner "AppointmentNotification::ScheduleExperimentReminders.perform_now"

--- a/db/data/20210725213406_create_small_test_experiments.rb
+++ b/db/data/20210725213406_create_small_test_experiments.rb
@@ -5,12 +5,14 @@ class CreateSmallTestExperiments < ActiveRecord::Migration[5.2]
     Seed::ExperimentSeeder.create_current_experiment(
       experiment_name: "Small Current Patient July 2021",
       start_time: Time.parse("Jul 28, 2021"),
-      end_time: Time.parse("Jul 30, 2021")
+      end_time: Time.parse("Jul 30, 2021"),
+      max_patients_per_day: 100
     )
     Seed::ExperimentSeeder.create_stale_experiment(
       experiment_name: "Small Stale Patient July 2021",
       start_time: Time.parse("Jul 28, 2021"),
-      end_time: Time.parse("Jul 30, 2021")
+      end_time: Time.parse("Jul 30, 2021"),
+      max_patients_per_day: 100
     )
   end
 

--- a/db/data/20211109123458_create_november_small_test_experiments.rb
+++ b/db/data/20211109123458_create_november_small_test_experiments.rb
@@ -1,0 +1,22 @@
+class CreateNovemberSmallTestExperiments < ActiveRecord::Migration[5.2]
+  def up
+    return unless CountryConfig.current_country?("India") && SimpleServer.env.production?
+
+    Seed::ExperimentSeeder.create_current_experiment(
+      experiment_name: "Small Current Patient November 2021",
+      start_time: Date.parse("Nov 10, 2021").beginning_of_day,
+      end_time: Date.parse("Nov 11, 2021").end_of_day,
+      max_patients_per_day: 100
+    )
+    Seed::ExperimentSeeder.create_stale_experiment(
+      experiment_name: "Small Stale Patient November 2021",
+      start_time: Date.parse("Nov 10, 2021").beginning_of_day,
+      end_time: Date.parse("Nov 11, 2021").end_of_day,
+      max_patients_per_day: 100
+    )
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20211019141036)
+DataMigrate::Data.define(version: 20211109123458)

--- a/lib/seed/experiment_seeder.rb
+++ b/lib/seed/experiment_seeder.rb
@@ -6,12 +6,13 @@ module Seed
       delegate :transaction, to: ActiveRecord::Base
     end
 
-    def self.create_current_experiment(start_time:, end_time:, experiment_name: "current patient test experiment")
+    def self.create_current_experiment(start_time:, end_time:, experiment_name:, max_patients_per_day:)
       transaction do
         Experimentation::Experiment.current_patients.create!(
           name: experiment_name,
           start_time: start_time,
-          end_time: end_time
+          end_time: end_time,
+          max_patients_per_day: max_patients_per_day
         ).tap do |experiment|
           _control_group = experiment.treatment_groups.create!(description: "control")
 
@@ -26,12 +27,13 @@ module Seed
       end
     end
 
-    def self.create_stale_experiment(start_time:, end_time:, experiment_name: "stale patient test experiment")
+    def self.create_stale_experiment(start_time:, end_time:, max_patients_per_day:, experiment_name:)
       transaction do
         Experimentation::Experiment.stale_patients.create!(
           name: experiment_name,
           start_time: start_time,
-          end_time: end_time
+          end_time: end_time,
+          max_patients_per_day: max_patients_per_day
         ).tap do |experiment|
           _control_group = experiment.treatment_groups.create!(description: "control")
 

--- a/lib/seed/experiment_seeder.rb
+++ b/lib/seed/experiment_seeder.rb
@@ -22,7 +22,7 @@ module Seed
           cascade = experiment.treatment_groups.create!(description: "cascade")
           cascade.reminder_templates.create!(message: "notifications.set01.basic", remind_on_in_days: -1)
           cascade.reminder_templates.create!(message: "notifications.set02.basic", remind_on_in_days: 0)
-          cascade.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 3)
+          cascade.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 2)
         end
       end
     end

--- a/spec/lib/seed/experiment_seeder_spec.rb
+++ b/spec/lib/seed/experiment_seeder_spec.rb
@@ -3,13 +3,18 @@ require "rails_helper"
 RSpec.describe Seed::ExperimentSeeder do
   describe ".create_current_experiment" do
     it "creates experiment, treatment groups, and reminder templates" do
-      expect(Experimentation::Experiment.count).to eq(0)
-      expect(Experimentation::TreatmentGroup.count).to eq(0)
-      expect(Experimentation::ReminderTemplate.count).to eq(0)
+      described_class.create_current_experiment(
+        start_time: 1.day.from_now,
+        end_time: 2.days.from_now,
+        experiment_name: "current patients",
+        max_patients_per_day: 10
+      )
 
-      experiment = described_class.create_current_experiment(start_time: 1.day.from_now, end_time: 2.days.from_now)
+      experiment = Experimentation::CurrentPatientExperiment.first
 
       expect(experiment).to be_current_patients
+      expect(experiment.name).to eq("current patients")
+      expect(experiment.max_patients_per_day).to eq(10)
       expect(experiment.treatment_groups.count).to eq(3)
       cascade_templates = experiment.treatment_groups.find_by!(description: "cascade").reminder_templates
       expect(cascade_templates.count).to eq(3)
@@ -20,13 +25,17 @@ RSpec.describe Seed::ExperimentSeeder do
 
   describe ".create_stale_experiment" do
     it "creates experiment, treatment groups, and reminder templates" do
-      expect(Experimentation::Experiment.count).to eq(0)
-      expect(Experimentation::TreatmentGroup.count).to eq(0)
-      expect(Experimentation::ReminderTemplate.count).to eq(0)
-
-      experiment = described_class.create_stale_experiment(start_time: 1.day.from_now, end_time: 2.days.from_now)
+      experiment = described_class.create_stale_experiment(
+        start_time: 1.day.from_now,
+        end_time: 2.days.from_now,
+        experiment_name: "stale patients",
+        max_patients_per_day: 10
+      )
 
       expect(experiment).to be_stale_patients
+      expect(experiment.name).to eq("stale patients")
+      expect(experiment.max_patients_per_day).to eq(10)
+      expect(experiment.max_patients_per_day).to eq(10)
       expect(experiment.treatment_groups.count).to eq(2)
       templates = experiment.treatment_groups.find_by!(description: "single_notification").reminder_templates
       expect(templates.count).to eq(1)


### PR DESCRIPTION
**Story card:** [ch5830](https://app.shortcut.com/simpledotorg/story/5830/run-small-test-experiment-in-ihci-production)

## Because

We want to run a small test experiment in IHCI production to test things end to end.

## This addresses
Adds a data migration that creates the two test experiments. The runner will pick up the experiments and kick them off tomorrow at `07:30 am`.
