### PR TITLE
Revert rate limit on find back to 1 in 5 minutes

### DIFF
--- a/config/initializers/rate_limiter.rb
+++ b/config/initializers/rate_limiter.rb
@@ -44,7 +44,7 @@ class Rack::Attack
     end
   end
 
-  throttle("throttle_user_find", RateLimit.user_api_options) do |req|
+  throttle("throttle_user_find", RateLimit.auth_api_options) do |req|
     if req.post? && req.path.start_with?("/api/v4/users/find")
       req.ip
     end


### PR DESCRIPTION
The changes made in https://github.com/simpledotorg/simple-server/pull/3082 caused a lot of 429s in production which interfere with registering legitimate users, etc. Reverting this to ensure we aren't restricting users.

See also the [datadog trend](https://app.datadoghq.com/apm/traces?query=service%3Asimple_server%20operation_name%3Arack.request%20env%3Aproduction%20%40http.url%3A%22%2Fapi%2Fv4%2Fusers%2Ffind%22%20%40http.status_code%3A429&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40_duration.by_service%2Cenv&historicalData=true&saved-view-id=241366&showAllSpans=true&spanViewType=metadata&streamTraces=true&start=1636550119208&end=1637759719208&paused=false) of 429s spiking today.