### PR TITLE
Track client app version in datadog

### DIFF
--- a/config/initializers/00_datadog.rb
+++ b/config/initializers/00_datadog.rb
@@ -13,7 +13,7 @@ Datadog.configure do |c|
   c.tracer.enabled = DATADOG_ENABLED
   c.profiling.enabled = ENABLE_DD_PROFILING
   c.version = SimpleServer.git_ref(short: true)
-  c.use :rack, headers: {request: %w[X-USER-ID X-FACILITY-ID X-SYNC-REGION-ID], response: %w[Content-Type X-Request-ID]}
+  c.use :rack, headers: {request: %w[X-USER-ID X-FACILITY-ID X-SYNC-REGION-ID X-APP-VERSION], response: %w[Content-Type X-Request-ID]}
   c.use :rake
   c.use :rails, analytics_enabled: true
   c.use :sidekiq, analytics_enabled: true


### PR DESCRIPTION
**Story card:** N/A

## Because
We want to start tracking the client app version so we can analyse traffic by app version, and push users to update.
## This addresses
Adds `X-APP-VERSION` to the list of headers we track via datadog