### PR TITLE
Update spring and make sure matviews are setup in test env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,7 @@ group :development do
   gem "guard-rspec", require: false
   gem "listen"
   gem "rails-erd"
-  gem "spring"
+  gem "spring", "3.1.1"
   gem "spring-commands-rspec"
   gem "web-console", ">= 3.3.0"
   gem "memory_profiler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -557,7 +557,7 @@ GEM
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
     slack-notifier (2.3.2)
-    spring (2.1.1)
+    spring (3.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     sprockets (4.0.2)
@@ -730,7 +730,7 @@ DEPENDENCIES
   sidekiq-throttled
   simplecov
   slack-notifier
-  spring
+  spring (= 3.1.1)
   spring-commands-rspec
   squid
   stackprof

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,6 +28,10 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :feature
   config.include Warden::Test::Helpers
 
+  config.before(:suite) do
+    RefreshReportingViews.call
+  end
+
   config.before(:all) do
     # create a root region and persist across all tests (the root region is effectively a singleton)
     Region.root || Region.create!(name: "India", region_type: Region.region_types[:root], path: "india")


### PR DESCRIPTION
Updating and locking Spring to latest version that works w/ Rails 5.

Also adding a matview refresh in `before(:suite)` to make sure they are all at least initialized once before any tests run.  This should fix an issue @timcheadle noticed w/ some specs complaining about matviews not being initialized.