### PR TITLE
A/B enhancements: Account for "Agreed to visit" stale patients 

### DIFF
--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -175,7 +175,7 @@ module Experimentation
         risk_level: patient.risk_priority,
         diagnosed_htn: medical_history.hypertension,
         experiment_inclusion_date: date,
-        expected_return_date: latest_scheduled_appointment&.scheduled_date,
+        expected_return_date: latest_scheduled_appointment&.remind_on || latest_scheduled_appointment&.scheduled_date,
         expected_return_facility_id: latest_scheduled_appointment&.facility_id,
         expected_return_facility_type: latest_scheduled_appointment&.facility&.facility_type,
         expected_return_facility_name: latest_scheduled_appointment&.facility&.name,

--- a/app/models/experimentation/stale_patient_experiment.rb
+++ b/app/models/experimentation/stale_patient_experiment.rb
@@ -14,9 +14,11 @@ module Experimentation
       no_appointments_after = date.end_of_day
 
       self.class.superclass.eligible_patients
-        .joins("inner join reporting_patient_visits ON reporting_patient_visits.patient_id = patients.id")
-        .joins("left outer join appointments future_appointments on future_appointments.patient_id = patients.id
-                AND future_appointments.scheduled_date > '#{no_appointments_after}'")
+        .joins("INNER JOIN reporting_patient_visits ON reporting_patient_visits.patient_id = patients.id")
+        .joins("LEFT OUTER JOIN appointments future_appointments
+                ON future_appointments.patient_id = patients.id
+                AND (future_appointments.scheduled_date > '#{no_appointments_after}'
+                      OR future_appointments.remind_on > '#{no_appointments_after}')")
         .where(reporting_patient_visits: {month_date: current_month})
         .where("visited_at > ? AND visited_at < ?", last_visit_since, last_visit_until)
         .where("future_appointments.id IS NULL")

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -214,6 +214,24 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
       Experimentation::CurrentPatientExperiment.first.enroll_patients(Date.today, 1)
       expect(Experimentation::TreatmentGroupMembership.count).to eq(1)
     end
+
+    it "sets the expected_return_date to the expected appointment's remind_on if it is present" do
+      overdue_patient = create(:patient)
+      remind_on_patient = create(:patient)
+      create(:experiment, :with_treatment_group, experiment_type: "current_patients")
+      allow_any_instance_of(Experimentation::CurrentPatientExperiment).to receive(:eligible_patients).and_return(Patient.where(id: [overdue_patient, remind_on_patient].map(&:id)))
+
+      appointment_scheduled_date = 100.days.ago.to_date
+      remind_on_date = 70.days.ago.to_date
+      create(:appointment, status: :scheduled, scheduled_date: appointment_scheduled_date, patient: overdue_patient)
+      create(:appointment, status: :scheduled, scheduled_date: appointment_scheduled_date, remind_on: remind_on_date, patient: remind_on_patient)
+      Experimentation::CurrentPatientExperiment.first.enroll_patients(Date.today)
+      overdue_patient_membership = Experimentation::TreatmentGroupMembership.find_by(patient_id: overdue_patient.id)
+      remind_on_patient_membership = Experimentation::TreatmentGroupMembership.find_by(patient_id: remind_on_patient.id)
+
+      expect(overdue_patient_membership.expected_return_date).to eq(appointment_scheduled_date)
+      expect(remind_on_patient_membership.expected_return_date).to eq(remind_on_date)
+    end
   end
 
   describe "#schedule_notifications" do
@@ -455,6 +473,20 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
 
       expect(experiment.treatment_group_memberships.status_enrolled.count).to eq 0
       expect(experiment.treatment_group_memberships.status_evicted.pluck(:patient_id)).to contain_exactly(patient.id)
+    end
+
+    it "does not evict patients who were enrolled with remind_on as the expected_return_date" do
+      patient = create(:patient)
+      remind_on_date = 70.days.ago
+      appointment = create(:appointment, status: :scheduled, scheduled_date: 100.days.ago, remind_on: remind_on_date, patient: patient)
+      experiment = Experimentation::NotificationsExperiment.find(create(:experiment).id)
+      treatment_group = create(:treatment_group, experiment: experiment)
+      treatment_group.enroll(patient, appointment_id: appointment.id, expected_return_date: remind_on_date)
+
+      experiment.evict_patients
+
+      expect(experiment.treatment_group_memberships.status_enrolled.pluck(:patient_id)).to contain_exactly(patient.id)
+      expect(experiment.treatment_group_memberships.status_evicted.count).to eq 0
     end
 
     it "evicts patients whose notification has failed" do

--- a/spec/models/experimentation/stale_patient_experiment_spec.rb
+++ b/spec/models/experimentation/stale_patient_experiment_spec.rb
@@ -92,6 +92,33 @@ RSpec.describe Experimentation::StalePatientExperiment do
       expect(result).to contain_exactly(patient_with_past_appt)
     end
 
+    it "does not include any patients that have an appointment with remind_on in the future" do
+      create(:experiment, experiment_type: "stale_patients")
+      patient_with_past_remind_on = create(:patient, age: 80)
+      patient_with_future_remind_on = create(:patient, age: 80)
+      patient_without_future_remind_on = create(:patient, age: 80)
+
+      create(:appointment,
+        patient: patient_with_past_remind_on,
+        device_created_at: 70.days.ago,
+        scheduled_date: 40.days.ago,
+        remind_on: 10.days.ago)
+      create(:appointment,
+        patient: patient_with_future_remind_on,
+        device_created_at: 70.days.ago,
+        scheduled_date: 40.days.ago,
+        remind_on: 10.days.from_now)
+      create(:appointment,
+        patient: patient_without_future_remind_on,
+        device_created_at: 70.days.ago,
+        scheduled_date: 40.days.ago)
+      RefreshReportingViews.new.refresh_v2
+
+      result = described_class.first.eligible_patients(Date.tomorrow)
+
+      expect(result).to contain_exactly(patient_without_future_remind_on)
+    end
+
     it "does not include the same patient more than once" do
       create(:experiment, experiment_type: "stale_patients")
       patient = create(:patient, age: 80)

--- a/spec/models/experimentation/stale_patient_experiment_spec.rb
+++ b/spec/models/experimentation/stale_patient_experiment_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Experimentation::StalePatientExperiment do
 
       result = described_class.first.eligible_patients(Date.tomorrow)
 
-      expect(result).to contain_exactly(patient_without_future_remind_on)
+      expect(result).to contain_exactly(patient_with_past_remind_on, patient_without_future_remind_on)
     end
 
     it "does not include the same patient more than once" do


### PR DESCRIPTION
**Story card:** [ch5856](https://app.shortcut.com/simpledotorg/story/5856/consider-the-agreed-to-visit-date-as-the-expected-return-date-for-stale-patients?vc_group_by=day&ct_workflow=all&cf_workflow=500000031)

## Because

We consider the `scheduled_date` of an appointment as the expected return date. For appointments which are marked as “Agreed to visit”, `scheduled_date` still stores the original date and we store the new date separately. Using `scheduled_date` in these cases is not accurate because they’ve agreed to visit on a future date. 

[Slack ref](https://simpledotorg.slack.com/archives/C01FMV58MEC/p1636519179026900)

## This addresses

Consider the “Agreed to visit” date as the expected return date if it is present
- Records the `remind_on` date as the expected return date if it is present
- Does not include any stale patients who have a `remind_on` in the future
