### PR TITLE
Skip phone number update if record invalid:

### DIFF
--- a/app/jobs/update_phone_number_details_worker.rb
+++ b/app/jobs/update_phone_number_details_worker.rb
@@ -3,13 +3,23 @@ class UpdatePhoneNumberDetailsWorker
   include Sidekiq::Throttled::Worker
 
   sidekiq_options queue: :low
+  sidekiq_options retry: 5
 
   sidekiq_throttle(
     threshold: {limit: ENV["EXOTEL_API_RATE_LIMIT_PER_MINUTE"].to_i || 250, period: 1.minute}
   )
 
+  def logger
+    @logger ||= Notification.logger(class: self.class.name)
+  end
+
   def perform(patient_phone_number_id, sid, token)
     patient_phone_number = PatientPhoneNumber.find(patient_phone_number_id)
+    if patient_phone_number.invalid?
+      errors = patient_phone_number.errors
+      logger.warn(msg: "Patient phone number #{patient_phone_number_id} is invalid, skipping phone number update", errors: errors)
+      return
+    end
     patient_phone_number.update_exotel_phone_number_detail(
       ExotelAPIService.new(sid, token)
         .phone_number_details(patient_phone_number.number)

--- a/spec/rachets/lets_not_spec.rb
+++ b/spec/rachets/lets_not_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe "Rachet down usage of let!" do
-  expected_usages = 468
+  expected_usages = 467
 
   it "prevents new usages" do
     command = %{grep -rn "\slet\!(:" spec}


### PR DESCRIPTION
also bump down the retry count to 5 from the default of 25 (!)

**Story card:** [ch6352](https://app.shortcut.com/simpledotorg/story/6352/handle-failed-phone-number-updates-gracefully)
This will also close out https://sentry.io/organizations/resolve-to-save-lives/issues/2861219450/?environment=production&project=1217715&query=is%3Aunresolved

## Because

We should handle this case more gracefully

## This addresses

* does not try to update a phone number if its invalid, as it will always fails
* logs the errors
* bumps retry count down to 5
