### PR TITLE
Make jQuery getScript a no-op

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,3 +30,6 @@ $(function () {
   // initialize bootstrap file input
   bsCustomFileInput.init();
 });
+
+// Disable including scripts using jquery from external websites
+$.getScript = function (){}


### PR DESCRIPTION
**Story card:** [ch5026](https://app.shortcut.com/simpledotorg/story/5026/medium-cross-domain-script-include)

## Because

This was requested by the security audit team to slow down people who want to use scripts from other websites with malicious intent on the dashboard.