### PR TITLE
Update datadog gems to 5.3.x latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       thor (~> 0.20.3)
     data_migrate (6.3.0)
       rails (>= 5.0)
-    ddtrace (0.52.0)
+    ddtrace (0.53.0)
       ffi (~> 1.0)
       msgpack
     devise (4.7.1)
@@ -152,7 +152,7 @@ GEM
     discard (1.2.0)
       activerecord (>= 4.2, < 7)
     docile (1.3.2)
-    dogstatsd-ruby (5.2.0)
+    dogstatsd-ruby (5.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.5)


### PR DESCRIPTION
**Story card:** ~No story, just updating these to latest.~ Actually, this may fix [ch5139](https://app.shortcut.com/simpledotorg/story/5139/argumenterror-start-sender-first)

This change is also something we want for our statsd stuff:

> [ENHANCEMENT] Automatically re-allocate resources (e.g. background thread) if dogstatsd-ruby is used in an application using forks #205 by @remeh

> This will help in scenarios where applications are not handling cleanup/re-creation of the dogstatsd-ruby instances in forked processes. If you are an user of v4.x versions of dogstatsd-ruby and want to migrate to v5.x, please make sure to go through this section of the README and through the migration guide.



## Changelogs

https://github.com/DataDog/dogstatsd-ruby/blob/master/CHANGELOG.md
https://github.com/DataDog/dd-trace-rb/blob/master/CHANGELOG.md
