### PR TITLE
Updated title

### DIFF
--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -3,7 +3,11 @@
     <div id="patient-breakdown" data-period="<%= @period.to_s %>" class="mt-8px mx-0px mb-16px p-20px bg-white br-4px bs-small w-lg-full mt-lg-0 pb-inside-avoid b-print-black w-print-16cm">
       <div class="d-flex flex-1 mb-8px">
         <h3 class="mb-0px mr-8px">
-          Hypertension patients
+          <% if current_admin.feature_enabled?(:estimated_population) && @region.supports_htn_population_coverage %>
+            Hypertension coverage 
+          <% else %>
+            Hypertension patients
+          <% end %>
         </h3>
       </div>
       <p class="mb-24px c-grey-dark mr-lg-12px">

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -1,21 +1,25 @@
 <div class="d-lg-flex flex-lg-wrap">
   <div class="d-lg-flex w-lg-50 pr-lg-2">
     <div id="patient-breakdown" data-period="<%= @period.to_s %>" class="mt-8px mx-0px mb-16px p-20px bg-white br-4px bs-small w-lg-full mt-lg-0 pb-inside-avoid b-print-black w-print-16cm">
-      <div class="d-flex flex-1 mb-8px">
-        <h3 class="mb-0px mr-8px">
-          <% if current_admin.feature_enabled?(:estimated_population) && @region.supports_htn_population_coverage %>
-            Hypertension coverage 
-          <% else %>
-            Hypertension patients
-          <% end %>
-        </h3>
-      </div>
-      <p class="mb-24px c-grey-dark mr-lg-12px">
-        All hypertensive individuals and patients in <%= @region.name %>
-      </p>
       <% if current_admin.feature_enabled?(:estimated_population) && @region.supports_htn_population_coverage %>
+        <div class="d-flex flex-1 mb-8px">
+          <h3 class="mb-0px mr-8px">
+            Hypertension coverage
+          </h3>
+        </div>
+        <p class="mb-24px c-grey-dark mr-lg-12px">
+          All hypertensive individuals and patients in <%= @region.name %>
+        </p>
         <%= render "reports/regions/hypertension_patient_coverage" %>
       <% else %>
+        <div class="d-flex flex-1 mb-8px">
+          <h3 class="mb-0px mr-8px">
+            Hypertension patients 
+          </h3>
+        </div>
+        <p class="mb-24px c-grey-dark mr-lg-12px">
+          All hypertensive patients in <%= @region.name %>
+        </p>
         <div class="d-flex ai-center jc-between">
           <p class="mb-8px">
             Total registered patients


### PR DESCRIPTION
**Story card:** [sc6429](https://app.shortcut.com/simpledotorg/story/6429/update-card-title)

## Because

Sets proper title for "Hypertension coverage" card.

## This addresses

Shows "Hypertension coverage" as a title when user has access to feature AND when region shows hypertension coverage. Otherwise, shows "Hypertension patients".

## Test instructions

1. Pull latest
2. Turn on the feature flag, `estimated_population`
3. Go to a state and district report, "Hypertension coverage" should show as a title and "All hypertensive individuals and patients in `region_name`" as a subtitle
4. Go to a block and facility report, "Hypertension patients" should show as a title and "All hypertensive patients in `region_name`" as a subtitle
5. Turn off the feature flag, `estimated_population`
6. Go to the same state and district reports, "Hypertension patients" should show as a title and "All hypertensive patients in `region_name`" as a subtitle
7. Go to the same block and facility reports, "Hypertension patients" should show as a title and "All hypertensive patients in `region_name`" as a subtitle