### PR TITLE
A/B: Fix notification period

### DIFF
--- a/app/models/experimentation/current_patient_experiment.rb
+++ b/app/models/experimentation/current_patient_experiment.rb
@@ -20,11 +20,5 @@ module Experimentation
         .joins(treatment_group: :reminder_templates)
         .where("expected_return_date::timestamp + make_interval(days := reminder_templates.remind_on_in_days) = ?", date)
     end
-
-    private
-
-    def earliest_remind_on
-      reminder_templates.pluck(:remind_on_in_days).min || 0
-    end
   end
 end

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -10,6 +10,8 @@ module Experimentation
     end
 
     def notifying?
+      return false unless reminder_templates.exists?
+
       notification_buffer = (last_remind_on - earliest_remind_on).days
       notify_until = (end_time + notification_buffer).to_date
       start_time <= Date.current && notify_until >= Date.current

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -164,6 +164,10 @@ module Experimentation
       end
     end
 
+    def earliest_remind_on
+      reminder_templates.pluck(:remind_on_in_days).min || 0
+    end
+
     private
 
     def remaining_enrollments_allowed(date)

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -57,21 +57,11 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
 
           notifying_until_date = experiment.end_time + expectation[:notifying_until_after_end_date]
 
-          Timecop.freeze(experiment.start_time) do
-            expect(described_class.find(experiment.id).notifying?).to eq true
-          end
-
-          Timecop.freeze(notifying_until_date - 1.day) do
-            expect(described_class.find(experiment.id).notifying?).to eq true
-          end
-          
-          Timecop.freeze(notifying_until_date) do
-            expect(described_class.find(experiment.id).notifying?).to eq true
-          end
-
-          Timecop.freeze(notifying_until_date + 1.day) do
-            expect(described_class.find(experiment.id).notifying?).to eq false
-          end
+          Timecop.freeze(experiment.start_time - 1.day) { expect(described_class.find(experiment.id).notifying?).to eq false }
+          Timecop.freeze(experiment.start_time) { expect(described_class.find(experiment.id).notifying?).to eq true }
+          Timecop.freeze(notifying_until_date - 1.day) { expect(described_class.find(experiment.id).notifying?).to eq true }
+          Timecop.freeze(notifying_until_date) { expect(described_class.find(experiment.id).notifying?).to eq true }
+          Timecop.freeze(notifying_until_date + 1.day) { expect(described_class.find(experiment.id).notifying?).to eq false }
 
           experiment.cancel
         end


### PR DESCRIPTION
**Story card:** -

## Because
A set of cascade notifications were not sent their last message in the small test experiment. This is due to a bug in our `notifying` window calculation. 


## This addresses

We enrol patients close to the date of notification, by accounting for the reminder template's remind_on. The last notification in a treatment group goes out on `earliest  remind_on days` + `last template's remind_on` days from the day of enrolment.

The current scope only takes into account the last reminder template's `remind_on`. This fixes the bug. This makes it a ruby method instead of a scope because it is hard to calculate this in SQL.
