### PR TITLE
Add queries to get monthly registrations and controlled counts by gender

### DIFF
--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -91,6 +91,16 @@ module Reports
       }
     end
 
+    memoize def monthly_registrations_by_gender
+      items = regions.map { |region| RegionEntry.new(region, __method__, group_by: :gender, period_type: period_type) }
+      result = cache.fetch_multi(*items, force: bust_cache?) do |entry|
+        registered_patients_query.count(entry.region, period_type, group_by: :gender)
+      end
+      result.each_with_object({}) { |(region_entry, counts), hsh|
+        hsh[region_entry.region.slug] = counts
+      }
+    end
+
     def follow_ups_v2_query(group_by: nil)
       group_field = case group_by
         when /user_id\z/ then :user_id

--- a/spec/models/reports/repository_spec.rb
+++ b/spec/models/reports/repository_spec.rb
@@ -137,6 +137,24 @@ RSpec.describe Reports::Repository, type: :model do
       expect(repo.monthly_registrations_by_user[facility_1.slug][july_2020.to_period]).to be_nil
     end
 
+    it "can count registrations and cumulative registrations by gender" do
+      facility_1 = FactoryBot.create(:facility, facility_group: facility_group_1)
+
+      default_attrs = {registration_facility: facility_1, assigned_facility: facility_1}
+      jan_1_2018 = Period.month("January 1 2018")
+      _facility_1_registered_before_repository_range = create_list(:patient, 2, default_attrs.merge(recorded_at: jan_1_2018.value, gender: :female))
+      _facility_1_registered_female = create_list(:patient, 3, default_attrs.merge(recorded_at: jan_2019, gender: :female))
+      _facility_1_registered_male = create_list(:patient, 2, default_attrs.merge(recorded_at: jan_2019, gender: :male))
+      _facility_1_registered_transgender = create_list(:patient, 1, default_attrs.merge(recorded_at: jan_2019, gender: :transgender))
+
+      refresh_views
+
+      repo = Reports::Repository.new(facility_1.region, periods: (july_2018.to_period..july_2020.to_period))
+      expect(repo.monthly_registrations_by_gender[facility_1.slug][jan_2019.to_period]["female"]).to eq(3)
+      expect(repo.monthly_registrations_by_gender[facility_1.slug][jan_2019.to_period]["male"]).to eq(2)
+      expect(repo.monthly_registrations_by_gender[facility_1.slug][jan_2019.to_period]["transgender"]).to eq(1)
+    end
+
     it "gets registration and assigned patient counts for brand new regions with no data" do
       facility_1 = FactoryBot.create(:facility, facility_group: facility_group_1)
       refresh_views


### PR DESCRIPTION
**Story card:** [ch5894](https://app.shortcut.com/simpledotorg/story/5894/add-gender-disaggregation-to-the-dhis2-data-elements-we-report)

## Because

Maharashtra DHIS2 requires disaggregating our data by gender.

## This addresses

We're only sending two data elements to DHIS2 in Maharashtra:
- Monthly registrations by facility
- Monthly controlled patients by facility

This adds queries for both, broken down by gender.