### PR TITLE
Send stock calculation errors to dd instead of sentry

### DIFF
--- a/app/models/reports/drug_stock_calculation.rb
+++ b/app/models/reports/drug_stock_calculation.rb
@@ -24,16 +24,18 @@ module Reports
        patient_days: patient_days_calculation}
     rescue => e
       # drug is not in formula, or other configuration error
-      Sentry.capture_message("Patient Days Calculation Error",
-        extra: {
-          coefficients: @coefficients,
-          drug_category: @drug_category,
-          in_stock_by_rxnorm_code: in_stock_by_rxnorm_code,
-          patient_count: @patient_count,
-          protocol: @protocol,
-          exception: e
-        },
-        tags: {type: "reports"})
+      error_info = {
+        coefficients: @coefficients,
+        drug_category: @drug_category,
+        in_stock_by_rxnorm_code: in_stock_by_rxnorm_code,
+        patient_count: @patient_count,
+        protocol: @protocol,
+        exception: e
+      }
+
+      span = Datadog.tracer.active_span
+      error_info.each { |tag, value| span.set_tag(tag.to_s, value.to_s) }
+
       {patient_days: "error"}
     end
 
@@ -50,17 +52,19 @@ module Reports
       drug_consumption
     rescue => e
       # drug is not in formula, or other configuration error
-      Sentry.capture_message("Consumption Calculation Error",
-        extra: {
-          coefficients: @coefficients,
-          drug_category: @drug_category,
-          in_stock_by_rxnorm_code: in_stock_by_rxnorm_code,
-          previous_month_in_stock_by_rxnorm_code: previous_month_in_stock_by_rxnorm_code,
-          patient_count: @patient_count,
-          protocol: @protocol,
-          exception: e
-        },
-        tags: {type: "reports"})
+      error_info = {
+        coefficients: @coefficients,
+        drug_category: @drug_category,
+        in_stock_by_rxnorm_code: in_stock_by_rxnorm_code,
+        previous_month_in_stock_by_rxnorm_code: previous_month_in_stock_by_rxnorm_code,
+        patient_count: @patient_count,
+        protocol: @protocol,
+        exception: e
+      }
+
+      span = Datadog.tracer.active_span
+      error_info.each { |tag, value| span.set_tag(tag.to_s, value.to_s) }
+
       {consumption: "error"}
     end
 
@@ -100,16 +104,18 @@ module Reports
         consumed: opening_balance + (received || 0) - (redistributed || 0) - closing_balance
       }
     rescue => e
-      Sentry.capture_message("Consumption Calculation Error",
-        extra: {
-          protocol: @protocol,
-          opening_balance: opening_balance,
-          received: received,
-          redistributed: redistributed,
-          closing_balance: closing_balance,
-          exception: e
-        },
-        tags: {type: "reports"})
+      error_info = {
+        protocol: @protocol,
+        opening_balance: opening_balance,
+        received: received,
+        redistributed: redistributed,
+        closing_balance: closing_balance,
+        exception: e
+      }
+
+      span = Datadog.tracer.active_span
+      error_info.each { |tag, value| span.set_tag(tag.to_s, value.to_s) }
+
       {consumed: "error"}
     end
 

--- a/app/models/reports/drug_stock_calculation.rb
+++ b/app/models/reports/drug_stock_calculation.rb
@@ -33,8 +33,9 @@ module Reports
         exception: e
       }
 
-      span = Datadog.tracer.active_span
-      error_info.each { |tag, value| span.set_tag(tag.to_s, value.to_s) }
+      Datadog.tracer.trace("patient_days", resource: "Reports::DrugStockCalculation#patient_days") do |span|
+        error_info.each { |tag, value| span.set_tag(tag.to_s, value.to_s) }
+      end
 
       {patient_days: "error"}
     end
@@ -62,8 +63,9 @@ module Reports
         exception: e
       }
 
-      span = Datadog.tracer.active_span
-      error_info.each { |tag, value| span.set_tag(tag.to_s, value.to_s) }
+      Datadog.tracer.trace("patient_days", resource: "Reports::DrugStockCalculation#patient_days") do |span|
+        error_info.each { |tag, value| span.set_tag(tag.to_s, value.to_s) }
+      end
 
       {consumption: "error"}
     end
@@ -113,8 +115,9 @@ module Reports
         exception: e
       }
 
-      span = Datadog.tracer.active_span
-      error_info.each { |tag, value| span.set_tag(tag.to_s, value.to_s) }
+      Datadog.tracer.trace("patient_days", resource: "Reports::DrugStockCalculation#patient_days") do |span|
+        error_info.each { |tag, value| span.set_tag(tag.to_s, value.to_s) }
+      end
 
       {consumed: "error"}
     end

--- a/app/models/reports/drug_stock_calculation.rb
+++ b/app/models/reports/drug_stock_calculation.rb
@@ -33,9 +33,7 @@ module Reports
         exception: e
       }
 
-      Datadog.tracer.trace("patient_days", resource: "Reports::DrugStockCalculation#patient_days") do |span|
-        error_info.each { |tag, value| span.set_tag(tag.to_s, value.to_s) }
-      end
+      trace("patient_days", "Reports::DrugStockCalculation#patient_days", error_info)
 
       {patient_days: "error"}
     end
@@ -63,9 +61,7 @@ module Reports
         exception: e
       }
 
-      Datadog.tracer.trace("patient_days", resource: "Reports::DrugStockCalculation#patient_days") do |span|
-        error_info.each { |tag, value| span.set_tag(tag.to_s, value.to_s) }
-      end
+      trace("consumption", "Reports::DrugStockCalculation#consumption", error_info)
 
       {consumption: "error"}
     end
@@ -115,9 +111,7 @@ module Reports
         exception: e
       }
 
-      Datadog.tracer.trace("patient_days", resource: "Reports::DrugStockCalculation#patient_days") do |span|
-        error_info.each { |tag, value| span.set_tag(tag.to_s, value.to_s) }
-      end
+      trace("consumption_calculation", "Reports::DrugStockCalculation#consumption_calculation", error_info)
 
       {consumed: "error"}
     end
@@ -183,6 +177,12 @@ module Reports
 
     memoize def previous_month_in_stock_by_rxnorm_code
       drug_attribute_sum_by_rxnorm_code(@previous_drug_stocks, :in_stock)
+    end
+
+    def trace(name, resource, error_info)
+      Datadog.tracer.trace(name, resource: resource) do |span|
+        error_info.each { |tag, value| span.set_tag(tag.to_s, value.to_s) }
+      end
     end
   end
 end

--- a/spec/models/reports/drug_stock_calculation_spec.rb
+++ b/spec/models/reports/drug_stock_calculation_spec.rb
@@ -187,8 +187,10 @@ RSpec.describe Reports::DrugStockCalculation, type: :model do
       expect(result).to eq(patient_days: "error")
     end
 
-    it "reports error to sentry" do
-      allow(Sentry).to receive(:capture_message)
+    it "reports error to datadog" do
+      allow_any_instance_of(Datadog::Tracer).to receive(:trace)
+      expect_any_instance_of(Datadog::Tracer).to receive(:trace)
+
       result = described_class.new(
         state: state,
         protocol_drugs: protocol_drugs,
@@ -197,7 +199,6 @@ RSpec.describe Reports::DrugStockCalculation, type: :model do
         patient_count: 0
       ).patient_days
       expect(result).to eq(patient_days: "error")
-      expect(Sentry).to have_received(:capture_message)
     end
   end
 


### PR DESCRIPTION
**Story card:** [sc-6468](https://app.shortcut.com/simpledotorg/story/6468/report-drug-stock-calculation-errors-to-datadog-instead-of-sentry)

## Because

These errors raise sentry alerts, which are noisy. They're also not usually actionable.

## This addresses

Removes the Sentry reporting code, and instead adds tags to the datadog span.