### PR TITLE
Remove RunnerTrace scheduled task

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -63,10 +63,6 @@ every 2.minutes, roles: [:cron] do
   runner "TracerJob.perform_async(Time.current.iso8601, false)"
 end
 
-every 5.minutes, roles: [:cron] do
-  runner "RunnerTrace.new.call"
-end
-
 every 30.minutes, roles: [:cron] do
   runner "RegionsIntegrityCheck.call"
 end


### PR DESCRIPTION
going to keep the actual service object around, as its tiny and could be
useful if we have issues in the future

**Story card:** [ch5860](https://app.shortcut.com/simpledotorg/story/5860/it-looks-like-we-aren-t-reporting-exceptions-from-rails-runner-to-sentry)
