### PR TITLE
add facility type and size columns to the drug stock downloads

### DIFF
--- a/app/exporters/drug_consumption_report_exporter.rb
+++ b/app/exporters/drug_consumption_report_exporter.rb
@@ -28,7 +28,7 @@ class DrugConsumptionReportExporter
   end
 
   def drug_categories_header
-    left_pad_size = 2
+    left_pad_size = 4
     left_padding_columns = [nil] * left_pad_size
 
     drug_category_cells = left_padding_columns + @drugs_by_category.flat_map do |category, drugs|
@@ -51,7 +51,7 @@ class DrugConsumptionReportExporter
         "#{protocol_drug_labels[category][:short]} base doses"
       end
 
-    ["Facilities", I18n.t("region_type.block").capitalize] + drug_name_cells + drug_category_name_cells
+    ["Facilities", "Facility type", "Facility size", I18n.t("region_type.block").capitalize] + drug_name_cells + drug_category_name_cells
   end
 
   def total_consumption_row
@@ -69,7 +69,7 @@ class DrugConsumptionReportExporter
         formatted_consumption_value(total)
       end
 
-    ["All", ""] + drug_consumption_cells + overall_consumption_cells
+    ["All", "", "", ""] + drug_consumption_cells + overall_consumption_cells
   end
 
   def district_warehouse_consumption_row
@@ -87,7 +87,7 @@ class DrugConsumptionReportExporter
         formatted_consumption_value(total)
       end
 
-    ["District Warehouse", ""] + drug_consumption_cells + overall_consumption_cells
+    ["District Warehouse", "", "", ""] + drug_consumption_cells + overall_consumption_cells
   end
 
   def facility_rows
@@ -111,7 +111,7 @@ class DrugConsumptionReportExporter
         formatted_consumption_value(total)
       end
 
-    [facility.name, facility.block_name] + drug_consumption_cells + overall_consumption_cells
+    [facility.name, facility.facility_type, facility.localized_facility_size, facility.block_name] + drug_consumption_cells + overall_consumption_cells
   end
 
   def formatted_consumption_value(consumption_value)

--- a/app/exporters/drug_stocks_report_exporter.rb
+++ b/app/exporters/drug_stocks_report_exporter.rb
@@ -30,7 +30,7 @@ class DrugStocksReportExporter
   end
 
   def drug_categories_header
-    left_pad_size = 2
+    left_pad_size = 4
     left_padding_columns = [nil] * left_pad_size
 
     left_padding_columns + @drugs_by_category.flat_map do |category, drugs|
@@ -39,7 +39,7 @@ class DrugStocksReportExporter
   end
 
   def drug_names_header
-    ["Facilities", I18n.t("region_type.block").capitalize] +
+    ["Facilities", "Facility type", "Facility size", I18n.t("region_type.block").capitalize] +
       @drugs_by_category.flat_map do |_drug_category, drugs|
         drug_columns = drugs.map do |drug|
           "#{drug.name} #{drug.dosage}"
@@ -49,7 +49,7 @@ class DrugStocksReportExporter
   end
 
   def total_stock_row
-    ["All", ""] +
+    ["All", "", "", ""] +
       @drugs_by_category.flat_map do |drug_category, drugs|
         patient_days = @report.dig(:total_patient_days, drug_category, :patient_days)
 
@@ -60,7 +60,7 @@ class DrugStocksReportExporter
   end
 
   def district_warehouse_stock_row
-    ["District Warehouse", ""] +
+    ["District Warehouse", "", "", ""] +
       @drugs_by_category.flat_map do |drug_category, drugs|
         patient_days = @report.dig(:district_patient_days, drug_category, :patient_days)
 
@@ -77,7 +77,7 @@ class DrugStocksReportExporter
   end
 
   def facility_row(facility)
-    [facility.name, facility.block_name] +
+    [facility.name, facility.facility_type, facility.localized_facility_size, facility.block_name] +
       @drugs_by_category.flat_map do |drug_category, drugs|
         patient_days = @report[:patient_days_by_facility_id].dig(facility.id, drug_category, :patient_days)
 

--- a/spec/exporters/drug_consumption_report_exporter_spec.rb
+++ b/spec/exporters/drug_consumption_report_exporter_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe DrugConsumptionReportExporter do
       allow(CountryConfig.current).to receive(:fetch).with(:custom_drug_category_order, []).and_return([])
 
       headers_row_1 = [
-        nil, nil,
+        nil, nil, nil, nil,
         "ARB Tablets", nil, nil,
         "CCB Tablets", nil,
         "Diuretic Tablets", nil,
@@ -85,6 +85,8 @@ RSpec.describe DrugConsumptionReportExporter do
 
       headers_row_2 = [
         "Facilities",
+        "Facility type",
+        "Facility size",
         "Block",
         "Losartan 50 mg",
         "Telmisartan 40 mg",
@@ -99,7 +101,7 @@ RSpec.describe DrugConsumptionReportExporter do
       ]
 
       totals_row = [
-        "All", "",
+        "All", "", "", "",
         2000, 0, -2000,
         0, -6000,
         "?", "?",
@@ -107,7 +109,7 @@ RSpec.describe DrugConsumptionReportExporter do
       ]
 
       district_warehouse_row = [
-        "District Warehouse", "",
+        "District Warehouse", "", "", "",
         1000, 0, -1000,
         0, -3000,
         "?", "?",
@@ -116,6 +118,8 @@ RSpec.describe DrugConsumptionReportExporter do
 
       facility_1_row =
         [facilities.first.name,
+          facilities.first.facility_type,
+          facilities.first.localized_facility_size,
           facilities.first.zone,
           1000, 0, -1000,
           0, -3000,
@@ -124,6 +128,8 @@ RSpec.describe DrugConsumptionReportExporter do
 
       facility_2_row =
         [facilities.second.name,
+          facilities.second.facility_type,
+          facilities.second.localized_facility_size,
           facilities.second.zone,
           "?", "?", "?", "?",
           "?", "?",
@@ -149,7 +155,7 @@ RSpec.describe DrugConsumptionReportExporter do
         .and_return(["hypertension_ccb", "hypertension_arb", "hypertension_diuretic"])
 
       headers_row_1 = [
-        nil, nil,
+        nil, nil, nil, nil,
         "CCB Tablets", nil,
         "ARB Tablets", nil, nil,
         "Diuretic Tablets", nil,
@@ -158,6 +164,8 @@ RSpec.describe DrugConsumptionReportExporter do
 
       headers_row_2 = [
         "Facilities",
+        "Facility type",
+        "Facility size",
         "Block",
         "Amlodipine 5 mg",
         "Amlodipine 10 mg",
@@ -172,7 +180,7 @@ RSpec.describe DrugConsumptionReportExporter do
       ]
 
       totals_row = [
-        "All", "",
+        "All", "", "", "",
         0, -6000,
         2000, 0, -2000,
         "?", "?",
@@ -180,7 +188,7 @@ RSpec.describe DrugConsumptionReportExporter do
       ]
 
       district_warehouse_row = [
-        "District Warehouse", "",
+        "District Warehouse", "", "", "",
         0, -3000,
         1000, 0, -1000,
         "?", "?",
@@ -189,6 +197,8 @@ RSpec.describe DrugConsumptionReportExporter do
 
       facility_1_row =
         [facilities.first.name,
+          facilities.first.facility_type,
+          facilities.first.localized_facility_size,
           facilities.first.zone,
           0, -3000,
           1000, 0, -1000,
@@ -197,6 +207,8 @@ RSpec.describe DrugConsumptionReportExporter do
 
       facility_2_row =
         [facilities.second.name,
+          facilities.second.facility_type,
+          facilities.first.localized_facility_size,
           facilities.second.zone,
           "?", "?", "?", "?",
           "?", "?",

--- a/spec/exporters/drug_stocks_report_exporter_spec.rb
+++ b/spec/exporters/drug_stocks_report_exporter_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe DrugStocksReportExporter do
       allow(CountryConfig.current).to receive(:fetch).with(:custom_drug_category_order, []).and_return([])
 
       headers_row_1 = [
-        nil, nil,
+        nil, nil, nil, nil,
         "ARB Tablets",
         nil, nil, nil,
         "CCB Tablets",
@@ -72,6 +72,8 @@ RSpec.describe DrugStocksReportExporter do
 
       headers_row_2 = [
         "Facilities",
+        "Facility type",
+        "Facility size",
         "Block",
         "Losartan 50 mg",
         "Telmisartan 40 mg",
@@ -86,14 +88,14 @@ RSpec.describe DrugStocksReportExporter do
       ]
 
       totals_row = [
-        "All", "",
+        "All", "", "", "",
         30000, 30000, 60000, 121621,
         30000, 60000, 26785,
         nil, nil, nil
       ]
 
       district_warehouse_row = [
-        "District Warehouse", "",
+        "District Warehouse", "", "", "",
         10000, 10000, 20000, 40540,
         10000, 20000, 8928,
         nil, nil, nil
@@ -101,6 +103,8 @@ RSpec.describe DrugStocksReportExporter do
 
       facility_1_row =
         [facilities.first.name,
+          facilities.first.facility_type,
+          facilities.first.localized_facility_size,
           facilities.first.zone,
           10000, 10000, 20000, 81081,
           10000, 20000, 17857,
@@ -108,6 +112,8 @@ RSpec.describe DrugStocksReportExporter do
 
       facility_2_row =
         [facilities.second.name,
+          facilities.second.facility_type,
+          facilities.second.localized_facility_size,
           facilities.second.zone,
           10000, 10000, 20000, 81081,
           10000, 20000, 17857,
@@ -133,7 +139,7 @@ RSpec.describe DrugStocksReportExporter do
         .with(:custom_drug_category_order, [])
         .and_return(["hypertension_ccb", "hypertension_arb", "hypertension_diuretic"])
       headers_row_1 = [
-        nil, nil,
+        nil, nil, nil, nil,
         "CCB Tablets",
         nil, nil,
         "ARB Tablets",
@@ -144,6 +150,8 @@ RSpec.describe DrugStocksReportExporter do
 
       headers_row_2 = [
         "Facilities",
+        "Facility type",
+        "Facility size",
         "Block",
         "Amlodipine 5 mg",
         "Amlodipine 10 mg",
@@ -158,14 +166,14 @@ RSpec.describe DrugStocksReportExporter do
       ]
 
       totals_row = [
-        "All", "",
+        "All", "", "", "",
         30000, 60000, 26785,
         30000, 30000, 60000, 121621,
         nil, nil, nil
       ]
 
       district_warehouse_row = [
-        "District Warehouse", "",
+        "District Warehouse", "", "", "",
         10000, 20000, 8928,
         10000, 10000, 20000, 40540,
         nil, nil, nil
@@ -173,6 +181,8 @@ RSpec.describe DrugStocksReportExporter do
 
       facility_1_row =
         [facilities.first.name,
+          facilities.first.facility_type,
+          facilities.first.localized_facility_size,
           facilities.first.zone,
           10000, 20000, 17857,
           10000, 10000, 20000, 81081,
@@ -180,6 +190,8 @@ RSpec.describe DrugStocksReportExporter do
 
       facility_2_row =
         [facilities.second.name,
+          facilities.second.facility_type,
+          facilities.second.localized_facility_size,
           facilities.second.zone,
           10000, 20000, 17857,
           10000, 10000, 20000, 81081,


### PR DESCRIPTION
**Story card:** [ch5826](https://app.shortcut.com/simpledotorg/story/5826/add-facility-information-to-the-drug-stock-downloadable-report)

## Because
We want additional facility information in the drug stock downloadable reports

## This addresses
Adds facility type and size to the drug stock downloadable reports