### PR TITLE
Updated title and card width

### DIFF
--- a/app/views/reports/regions/_non_facility_details.html.erb
+++ b/app/views/reports/regions/_non_facility_details.html.erb
@@ -112,10 +112,10 @@
 </div>
 
 <% if current_admin.feature_enabled?(:show_call_results) %>
-  <div class="card mt-0 pr-0 pr-md-3 pb-inside-avoid">
+  <div class="card w-100pt mt-0 pr-0 pr-md-3 pb-inside-avoid">
     <div class="d-flex flex-1 mb-8px">
       <h3 class="mb-0px mr-8px">
-        Healthcare worker activity
+        Overdue patients contacted
       </h3>
       <%= render "definition_tooltip",
                  definitions: { "Overdue patients contacted" => t("call_results_copy.monthly_overdue_calls_made", region_name: @region.name) } %>

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,20 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
--- COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
---
 -- Name: ltree; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -63,8 +49,6 @@ CREATE TYPE public.gender_enum AS ENUM (
 
 
 SET default_tablespace = '';
-
-SET default_with_oids = false;
 
 --
 -- Name: accesses; Type: TABLE; Schema: public; Owner: -


### PR DESCRIPTION
**Story card:** [sc-6497](https://app.shortcut.com/simpledotorg/story/6497/fix-overdue-patients-contacted-card-width-and-title)

## Because

The "Healthcare worker activity" card in non-facility report "Details" pages should be `width: 100%;` and use `Overdue patients contacted` as a title.

## This addresses

1. Makes card width `100%`
2. Updates card title to `Overdue patients contacted`

## Test instructions

1. Open `http://localhost:3000`
2. Add a new `show_call_results` Flipper flag in `http://localhost:3000/flipper/features`
3. Go to a state report "Details" page and verify the card after `Patient registrations and follow-ups` is full-width and uses `Overdue patients contacted` as a title
4. Go to a block report "Details" page and verify the card after `Patient registrations and follow-ups` is full-width and uses `Overdue patients contacted` as a title
5. Go to a facility report "Details" page and verify the card after `Patient registrations and follow-ups` is full-width and uses `Healthcare worker activity` as a title