### PR TITLE
Add follow ups to facility states

### DIFF
--- a/app/models/reports/region_summary.rb
+++ b/app/models/reports/region_summary.rb
@@ -19,6 +19,7 @@ module Reports
       lost_to_follow_up
       monthly_registrations
       monthly_overdue_calls
+      monthly_follow_ups
     ].sort.freeze
 
     UNDER_CARE_WITH_LTFU = %i[

--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -99,7 +99,7 @@ module Reports
         else raise(ArgumentError, "unknown group for follow ups #{group_by}")
       end
       regions.each_with_object({}) do |region, results|
-        query = Reports::PatientFollowUp.where(facility_id: region.facility_ids)
+        query = Reports::PatientFollowUp.with_hypertension.where(facility_id: region.facility_ids)
         counts = if group_field
           grouped_counts = query.group(group_field).group_by_period(:month, :month_date, {format: Period.formatter(period_type)}).count
           grouped_counts.each_with_object({}) { |(key, count), result|

--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -96,14 +96,18 @@ module Reports
       if follow_ups_v2?
         schema.hypertension_follow_ups(group_by: group_by)
       else
-        items = regions.map { |region| RegionEntry.new(region, __method__, group_by: group_by, period_type: period_type) }
-        result = cache.fetch_multi(*items, force: bust_cache?) do |entry|
-          follow_ups_query.hypertension(entry.region, period_type, group_by: group_by)
-        end
-        result.each_with_object({}) { |(region_entry, counts), hsh|
-          hsh[region_entry.region.slug] = counts
-        }
+        follow_ups_v1(group_by: group_by)
       end
+    end
+
+    memoize def follow_ups_v1(group_by: nil)
+      items = regions.map { |region| RegionEntry.new(region, __method__, group_by: group_by, period_type: period_type) }
+      result = cache.fetch_multi(*items, force: bust_cache?) do |entry|
+        follow_ups_query.hypertension(entry.region, period_type, group_by: group_by)
+      end
+      result.each_with_object({}) { |(region_entry, counts), hsh|
+        hsh[region_entry.region.slug] = counts
+      }
     end
 
     def follow_ups_v2?

--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -91,33 +91,10 @@ module Reports
       }
     end
 
-    def follow_ups_v2_query(group_by: nil)
-      group_field = case group_by
-        when /user_id\z/ then :user_id
-        when /gender\z/ then :patient_gender
-        when nil then nil
-        else raise(ArgumentError, "unknown group for follow ups #{group_by}")
-      end
-      regions.each_with_object({}) do |region, results|
-        query = Reports::PatientFollowUp.with_hypertension.where(facility_id: region.facility_ids)
-        counts = if group_field
-          grouped_counts = query.group(group_field).group_by_period(:month, :month_date, {format: Period.formatter(period_type)}).count
-          grouped_counts.each_with_object({}) { |(key, count), result|
-            group, period = *key
-            result[period] ||= {}
-            result[period][group] = count
-          }
-        else
-          query.group_by_period(:month, :month_date, {format: Period.formatter(period_type)}).select(:patient_id).distinct.count
-        end
-        results[region.slug] = counts
-      end
-    end
-
     # Returns Follow ups per Region / Period. Takes an optional group_by clause (commonly used to group by user_id)
     memoize def hypertension_follow_ups(group_by: nil)
       if follow_ups_v2?
-        follow_ups_v2_query(group_by: group_by)
+        schema.hypertension_follow_ups(group_by: group_by)
       else
         items = regions.map { |region| RegionEntry.new(region, __method__, group_by: group_by, period_type: period_type) }
         result = cache.fetch_multi(*items, force: bust_cache?) do |entry|

--- a/app/models/reports/schema_v2.rb
+++ b/app/models/reports/schema_v2.rb
@@ -119,6 +119,29 @@ module Reports
       end
     end
 
+    def hypertension_follow_ups(group_by: nil)
+      group_field = case group_by
+        when /user_id\z/ then :user_id
+        when /gender\z/ then :patient_gender
+        when nil then nil
+        else raise(ArgumentError, "unknown group for follow ups #{group_by}")
+      end
+      regions.each_with_object({}) do |region, results|
+        query = Reports::PatientFollowUp.with_hypertension.where(facility_id: region.facility_ids)
+        counts = if group_field
+          grouped_counts = query.group(group_field).group_by_period(:month, :month_date, {format: Period.formatter(:month)}).count
+          grouped_counts.each_with_object({}) { |(key, count), result|
+            group, period = *key
+            result[period] ||= {}
+            result[period][group] = count
+          }
+        else
+          query.group_by_period(:month, :month_date, {format: Period.formatter(:month)}).select(:patient_id).distinct.count
+        end
+        results[region.slug] = counts
+      end
+    end
+
     memoize def monthly_overdue_calls
       values_at("monthly_overdue_calls")
     end

--- a/app/services/refresh_reporting_views.rb
+++ b/app/services/refresh_reporting_views.rb
@@ -58,10 +58,10 @@ class RefreshReportingViews
     Reports::OverdueCalls
     Reports::PatientVisit
     Reports::Prescriptions
+    Reports::PatientFollowUp
     Reports::PatientState
     Reports::FacilityState
     Reports::QuarterlyFacilityState
-    Reports::PatientFollowUp
   ].freeze
 
   def refresh_v1

--- a/db/migrate/20211216154413_update_reporting_facility_states_to_version_5.rb
+++ b/db/migrate/20211216154413_update_reporting_facility_states_to_version_5.rb
@@ -1,0 +1,8 @@
+class UpdateReportingFacilityStatesToVersion5 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :reporting_facility_states,
+      version: 5,
+      revert_to_version: 4,
+      materialized: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1740,6 +1740,122 @@ CREATE MATERIALIZED VIEW public.reporting_patient_blood_pressures AS
 
 
 --
+-- Name: reporting_patient_follow_ups; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.reporting_patient_follow_ups AS
+ WITH follow_up_blood_pressures AS (
+         SELECT DISTINCT ON (p.id, bp.facility_id, bp.user_id, (to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bp.recorded_at)), 'YYYY-MM'::text))) p.id AS patient_id,
+            (p.gender)::public.gender_enum AS patient_gender,
+            bp.id AS visit_id,
+            'BloodPressure'::text AS visit_type,
+            bp.facility_id,
+            bp.user_id,
+            bp.recorded_at AS visited_at,
+            to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bp.recorded_at)), 'YYYY-MM'::text) AS month_string
+           FROM (public.patients p
+             JOIN public.blood_pressures bp ON (((p.id = bp.patient_id) AND (date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bp.recorded_at))) > date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
+          WHERE (p.deleted_at IS NULL)
+        ), follow_up_blood_sugars AS (
+         SELECT DISTINCT ON (p.id, bs.facility_id, bs.user_id, (to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at)), 'YYYY-MM'::text))) p.id AS patient_id,
+            (p.gender)::public.gender_enum AS patient_gender,
+            bs.id AS visit_id,
+            'BloodSugar'::text AS visit_type,
+            bs.facility_id,
+            bs.user_id,
+            bs.recorded_at AS visited_at,
+            to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at)), 'YYYY-MM'::text) AS month_string
+           FROM (public.patients p
+             JOIN public.blood_sugars bs ON (((p.id = bs.patient_id) AND (date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at))) > date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
+          WHERE (p.deleted_at IS NULL)
+        ), follow_up_prescription_drugs AS (
+         SELECT DISTINCT ON (p.id, pd.facility_id, pd.user_id, (to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at)), 'YYYY-MM'::text))) p.id AS patient_id,
+            (p.gender)::public.gender_enum AS patient_gender,
+            pd.id AS visit_id,
+            'PrescriptionDrug'::text AS visit_type,
+            pd.facility_id,
+            pd.user_id,
+            pd.device_created_at AS visited_at,
+            to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at)), 'YYYY-MM'::text) AS month_string
+           FROM (public.patients p
+             JOIN public.prescription_drugs pd ON (((p.id = pd.patient_id) AND (date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at))) > date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
+          WHERE (p.deleted_at IS NULL)
+        ), follow_up_appointments AS (
+         SELECT DISTINCT ON (p.id, app.creation_facility_id, app.user_id, (to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at)), 'YYYY-MM'::text))) p.id AS patient_id,
+            (p.gender)::public.gender_enum AS patient_gender,
+            app.id AS visit_id,
+            'Appointment'::text AS visit_type,
+            app.creation_facility_id AS facility_id,
+            app.user_id,
+            app.device_created_at AS visited_at,
+            to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at)), 'YYYY-MM'::text) AS month_string
+           FROM (public.patients p
+             JOIN public.appointments app ON (((p.id = app.patient_id) AND (date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at))) > date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
+          WHERE (p.deleted_at IS NULL)
+        ), all_follow_ups AS (
+         SELECT follow_up_blood_pressures.patient_id,
+            follow_up_blood_pressures.patient_gender,
+            follow_up_blood_pressures.visit_id,
+            follow_up_blood_pressures.visit_type,
+            follow_up_blood_pressures.facility_id,
+            follow_up_blood_pressures.user_id,
+            follow_up_blood_pressures.visited_at,
+            follow_up_blood_pressures.month_string
+           FROM follow_up_blood_pressures
+        UNION
+         SELECT follow_up_blood_sugars.patient_id,
+            follow_up_blood_sugars.patient_gender,
+            follow_up_blood_sugars.visit_id,
+            follow_up_blood_sugars.visit_type,
+            follow_up_blood_sugars.facility_id,
+            follow_up_blood_sugars.user_id,
+            follow_up_blood_sugars.visited_at,
+            follow_up_blood_sugars.month_string
+           FROM follow_up_blood_sugars
+        UNION
+         SELECT follow_up_prescription_drugs.patient_id,
+            follow_up_prescription_drugs.patient_gender,
+            follow_up_prescription_drugs.visit_id,
+            follow_up_prescription_drugs.visit_type,
+            follow_up_prescription_drugs.facility_id,
+            follow_up_prescription_drugs.user_id,
+            follow_up_prescription_drugs.visited_at,
+            follow_up_prescription_drugs.month_string
+           FROM follow_up_prescription_drugs
+        UNION
+         SELECT follow_up_appointments.patient_id,
+            follow_up_appointments.patient_gender,
+            follow_up_appointments.visit_id,
+            follow_up_appointments.visit_type,
+            follow_up_appointments.facility_id,
+            follow_up_appointments.user_id,
+            follow_up_appointments.visited_at,
+            follow_up_appointments.month_string
+           FROM follow_up_appointments
+        )
+ SELECT DISTINCT ON (cal.month_string, all_follow_ups.facility_id, all_follow_ups.user_id, all_follow_ups.patient_id) all_follow_ups.patient_id,
+    all_follow_ups.patient_gender,
+    all_follow_ups.facility_id,
+    mh.diabetes,
+    mh.hypertension,
+    all_follow_ups.user_id,
+    all_follow_ups.visit_id,
+    all_follow_ups.visit_type,
+    all_follow_ups.visited_at,
+    cal.month_date,
+    cal.month,
+    cal.quarter,
+    cal.year,
+    cal.month_string,
+    cal.quarter_string
+   FROM ((all_follow_ups
+     JOIN public.medical_histories mh ON ((all_follow_ups.patient_id = mh.patient_id)))
+     LEFT JOIN public.reporting_months cal ON ((all_follow_ups.month_string = cal.month_string)))
+  ORDER BY cal.month_string DESC
+  WITH NO DATA;
+
+
+--
 -- Name: reporting_patient_visits; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
@@ -2603,6 +2719,13 @@ CREATE MATERIALIZED VIEW public.reporting_facility_states AS
             count(DISTINCT reporting_overdue_calls.appointment_id) AS call_results
            FROM public.reporting_overdue_calls
           GROUP BY reporting_overdue_calls.appointment_facility_region_id, reporting_overdue_calls.month_date
+        ), monthly_follow_ups AS (
+         SELECT reporting_patient_follow_ups.facility_id,
+            reporting_patient_follow_ups.month_date,
+            count(DISTINCT reporting_patient_follow_ups.patient_id) AS follow_ups
+           FROM public.reporting_patient_follow_ups
+          WHERE (reporting_patient_follow_ups.hypertension = 'yes'::text)
+          GROUP BY reporting_patient_follow_ups.facility_id, reporting_patient_follow_ups.month_date
         )
  SELECT cal.month_date,
     cal.month,
@@ -2650,130 +2773,16 @@ CREATE MATERIALIZED VIEW public.reporting_facility_states AS
     monthly_cohort_outcomes.missed_visit AS monthly_cohort_missed_visit,
     monthly_cohort_outcomes.visited_no_bp AS monthly_cohort_visited_no_bp,
     monthly_cohort_outcomes.patients AS monthly_cohort_patients,
-    monthly_overdue_calls.call_results AS monthly_overdue_calls
-   FROM ((((((public.reporting_facilities rf
+    monthly_overdue_calls.call_results AS monthly_overdue_calls,
+    monthly_follow_ups.follow_ups AS monthly_follow_ups
+   FROM (((((((public.reporting_facilities rf
      JOIN public.reporting_months cal ON (true))
      LEFT JOIN registered_patients ON (((registered_patients.month_date = cal.month_date) AND (registered_patients.region_id = rf.facility_region_id))))
      LEFT JOIN assigned_patients ON (((assigned_patients.month_date = cal.month_date) AND (assigned_patients.region_id = rf.facility_region_id))))
      LEFT JOIN adjusted_outcomes ON (((adjusted_outcomes.month_date = cal.month_date) AND (adjusted_outcomes.region_id = rf.facility_region_id))))
      LEFT JOIN monthly_cohort_outcomes ON (((monthly_cohort_outcomes.month_date = cal.month_date) AND (monthly_cohort_outcomes.region_id = rf.facility_region_id))))
      LEFT JOIN monthly_overdue_calls ON (((monthly_overdue_calls.month_date = cal.month_date) AND (monthly_overdue_calls.region_id = rf.facility_region_id))))
-  WITH NO DATA;
-
-
---
--- Name: reporting_patient_follow_ups; Type: MATERIALIZED VIEW; Schema: public; Owner: -
---
-
-CREATE MATERIALIZED VIEW public.reporting_patient_follow_ups AS
- WITH follow_up_blood_pressures AS (
-         SELECT DISTINCT ON (p.id, bp.facility_id, bp.user_id, (to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bp.recorded_at)), 'YYYY-MM'::text))) p.id AS patient_id,
-            (p.gender)::public.gender_enum AS patient_gender,
-            bp.id AS visit_id,
-            'BloodPressure'::text AS visit_type,
-            bp.facility_id,
-            bp.user_id,
-            bp.recorded_at AS visited_at,
-            to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bp.recorded_at)), 'YYYY-MM'::text) AS month_string
-           FROM (public.patients p
-             JOIN public.blood_pressures bp ON (((p.id = bp.patient_id) AND (date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bp.recorded_at))) > date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
-          WHERE (p.deleted_at IS NULL)
-        ), follow_up_blood_sugars AS (
-         SELECT DISTINCT ON (p.id, bs.facility_id, bs.user_id, (to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at)), 'YYYY-MM'::text))) p.id AS patient_id,
-            (p.gender)::public.gender_enum AS patient_gender,
-            bs.id AS visit_id,
-            'BloodSugar'::text AS visit_type,
-            bs.facility_id,
-            bs.user_id,
-            bs.recorded_at AS visited_at,
-            to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at)), 'YYYY-MM'::text) AS month_string
-           FROM (public.patients p
-             JOIN public.blood_sugars bs ON (((p.id = bs.patient_id) AND (date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at))) > date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
-          WHERE (p.deleted_at IS NULL)
-        ), follow_up_prescription_drugs AS (
-         SELECT DISTINCT ON (p.id, pd.facility_id, pd.user_id, (to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at)), 'YYYY-MM'::text))) p.id AS patient_id,
-            (p.gender)::public.gender_enum AS patient_gender,
-            pd.id AS visit_id,
-            'PrescriptionDrug'::text AS visit_type,
-            pd.facility_id,
-            pd.user_id,
-            pd.device_created_at AS visited_at,
-            to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at)), 'YYYY-MM'::text) AS month_string
-           FROM (public.patients p
-             JOIN public.prescription_drugs pd ON (((p.id = pd.patient_id) AND (date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at))) > date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
-          WHERE (p.deleted_at IS NULL)
-        ), follow_up_appointments AS (
-         SELECT DISTINCT ON (p.id, app.creation_facility_id, app.user_id, (to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at)), 'YYYY-MM'::text))) p.id AS patient_id,
-            (p.gender)::public.gender_enum AS patient_gender,
-            app.id AS visit_id,
-            'Appointment'::text AS visit_type,
-            app.creation_facility_id AS facility_id,
-            app.user_id,
-            app.device_created_at AS visited_at,
-            to_char(timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at)), 'YYYY-MM'::text) AS month_string
-           FROM (public.patients p
-             JOIN public.appointments app ON (((p.id = app.patient_id) AND (date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at))) > date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
-          WHERE (p.deleted_at IS NULL)
-        ), all_follow_ups AS (
-         SELECT follow_up_blood_pressures.patient_id,
-            follow_up_blood_pressures.patient_gender,
-            follow_up_blood_pressures.visit_id,
-            follow_up_blood_pressures.visit_type,
-            follow_up_blood_pressures.facility_id,
-            follow_up_blood_pressures.user_id,
-            follow_up_blood_pressures.visited_at,
-            follow_up_blood_pressures.month_string
-           FROM follow_up_blood_pressures
-        UNION
-         SELECT follow_up_blood_sugars.patient_id,
-            follow_up_blood_sugars.patient_gender,
-            follow_up_blood_sugars.visit_id,
-            follow_up_blood_sugars.visit_type,
-            follow_up_blood_sugars.facility_id,
-            follow_up_blood_sugars.user_id,
-            follow_up_blood_sugars.visited_at,
-            follow_up_blood_sugars.month_string
-           FROM follow_up_blood_sugars
-        UNION
-         SELECT follow_up_prescription_drugs.patient_id,
-            follow_up_prescription_drugs.patient_gender,
-            follow_up_prescription_drugs.visit_id,
-            follow_up_prescription_drugs.visit_type,
-            follow_up_prescription_drugs.facility_id,
-            follow_up_prescription_drugs.user_id,
-            follow_up_prescription_drugs.visited_at,
-            follow_up_prescription_drugs.month_string
-           FROM follow_up_prescription_drugs
-        UNION
-         SELECT follow_up_appointments.patient_id,
-            follow_up_appointments.patient_gender,
-            follow_up_appointments.visit_id,
-            follow_up_appointments.visit_type,
-            follow_up_appointments.facility_id,
-            follow_up_appointments.user_id,
-            follow_up_appointments.visited_at,
-            follow_up_appointments.month_string
-           FROM follow_up_appointments
-        )
- SELECT DISTINCT ON (cal.month_string, all_follow_ups.facility_id, all_follow_ups.user_id, all_follow_ups.patient_id) all_follow_ups.patient_id,
-    all_follow_ups.patient_gender,
-    all_follow_ups.facility_id,
-    mh.diabetes,
-    mh.hypertension,
-    all_follow_ups.user_id,
-    all_follow_ups.visit_id,
-    all_follow_ups.visit_type,
-    all_follow_ups.visited_at,
-    cal.month_date,
-    cal.month,
-    cal.quarter,
-    cal.year,
-    cal.month_string,
-    cal.quarter_string
-   FROM ((all_follow_ups
-     JOIN public.medical_histories mh ON ((all_follow_ups.patient_id = mh.patient_id)))
-     LEFT JOIN public.reporting_months cal ON ((all_follow_ups.month_string = cal.month_string)))
-  ORDER BY cal.month_string DESC
+     LEFT JOIN monthly_follow_ups ON (((monthly_follow_ups.month_date = cal.month_date) AND (monthly_follow_ups.facility_id = rf.facility_id))))
   WITH NO DATA;
 
 
@@ -4892,6 +4901,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20211210152752'),
 ('20211214014913'),
 ('20211215192748'),
-('20211216144440');
+('20211216144440'),
+('20211216154413');
 
 

--- a/db/views/reporting_facility_states_v05.sql
+++ b/db/views/reporting_facility_states_v05.sql
@@ -1,0 +1,133 @@
+WITH
+    registered_patients AS (
+        SELECT registration_facility_region_id AS region_id, month_date,
+               COUNT(*) AS cumulative_registrations,
+               COUNT(*) FILTER (WHERE months_since_registration = 0) AS monthly_registrations
+
+        FROM reporting_patient_states
+        WHERE hypertension = 'yes'
+        GROUP BY 1, 2
+    ),
+
+    assigned_patients AS (
+        SELECT assigned_facility_region_id AS region_id, month_date,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care') AS under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'lost_to_follow_up') AS lost_to_follow_up,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'dead') AS dead,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state != 'dead') AS cumulative_assigned_patients
+
+        FROM reporting_patient_states
+        WHERE hypertension = 'yes'
+        GROUP BY 1, 2
+    ),
+
+    adjusted_outcomes AS (
+        SELECT assigned_facility_region_id AS region_id, month_date,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND htn_treatment_outcome_in_last_3_months = 'controlled') AS controlled_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND htn_treatment_outcome_in_last_3_months = 'uncontrolled') AS uncontrolled_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND htn_treatment_outcome_in_last_3_months = 'missed_visit') AS missed_visit_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND htn_treatment_outcome_in_last_3_months = 'visited_no_bp') AS visited_no_bp_under_care,
+
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'lost_to_follow_up' AND htn_treatment_outcome_in_last_3_months = 'missed_visit') AS missed_visit_lost_to_follow_up,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'lost_to_follow_up' AND htn_treatment_outcome_in_last_3_months = 'visited_no_bp') AS visited_no_bp_lost_to_follow_up,
+
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care') AS patients_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'lost_to_follow_up') AS patients_lost_to_follow_up
+
+        FROM reporting_patient_states
+        WHERE hypertension = 'yes'
+          AND months_since_registration >= 3
+        GROUP BY 1, 2
+    ),
+
+    monthly_cohort_outcomes AS (
+        SELECT assigned_facility_region_id AS region_id, month_date,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_treatment_outcome_in_last_2_months = 'controlled') AS controlled,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_treatment_outcome_in_last_2_months = 'uncontrolled') AS uncontrolled,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_treatment_outcome_in_last_2_months = 'missed_visit') AS missed_visit,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_treatment_outcome_in_last_2_months = 'visited_no_bp') AS visited_no_bp,
+               COUNT(distinct(patient_id)) AS patients
+
+        FROM reporting_patient_states
+        WHERE hypertension = 'yes'
+          AND months_since_registration = 2
+        GROUP BY 1, 2
+    ),
+
+    monthly_overdue_calls AS (
+        SELECT appointment_facility_region_id AS region_id, month_date,
+               COUNT(distinct(appointment_id)) AS call_results
+        FROM reporting_overdue_calls
+        GROUP BY 1, 2
+    ),
+
+    monthly_follow_ups AS (
+        SELECT facility_id, month_date, COUNT(distinct(patient_id)) as follow_ups
+        FROM reporting_patient_follow_ups
+        WHERE hypertension = 'yes'
+        GROUP BY facility_id, month_date
+    )
+
+SELECT
+-- months and facilities
+cal.*,
+rf.*,
+
+-- registration counts
+registered_patients.cumulative_registrations,
+registered_patients.monthly_registrations,
+
+-- assigned counts by care state
+assigned_patients.under_care,
+assigned_patients.lost_to_follow_up,
+assigned_patients.dead,
+assigned_patients.cumulative_assigned_patients,
+
+-- adjusted outcomes
+adjusted_outcomes.controlled_under_care AS adjusted_controlled_under_care,
+adjusted_outcomes.uncontrolled_under_care AS adjusted_uncontrolled_under_care,
+adjusted_outcomes.missed_visit_under_care AS adjusted_missed_visit_under_care,
+adjusted_outcomes.visited_no_bp_under_care AS adjusted_visited_no_bp_under_care,
+
+adjusted_outcomes.missed_visit_lost_to_follow_up AS adjusted_missed_visit_lost_to_follow_up,
+adjusted_outcomes.visited_no_bp_lost_to_follow_up AS adjusted_visited_no_bp_lost_to_follow_up,
+
+adjusted_outcomes.patients_under_care AS adjusted_patients_under_care,
+adjusted_outcomes.patients_lost_to_follow_up AS adjusted_patients_lost_to_follow_up,
+
+-- monthly cohort outcomes
+monthly_cohort_outcomes.controlled AS monthly_cohort_controlled,
+monthly_cohort_outcomes.uncontrolled AS monthly_cohort_uncontrolled,
+monthly_cohort_outcomes.missed_visit AS monthly_cohort_missed_visit,
+monthly_cohort_outcomes.visited_no_bp AS monthly_cohort_visited_no_bp,
+monthly_cohort_outcomes.patients AS monthly_cohort_patients,
+
+-- monthly overdue calls
+monthly_overdue_calls.call_results AS monthly_overdue_calls,
+
+-- monthly follow ups
+monthly_follow_ups.follow_ups AS monthly_follow_ups
+
+FROM reporting_facilities rf
+INNER JOIN reporting_months cal
+-- ensure a row for every facility and month combination
+    ON TRUE
+LEFT OUTER JOIN registered_patients
+    ON registered_patients.month_date = cal.month_date
+    AND registered_patients.region_id = rf.facility_region_id
+LEFT OUTER JOIN assigned_patients
+    ON assigned_patients.month_date = cal.month_date
+    AND assigned_patients.region_id = rf.facility_region_id
+LEFT OUTER JOIN adjusted_outcomes
+    ON adjusted_outcomes.month_date = cal.month_date
+    AND adjusted_outcomes.region_id = rf.facility_region_id
+LEFT OUTER JOIN monthly_cohort_outcomes
+    ON monthly_cohort_outcomes.month_date = cal.month_date
+    AND monthly_cohort_outcomes.region_id = rf.facility_region_id
+LEFT OUTER JOIN monthly_overdue_calls
+    ON monthly_overdue_calls.month_date = cal.month_date
+    AND monthly_overdue_calls.region_id = rf.facility_region_id
+LEFT OUTER JOIN monthly_follow_ups
+    ON monthly_follow_ups.month_date = cal.month_date
+    AND monthly_follow_ups.facility_id = rf.facility_id
+

--- a/spec/models/reports/region_summary_spec.rb
+++ b/spec/models/reports/region_summary_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
         monthly_registrations
         month_date
         monthly_overdue_calls
+        monthly_follow_ups
       ].map(&:to_s)
       (3.months.ago.to_period..now.to_period).each do |period|
         expect(results["facility-1"][period].keys).to match_array(expected_keys)

--- a/spec/models/reports/region_summary_spec.rb
+++ b/spec/models/reports/region_summary_spec.rb
@@ -174,35 +174,35 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
     refresh_views
 
     expected_facility_1_follow_ups = {
-      "October 1st 2019" => { "monthly_follow_ups" => 2},
-      "November 1st 2019" => { "monthly_follow_ups" => 2},
-      "December 1st 2019" => { "monthly_follow_ups" => 2},
-      "January 1st 2020" => { "monthly_follow_ups" => 4},
-      "February 1st 2020" => { "monthly_follow_ups" => 2},
-      "March 1st 2020" => { "monthly_follow_ups" => 2},
+      "October 1st 2019" => {"monthly_follow_ups" => 2},
+      "November 1st 2019" => {"monthly_follow_ups" => 2},
+      "December 1st 2019" => {"monthly_follow_ups" => 2},
+      "January 1st 2020" => {"monthly_follow_ups" => 4},
+      "February 1st 2020" => {"monthly_follow_ups" => 2},
+      "March 1st 2020" => {"monthly_follow_ups" => 2}
     }.transform_keys!(&:to_period)
     facility_1_results = described_class.call(facility_1, range: range)["facility-1"].transform_values { |values| values.slice("monthly_follow_ups") }
     expect(facility_1_results).to eq(expected_facility_1_follow_ups)
 
     expected_facility_2_follow_ups = {
-      "October 1st 2019" => { "monthly_follow_ups" => 0},
-      "November 1st 2019" => { "monthly_follow_ups" => 0},
-      "December 1st 2019" => { "monthly_follow_ups" => 0},
-      "January 1st 2020" => { "monthly_follow_ups" => 2},
-      "February 1st 2020" => { "monthly_follow_ups" => 0},
-      "March 1st 2020" => { "monthly_follow_ups" => 0},
+      "October 1st 2019" => {"monthly_follow_ups" => 0},
+      "November 1st 2019" => {"monthly_follow_ups" => 0},
+      "December 1st 2019" => {"monthly_follow_ups" => 0},
+      "January 1st 2020" => {"monthly_follow_ups" => 2},
+      "February 1st 2020" => {"monthly_follow_ups" => 0},
+      "March 1st 2020" => {"monthly_follow_ups" => 0}
     }.transform_keys!(&:to_period)
     facility_2_results = described_class.call([facility_2, facility_1], range: range)["facility-2"].transform_values { |values| values.slice("monthly_follow_ups") }
     expect(facility_2_results).to eq(expected_facility_2_follow_ups)
 
-    district_results = described_class.call(facility_group_1, range: range)[facility_group_1.region.slug].transform_values {|values| values.slice("monthly_follow_ups")}
+    district_results = described_class.call(facility_group_1, range: range)[facility_group_1.region.slug].transform_values { |values| values.slice("monthly_follow_ups") }
     expected_district_follow_ups = {
-      "October 1st 2019" => { "monthly_follow_ups" => 2},
-      "November 1st 2019" => { "monthly_follow_ups" => 2},
-      "December 1st 2019" => { "monthly_follow_ups" => 2},
-      "January 1st 2020" => { "monthly_follow_ups" => 6},
-      "February 1st 2020" => { "monthly_follow_ups" => 2},
-      "March 1st 2020" => { "monthly_follow_ups" => 2},
+      "October 1st 2019" => {"monthly_follow_ups" => 2},
+      "November 1st 2019" => {"monthly_follow_ups" => 2},
+      "December 1st 2019" => {"monthly_follow_ups" => 2},
+      "January 1st 2020" => {"monthly_follow_ups" => 6},
+      "February 1st 2020" => {"monthly_follow_ups" => 2},
+      "March 1st 2020" => {"monthly_follow_ups" => 2}
     }.transform_keys!(&:to_period)
     expect(district_results).to eq(expected_district_follow_ups)
   end

--- a/spec/models/reports/region_summary_spec.rb
+++ b/spec/models/reports/region_summary_spec.rb
@@ -154,7 +154,8 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
   end
 
   it "returns follow ups" do
-    facility_1, facility_2 = *FactoryBot.create_list(:facility, 2, block: "block-1", facility_group: facility_group_1).sort_by(&:slug)
+    facility_1 = FactoryBot.create(:facility, name: "facility 1", block: "block-1", facility_group: facility_group_1)
+    facility_2 = FactoryBot.create(:facility, name: "facility 2", block: "block-1", facility_group: facility_group_1)
     htn_patients_with_one_follow_up_every_month = create_list(:patient, 2, full_name: "facility 1 patient with HTN", recorded_at: jan_2019, assigned_facility: facility_1, registration_user: user)
     htn_patients_with_many_follow_ups_in_one_month = create_list(:patient, 2, full_name: "facility 2 patient with HTN", recorded_at: jan_2019, assigned_facility: facility_2, registration_user: user)
     diabetes_patients = create_list(:patient, 2, :diabetes, full_name: "patient with diabetes", recorded_at: jan_2019, assigned_facility: facility_1, registration_user: user)

--- a/spec/models/reports/region_summary_spec.rb
+++ b/spec/models/reports/region_summary_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
   let(:mar_2020) { Time.zone.parse("March 1st, 2020 00:00:00+00:00") }
 
   around do |example|
+    Flipper.enable(:follow_ups_v2)
     with_reporting_time_zone { example.run }
+    Flipper.disable(:follow_ups_v2)
   end
 
   def refresh_views

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -390,8 +390,8 @@ RSpec.describe Reports::Repository, type: :model do
           "October 1st 2019" => 2,
           "November 1st 2019" => 2,
           "December 1st 2019" => 2,
-          "January 1st 2020" => 2, 
-          "February 1st 2020" => 2,
+          "January 1st 2020" => 2,
+          "February 1st 2020" => 2
         }.transform_keys!(&:to_period)
         expected_v2 = {
           "October 1st 2019" => 2,

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -408,6 +408,8 @@ RSpec.describe Reports::Repository, type: :model do
 
       it "returns counts of follow_ups taken per region" do
         facility_1, facility_2 = create_list(:facility, 2)
+        create(:patient, registration_facility: facility_1, recorded_at: "February 1st 2021", registration_user: user)
+        create(:patient, registration_facility: facility_2, recorded_at: "February 1st 2021", registration_user: user)
         Timecop.freeze("May 10th 2021") do
           periods = (6.months.ago.to_period..1.month.ago.to_period)
           patient_1, patient_2 = create_list(:patient, 2, recorded_at: 10.months.ago)
@@ -428,10 +430,14 @@ RSpec.describe Reports::Repository, type: :model do
           repo_2 = described_class.new([facility_1, facility_2], periods: periods, follow_ups_v2: follow_ups_v2)
 
           expect(repo.hypertension_follow_ups[facility_1.region.slug]).to eq({
-            Period.month("February 1st 2021") => 2, Period.month("March 1st 2021") => 1
+            Period.month("February 1st 2021") => 2, Period.month("March 1st 2021") => 1, Period.month("April 1st 2021") => 0
           })
-          expect(repo.hypertension_follow_ups[facility_2.region.slug]).to eq({Period.month("April 1st 2021") => 1})
-          expect(repo_2.hypertension_follow_ups[facility_2.region.slug]).to eq({Period.month("April 1st 2021") => 1})
+          expect(repo.hypertension_follow_ups[facility_2.region.slug]).to eq({
+            Period.month("February 1st 2021") => 0, Period.month("March 1st 2021") => 0, Period.month("April 1st 2021") => 1
+          })
+          expect(repo_2.hypertension_follow_ups[facility_2.region.slug]).to eq({
+            Period.month("February 1st 2021") => 0, Period.month("March 1st 2021") => 0, Period.month("April 1st 2021") => 1
+          })
         end
       end
 

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -429,15 +429,11 @@ RSpec.describe Reports::Repository, type: :model do
           repo = described_class.new([facility_1, facility_2], periods: periods, follow_ups_v2: follow_ups_v2)
           repo_2 = described_class.new([facility_1, facility_2], periods: periods, follow_ups_v2: follow_ups_v2)
 
-          expect(repo.hypertension_follow_ups[facility_1.region.slug]).to eq({
-            Period.month("February 1st 2021") => 2, Period.month("March 1st 2021") => 1, Period.month("April 1st 2021") => 0
+          expect(repo.hypertension_follow_ups[facility_1.region.slug]).to include({
+            Period.month("February 1st 2021") => 2, Period.month("March 1st 2021") => 1
           })
-          expect(repo.hypertension_follow_ups[facility_2.region.slug]).to eq({
-            Period.month("February 1st 2021") => 0, Period.month("March 1st 2021") => 0, Period.month("April 1st 2021") => 1
-          })
-          expect(repo_2.hypertension_follow_ups[facility_2.region.slug]).to eq({
-            Period.month("February 1st 2021") => 0, Period.month("March 1st 2021") => 0, Period.month("April 1st 2021") => 1
-          })
+          expect(repo.hypertension_follow_ups[facility_2.region.slug]).to include({Period.month("April 1st 2021") => 1})
+          expect(repo_2.hypertension_follow_ups[facility_2.region.slug]).to include({Period.month("April 1st 2021") => 1})
         end
       end
 

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -410,6 +410,7 @@ RSpec.describe Reports::Repository, type: :model do
           create(:bp_with_encounter, recorded_at: 3.months.ago, facility: facility_1, patient: patient_2, user: user_2)
           create(:bp_with_encounter, recorded_at: 2.months.ago, facility: facility_1, patient: patient_2, user: user_2)
           create(:bp_with_encounter, recorded_at: 1.month.ago, facility: facility_2, patient: patient_1)
+          create(:appointment, recorded_at: 1.month.ago, facility: facility_2, patient: patient_1)
           refresh_views
 
           repo = described_class.new([facility_1, facility_2], periods: periods, follow_ups_v2: follow_ups_v2)

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -438,6 +438,7 @@ RSpec.describe Reports::Repository, type: :model do
       it "counts distinct follow ups per region / patient" do
         facility_1, facility_2 = create_list(:facility, 2)
         Timecop.freeze("May 10th 2021") do
+          other_patient = create(:patient, registration_facility: facility_1, recorded_at: 6.months.ago)
           periods = (6.months.ago.to_period..1.month.ago.to_period)
           patient_1 = create(:patient, :hypertension, recorded_at: 10.months.ago)
           user_1 = create(:user)
@@ -450,7 +451,7 @@ RSpec.describe Reports::Repository, type: :model do
 
           repo = described_class.new([facility_1, facility_2], periods: periods, follow_ups_v2: follow_ups_v2)
 
-          expect(repo.hypertension_follow_ups[facility_1.region.slug]).to eq({
+          expect(repo.hypertension_follow_ups[facility_1.region.slug]).to include({
             Period.month("February 1st 2021") => 1
           })
         end

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -468,9 +468,9 @@ RSpec.describe Reports::Repository, type: :model do
         facility_1, facility_2 = create_list(:facility, 2)
         Timecop.freeze("May 10th 2021") do
           periods = (6.months.ago.to_period..1.month.ago.to_period)
-          patient_1 = create(:patient, :hypertension, recorded_at: 10.months.ago, gender: :male)
-          patient_2 = create(:patient, :hypertension, recorded_at: 10.months.ago, gender: :female)
-          patient_3 = create(:patient, :hypertension, recorded_at: 10.months.ago, gender: :transgender)
+          patient_1 = create(:patient, :hypertension, recorded_at: 10.months.ago, gender: :male, registration_facility: facility_1)
+          patient_2 = create(:patient, :hypertension, recorded_at: 10.months.ago, gender: :female, registration_facility: facility_2)
+          patient_3 = create(:patient, :hypertension, recorded_at: 10.months.ago, gender: :transgender, registration_facility: facility_2)
 
           create(:bp_with_encounter, recorded_at: "February 10th 2021", facility: facility_1, patient: patient_1)
           create(:bp_with_encounter, recorded_at: "February 11th 2021", facility: facility_1, patient: patient_2)
@@ -479,8 +479,12 @@ RSpec.describe Reports::Repository, type: :model do
 
           repo = described_class.new([facility_1, facility_2], periods: periods, follow_ups_v2: follow_ups_v2)
 
-          expect(repo.hypertension_follow_ups[facility_1.region.slug]).to eq({
-            Period.month("February 1st 2021") => 3
+          expect(repo.hypertension_follow_ups[facility_1.region.slug]).to include({
+            "November 1st 2020".to_period => 0,
+            "December 1st 2020".to_period => 0,
+            "January 1st 2021".to_period => 0,
+            "February 1st 2021".to_period => 3,
+            "March 1st 2021".to_period => 0
           })
           expect(repo.hypertension_follow_ups(group_by: :patient_gender)[facility_1.region.slug]).to eq({
             Period.month("February 1st 2021") => {"female" => 1, "male" => 1, "transgender" => 1}

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -382,8 +382,18 @@ RSpec.describe Reports::Repository, type: :model do
         end
 
         refresh_views
-
-        expected_facility_1_follow_ups = {
+        # We get different results for v1 compared v2 here, and that is okay because:
+        #   v1 only tracks BPs, not visits, as follow ups
+        #   v1 does not correctly filter based on the range provided, which is a bug and will be fixed in v2
+        expected_v1 = {
+          "September 1st 2019" => 2,
+          "October 1st 2019" => 2,
+          "November 1st 2019" => 2,
+          "December 1st 2019" => 2,
+          "January 1st 2020" => 2, 
+          "February 1st 2020" => 2,
+        }.transform_keys!(&:to_period)
+        expected_v2 = {
           "October 1st 2019" => 2,
           "November 1st 2019" => 2,
           "December 1st 2019" => 2,
@@ -391,8 +401,9 @@ RSpec.describe Reports::Repository, type: :model do
           "February 1st 2020" => 2,
           "March 1st 2020" => 2
         }.transform_keys!(&:to_period)
+        expected = follow_ups_v2 ? expected_v2 : expected_v1
         repo = described_class.new(facility_1, periods: range, follow_ups_v2: follow_ups_v2)
-        expect(repo.hypertension_follow_ups["facility-1"]).to eq(expected_facility_1_follow_ups)
+        expect(repo.hypertension_follow_ups["facility-1"]).to eq(expected)
       end
 
       it "returns counts of follow_ups taken per region" do

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -440,7 +440,7 @@ RSpec.describe Reports::Repository, type: :model do
       it "counts distinct follow ups per region / patient" do
         facility_1, facility_2 = create_list(:facility, 2)
         Timecop.freeze("May 10th 2021") do
-          other_patient = create(:patient, registration_facility: facility_1, recorded_at: 6.months.ago)
+          create(:patient, registration_facility: facility_1, recorded_at: 6.months.ago)
           periods = (6.months.ago.to_period..1.month.ago.to_period)
           patient_1 = create(:patient, :hypertension, recorded_at: 10.months.ago)
           user_1 = create(:user)


### PR DESCRIPTION
**Story card:** [ch4212](https://app.shortcut.com/simpledotorg/story/4212/support-follow-ups-in-the-reporting-pipeline)

Follow up to https://github.com/simpledotorg/simple-server/pull/3187
Extracting more pieces from #3166 here

## Because

Adds follow ups count to the facility_states matview.

This means we can grab follow ups from the highest level matview for cases where its **not** grouped on gender.  This is much faster and quicker.
