### PR TITLE
Use ruby 274 on semaphore

### DIFF
--- a/bin/heroku-setup
+++ b/bin/heroku-setup
@@ -1,4 +1,4 @@
 #! /bin/bash
 
-bundle exec rails db:structure:load:with_data
+# bundle exec rails db:structure:load:with_data
 bundle exec rails db:seed

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -7,7 +7,7 @@ source ~/.toolbox/toolbox
 # Temporarily turn on cache clear if Semaphore has weird bunlding issues
 # cache clear
 
-sem-version ruby 2.6.6
+sem-version ruby 2.7.4
 sem-service start postgres 10
 wget -O /tmp/libpng12.deb http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb
 sudo dpkg -i /tmp/libpng12.deb


### PR DESCRIPTION
No story, looks like this was just missed during the ruby upgrade.