### PR TITLE
Start using dependabot for ruby

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
**Story card:** [ch6274](https://app.shortcut.com/simpledotorg/story/6274/setup-dependabot-to-monitor-and-open-prs-for-outdated-ruby-gems)

## Because

We shouldn't have to manually open PRs for gem bumps - lets let computers do it for us.

## This addresses

adds dependabot config for bundler

