### PR TITLE
Bump semaphore cache; update ruby version in semaphore pipelines

### DIFF
--- a/.semaphore/bangladesh_demo_deployment.yml
+++ b/.semaphore/bangladesh_demo_deployment.yml
@@ -10,7 +10,7 @@ blocks:
         - name: Deploy to Bangladesh Demo
           commands:
             - checkout
-            - sem-version ruby 2.6.6
+            - sem-version ruby 2.7.4
             - cache restore
             - yarn install
             - bundle install --deployment --path vendor/bundle

--- a/.semaphore/bangladesh_production_deployment.yml
+++ b/.semaphore/bangladesh_production_deployment.yml
@@ -10,7 +10,7 @@ blocks:
         - name: Deploy to Bangladesh Production
           commands:
             - checkout
-            - sem-version ruby 2.6.6
+            - sem-version ruby 2.7.4
             - cache restore
             - yarn install
             - bundle install --deployment --path vendor/bundle

--- a/.semaphore/deploy.yml
+++ b/.semaphore/deploy.yml
@@ -10,7 +10,7 @@ blocks:
         - name: Deploy to Sandbox
           commands:
             - checkout
-            - sem-version ruby 2.6.6
+            - sem-version ruby 2.7.4
             - cache restore
             - yarn install
             - bundle install --deployment --path vendor/bundle
@@ -35,7 +35,7 @@ blocks:
         - name: Deploy to QA
           commands:
             - checkout
-            - sem-version ruby 2.6.6
+            - sem-version ruby 2.7.4
             - cache restore
             - yarn install
             - bundle install --deployment --path vendor/bundle

--- a/.semaphore/india_demo_deployment.yml
+++ b/.semaphore/india_demo_deployment.yml
@@ -10,7 +10,7 @@ blocks:
         - name: Deploy to India Demo
           commands:
             - checkout
-            - sem-version ruby 2.6.6
+            - sem-version ruby 2.7.4
             - cache restore
             - yarn install
             - bundle install --deployment --path vendor/bundle

--- a/.semaphore/india_production_deployment.yml
+++ b/.semaphore/india_production_deployment.yml
@@ -10,7 +10,7 @@ blocks:
         - name: Deploy to India Production
           commands:
             - checkout
-            - sem-version ruby 2.6.6
+            - sem-version ruby 2.7.4
             - cache restore
             - yarn install
             - bundle install --deployment --path vendor/bundle

--- a/.semaphore/sri_lanka_demo_deployment.yml
+++ b/.semaphore/sri_lanka_demo_deployment.yml
@@ -10,7 +10,7 @@ blocks:
         - name: Deploy to Sri Lanka Demo
           commands:
             - checkout
-            - sem-version ruby 2.6.6
+            - sem-version ruby 2.7.4
             - cache restore
             - yarn install
             - bundle install --deployment --path vendor/bundle

--- a/.semaphore/sri_lanka_production_deployment.yml
+++ b/.semaphore/sri_lanka_production_deployment.yml
@@ -10,7 +10,7 @@ blocks:
         - name: Deploy to Sri Lanka Production
           commands:
             - checkout
-            - sem-version ruby 2.6.6
+            - sem-version ruby 2.7.4
             - cache restore
             - yarn install
             - bundle install --deployment --path vendor/bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6
+FROM ruby:2.7.4
 
 RUN apt-get update && apt-get install -y yarn redis-server postgresql-client nodejs jq
 

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -4,8 +4,8 @@ set -ex
 # See https://github.com/semaphoreci/toolbox for more details on the "sem-" commands
 source ~/.toolbox/toolbox
 
-# Temporarily turn on cache clear if Semaphore has weird bunlding issues
-cache clear
+# Temporarily turn on cache clear if Semaphore has weird bundling issues
+# cache clear
 
 sem-version ruby 2.7.4
 sem-service start postgres 10

--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -5,7 +5,7 @@ set -ex
 source ~/.toolbox/toolbox
 
 # Temporarily turn on cache clear if Semaphore has weird bunlding issues
-# cache clear
+cache clear
 
 sem-version ruby 2.7.4
 sem-service start postgres 10


### PR DESCRIPTION
I noticed that a previous deploy failed - probably has something to do with our pipelines being on the old version of Ruby.  Fixing that here.