### PR TITLE
Add localized_region_type and use it in dashboard

### DIFF
--- a/app/exporters/drug_consumption_report_exporter.rb
+++ b/app/exporters/drug_consumption_report_exporter.rb
@@ -51,7 +51,7 @@ class DrugConsumptionReportExporter
         "#{protocol_drug_labels[category][:short]} base doses"
       end
 
-    ["Facilities", I18n.t("facility_group_zone").capitalize] + drug_name_cells + drug_category_name_cells
+    ["Facilities", I18n.t("region_type.block").capitalize] + drug_name_cells + drug_category_name_cells
   end
 
   def total_consumption_row

--- a/app/exporters/drug_stocks_report_exporter.rb
+++ b/app/exporters/drug_stocks_report_exporter.rb
@@ -39,7 +39,7 @@ class DrugStocksReportExporter
   end
 
   def drug_names_header
-    ["Facilities", I18n.t("facility_group_zone").capitalize] +
+    ["Facilities", I18n.t("region_type.block").capitalize] +
       @drugs_by_category.flat_map do |_drug_category, drugs|
         drug_columns = drugs.map do |drug|
           "#{drug.name} #{drug.dosage}"

--- a/app/helpers/drug_stock_helper.rb
+++ b/app/helpers/drug_stock_helper.rb
@@ -1,0 +1,9 @@
+module DrugStockHelper
+  def drug_stock_region_label(region)
+    if region.district_region?
+      "#{region.localized_region_type.capitalize} warehouse"
+    else
+      region.localized_region_type.capitalize
+    end
+  end
+end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -179,6 +179,10 @@ class Region < ApplicationRecord
     end
   end
 
+  def localized_region_type
+    I18n.t("region_type.#{region_type}")
+  end
+
   def log_payload
     attrs = attributes.slice("name", "slug", "path")
     attrs["id"] = id.presence

--- a/app/services/facility_region_csv.rb
+++ b/app/services/facility_region_csv.rb
@@ -12,8 +12,7 @@ class FacilityRegionCsv
 
   def self.localize_header(header)
     return header unless Region.region_types.include?(header)
-    header = header == :block ? :zone : header # our I18n keys still use zone for block region type
-    I18n.t("helpers.label.facility.#{header}", default: header.to_s).gsub(" *", "")
+    I18n.t("region_type.#{header}").capitalize
   end
 
   def self.headers

--- a/app/views/admin/facilities/_form.html.erb
+++ b/app/views/admin/facilities/_form.html.erb
@@ -17,8 +17,8 @@
           {id: :facility_zone, include_blank: true, wrapper_class: "mb-0"},
           required: true %>
       <small class="form-text text-muted mb-3">
-        If you don't see a <%= t("facility_group_zone") %> in the list,
-        <%= link_to "add it to the #{t("facility_group")}", edit_admin_facility_group_path(@facility_group, anchor: "block-list"), target: :_blank %>
+        If you don't see a <%= t("region_type.block") %> in the list,
+        <%= link_to "add it to the #{t("region_type.district")}", edit_admin_facility_group_path(@facility_group, anchor: "block-list"), target: :_blank %>
         and refresh this page.
       </small>
       <%= form.text_field :district, id: :facility_district, required: true %>

--- a/app/views/admin/facility_groups/_form.html.erb
+++ b/app/views/admin/facility_groups/_form.html.erb
@@ -38,9 +38,9 @@
       <% end %>
 
       <div class="mt-3">
-        <label><%= I18n.t("facility_group_zone").tr("* ", "").pluralize.capitalize %></label>
+        <label><%= I18n.t("region_type.block").pluralize.capitalize %></label>
         <div class="input-group mb-2">
-          <input type="text" class="form-control" id="new-block-name" placeholder="Add new <%= I18n.t("facility_group_zone").downcase.tr("* ", "") %>">
+          <input type="text" class="form-control" id="new-block-name" placeholder="Add new <%= I18n.t("region_type.block") %>">
           <div class="input-group-append">
             <a class="btn btn-primary text-white add-block">Add</a>
           </div>

--- a/app/views/admin/facility_groups/new.html.erb
+++ b/app/views/admin/facility_groups/new.html.erb
@@ -1,3 +1,3 @@
-<h1>New <%= t("region_type.district").capitalize %></h1>
+<h1>New <%= t("region_type.district") %></h1>
 
 <%= render 'form', facility_group: @facility_group, organizations: @organizations, protocols: @protocols %>

--- a/app/views/admin/facility_groups/new.html.erb
+++ b/app/views/admin/facility_groups/new.html.erb
@@ -1,3 +1,3 @@
-<h1>New <%= t("facility_group") %></h1>
+<h1>New <%= t("region_type.district").capitalize %></h1>
 
 <%= render 'form', facility_group: @facility_group, organizations: @organizations, protocols: @protocols %>

--- a/app/views/my_facilities/drug_stocks/_drug_consumption_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_consumption_table.html.erb
@@ -84,7 +84,7 @@
     <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
         data-original-title='District: <%= "#{@report[:district_patient_count]} patients" %>'>
       <%= link_to(reports_region_path(@district_region, report_scope: "district")) do %>
-        District Warehouse
+        <%= drug_stock_region_label(@district_region).titleize %>
       <% end %>
     </td>
     <% @drugs_by_category.map do |drug_category, drugs| %>

--- a/app/views/my_facilities/drug_stocks/_drug_stocks_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_stocks_table.html.erb
@@ -70,7 +70,7 @@
       <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
           data-original-title='District: <%= "#{@report[:district_patient_count]} patients" %>'>
         <%= link_to(reports_region_path(@district_region, report_scope: "district")) do %>
-          District Warehouse
+          <%= drug_stock_region_label(@district_region).titleize %>
         <% end %>
       </td>
       <td class="text-center">

--- a/app/views/my_facilities/drug_stocks/new.html.erb
+++ b/app/views/my_facilities/drug_stocks/new.html.erb
@@ -11,11 +11,7 @@
 
     <div class="modal-body">
       <div class="form-group">
-        <% if @region_type == "district" %>
-          <label> District warehouse: </label>
-        <% else %>
-          <label> Facility: </label>
-        <% end %>
+        <label> <%= drug_stock_region_label(@region) %>:</label>
         <span> <%= @region.name %> </span>
         <%= form.hidden_field :region_id, value: @region.id %>
         <%= form.hidden_field :region_type, value: @region_type %>

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -1,6 +1,6 @@
 <div class="card mb-0">
   <h3 class="mb-16px c-black">
-    <%= @period %> <%= region_type %> performance
+    <%= @period %> <%= localized_region_type %> performance
   </h3>
   <div class="table-responsive">
     <table id="region-comparison-table" class="table-compact">
@@ -57,7 +57,7 @@
       </tr>
       <tr class="sorts" data-sort-method="thead">
         <th class="row-label sort-label sort-label-small ta-left" data-sort-default>
-          <%= region_type.capitalize %>
+          <%= localized_region_type.capitalize %>
         </th>
         <th class="row-label sort-label sort-label-small ta-left" data-sort-method="number">
           Percent
@@ -144,7 +144,7 @@
         <% next if result.dig(:missed_visits_rate, @period).nil? %>
         <tr>
           <td class="ta-left">
-            <%= link_to(reports_region_path(child, report_scope: region_type)) do %>
+            <%= link_to(reports_region_path(child, report_scope: child.region_type)) do %>
               <%= child.name %>
             <% end %>
           </td>

--- a/app/views/reports/regions/_downloads.html.erb
+++ b/app/views/reports/regions/_downloads.html.erb
@@ -22,7 +22,7 @@
     <% if @region.district_region? && CountryConfig.current_country?("India") %>
       <%= link_to(reports_region_monthly_district_data_path(@region, report_scope: params[:report_scope], period: params.dig(:period, :value), format: :csv), class: "dropdown-item") do %>
         <i class="far fa-file w-16px ta-center mr-4px c-grey-medium"></i>
-        Monthly district data
+        Monthly <%= @region.localized_region_type %> data
       <% end %>
     <% end %>
 

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -209,7 +209,7 @@
 <%= render "treatment_outcomes_card" %>
 
 <% if @children_data.any? %>
-  <%= render "child_data_tables", data: @children_data, region_type: @child_regions.first.localized_region_type %>
+  <%= render "child_data_tables", data: @children_data, localized_region_type: @child_regions.first.localized_region_type %>
 <% end %>
 
 <%= render "overview_footnotes" %>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -209,7 +209,7 @@
 <%= render "treatment_outcomes_card" %>
 
 <% if @children_data.any? %>
-  <%= render "child_data_tables", data: @children_data, region_type: @child_regions.first.region_type %>
+  <%= render "child_data_tables", data: @children_data, region_type: @child_regions.first.localized_region_type %>
 <% end %>
 
 <%= render "overview_footnotes" %>

--- a/app/views/shared/_my_facilities_filters.erb
+++ b/app/views/shared/_my_facilities_filters.erb
@@ -44,7 +44,7 @@
     <% if @selected_zones.size == 1 %>
       <%= @selected_zones.first.titleize %>
     <% else %>
-      All blocks
+      All <%= t("region_type.block").pluralize %>
     <% end %>
   </a>
   <div class="dropdown-menu mh-350px oy-scroll" aria-labelledby="dropdownMenuLink">
@@ -57,7 +57,7 @@
         form="query-filters"
         onclick="$('#selected-zone').remove()"
       >
-        All blocks
+        All <%= t("region_type.block").pluralize %>
       </button>
       <div class="dropdown-divider"></div>
       <% @zones.each do |zone| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,9 +16,9 @@ en:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
   region_type:
-    state: State
-    district: District
-    block: Block
+    state: state
+    district: district
+    block: block
   name: "Name"
   phone_number: "Phone Number"
   registration_approval_email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
     state: state
     district: district
     block: block
+    facility: facility
   name: "Name"
   phone_number: "Phone Number"
   registration_approval_email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,10 @@ en:
       not_saved:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
+  region_type:
+    state: State
+    district: District
+    block: Block
   name: "Name"
   phone_number: "Phone Number"
   registration_approval_email:

--- a/config/locales/en_BD.yml
+++ b/config/locales/en_BD.yml
@@ -1,6 +1,10 @@
 en_BD:
   facility_group: "District"
   facility_group_zone: "Upazila"
+  region_type:
+    state: Division
+    district: District
+    block: Upazila
   helpers:
     label:
       facility:

--- a/config/locales/en_BD.yml
+++ b/config/locales/en_BD.yml
@@ -2,9 +2,9 @@ en_BD:
   facility_group: "District"
   facility_group_zone: "Upazila"
   region_type:
-    state: Division
-    district: District
-    block: Upazila
+    state: division
+    district: district
+    block: upazila
   helpers:
     label:
       facility:

--- a/config/locales/en_BD.yml
+++ b/config/locales/en_BD.yml
@@ -1,6 +1,5 @@
 en_BD:
   facility_group: "District"
-  facility_group_zone: "Upazila"
   region_type:
     state: division
     district: district

--- a/config/locales/en_ET.yml
+++ b/config/locales/en_ET.yml
@@ -1,6 +1,5 @@
 en_ET:
   facility_group: "zone"
-  facility_group_zone: "woreda"
   region_type:
     state: region
     district: zone

--- a/config/locales/en_ET.yml
+++ b/config/locales/en_ET.yml
@@ -1,6 +1,10 @@
 en_ET:
   facility_group: "zone"
   facility_group_zone: "woreda"
+  region_type:
+    state: Region
+    district: Zone
+    block: Woreda
   helpers:
     label:
       facility:

--- a/config/locales/en_ET.yml
+++ b/config/locales/en_ET.yml
@@ -2,9 +2,9 @@ en_ET:
   facility_group: "zone"
   facility_group_zone: "woreda"
   region_type:
-    state: Region
-    district: Zone
-    block: Woreda
+    state: region
+    district: zone
+    block: woreda
   helpers:
     label:
       facility:

--- a/config/locales/en_IN.yml
+++ b/config/locales/en_IN.yml
@@ -2,9 +2,9 @@ en_IN:
   facility_group: "district"
   facility_group_zone: "block"
   region_type:
-    state: State
-    district: District
-    block: Block
+    state: state
+    district: district
+    block: block
   helpers:
     label:
       facility:

--- a/config/locales/en_IN.yml
+++ b/config/locales/en_IN.yml
@@ -1,6 +1,5 @@
 en_IN:
   facility_group: "district"
-  facility_group_zone: "block"
   region_type:
     state: state
     district: district

--- a/config/locales/en_IN.yml
+++ b/config/locales/en_IN.yml
@@ -1,6 +1,10 @@
 en_IN:
   facility_group: "district"
   facility_group_zone: "block"
+  region_type:
+    state: State
+    district: District
+    block: Block
   helpers:
     label:
       facility:

--- a/config/locales/en_LK.yml
+++ b/config/locales/en_LK.yml
@@ -1,6 +1,10 @@
 en_LK:
   facility_group: "district"
   facility_group_zone: "town"
+  region_type:
+    state: province
+    district: district
+    block: town
   helpers:
     label:
       facility:

--- a/config/locales/en_LK.yml
+++ b/config/locales/en_LK.yml
@@ -1,6 +1,5 @@
 en_LK:
   facility_group: "district"
-  facility_group_zone: "town"
   region_type:
     state: province
     district: district

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -42,6 +42,31 @@ RSpec.describe Region, type: :model do
     end
   end
 
+  describe "localized_region_type" do
+    it "returns country specific names" do
+      state = build(:region, region_type: :state)
+      district = build(:region, region_type: :district)
+      block = build(:region, region_type: :block)
+      expect(district.district_region?).to be_truthy
+      I18n.with_locale(:en_IN) do
+        expect(state.localized_region_type).to eq("State")
+        expect(district.localized_region_type).to eq("District")
+        expect(block.localized_region_type).to eq("Block")
+      end
+      I18n.with_locale(:en_BD) do
+        expect(state.localized_region_type).to eq("Division")
+        expect(district.localized_region_type).to eq("District")
+        expect(block.localized_region_type).to eq("Upazila")
+      end
+      I18n.with_locale(:en_ET) do
+        expect(state.localized_region_type).to eq("Region")
+        expect(district.localized_region_type).to eq("Zone")
+        expect(block.localized_region_type).to eq("Woreda")
+      end
+      expect(district.localized_region_type).to eq("District")
+    end
+  end
+
   describe "region_type" do
     it "has question methods for determining type" do
       region_1 = Region.create!(name: "New York", region_type: "state", reparent_to: Region.root)

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -47,23 +47,37 @@ RSpec.describe Region, type: :model do
       state = build(:region, region_type: :state)
       district = build(:region, region_type: :district)
       block = build(:region, region_type: :block)
-      expect(district.district_region?).to be_truthy
+      facility = build(:region, region_type: :facility)
       I18n.with_locale(:en_IN) do
-        expect(state.localized_region_type).to eq("State")
-        expect(district.localized_region_type).to eq("District")
-        expect(block.localized_region_type).to eq("Block")
+        expect(state.localized_region_type).to eq("state")
+        expect(district.localized_region_type).to eq("district")
+        expect(block.localized_region_type).to eq("block")
+        expect(facility.localized_region_type).to eq("facility")
       end
       I18n.with_locale(:en_BD) do
-        expect(state.localized_region_type).to eq("Division")
-        expect(district.localized_region_type).to eq("District")
-        expect(block.localized_region_type).to eq("Upazila")
+        expect(state.localized_region_type).to eq("division")
+        expect(district.localized_region_type).to eq("district")
+        expect(block.localized_region_type).to eq("upazila")
+        expect(facility.localized_region_type).to eq("facility")
       end
       I18n.with_locale(:en_ET) do
-        expect(state.localized_region_type).to eq("Region")
-        expect(district.localized_region_type).to eq("Zone")
-        expect(block.localized_region_type).to eq("Woreda")
+        expect(state.localized_region_type).to eq("region")
+        expect(district.localized_region_type).to eq("zone")
+        expect(block.localized_region_type).to eq("woreda")
+        expect(facility.localized_region_type).to eq("facility")
       end
-      expect(district.localized_region_type).to eq("District")
+    end
+
+    it "has a fallback for default locale (which is the same as the India region_types)" do
+      state = build(:region, region_type: :state)
+      district = build(:region, region_type: :district)
+      block = build(:region, region_type: :block)
+      facility = build(:region, region_type: :facility)
+      expect(I18n.locale).to eq(:en)
+      expect(state.localized_region_type).to eq("state")
+      expect(district.localized_region_type).to eq("district")
+      expect(block.localized_region_type).to eq("block")
+      expect(facility.localized_region_type).to eq("facility")
     end
   end
 


### PR DESCRIPTION
**Story card:** [ch3403](https://app.shortcut.com/simpledotorg/story/3403/localize-dashboard-region-names)

This updates all region type headers to use the country localized names -- take a look at the diff to see what names are used across each country.  The yaml files are pretty self explanatory.

I'm also making this a top level localization key (`region_type.district` etc) that can be easily returned from a `Region` instance for ease of use going forward.

## How to test

Change your local country and run the app locally to see the changes - for example, to run as Ethiopia:

```
DEFAULT_COUNTRY=ET rails server
```


## Screenshots

### Bangladesh

<img width="1174" alt="image" src="https://user-images.githubusercontent.com/69/141173451-eea6589f-6849-4f65-a8b0-d5c42ea50333.png">

<img width="1239" alt="image" src="https://user-images.githubusercontent.com/69/141173369-46355397-c200-419a-a357-52e1132c58bb.png">

### Ethiopia

<img width="1185" alt="image" src="https://user-images.githubusercontent.com/69/141173624-dabd2012-e505-4068-8b79-360bdf54540f.png">


<img width="1154" alt="image" src="https://user-images.githubusercontent.com/69/141173549-2fcc0fe6-0031-45ad-938d-c97f1ad81d2b.png">

