### PR TITLE
A/B notifications: Cancel notifications for invalid phone numbers

### DIFF
--- a/app/jobs/appointment_notification/worker.rb
+++ b/app/jobs/appointment_notification/worker.rb
@@ -140,8 +140,9 @@ class AppointmentNotification::Worker
     end
 
     unless notification.patient.latest_mobile_number
-      logger.info "skipping notification #{notification.id}, patient #{patient.id} does not have a mobile number"
+      logger.info "skipping notification #{notification.id}, patient #{notification.patient_id} does not have a mobile number"
       metrics.increment("skipped.no_mobile_number")
+      notification.status_cancelled!
       return
     end
 

--- a/spec/jobs/appointment_notification/worker_spec.rb
+++ b/spec/jobs/appointment_notification/worker_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe AppointmentNotification::Worker, type: :job do
       }.not_to change { Communication.count }
     end
 
-    it "logs but creates nothing when patient doesn't have phone number" do
+    it "logs and cancels notification when patient doesn't have a mobile number" do
       notification.patient.phone_numbers.update_all(phone_type: :invalid)
       expect(Statsd.instance).to receive(:increment).with("appointment_notification.worker.skipped.no_mobile_number")
       expect {


### PR DESCRIPTION
**Story card:** [ch6143](https://app.shortcut.com/simpledotorg/story/6143/handle-patients-whose-mobile-number-is-invalid)

## Because

Some patients who had a `mobile` number while enrolling got marked as `invalid` during the experiment. We should handle these patients correctly by marking their notifications cancelled (and thereby evicting them).

## This addresses

This cancels notification if the patient doesn't have a mobile number at the time of sending.
