### PR TITLE
A/B: Exclude patients whose assigned facility has been discarded

### DIFF
--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -30,6 +30,7 @@ module Experimentation
     def self.eligible_patients
       Patient.with_hypertension
         .contactable
+        .joins(:assigned_facility)
         .where_current_age(">=", 18)
         .where("NOT EXISTS (:recent_experiment_memberships)",
           recent_experiment_memberships: Experimentation::TreatmentGroupMembership

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -165,6 +165,17 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
       expect(described_class.eligible_patients).not_to include(excluded_patient)
       expect(described_class.eligible_patients).to include(included_patient)
     end
+
+    it "doesn't include any patients whose assigned facility has been deleted" do
+      excluded_patient = create(:patient, age: 18)
+      excluded_patient.assigned_facility.discard
+
+      included_patient = create(:patient, age: 18)
+      create(:appointment, patient: included_patient, status: :scheduled)
+
+      expect(described_class.eligible_patients).not_to include(excluded_patient)
+      expect(described_class.eligible_patients).to include(included_patient)
+    end
   end
 
   describe "#enroll_patients" do


### PR DESCRIPTION
**Story card:** -

## Because

We don't want to enroll patients whose assigned facility has been deleted, since they are ambiguous to deal with and also cause an exception while sending notifications (which is expected)

## This addresses

Adds an exclusion for such patients in the enrollment criteria.
 