### PR TITLE
Sort facility names in the My Facilities CSV

### DIFF
--- a/app/services/blood_pressure_export_service.rb
+++ b/app/services/blood_pressure_export_service.rb
@@ -51,7 +51,7 @@ class BloodPressureExportService
 
         csv << row
         facilities = data[size]["facilities"]
-        facilities.sort { |a,b| a["Facilities"] <=> b["Facilities"] }.each do |facility|
+        facilities.sort_by { |a| a["Facilities"] }.each do |facility|
           facility_row = []
           facility_row << facility["Facilities"]
           facility_row << facility["Total assigned"]

--- a/app/services/blood_pressure_export_service.rb
+++ b/app/services/blood_pressure_export_service.rb
@@ -51,7 +51,7 @@ class BloodPressureExportService
 
         csv << row
         facilities = data[size]["facilities"]
-        facilities.each do |facility|
+        facilities.sort { |a,b| a["Facilities"] <=> b["Facilities"] }.each do |facility|
           facility_row = []
           facility_row << facility["Facilities"]
           facility_row << facility["Total assigned"]


### PR DESCRIPTION
**Story card:** [ch6196](https://app.shortcut.com/simpledotorg/story/6196/sort-the-facility-names-in-the-csv)

## Because

Facility names should be sorted like they are on the web view (alphabetical order)

## This addresses

Sorts the CSV facility names

## Test instructions

Enable the `my_facilities_csv` flipper flag and download a report from the BP Controlled page