### PR TITLE
Fix review apps: Load from structure, not schema; update schema w/ latest rx matview changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ rails db:setup
 ```
 
 We cleanup old migration files every once in a while and so running `db:migrate` would not work for the initial setup.
-While setting up a fresh DB you will need to load the schema first with `db:structure:load`. `db:setup` already takes care of this.
+When setting up a new database, `db:setup` wil take care of everything (it runs `db:structure:load` under the hood).
 
 #### Developing with the Android app
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,6 @@ bin/rspec
 
 Run tests interactively quickly while developing:
 
-
 ```
 bin/guard
 ```

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ rails db:setup
 ```
 
 We cleanup old migration files every once in a while and so running `db:migrate` would not work for the initial setup.
-When setting up a new database, `db:setup` wil take care of everything (it runs `db:structure:load` under the hood).
+When setting up a new database, `db:setup` will take care of everything (it runs `db:structure:load` under the hood).
 
 #### Developing with the Android app
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ rails db:setup
 ```
 
 We cleanup old migration files every once in a while and so running `db:migrate` would not work for the initial setup.
-While setting up a fresh DB you will need to load the schema first with `db:schema:load`. `db:setup` already takes care of this.
+While setting up a fresh DB you will need to load the schema first with `db:structure:load`. `db:setup` already takes care of this.
 
 #### Developing with the Android app
 

--- a/bin/heroku-setup
+++ b/bin/heroku-setup
@@ -1,4 +1,4 @@
 #! /bin/bash
 
-bundle exec rails db:schema:load:with_data
+bundle exec rails db:structure:load:with_data
 bundle exec rails db:seed

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2648,14 +2648,14 @@ CREATE MATERIALIZED VIEW public.reporting_patient_follow_ups AS
 CREATE MATERIALIZED VIEW public.reporting_prescriptions AS
  SELECT p.id AS patient_id,
     p.month_date,
-    COALESCE(sum(prescriptions.clean_dosage) FILTER (WHERE ((prescriptions.clean_name)::text = 'Amlodipine'::text)), (0)::double precision) AS amlodipine,
-    COALESCE(sum(prescriptions.clean_dosage) FILTER (WHERE ((prescriptions.clean_name)::text = 'Telmisartan'::text)), (0)::double precision) AS telmisartan,
-    COALESCE(sum(prescriptions.clean_dosage) FILTER (WHERE ((prescriptions.clean_name)::text = 'Losartan Potassium'::text)), (0)::double precision) AS losartan,
-    COALESCE(sum(prescriptions.clean_dosage) FILTER (WHERE ((prescriptions.clean_name)::text = 'Atenolol'::text)), (0)::double precision) AS atenolol,
-    COALESCE(sum(prescriptions.clean_dosage) FILTER (WHERE ((prescriptions.clean_name)::text = 'Enalapril'::text)), (0)::double precision) AS enalapril,
-    COALESCE(sum(prescriptions.clean_dosage) FILTER (WHERE ((prescriptions.clean_name)::text = 'Chlorthalidone'::text)), (0)::double precision) AS chlorthalidone,
-    COALESCE(sum(prescriptions.clean_dosage) FILTER (WHERE ((prescriptions.clean_name)::text = 'Hydrochlorothiazide'::text)), (0)::double precision) AS hydrochlorothiazide,
-    COALESCE(sum(prescriptions.clean_dosage) FILTER (WHERE (((prescriptions.clean_name)::text <> ALL (ARRAY[('Amlodipine'::character varying)::text, ('Telmisartan'::character varying)::text, ('Losartan'::character varying)::text, ('Atenolol'::character varying)::text, ('Enalapril'::character varying)::text, ('Chlorthalidone'::character varying)::text, ('Hydrochlorothiazide'::character varying)::text])) AND (prescriptions.medicine_purpose_hypertension = true))), (0)::double precision) AS other_bp_medications
+    COALESCE(max(prescriptions.clean_dosage) FILTER (WHERE ((prescriptions.clean_name)::text = 'Amlodipine'::text)), (0)::double precision) AS amlodipine,
+    COALESCE(max(prescriptions.clean_dosage) FILTER (WHERE ((prescriptions.clean_name)::text = 'Telmisartan'::text)), (0)::double precision) AS telmisartan,
+    COALESCE(max(prescriptions.clean_dosage) FILTER (WHERE ((prescriptions.clean_name)::text = 'Losartan Potassium'::text)), (0)::double precision) AS losartan,
+    COALESCE(max(prescriptions.clean_dosage) FILTER (WHERE ((prescriptions.clean_name)::text = 'Atenolol'::text)), (0)::double precision) AS atenolol,
+    COALESCE(max(prescriptions.clean_dosage) FILTER (WHERE ((prescriptions.clean_name)::text = 'Enalapril'::text)), (0)::double precision) AS enalapril,
+    COALESCE(max(prescriptions.clean_dosage) FILTER (WHERE ((prescriptions.clean_name)::text = 'Chlorthalidone'::text)), (0)::double precision) AS chlorthalidone,
+    COALESCE(max(prescriptions.clean_dosage) FILTER (WHERE ((prescriptions.clean_name)::text = 'Hydrochlorothiazide'::text)), (0)::double precision) AS hydrochlorothiazide,
+    COALESCE(max(prescriptions.clean_dosage) FILTER (WHERE (((prescriptions.clean_name)::text <> ALL ((ARRAY['Amlodipine'::character varying, 'Telmisartan'::character varying, 'Losartan'::character varying, 'Atenolol'::character varying, 'Enalapril'::character varying, 'Chlorthalidone'::character varying, 'Hydrochlorothiazide'::character varying])::text[])) AND (prescriptions.medicine_purpose_hypertension = true))), (0)::double precision) AS other_bp_medications
    FROM (( SELECT p_1.id,
             p_1.full_name,
             p_1.age,


### PR DESCRIPTION
Changing our heroku setup to load from the structure.sql instead of ruby schema.

Also includes a small fix to update structure.sql from https://github.com/simpledotorg/simple-server/pull/3125.