### PR TITLE
Cache drug stock report

### DIFF
--- a/app/queries/drug_stocks_query.rb
+++ b/app/queries/drug_stocks_query.rb
@@ -17,26 +17,30 @@ class DrugStocksQuery
   attr_reader :for_end_of_month, :facilities, :blocks, :facility_group
 
   def drug_stocks_report
-    {total_patient_count: district_patient_count,
-     total_drugs_in_stock: total_drugs_in_stock,
-     total_patient_days: total_patient_days,
+    Rails.cache.fetch(drug_stocks_cache_key,
+      expires_in: ENV.fetch("ANALYTICS_DASHBOARD_CACHE_TTL"),
+      force: RequestStore.store[:bust_cache]) do
+      {total_patient_count: district_patient_count,
+       total_drugs_in_stock: total_drugs_in_stock,
+       total_patient_days: total_patient_days,
 
-     district_patient_count: district_patient_count,
-     district_patient_days: district_patient_days,
-     district_drugs_in_stock: district_drugs_in_stock,
+       district_patient_count: district_patient_count,
+       district_patient_days: district_patient_days,
+       district_drugs_in_stock: district_drugs_in_stock,
 
-     facilities_total_patient_count: facilities_total_patient_count,
-     facilities_total_patient_days: facilities_total_patient_days,
-     facilities_total_drugs_in_stock: facilities_total_drugs_in_stock,
+       facilities_total_patient_count: facilities_total_patient_count,
+       facilities_total_patient_days: facilities_total_patient_days,
+       facilities_total_drugs_in_stock: facilities_total_drugs_in_stock,
 
-     patient_count_by_facility_id: patient_count_by_facility_id,
-     patient_days_by_facility_id: patient_days_by_facility_id,
-     drugs_in_stock_by_facility_id: drugs_in_stock_by_facility_id,
+       patient_count_by_facility_id: patient_count_by_facility_id,
+       patient_days_by_facility_id: patient_days_by_facility_id,
+       drugs_in_stock_by_facility_id: drugs_in_stock_by_facility_id,
 
-     patient_count_by_block_id: patient_count_by_block_id,
-     patient_days_by_block_id: patient_days_by_block_id,
-     drugs_in_stock_by_block_id: drugs_in_stock_by_block_id,
-     last_updated_at: Time.now}
+       patient_count_by_block_id: patient_count_by_block_id,
+       patient_days_by_block_id: patient_days_by_block_id,
+       drugs_in_stock_by_block_id: drugs_in_stock_by_block_id,
+       last_updated_at: Time.now}
+    end
   end
 
   def drug_consumption_report


### PR DESCRIPTION
This was mistakenly removed in 8f6bcc797b662f9b4d0225c36b17356ab5463e92.
**Story card:** [ch6365](https://app.shortcut.com/simpledotorg/story/6365/improve-drug-stock-report-performance)