### PR TITLE
Sri Lanka training presentation

### DIFF
--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -8,6 +8,7 @@ module ExternalLinksHelper
   INDIA_SIMPLE_TRAINING_GUIDE_LINK = "https://docs.google.com/presentation/d/1YKlZfXpnX0tGk6NMO6JLuZY0l9O3P3zOxKXsWNJh7W0/edit#slide=id.g25f6af9dd6_0_0"
   BANGLADESH_SIMPLE_TRAINING_GUIDE_LINK = "https://docs.google.com/presentation/d/1Ce2LIPlnByn-6LPhgbKUkhoGold3R5ciXtFbVXFOhaU/edit#slide=id.g25f6af9dd6_0_0"
   ETHIOPIA_SIMPLE_TRAINING_GUIDE_LINK = "https://docs.google.com/presentation/d/1GM57_sHZ53huaMCi1Vsg5O2aAjtXKWdLGvsvKzMROME/edit#slide=id.g25f6af9dd6_0_0"
+  SRI_LANKA_SIMPLE_TRAINING_GUIDE_LINK = "https://docs.google.com/presentation/d/1hjgVHNcFfpWVeK7K0ZOvilIYGo5TlITFFNZLdKIE03g/edit#slide=id.g25f6af9dd6_0_0"
 
   TELEMEDICINE_SIMPLE_TRAINING_GUIDE_LINK = "https://docs.google.com/presentation/d/1wg0VlsEpBFWjSoqIUH5Jwj368g9Ku-IEj9DoujdqG5c/edit?usp=sharing"
 

--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -65,6 +65,8 @@
             <%= render "shared/simple_training_guide_telemedicine" %>
           <% elsif CountryConfig.current[:name] == "Bangladesh" %>
             <%= render "shared/simple_training_guide_bangladesh" %>
+          <% elsif CountryConfig.current[:name] == "Sri Lanka" %>
+            <%= render "shared/simple_training_guide_sri_lanka" %>
           <% end %>
         </div>
         <div class="card" id="card-videos">

--- a/app/views/shared/_simple_training_guide_sri_lanka.erb
+++ b/app/views/shared/_simple_training_guide_sri_lanka.erb
@@ -1,0 +1,12 @@
+<div class="resource-link resource-presentation">
+  <a
+    href="<%= ExternalLinksHelper::SRI_LANKA_SIMPLE_TRAINING_GUIDE_LINK %>" 
+    class="resource-url"
+  >
+    Simple training guide
+    <span>
+      Use this presentation to learn about the Simple program and how to use the Android App and Dashboard
+    </span>
+    <i class="fas fa-chalkboard-teacher"></i>
+  </a>
+</div>


### PR DESCRIPTION
**Story card:** [ch6263](https://app.shortcut.com/simpledotorg/story/6263/add-training-presentation-to-sri-lanka-resources-page-on-dashboard)

## Because

The Sri Lanka Dashboard should display the Sri Lanka training presentation.

## This addresses

Add's a specific google doc link for the Sri Lanka deployment.

## Test instructions

1. Open `.env.development`
2. Set `DEFAULT_COUNTRY=LK`
3. Restart the rails server
4. Go to `http://localhost:3000/resources`
5. Click the "Simple training guide" link in the "Training presentations" card
6. Verify the link opens a Google Presentation titled "Simple Training Guide - Srilanka"