### PR TITLE
Do not rate limit user/activate in non production environments

### DIFF
--- a/config/initializers/rate_limiter.rb
+++ b/config/initializers/rate_limiter.rb
@@ -51,7 +51,7 @@ class Rack::Attack
   end
 
   throttle("throttle_user_activate", RateLimit.user_api_options) do |req|
-    if req.post? && req.path.start_with?("/api/v4/users/activate")
+    if req.post? && req.path.start_with?("/api/v4/users/activate") && SimpleServer.env.production?
       req.ip
     end
   end


### PR DESCRIPTION
This makes the android tests fail. See the [slack thread](https://simpledotorg.slack.com/archives/CFK2PHJ1L/p1637750433167100) for more context.