### PR TITLE
Add a RunnerTrace and schedule every five minutes

### DIFF
--- a/app/services/runner_trace.rb
+++ b/app/services/runner_trace.rb
@@ -1,0 +1,27 @@
+class RunnerTrace
+  class Error < StandardError
+  end
+
+  attr_reader :logger
+
+  def initialize
+    @logger = Rails.logger.child(class: self.class.name)
+    @logger.info msg: "runner trace initialized",
+                 sentry_debug_info: sentry_debug_info
+  end
+
+  def call
+    Statsd.instance.increment("runner_trace.count")
+    logger.info msg: "about to raise an error",
+                sentry_debug_info: sentry_debug_info
+    raise Error, "Runner trace error"
+  end
+
+  def sentry_debug_info
+    {
+      sentry_initialized: Sentry.initialized?,
+      sentry_background_threads: Sentry.configuration.background_worker_threads
+    }
+  end
+
+end

--- a/app/services/runner_trace.rb
+++ b/app/services/runner_trace.rb
@@ -19,6 +19,7 @@ class RunnerTrace
 
   def sentry_debug_info
     {
+      sentry_env: Sentry.configuration.environment,
       sentry_initialized: Sentry.initialized?,
       sentry_background_threads: Sentry.configuration.background_worker_threads
     }

--- a/app/services/runner_trace.rb
+++ b/app/services/runner_trace.rb
@@ -24,5 +24,4 @@ class RunnerTrace
       sentry_background_threads: Sentry.configuration.background_worker_threads
     }
   end
-
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -63,6 +63,10 @@ every 2.minutes, roles: [:cron] do
   runner "TracerJob.perform_async(Time.current.iso8601, false)"
 end
 
+every 5.minutes, roles; [:cron] do
+  runner "RunnerTrace.new.call"
+end
+
 every 30.minutes, roles: [:cron] do
   runner "RegionsIntegrityCheck.sweep"
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -63,7 +63,7 @@ every 2.minutes, roles: [:cron] do
   runner "TracerJob.perform_async(Time.current.iso8601, false)"
 end
 
-every 5.minutes, roles; [:cron] do
+every 5.minutes, roles: [:cron] do
   runner "RunnerTrace.new.call"
 end
 

--- a/spec/services/runner_trace_spec.rb
+++ b/spec/services/runner_trace_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe RunnerTrace, type: :model do
+  it "raises an error for confirming Sentry" do
+    expect {
+      described_class.new.call
+    }.to raise_error(RunnerTrace::Error)
+  end
+end


### PR DESCRIPTION
to help track down what is going on with Sentry and scheduled 'runner'
jobs

see also https://github.com/getsentry/sentry-ruby/issues/1324 and https://github.com/getsentry/sentry-ruby/pull/1448

**Story card:** [ch5860](https://app.shortcut.com/simpledotorg/story/5860/it-looks-like-we-aren-t-reporting-exceptions-from-rails-runner-to-sentry)

## Because

we want more information about what is going on w/ Sentry when things are scheduled to use `rails runner`

## This addresses

adding a trace job scheduled every 5 minutes

