### PR TITLE
New "Hypertension patients" card copy and styling

### DIFF
--- a/app/assets/stylesheets/partials/_reports.scss
+++ b/app/assets/stylesheets/partials/_reports.scss
@@ -96,6 +96,7 @@
 .lh-1 { line-height: 1; }
 .lh-18px { line-height: 18px; }
 .ls-145 { letter-spacing: 1.45; }
+.ls-2px { letter-spacing: 2px; }
 .ta-left { text-align: left; }
 .ta-center { text-align: center; }
 .c-grey-dark { color: $grey-dark; }

--- a/app/assets/stylesheets/partials/_reports.scss
+++ b/app/assets/stylesheets/partials/_reports.scss
@@ -50,6 +50,7 @@
 .h-12px { height: 12px; }
 .h-10pt { height: 10%; }
 .h-20px { height: 20px; }
+.h-24px { height: 24px; }
 .h-100px { height: 100px; }
 .h-100pt { height: 100%; }
 .h-200px { height: 200px; }

--- a/app/models/facility_group_region_sync.rb
+++ b/app/models/facility_group_region_sync.rb
@@ -22,14 +22,14 @@ class FacilityGroupRegionSync < SimpleDelegator
     region.name = name
     if district_estimated_population
       if district_estimated_population.blank?
-        region.estimated_population.mark_for_destruction
+        region.estimated_population.destroy
       else
         population = region.estimated_population || region.build_estimated_population
         population.population = district_estimated_population
       end
-      state_region.recalculate_state_population!
     end
     region.save!
+    state_region.recalculate_state_population!
   end
 
   def sync_block_regions

--- a/app/models/facility_group_region_sync.rb
+++ b/app/models/facility_group_region_sync.rb
@@ -22,7 +22,7 @@ class FacilityGroupRegionSync < SimpleDelegator
     region.name = name
     if district_estimated_population
       if district_estimated_population.blank?
-        region.estimated_population.destroy
+        region.estimated_population.mark_for_destruction
       else
         population = region.estimated_population || region.build_estimated_population
         population.population = district_estimated_population

--- a/app/views/reports/regions/_hypertension_patient_coverage.html.erb
+++ b/app/views/reports/regions/_hypertension_patient_coverage.html.erb
@@ -1,4 +1,4 @@
-<div class="d-flex mb-16px o-hidden <% if @region.estimated_population&.hypertension_patient_coverage_rate == 100.0 %>br-4px<% end %>" style="height: 24px;">
+<div class="d-flex h-24px mb-16px o-hidden <% if @region.estimated_population&.hypertension_patient_coverage_rate == 100.0 %>br-4px<% end %>">
   <div
     class="br-tl-4px br-bl-4px <% if @region.estimated_population&.show_coverage %>bg-green-dark<% else %>bg-grey-light<% end %>"
     style="width: <% if @region.estimated_population&.show_coverage %><%= number_to_percentage(@region.estimated_population.hypertension_patient_coverage_rate, precision: 0) %><% else %>5%<% end %>;"

--- a/app/views/reports/regions/_hypertension_patient_coverage.html.erb
+++ b/app/views/reports/regions/_hypertension_patient_coverage.html.erb
@@ -1,3 +1,10 @@
+<div class="d-flex mb-16px o-hidden <% if @region.estimated_population&.hypertension_patient_coverage_rate == 100.0 %>br-4px<% end %>" style="height: 24px;">
+  <div
+    class="br-tl-4px br-bl-4px <% if @region.estimated_population&.show_coverage %>bg-green-dark<% else %>bg-grey-light<% end %>"
+    style="width: <% if @region.estimated_population&.show_coverage %><%= number_to_percentage(@region.estimated_population.hypertension_patient_coverage_rate, precision: 0) %><% else %>5%<% end %>;"
+  ></div>
+  <div class="flex-1 br-tr-4px br-br-4px bg-grey-light"></div>
+</div>
 <div class="d-flex ai-center jc-between">
   <p class="mb-8px">
     Hypertension patient coverage
@@ -23,13 +30,6 @@
     <% end %>
   </p>
 </div>
-<div class="d-flex h-8px mb-16px o-hidden <% if @region.estimated_population&.hypertension_patient_coverage_rate == 100.0 %>br-4px<% end %>">
-  <div
-    class="br-tl-4px br-bl-4px <% if @region.estimated_population&.show_coverage %>bg-green-dark<% else %>bg-grey-light<% end %>"
-    style="width: <% if @region.estimated_population&.show_coverage %><%= number_to_percentage(@region.estimated_population.hypertension_patient_coverage_rate, precision: 0) %><% else %>5%<% end %>;"
-  ></div>
-  <div class="flex-1 br-tr-4px br-br-4px bg-grey-light"></div>
-</div>
 <div class="d-flex ai-center jc-between">
   <p class="mb-8px">
     Total registered patients
@@ -49,7 +49,7 @@
     <%= number_with_delimiter(@chart_data[:patient_breakdown][:total_patients]) %>
   </p>
 </div>
-<div class="d-flex ai-center jc-between">
+<div class="d-flex ai-center jc-between mb-16px">
   <p class="mb-8px">
     Total est. hypertensive population
     <span class="p-relative t-1px">
@@ -82,3 +82,6 @@
     <% end %>
   </p>
 </div>
+<p class="mb-12px fs-14px tt-uppercase fw-bold ls-2px">
+  Registered patients
+</p>

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -3,11 +3,11 @@
     <div id="patient-breakdown" data-period="<%= @period.to_s %>" class="mt-8px mx-0px mb-16px p-20px bg-white br-4px bs-small w-lg-full mt-lg-0 pb-inside-avoid b-print-black w-print-16cm">
       <div class="d-flex flex-1 mb-8px">
         <h3 class="mb-0px mr-8px">
-          Hypertension patient
+          Hypertension patients
         </h3>
       </div>
-      <p class="mb-16px c-grey-dark mr-lg-12px">
-        Registration progress and follow-up status of patients registered in <%= @region.name %>
+      <p class="mb-24px c-grey-dark mr-lg-12px">
+        All hypertensive individuals and patients in <%= @region.name %>
       </p>
       <% if current_admin.feature_enabled?(:estimated_population) && @region.supports_htn_population_coverage %>
         <%= render "reports/regions/hypertension_patient_coverage" %>

--- a/spec/models/facility_group_spec.rb
+++ b/spec/models/facility_group_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe FacilityGroup, type: :model do
         expect(facility_group.region.path).to eq "india.ihci.maharashtra.fg"
       end
 
-      it "updates district estimed population if one is provided" do
+      it "updates district estimated population if one is provided" do
         expect {
           facility_group.update!(district_estimated_population: 1000)
         }.to change(EstimatedPopulation, :count).by(2)
@@ -261,6 +261,13 @@ RSpec.describe FacilityGroup, type: :model do
           facility_group.update!(district_estimated_population: 3333)
         }.to change(EstimatedPopulation, :count).by(0)
         expect(facility_group.region.estimated_population.population).to eq(3333)
+      end
+
+      it "updates state estimated population if a district population is updated" do
+        facility_group.update!(district_estimated_population: 1000)
+        expect(facility_group.state_region.estimated_population.population).to be(1000)
+        facility_group.update!(district_estimated_population: 5000)
+        expect(facility_group.state_region.estimated_population.population).to be(5000)
       end
     end
   end


### PR DESCRIPTION
**Story card:** [sc6425](https://app.shortcut.com/simpledotorg/epic/5831/add-estimated-hypertensive-population-data?cf_workflow=500000031&ct_workflow=all&vc_group_by=day)

## Because
Daniel suggested some UI layout/copy improvements to the "Hypertension patients" card.

## This addresses
1. Make "Hypertension patients" progress bar `24px` high
2. Move the "Hypertension patient coverage" row below the progress bar
3. Add a new section, "Registered patients", and move "Patients under care", "Lost to follow-up", and "Dead patients" below the new section
4. Update the card's title and subtitle to be "Hypertension patients" and "All hypertensive individuals and patients in `region_name`"

## Test instructions
1/2 Verify the "Hypertension patient coverage" card in state and district reports look like the screenshot below:
![image](https://user-images.githubusercontent.com/16785131/147115189-16a5b6c0-77c6-4ac3-911b-a5e212fbb503.png)

2/2 Verify the "Hypertension patient coverage" card in block and facility reports look like the screenshot below:
![image](https://user-images.githubusercontent.com/16785131/147115260-b5e1e4a6-d37b-45d1-9b2b-111d18e77bc3.png)
