### PR TITLE
Imo invitation fixes and enhancements 

### DIFF
--- a/app/controllers/api/v3/imo_callbacks_controller.rb
+++ b/app/controllers/api/v3/imo_callbacks_controller.rb
@@ -12,13 +12,16 @@ class Api::V3::ImoCallbacksController < ApplicationController
 
   def subscribe
     unless params[:event] == "accept_invite"
+      Statsd.instance.increment("imo.callback.unknown_error")
       raise ImoCallbackError.new("unexpected Imo invitation event: #{params[:event]}")
     end
 
     patient = Patient.find(params[:patient_id])
     unless patient.imo_authorization
+      Statsd.instance.increment("imo.callback.missing_imo_auth_error")
       raise ImoCallbackError.new("patient #{patient.id} does not have an ImoAuthorization")
     end
+    Statsd.instance.increment("imo.callback.subscribed")
     patient.imo_authorization.status_subscribed!
     head :ok
   end

--- a/app/controllers/api/v3/imo_callbacks_controller.rb
+++ b/app/controllers/api/v3/imo_callbacks_controller.rb
@@ -1,5 +1,4 @@
 class Api::V3::ImoCallbacksController < ApplicationController
-  http_basic_authenticate_with name: ENV["IMO_CALLBACK_USERNAME"], password: ENV["IMO_CALLBACK_PASSWORD"]
   skip_before_action :verify_authenticity_token
 
   class ImoCallbackError < StandardError; end

--- a/app/jobs/imo/invite_unsubscribed_patients.rb
+++ b/app/jobs/imo/invite_unsubscribed_patients.rb
@@ -5,16 +5,16 @@ class Imo::InviteUnsubscribedPatients
 
   REINVITATION_BUFFER = 6.months.freeze
 
-  def perform
+  def perform(patient_count = 0)
     return unless Flipper.enabled?(:imo_messaging)
 
     next_messaging_time = Communication.next_messaging_time
-    patient_ids.each do |patient_id|
+    patient_ids(patient_count).each do |patient_id|
       Imo::InvitePatient.perform_at(next_messaging_time, patient_id)
     end
   end
 
-  def patient_ids
+  def patient_ids(patient_count)
     Patient
       .contactable
       .not_ltfu_as_of(Time.current)
@@ -23,6 +23,7 @@ class Imo::InviteUnsubscribedPatients
         "(imo_authorizations.last_invited_at < ? AND imo_authorizations.status != ?) OR imo_authorizations.id IS NULL",
         REINVITATION_BUFFER.ago, "subscribed"
       )
+      .limit(patient_count)
       .pluck(:id)
   end
 end

--- a/spec/controllers/api/v3/imo_callbacks_controller_spec.rb
+++ b/spec/controllers/api/v3/imo_callbacks_controller_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe Api::V3::ImoCallbacksController, type: :controller do
   describe "#subscribe" do
-    it "returns 401 when authentication fails" do
+    # Skipping this since Imo callbacks aren't authenticated for now
+    xit "returns 401 when authentication fails" do
       post :subscribe, params: {patient_id: "does_not_matter", event: "accept_invite"}
       expect(response.status).to eq(401)
     end
@@ -55,7 +56,8 @@ RSpec.describe Api::V3::ImoCallbacksController, type: :controller do
   end
 
   describe "#read_receipt" do
-    it "returns 401 when authentication fails" do
+    # Skipping this since Imo callbacks aren't authenticated for now
+    xit "returns 401 when authentication fails" do
       post :read_receipt
       expect(response.status).to eq(401)
     end

--- a/spec/jobs/imo/invite_unsubscribed_patients_spec.rb
+++ b/spec/jobs/imo/invite_unsubscribed_patients_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe Imo::InviteUnsubscribedPatients, type: :job do
       end
 
       it "invites only the selected number of patients" do
-        patient_1 = create(:patient)
-        patient_2 = create(:patient)
+        _patient_1 = create(:patient)
+        _patient_2 = create(:patient)
 
         Timecop.freeze(date) do
           expect(Imo::InvitePatient).to receive(:perform_at).exactly(1).time


### PR DESCRIPTION
**Story card:** none

## Because

We found a few issues while testing Imo invitations

## This addresses

- Callback authentication doesn't work, removing this while we wait for feedback from the Imo team
- Adds datadog metrics around the subscription callbacks for improved visibility
- The `Imo::InviteUnsubscribedPatients` job now accepts a patient count arg so we can invite a limited number of patients
