### PR TITLE
A/B enhancements: Improve reporting data

### DIFF
--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -215,6 +215,7 @@ module Experimentation
           {notification_status: notification.status,
            notification_status_updated_at: notification.updated_at,
            result: :success,
+           successful_communication_id: successful_delivery.id,
            successful_communication_type: successful_delivery.communication_type,
            successful_communication_created_at: successful_delivery.created_at.to_s,
            successful_delivery_status: successful_delivery.result}

--- a/app/models/experimentation/treatment_group_membership.rb
+++ b/app/models/experimentation/treatment_group_membership.rb
@@ -43,15 +43,15 @@ module Experimentation
       return if visits.blank?
 
       earliest_visit = visits.min_by(&:recorded_at)
-      visit_date = earliest_visit.recorded_at
+      visit_at = earliest_visit.recorded_at
       visit_facility = earliest_visit.facility
-      days_to_visit = (visit_date.to_date - expected_return_date.to_date).to_i if expected_return_date.present?
+      days_to_visit = (visit_at.to_date - expected_return_date.to_date).to_i if expected_return_date.present?
 
       update!(
         visit_blood_pressure_id: blood_pressure&.id,
         visit_blood_sugar_id: blood_sugar&.id,
         visit_prescription_drug_created: prescription_drug.present?,
-        visit_date: visit_date,
+        visit_at: visit_at,
         visit_facility_id: visit_facility.id,
         visit_facility_name: visit_facility.name,
         visit_facility_type: visit_facility.facility_type,

--- a/app/models/experimentation/treatment_group_membership.rb
+++ b/app/models/experimentation/treatment_group_membership.rb
@@ -43,15 +43,15 @@ module Experimentation
       return if visits.blank?
 
       earliest_visit = visits.min_by(&:recorded_at)
-      visit_at = earliest_visit.recorded_at
+      visited_at = earliest_visit.recorded_at
       visit_facility = earliest_visit.facility
-      days_to_visit = (visit_at.to_date - expected_return_date.to_date).to_i if expected_return_date.present?
+      days_to_visit = (visited_at.to_date - expected_return_date.to_date).to_i if expected_return_date.present?
 
       update!(
         visit_blood_pressure_id: blood_pressure&.id,
         visit_blood_sugar_id: blood_sugar&.id,
         visit_prescription_drug_created: prescription_drug.present?,
-        visit_at: visit_at,
+        visited_at: visited_at,
         visit_facility_id: visit_facility.id,
         visit_facility_name: visit_facility.name,
         visit_facility_type: visit_facility.facility_type,

--- a/db/migrate/20211115070346_change_visit_date_to_visit_time_in_treatment_group_membership.rb
+++ b/db/migrate/20211115070346_change_visit_date_to_visit_time_in_treatment_group_membership.rb
@@ -1,0 +1,6 @@
+class ChangeVisitDateToVisitTimeInTreatmentGroupMembership < ActiveRecord::Migration[5.2]
+  def change
+    change_column :treatment_group_memberships, :visit_date, :datetime
+    rename_column :treatment_group_memberships, :visit_date, :visited_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_05_065243) do
+ActiveRecord::Schema.define(version: 2021_11_15_070346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -661,7 +661,7 @@ ActiveRecord::Schema.define(version: 2021_11_05_065243) do
     t.string "registration_facility_block"
     t.string "registration_facility_district"
     t.string "registration_facility_state"
-    t.date "visit_date"
+    t.datetime "visited_at"
     t.uuid "visit_facility_id"
     t.string "visit_facility_name"
     t.string "visit_facility_type"

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -275,6 +275,7 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
         {
           notification_status: "sent",
           result: "success",
+          successful_communication_id: successful_communication.id,
           successful_communication_type: successful_communication.communication_type,
           successful_communication_created_at: successful_communication.created_at.to_s,
           successful_delivery_status: "delivered"

--- a/spec/models/experimentation/treatment_group_membership_spec.rb
+++ b/spec/models/experimentation/treatment_group_membership_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Experimentation::TreatmentGroupMembership, type: :model do
       expect(membership.visit_blood_pressure_id).to eq(bp.id)
       expect(membership.visit_blood_sugar_id).to eq(bs.id)
       expect(membership.visit_prescription_drug_created).to eq(true)
-      expect(membership.visit_date).to eq(drug.device_created_at.to_date)
+      expect(membership.visited_at).to eq(drug.device_created_at)
       expect(membership.visit_facility_id).to eq(drug.facility_id)
       expect(membership.visit_facility_name).to eq(drug.facility.name)
       expect(membership.visit_facility_type).to eq(drug.facility.facility_type)


### PR DESCRIPTION
**Story card:** -

## Because

We want more granularity in some of the reporting data on experiments.

## This addresses

- Captures `visited_at` timestamp instead of `visit_date` for more granularity
- Adds successful communication ID to notification result