### PR TITLE
Don't use imo in Bangladesh

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -113,7 +113,6 @@ class Notification < ApplicationRecord
 
   def preferred_communication_method
     return "whatsapp" if Flipper.enabled?(:whatsapp_appointment_reminders)
-    return "imo" if Flipper.enabled?(:imo_messaging) && patient.imo_authorization&.status_subscribed?
     nil
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -79,34 +79,7 @@ describe Notification, type: :model do
       end
     end
 
-    context "when imo flag is on" do
-      before { Flipper.enable(:imo_messaging) }
-
-      it "returns sms if patient can't receive Imo notifications" do
-        create(:imo_authorization, status: "no_imo_account", patient: notification.patient)
-        expect(notification.next_communication_type).to eq("sms")
-      end
-
-      it "returns imo if it has no imo communications" do
-        create(:imo_authorization, status: "subscribed", patient: notification.patient)
-        expect(notification.next_communication_type).to eq("imo")
-      end
-
-      it "returns sms if it has a imo communication but no sms communication" do
-        create(:imo_authorization, status: "subscribed", patient: notification.patient)
-        create(:communication, communication_type: "imo", notification: notification)
-        expect(notification.next_communication_type).to eq("sms")
-      end
-
-      it "returns nil if it has both a imo and sms communication" do
-        create(:imo_authorization, status: "subscribed", patient: notification.patient)
-        create(:communication, communication_type: "imo", notification: notification)
-        create(:communication, communication_type: "sms", notification: notification)
-        expect(notification.next_communication_type).to eq(nil)
-      end
-    end
-
-    context "when WhatsApp and Imo flags are off" do
+    context "when WhatsApp flag is off" do
       it "returns sms if it has no sms communication" do
         expect(notification.next_communication_type).to eq("sms")
       end


### PR DESCRIPTION
**Story card:** [ch6145](https://app.shortcut.com/simpledotorg/story/6145/don-t-use-imo-or-whatsapp-in-bangladesh)

## Because

We don't want to use imo in Bangladesh for the A/B experiment given the low acceptance rate.

## This addresses

This removes `imo` as a preferred communication type. This doesn't cleanup any IMO related code, which will be done separately in [this epic](https://app.shortcut.com/simpledotorg/epic/5928/remove-imo-code-from-simple).