### PR TITLE
Don't mark visits for discarded patients

### DIFF
--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -113,6 +113,7 @@ module Experimentation
     def mark_visits
       time(__method__) do
         treatment_group_memberships
+          .joins(:patient)
           .where("status = 'enrolled' OR (status = 'evicted' AND visited_at IS NULL)")
           .select("distinct on (treatment_group_memberships.patient_id) treatment_group_memberships.*,
                  bp.id bp_id, bs.id bs_id, pd.id pd_id")

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -114,7 +114,9 @@ module Experimentation
       time(__method__) do
         treatment_group_memberships
           .joins(:patient)
-          .where("status = 'enrolled' OR (status = 'evicted' AND visited_at IS NULL)")
+          .where("treatment_group_memberships.status = 'enrolled' OR
+                  (treatment_group_memberships.status = 'evicted' AND
+                   visited_at IS NULL)")
           .select("distinct on (treatment_group_memberships.patient_id) treatment_group_memberships.*,
                  bp.id bp_id, bs.id bs_id, pd.id pd_id")
           .joins("left outer join blood_pressures bp

--- a/app/models/experimentation/treatment_group_membership.rb
+++ b/app/models/experimentation/treatment_group_membership.rb
@@ -1,5 +1,5 @@
 module Experimentation
-  class TreatmentGroupMembership < ActiveRecord::Base
+  class TreatmentGroupMembership < ApplicationRecord
     belongs_to :treatment_group
     belongs_to :patient
     belongs_to :experiment


### PR DESCRIPTION
**Story card:** [chXXXX](URL)

## Because

We started recording visits for evicted patients as part of https://github.com/simpledotorg/simple-server/pull/3086. Patients who are soft deleted break the update because they were evicted. [Sentry](https://sentry.io/organizations/resolve-to-save-lives/issues/2816104398/?referrer=slack)

## This addresses

Fixes the query to ignore discarded patients.
