### PR TITLE
Dont try to use DataDog on android review apps

### DIFF
--- a/config/initializers/00_datadog.rb
+++ b/config/initializers/00_datadog.rb
@@ -4,7 +4,7 @@ require "datadog/statsd"
 
 # Allow running via an ENV var (for development usage, for example) ...otherwise
 # exclude some envs by default
-DATADOG_ENABLED = ENV["DATADOG_ENABLED"] || !(Rails.env.development? || Rails.env.test? || SimpleServer.env.review?)
+DATADOG_ENABLED = ENV["DATADOG_ENABLED"] || !(Rails.env.development? || Rails.env.test? || SimpleServer.env.review? || SimpleServer.env.android_review?)
 
 # Trying out Ruby code profiling in selected environments
 ENABLE_DD_PROFILING = SimpleServer.env.sandbox?


### PR DESCRIPTION
android e2e tests use SIMPLE_SERVER_ENV=android_review, so we should
explicitly disable DD tracing there as well

seen while pairing with @vinaysshenoy, as the app was trying to connect to DD.  This doesn't cause an error but does cause noise and unnecessary connection attempts