### PR TITLE
Fix capistrano sidekiq script

### DIFF
--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -11,7 +11,7 @@ namespace :sidekiq do
   desc "Quiet sidekiq (stop fetching new tasks from Redis)"
   task :quiet do
     on roles :sidekiq do
-      execute :systemctl, :reload, fetch(:sidekiq_service_name), "--user", raise_on_non_zero_exit: false
+      execute :systemctl, "--user", "kill -s TSTP", fetch(:sidekiq_service_name)
     end
   end
 


### PR DESCRIPTION
**Story card:** [ch6336](https://app.shortcut.com/simpledotorg/story/6336)

## Because

We use a `systemd reload` while deploying to quiet the sidekiq workers, even though it's not a supported interrupt signal by sidekiq. The recommended way to quiet sidekiq workers using a `kill -s TSTP`. We borrowed the sidekiq script from capistrano-sidekiq which is incorrect as discussed [here](https://github.com/seuros/capistrano-sidekiq/issues/276).

## This addresses

Fixes `sidekiq:quiet`