### PR TITLE
Introduce SentryHandler to report Sentry errors from `runner` tasks

### DIFF
--- a/app/jobs/appointment_notification/schedule_experiment_reminders.rb
+++ b/app/jobs/appointment_notification/schedule_experiment_reminders.rb
@@ -1,5 +1,12 @@
 class AppointmentNotification::ScheduleExperimentReminders < ApplicationJob
   queue_as :high
+  class << self
+    prepend SentryHandler
+  end
+
+  def self.call
+    perform_now
+  end
 
   def logger
     @logger ||= Notification.logger(class: self.class.name)

--- a/app/services/duplicate_passport_analytics.rb
+++ b/app/services/duplicate_passport_analytics.rb
@@ -1,5 +1,8 @@
 class DuplicatePassportAnalytics
   require "squid"
+  class << self
+    prepend SentryHandler
+  end
   include Memery
   include ApplicationHelper
 
@@ -12,7 +15,7 @@ class DuplicatePassportAnalytics
   }
 
   # for continuously reporting metrics in an automated way
-  def self.report
+  def self.call
     new.report
   end
 

--- a/app/services/experimentation/runner.rb
+++ b/app/services/experimentation/runner.rb
@@ -1,5 +1,9 @@
 module Experimentation
   class Runner
+    class << self
+      prepend SentryHandler
+    end
+
     def self.call
       unless Flipper.enabled?(:experiment)
         Rails.logger.info("Experiment feature flag is off. Experiments #{name} will not be started.")

--- a/app/services/mark_patient_mobile_numbers.rb
+++ b/app/services/mark_patient_mobile_numbers.rb
@@ -1,4 +1,6 @@
 class MarkPatientMobileNumbers
+  prepend SentryHandler
+
   def self.call
     new.call
   end

--- a/app/services/patient_deduplication/runner.rb
+++ b/app/services/patient_deduplication/runner.rb
@@ -1,5 +1,7 @@
 module PatientDeduplication
   class Runner
+    prepend SentryHandler
+
     def initialize(duplicate_patient_ids)
       @duplicate_patient_ids = duplicate_patient_ids
       @merge_failures = []
@@ -7,7 +9,7 @@ module PatientDeduplication
 
     attr_accessor :merge_failures, :duplicate_patient_ids
 
-    def perform
+    def call
       duplicate_patient_ids.each do |patient_ids|
         deduplicator = Deduplicator.new(Patient.where(id: patient_ids))
         deduplicator.merge

--- a/app/services/refresh_reporting_views.rb
+++ b/app/services/refresh_reporting_views.rb
@@ -1,4 +1,5 @@
 class RefreshReportingViews
+  prepend SentryHandler
   include ActiveSupport::Benchmarkable
   REPORTING_VIEW_REFRESH_TIME_KEY = "last_reporting_view_refresh_time".freeze
 

--- a/app/services/regions_integrity_check.rb
+++ b/app/services/regions_integrity_check.rb
@@ -17,6 +17,7 @@
 # Reporting –
 # It reports inconsistencies to Sentry and Logs to standard logger
 class RegionsIntegrityCheck
+  prepend SentryHandler
   SENTRY_ERROR_TITLE = "Regions Integrity Failure"
 
   attr_reader :inconsistencies
@@ -35,7 +36,7 @@ class RegionsIntegrityCheck
     }
   end
 
-  def sweep
+  def call
     add_inconsistencies(:organizations, :missing_regions, organizations[:missing_regions])
     add_inconsistencies(:organizations, :duplicate_regions, organizations[:duplicate_regions])
 
@@ -54,6 +55,7 @@ class RegionsIntegrityCheck
     report_inconsistencies
     self
   end
+  alias_method :sweep, :call
 
   private
 

--- a/app/services/reports/region_cache_warmer.rb
+++ b/app/services/reports/region_cache_warmer.rb
@@ -1,5 +1,7 @@
 module Reports
   class RegionCacheWarmer
+    prepend SentryHandler
+
     def self.call
       new.call
     end

--- a/app/services/runner_trace.rb
+++ b/app/services/runner_trace.rb
@@ -1,4 +1,5 @@
 class RunnerTrace
+  prepend SentryHandler
   class Error < StandardError
   end
 
@@ -15,8 +16,6 @@ class RunnerTrace
     logger.info msg: "about to raise an error",
                 sentry_debug_info: sentry_debug_info
     raise Error, "Runner trace error"
-  rescue => e
-    Sentry.capture_exception(e)
   end
 
   def sentry_debug_info

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -68,7 +68,7 @@ every 5.minutes, roles: [:cron] do
 end
 
 every 30.minutes, roles: [:cron] do
-  runner "RegionsIntegrityCheck.sweep"
+  runner "RegionsIntegrityCheck.call"
 end
 
 every 1.month, at: local("4:00 am"), roles: [:cron] do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -32,7 +32,7 @@ every :day, at: local("01:00 am"), roles: [:cron] do
 end
 
 every :day, at: local("02:00 am"), roles: [:cron] do
-  runner "PatientDeduplication::Runner.new(PatientDeduplication::Strategies.identifier_and_full_name_match).perform"
+  runner "PatientDeduplication::Runner.new(PatientDeduplication::Strategies.identifier_and_full_name_match).call"
 end
 
 every :day, at: local("02:30 am"), roles: [:cron] do
@@ -44,7 +44,7 @@ every :day, at: local("04:00 am"), roles: [:cron] do
 end
 
 every :day, at: local("05:00 am"), roles: [:cron] do
-  runner "DuplicatePassportAnalytics.report"
+  runner "DuplicatePassportAnalytics.call"
 end
 
 every :monday, at: local("6:00 am"), roles: [:cron] do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -55,7 +55,7 @@ end
 
 every :day, at: local("07:30 am"), roles: [:cron] do
   if CountryConfig.current_country?("India")
-    runner "Experimentation::Runner.call;AppointmentNotification::ScheduleExperimentReminders.perform_now"
+    runner "Experimentation::Runner.call;AppointmentNotification::ScheduleExperimentReminders.call"
   end
 end
 

--- a/lib/sentry_handler.rb
+++ b/lib/sentry_handler.rb
@@ -1,8 +1,20 @@
+# Useful for reporting to Sentry from cron scheduled `runner` tasks - other contexts already have Sentry
+# middlewares setup that do this for us.
+#
+# Example usage:
+#
+# class MyService
+# . prepend SentryHandler
+#
+#   def call
+# .   # do things
+# . end
 module SentryHandler
   def call
     super
-  rescue => e
+  rescue => exception
+    Rails.logger.error("captured exception #{e} in #{self.class.name}, reporting and reraising", exception: exception)
     Sentry.capture_exception(e)
-    raise e
+    raise exception
   end
 end

--- a/lib/sentry_handler.rb
+++ b/lib/sentry_handler.rb
@@ -1,0 +1,8 @@
+module SentryHandler
+  def call
+    super
+  rescue => e
+    Sentry.capture_exception(e)
+    raise e
+  end
+end

--- a/lib/sentry_handler.rb
+++ b/lib/sentry_handler.rb
@@ -14,7 +14,7 @@ module SentryHandler
     super
   rescue => exception
     Rails.logger.error("captured exception #{e} in #{self.class.name}, reporting and reraising", exception: exception)
-    Sentry.capture_exception(e)
+    Sentry.capture_exception(exception)
     raise exception
   end
 end

--- a/lib/sentry_handler.rb
+++ b/lib/sentry_handler.rb
@@ -13,7 +13,7 @@ module SentryHandler
   def call
     super
   rescue => exception
-    Rails.logger.error("captured exception #{e} in #{self.class.name}, reporting and reraising", exception: exception)
+    Rails.logger.error("captured exception #{exception} in #{self.class.name}, reporting and reraising", exception: exception)
     Sentry.capture_exception(exception)
     raise exception
   end

--- a/spec/services/experimentation/runner_spec.rb
+++ b/spec/services/experimentation/runner_spec.rb
@@ -25,5 +25,14 @@ describe Experimentation::Runner, type: :model do
 
       described_class.call
     end
+
+    it "sends exceptions to Sentry and re-raises" do
+      exception = RuntimeError.new("bad things")
+      expect(Sentry).to receive(:capture_exception).with(exception)
+      expect(Experimentation::CurrentPatientExperiment).to receive(:conduct_daily).and_raise(exception)
+      expect {
+        described_class.call
+      }.to raise_error(exception)
+    end
   end
 end

--- a/spec/services/patient_deduplication/runner_spec.rb
+++ b/spec/services/patient_deduplication/runner_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PatientDeduplication::Runner do
       allow_any_instance_of(PatientDeduplication::Deduplicator).to receive(:errors).and_return(["Some error"])
 
       instance = described_class.new(PatientDeduplication::Strategies.identifier_and_full_name_match)
-      instance.perform
+      instance.call
       expect(instance.merge_failures).to eq [["Some error"]]
     end
 
@@ -24,7 +24,7 @@ RSpec.describe PatientDeduplication::Runner do
       patient_2.business_identifiers.first.update(identifier: passport_id)
 
       instance = described_class.new(PatientDeduplication::Strategies.identifier_and_full_name_match)
-      instance.perform
+      instance.call
       expect(instance.report_stats).to eq({processed: {total: 2,
                                                        distinct: 1},
                                            merged: {total: 2,

--- a/spec/services/runner_trace_spec.rb
+++ b/spec/services/runner_trace_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe RunnerTrace, type: :model do
   it "raises an error for confirming Sentry" do
     expect(Sentry).to receive(:capture_exception)
-    described_class.new.call
+    expect {
+      described_class.new.call
+    }.to raise_error(RunnerTrace::Error, "Runner trace error")
   end
 end


### PR DESCRIPTION
This is needed for areas where Sentry doesn't already install a hook via
its own middlewares...so any Rails controller or Sidekiq job is already
handled via Sentry's code.  But things that raise an error from a cron
scheduled `runner` task need to have their own rescue wired up.

This assumes that the method being called here is just `call`, which is
a good enough simplifying assumption: any tasks being kicked off from
cron should probably follow our service object conventions anyways.

Note: I'm still re-raising the exception here so that the task will fail and abort with a non-zero exit code.
Rescuing a top level error and continuing processing is often _not_ a great thing to do, and can be done manually with `rescue` if need be.

**Story card:** [ch5860](https://app.shortcut.com/simpledotorg/story/5860/it-looks-like-we-aren-t-reporting-exceptions-from-rails-runner-to-sentry)

