### PR TITLE
Manually capture the exception and send to Sentry

### DIFF
--- a/app/services/runner_trace.rb
+++ b/app/services/runner_trace.rb
@@ -15,6 +15,8 @@ class RunnerTrace
     logger.info msg: "about to raise an error",
                 sentry_debug_info: sentry_debug_info
     raise Error, "Runner trace error"
+  rescue => e
+    Sentry.capture_exception(e)
   end
 
   def sentry_debug_info

--- a/spec/services/runner_trace_spec.rb
+++ b/spec/services/runner_trace_spec.rb
@@ -2,8 +2,7 @@ require "rails_helper"
 
 RSpec.describe RunnerTrace, type: :model do
   it "raises an error for confirming Sentry" do
-    expect {
-      described_class.new.call
-    }.to raise_error(RunnerTrace::Error)
+    expect(Sentry).to receive(:capture_exception)
+    described_class.new.call
   end
 end


### PR DESCRIPTION
**Story card:** [ch5860](https://app.shortcut.com/simpledotorg/story/5860/it-looks-like-we-aren-t-reporting-exceptions-from-rails-runner-to-sentry)

Try manually capturing, as I suppose sentry-ruby doesn't install any sort of global capture hook.