### PR TITLE
A/B experiments: Schedule notifications with runner

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -55,13 +55,7 @@ end
 
 every :day, at: local("07:30 am"), roles: [:cron] do
   if CountryConfig.current_country?("India")
-    runner "Experimentation::Runner.call"
-  end
-end
-
-every :day, at: local("08:30 am"), roles: [:cron] do
-  if CountryConfig.current_country?("India")
-    runner "AppointmentNotification::ScheduleExperimentReminders.perform_now"
+    runner "Experimentation::Runner.call;AppointmentNotification::ScheduleExperimentReminders.perform_now"
   end
 end
 


### PR DESCRIPTION
**Story card:** - 

## Because

The experiment reminder scheduler runs at 08:30am, which is half an hour after our communication window starts (8am).  We don't need to do this anymore and can schedule notifications right away. Reducing the window between when notifications are scheduled and they are sent out will also reduce chances of patients visiting in that window.

## This addresses

Updates `schedule.rb`
