### PR TITLE
Exclude facilities with no registered or assigned patients from drug stock reports

### DIFF
--- a/app/controllers/concerns/my_facilities_filtering.rb
+++ b/app/controllers/concerns/my_facilities_filtering.rb
@@ -76,7 +76,7 @@ module MyFacilitiesFiltering
     end
 
     def accessible_facility_groups
-      FacilityGroup.where(id: @accessible_facilities.map(&:facility_group_id).uniq).order(:name)
+      FacilityGroup.where(id: @accessible_facilities.pluck(:facility_group_id).uniq).order(:name)
     end
 
     def drug_stock_facility_groups

--- a/app/controllers/my_facilities/drug_stocks_controller.rb
+++ b/app/controllers/my_facilities/drug_stocks_controller.rb
@@ -126,9 +126,9 @@ class MyFacilities::DrugStocksController < AdminController
     # Filtered list of facilities that match user selected filters,
     # and have stock tracking enabled and at least one registered or assigned patient
     active_facility_ids = filter_facilities
-                          .joins("INNER JOIN reporting_facility_states on reporting_facility_states.facility_id = facilities.id")
-                          .where("cumulative_registrations > 0 OR cumulative_assigned_patients > 0")
-                          .pluck("facilities.id")
+      .joins("INNER JOIN reporting_facility_states on reporting_facility_states.facility_id = facilities.id")
+      .where("cumulative_registrations > 0 OR cumulative_assigned_patients > 0")
+      .pluck("facilities.id")
 
     filter_facilities
       .eager_load(facility_group: :protocol_drugs)

--- a/app/controllers/my_facilities/drug_stocks_controller.rb
+++ b/app/controllers/my_facilities/drug_stocks_controller.rb
@@ -14,8 +14,13 @@ class MyFacilities::DrugStocksController < AdminController
   before_action :redirect_unless_drug_stocks_enabled
 
   def drug_stocks
-    create_drug_report
-    @report = @query.drug_stocks_report
+    @facilities = drug_stock_enabled_facilities
+    @for_end_of_month_display = @for_end_of_month.strftime("%b-%Y")
+
+    if @facilities.present?
+      create_drug_report
+      @report = @query.drug_stocks_report
+    end
 
     respond_to do |format|
       format.html { render :drug_stocks }
@@ -26,9 +31,13 @@ class MyFacilities::DrugStocksController < AdminController
   end
 
   def drug_consumption
-    create_drug_report
-    @report = @query.drug_consumption_report
+    @facilities = drug_stock_enabled_facilities
+    @for_end_of_month_display = @for_end_of_month.strftime("%b-%Y")
 
+    if @facilities.present?
+      create_drug_report
+      @report = @query.drug_consumption_report
+    end
     respond_to do |format|
       format.html { render :drug_consumption }
       format.csv do
@@ -55,8 +64,6 @@ class MyFacilities::DrugStocksController < AdminController
   private
 
   def create_drug_report
-    @facilities = drug_stock_enabled_facilities
-    @for_end_of_month_display = @for_end_of_month.strftime("%b-%Y")
     @query = DrugStocksQuery.new(facilities: @facilities,
       for_end_of_month: @for_end_of_month)
     @blocks = blocks_to_display
@@ -116,8 +123,16 @@ class MyFacilities::DrugStocksController < AdminController
   end
 
   def drug_stock_enabled_facilities
+    # Filtered list of facilities that match user selected filters,
+    # and have stock tracking enabled and at least one registered or assigned patient
+    active_facility_ids = filter_facilities
+                          .joins("INNER JOIN reporting_facility_states on reporting_facility_states.facility_id = facilities.id")
+                          .where("cumulative_registrations > 0 OR cumulative_assigned_patients > 0")
+                          .pluck("facilities.id")
+
     filter_facilities
-      .includes(facility_group: :protocol_drugs)
-      .where(protocol_drugs: {stock_tracked: true})
+      .eager_load(facility_group: :protocol_drugs)
+      .where(protocol_drugs: {stock_tracked: true}, id: active_facility_ids)
+      .distinct("facilities.id")
   end
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -50,6 +50,8 @@ class Facility < ApplicationRecord
     class_name: "Patient",
     foreign_key: "assigned_facility_id"
 
+  has_many :facility_states, class_name: "Reports::FacilityState"
+
   pg_search_scope :search_by_name, against: {name: "A", slug: "B"}, using: {tsearch: {prefix: true}}
   scope :with_block_region_id, -> {
     joins("INNER JOIN regions facility_regions ON facility_regions.source_id = facilities.id")

--- a/app/views/my_facilities/drug_stocks/drug_consumption.html.erb
+++ b/app/views/my_facilities/drug_stocks/drug_consumption.html.erb
@@ -6,9 +6,11 @@
           <h3>
             Drug consumption during <%= @for_end_of_month_display %>
           </h3>
-          <p class="c-grey-dark">
-            Last updated: <%= @report&.fetch(:last_updated_at) %>
-          </p>
+          <% if @facilities.present? %>
+            <p class="c-grey-dark">
+              Last updated: <%= @report&.fetch(:last_updated_at) %>
+            </p>
+          <% end %>
         </div>
 
         <p class="mb-4">
@@ -41,11 +43,13 @@
             <% end %>
           </div>
         </div>
-        <div class="mb-8px mr-8px d-flex flex-grow-1 justify-content-sm-end">
-          <%= link_to "Download Report",
+        <% if @facilities.present? %>
+          <div class="mb-8px mr-8px d-flex flex-grow-1 justify-content-sm-end">
+            <%= link_to "Download Report",
                       my_facilities_drug_consumption_path(format: :csv, **request.query_parameters.symbolize_keys),
                       class: "btn btn-sm btn-outline-primary" %>
-        </div>
+          </div>
+        <% end %>
       </div>
       <% if @facilities.present? %>
         <%= render "drug_consumption_table" %>

--- a/app/views/my_facilities/drug_stocks/drug_stocks.html.erb
+++ b/app/views/my_facilities/drug_stocks/drug_stocks.html.erb
@@ -6,9 +6,11 @@
           <h3>
             Drug stock on hand: end of <%= @for_end_of_month_display %>
           </h3>
-          <p class="c-grey-dark">
-            Last updated: <%= @report&.fetch(:last_updated_at) %>
-          </p>
+          <% if @facilities.present? %>
+            <p class="c-grey-dark">
+              Last updated: <%= @report&.fetch(:last_updated_at) %>
+            </p>
+          <% end %>
         </div>
 
         <p class="mb-4">
@@ -36,11 +38,13 @@
             <% end %>
           </div>
         </div>
-        <div class="mb-8px mr-8px d-flex flex-grow-1 justify-content-sm-end">
-          <%= link_to "Download Report",
+        <% if @facilities.present? %>
+          <div class="mb-8px mr-8px d-flex flex-grow-1 justify-content-sm-end">
+            <%= link_to "Download Report",
                       my_facilities_drug_stocks_path(format: :csv, **request.query_parameters.symbolize_keys),
                       class: "btn btn-sm btn-outline-primary" %>
-        </div>
+          </div>
+        <% end %>
       </div>
       <% if @facilities.present? %>
         <%= render "drug_stocks_table" %>

--- a/spec/controllers/my_facilities/drug_stocks_controller_spec.rb
+++ b/spec/controllers/my_facilities/drug_stocks_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe MyFacilities::DrugStocksController, type: :controller do
         sign_in(report_viewer.email_authentication)
         get :drug_stocks, params: {}
 
-        expect(assigns(:facilities)).to contain_exactly(*[facilities_with_stock_tracked.first, facilities_with_stock_tracked.second])
+        expect(assigns(:facilities)).to contain_exactly(facilities_with_stock_tracked.first, facilities_with_stock_tracked.second)
       end
     end
 

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Facility, type: :model do
     it { is_expected.to have_many(:registered_patients).class_name("Patient").with_foreign_key("registration_facility_id") }
     it { is_expected.to have_many(:assigned_patients).class_name("Patient").with_foreign_key("assigned_facility_id") }
     it { is_expected.to have_many(:assigned_hypertension_patients).class_name("Patient").with_foreign_key("assigned_facility_id") }
-    it { is_expected.to have_many(:facility_states).class_name("Reports::FacilityState")}
+    it { is_expected.to have_many(:facility_states).class_name("Reports::FacilityState") }
 
     context "slugs" do
       it "generates slug on creation and avoids conflicts via appending a UUID" do

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Facility, type: :model do
     it { is_expected.to have_many(:registered_patients).class_name("Patient").with_foreign_key("registration_facility_id") }
     it { is_expected.to have_many(:assigned_patients).class_name("Patient").with_foreign_key("assigned_facility_id") }
     it { is_expected.to have_many(:assigned_hypertension_patients).class_name("Patient").with_foreign_key("assigned_facility_id") }
+    it { is_expected.to have_many(:facility_states).class_name("Reports::FacilityState")}
 
     context "slugs" do
       it "generates slug on creation and avoids conflicts via appending a UUID" do


### PR DESCRIPTION
**Story card:** [sc-6312](https://app.shortcut.com/simpledotorg/story/6312/exclude-facilities-with-no-registered-or-assigned-patients-in-the-drug-stock-reports)

## Because

Showing facilities that have no patients makes it difficult to tell if a facility is inactive, or just hasn't submitted data

## This addresses

Filters out facilities that have no registered or assigned patients