### PR TITLE
Remove experiments guard clause

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -54,9 +54,7 @@ every :monday, at: local("6:00 am"), roles: [:cron] do
 end
 
 every :day, at: local("07:30 am"), roles: [:cron] do
-  if CountryConfig.current_country?("India")
-    runner "Experimentation::Runner.call;AppointmentNotification::ScheduleExperimentReminders.call"
-  end
+  runner "Experimentation::Runner.call;AppointmentNotification::ScheduleExperimentReminders.call"
 end
 
 every 2.minutes, roles: [:cron] do


### PR DESCRIPTION
**Story card:** -

## This addresses

Removes an extra guard clause to allow running experiments everywhere where the flipper flag is enabled.