### PR TITLE
Remove COMMENT ON EXTENSION bits from structure.sql

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,6 +10,20 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+--
 -- Name: ltree; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -49,6 +63,8 @@ CREATE TYPE public.gender_enum AS ENUM (
 
 
 SET default_tablespace = '';
+
+SET default_with_oids = false;
 
 --
 -- Name: accesses; Type: TABLE; Schema: public; Owner: -

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -20,7 +20,7 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 -- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
 --
 
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+-- COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
 --
@@ -34,7 +34,7 @@ CREATE EXTENSION IF NOT EXISTS ltree WITH SCHEMA public;
 -- Name: EXTENSION ltree; Type: COMMENT; Schema: -; Owner: -
 --
 
-COMMENT ON EXTENSION ltree IS 'data type for hierarchical tree-like structures';
+-- COMMENT ON EXTENSION ltree IS 'data type for hierarchical tree-like structures';
 
 
 --
@@ -48,7 +48,7 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 -- Name: EXTENSION pgcrypto; Type: COMMENT; Schema: -; Owner: -
 --
 
-COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
+-- COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 
 
 --

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -25,6 +25,19 @@ namespace :db do
 
     RefreshReportingViews.call
   end
+
+  namespace :structure do
+    desc "Clean structure.sql - commenting out COMMENT ON EXTENSION"
+    task :clean do
+      structure = IO.read("db/structure.sql")
+      structure.gsub!(/^(COMMENT ON EXTENSION)/, '-- \1')
+      File.write("db/structure.sql", structure)
+    end
+  end
+end
+
+Rake::Task["db:structure:dump"].enhance do
+  Rake::Task["db:structure:clean"].invoke
 end
 
 Rake::Task["db:seed"].enhance do

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -27,7 +27,7 @@ namespace :db do
   end
 
   namespace :structure do
-    desc "Clean structure.sql - commenting out COMMENT ON EXTENSION"
+    desc "Clean structure.sql - commenting out COMMENT ON EXTENSION commands. See https://app.shortcut.com/simpledotorg/story/6333 for details"
     task :clean do
       structure = IO.read("db/structure.sql")
       structure.gsub!(/^(COMMENT ON EXTENSION)/, '-- \1')


### PR DESCRIPTION
**Story card:** [ch6333](https://app.shortcut.com/simpledotorg/story/6333/fix-structure-sql-to-run-smoothly-on-heroku-other-envs-without-needed-superuser-privileges)

This manually strips out the `COMMENT ON EXTENSION` bits from our structure.sql that break on Heroku.

Note that we can do this in a cleaner way once we are on PostgreSQL 11, see the story for details.

Looks like it is also fixed in mainline Rails in version 7 - https://github.com/rails/rails/pull/43216