### PR TITLE
DRY up semaphore deploy pipelines

### DIFF
--- a/.semaphore/bangladesh_demo_deployment.yml
+++ b/.semaphore/bangladesh_demo_deployment.yml
@@ -10,12 +10,7 @@ blocks:
         - name: Deploy to Bangladesh Demo
           commands:
             - checkout
-            - sem-version ruby 2.7.4
-            - cache restore
-            - yarn install
-            - bundle install --deployment --path vendor/bundle
-            - cache store
-            - 'BRANCH=$SEMAPHORE_GIT_SHA bundle exec cap bangladesh:demo deploy'
+            - deploy_target=bangladesh:demo script/semaphore_deploy
       prologue:
         commands:
           - chmod 600 ~/.ssh/semaphore_id_rsa

--- a/.semaphore/bangladesh_production_deployment.yml
+++ b/.semaphore/bangladesh_production_deployment.yml
@@ -10,12 +10,7 @@ blocks:
         - name: Deploy to Bangladesh Production
           commands:
             - checkout
-            - sem-version ruby 2.7.4
-            - cache restore
-            - yarn install
-            - bundle install --deployment --path vendor/bundle
-            - cache store
-            - 'BRANCH=$SEMAPHORE_GIT_SHA bundle exec cap bangladesh:production deploy'
+            - deploy_target=bangladesh:production script/semaphore_deploy
       prologue:
         commands:
           - chmod 600 ~/.ssh/semaphore_id_rsa

--- a/.semaphore/india_demo_deployment.yml
+++ b/.semaphore/india_demo_deployment.yml
@@ -10,12 +10,7 @@ blocks:
         - name: Deploy to India Demo
           commands:
             - checkout
-            - sem-version ruby 2.7.4
-            - cache restore
-            - yarn install
-            - bundle install --deployment --path vendor/bundle
-            - cache store
-            - 'BRANCH=$SEMAPHORE_GIT_SHA bundle exec cap india:staging deploy'
+            - deploy_target=india:staging script/semaphore_deploy
       prologue:
         commands:
           - chmod 600 ~/.ssh/semaphore_id_rsa

--- a/.semaphore/india_production_deployment.yml
+++ b/.semaphore/india_production_deployment.yml
@@ -10,12 +10,7 @@ blocks:
         - name: Deploy to India Production
           commands:
             - checkout
-            - sem-version ruby 2.7.4
-            - cache restore
-            - yarn install
-            - bundle install --deployment --path vendor/bundle
-            - cache store
-            - 'BRANCH=$SEMAPHORE_GIT_SHA bundle exec cap india:production deploy'
+            - deploy_target=india:production script/semaphore_deploy
       prologue:
         commands:
           - chmod 600 ~/.ssh/semaphore_id_rsa

--- a/.semaphore/sri_lanka_demo_deployment.yml
+++ b/.semaphore/sri_lanka_demo_deployment.yml
@@ -10,12 +10,7 @@ blocks:
         - name: Deploy to Sri Lanka Demo
           commands:
             - checkout
-            - sem-version ruby 2.7.4
-            - cache restore
-            - yarn install
-            - bundle install --deployment --path vendor/bundle
-            - cache store
-            - 'BRANCH=$SEMAPHORE_GIT_SHA bundle exec cap sri-lanka:demo deploy'
+            - deploy_target=sri-lanka:demo script/semaphore_deploy
       prologue:
         commands:
           - chmod 600 ~/.ssh/semaphore_id_rsa

--- a/.semaphore/sri_lanka_production_deployment.yml
+++ b/.semaphore/sri_lanka_production_deployment.yml
@@ -10,12 +10,7 @@ blocks:
         - name: Deploy to Sri Lanka Production
           commands:
             - checkout
-            - sem-version ruby 2.7.4
-            - cache restore
-            - yarn install
-            - bundle install --deployment --path vendor/bundle
-            - cache store
-            - 'BRANCH=$SEMAPHORE_GIT_SHA bundle exec cap sri-lanka:production deploy'
+            - deploy_target=sri-lanka:production script/semaphore_deploy
       prologue:
         commands:
           - chmod 600 ~/.ssh/semaphore_id_rsa


### PR DESCRIPTION
**Story card:** [ch6325](https://app.shortcut.com/simpledotorg/story/6325/semaphore-caching-is-breaking-frequently)

Follow up to https://github.com/simpledotorg/simple-server/pull/3171

Now that CI caching seems more stable, we can simplify the deployment commands to use a script.
