### PR TITLE
A/B: Flush statsd after sending metrics

### DIFF
--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -160,7 +160,7 @@ module Experimentation
         end
       end
 
-      Statsd.flush # The metric is not sent to datadog until the buffer is full, hence we explicitly flush.
+      Statsd.instance.flush # The metric is not sent to datadog until the buffer is full, hence we explicitly flush.
     end
 
     private

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -520,4 +520,13 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
       expect(Notification.status_cancelled).to contain_exactly(pending_notification, scheduled_notification)
     end
   end
+
+  describe "#time" do
+    it "calls statsd instance time" do
+      expect(Statsd.instance).to receive(:time).with("current_patients.monitor")
+
+      create(:experiment)
+      described_class.first.monitor
+    end
+  end
 end


### PR DESCRIPTION
**Story card:** -

## Because

Experiment runner statsd metrics are not being reported to datadog. 

## This addresses

Dogstatsd does not flush statsd metrics to the connect until the buffer is filled [discussion thread](https://github.com/DataDog/dogstatsd-ruby/issues/179). This calls `.flush` to make sure the metrics are sent.

