### PR TITLE
Handle invalid phone numbers in OTP job

### DIFF
--- a/app/jobs/appointment_notification/worker.rb
+++ b/app/jobs/appointment_notification/worker.rb
@@ -87,6 +87,7 @@ class AppointmentNotification::Worker
     if error.reason == :invalid_phone_number
       notification.status_cancelled!
       logger.info("notification #{notification.id} cancelled because of an invalid phone number")
+      Statsd.instance.increment("twilio.errors.invalid_phone_number")
       false
     else
       raise error

--- a/app/jobs/request_otp_sms_job.rb
+++ b/app/jobs/request_otp_sms_job.rb
@@ -5,7 +5,10 @@ class RequestOtpSmsJob < ApplicationJob
       user_id: user.id,
       communication_type: :sms
     }
-    TwilioApiService.new.send_sms(recipient_number: user.localized_phone_number, message: otp_message(user), context: context)
+
+    handle_twilio_errors(user) do
+      TwilioApiService.new.send_sms(recipient_number: user.localized_phone_number, message: otp_message(user), context: context)
+    end
   end
 
   private
@@ -13,5 +16,17 @@ class RequestOtpSmsJob < ApplicationJob
   def otp_message(user)
     app_signature = ENV["SIMPLE_APP_SIGNATURE"]
     I18n.t("communications.request_otp", otp: user.otp, app_signature: app_signature)
+  end
+
+  def handle_twilio_errors(user, &block)
+    block.call
+  rescue TwilioApiService::Error => error
+    if error.reason == :invalid_phone_number
+      logger.info("OTP to #{user.id} failed because of an invalid phone number")
+      Statsd.instance.increment("twilio.errors.invalid_phone_number")
+      false
+    else
+      raise error
+    end
   end
 end

--- a/app/services/twilio_api_service.rb
+++ b/app/services/twilio_api_service.rb
@@ -4,11 +4,11 @@
 # Instead, they build mocked TO/FROM numbers into the gem. So by using different TO/FROM
 # numbers you can force different response types. To have a fully functional sandbox environment
 # with its own logging, you would need to set up a different Twilio account and use those credentials.
-# ERROR HANDLING: this class is primarily used by background jobs. We raise an error on
-# twilio errors without error codes because network errors do not have error codes
-# and we want to force a retry on network errors. If a twilio error has a code,
-# we log the error but do not want to retry because the errors listed in their docs
-# are idempotent and retries would yield the same errors.
+#
+# ERROR HANDLING: This service raises any errors related to the Twilio API as an exception.
+# This is to allow background jobs to retry in case of network/limit errors.
+# The error object contains the reason of failure if the error has a twilio error code.
+# The users of this service should use it to handle known errors properly.
 
 class TwilioApiService
   attr_accessor :communication_type

--- a/spec/jobs/request_otp_sms_job_spec.rb
+++ b/spec/jobs/request_otp_sms_job_spec.rb
@@ -22,4 +22,9 @@ RSpec.describe RequestOtpSmsJob, type: :job do
 
     described_class.perform_now(user)
   end
+
+  it "does not raise an exception if twilio responds with invalid phone number error" do
+    allow_any_instance_of(TwilioApiService).to receive(:send_sms).and_raise(TwilioApiService::Error.new("An error", 21211))
+    described_class.perform_now(user)
+  end
 end


### PR DESCRIPTION
**Story card:** [ch5502](https://app.shortcut.com/simpledotorg/story/5502/move-twilio-errors-from-sentry-to-datadog)

## Because

We raise an exception when an OTP is attempted to be sent to an invalid phone number errors. The exception raises an alert on Slack which causes noise.

## This addresses

Handles invalid phone number errors in the OTP jobs similar to `AppointmentNotification::Worker`. Adds a statsd metric to track these failures (since logs are retained only for a month)
