### PR TITLE
Grab data even if a facility _just_ has follow ups

### DIFF
--- a/app/models/reports/region_summary.rb
+++ b/app/models/reports/region_summary.rb
@@ -68,7 +68,7 @@ module Reports
     def for_regions
       FacilityState
         .where(id_field => regions.map(&:id))
-        .where("cumulative_registrations IS NOT NULL OR cumulative_assigned_patients IS NOT NULL")
+        .where("cumulative_registrations IS NOT NULL OR cumulative_assigned_patients IS NOT NULL OR monthly_follow_ups IS NOT NULL")
     end
   end
 end

--- a/app/models/reports/schema_v2.rb
+++ b/app/models/reports/schema_v2.rb
@@ -198,7 +198,7 @@ module Reports
 
     memoize def earliest_patient_data_query_v2(region)
       FacilityState.for_region(region)
-        .where("cumulative_registrations > 0 OR cumulative_assigned_patients > 0")
+        .where("cumulative_registrations > 0 OR cumulative_assigned_patients > 0 OR monthly_follow_ups > 0")
         .minimum(:month_date)
     end
 

--- a/spec/models/reports/patient_state_spec.rb
+++ b/spec/models/reports/patient_state_spec.rb
@@ -620,7 +620,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
 
             expect(patient_states(patient, to: twelve_months_ago).pluck(:htn_care_state)).to all(eq("under_care"))
             expect(patient_states(patient, from: twelve_months_ago, to: ten_months_ago).pluck(:htn_care_state)).to all(eq("lost_to_follow_up"))
-            expect(patient_states(patient, from: ten_months_ago).pluck(:htn_care_state)).to all(eq("under_care"))
+            expect(patient_states(patient, from: ten_months_ago, to: now).pluck(:htn_care_state)).to all(eq("under_care"))
 
             expect(patient_states(patient, to: ten_months_ago).pluck(:htn_treatment_outcome_in_last_3_months)).to all(eq("missed_visit"))
             expect(patient_states(patient, from: ten_months_ago, to: seven_months_ago).pluck(:htn_treatment_outcome_in_last_3_months)).to all(eq("controlled"))

--- a/spec/queries/bp_measures_query_spec.rb
+++ b/spec/queries/bp_measures_query_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe BPMeasuresQuery do
 
   it "handles period boundaries correctly, taking into account time zones" do
     facility = create(:facility)
-    end_of_jan = Time.zone.parse("January 31st 23:59:59 IST")
-    beg_of_feb = Time.zone.parse("February 1st 00:00:00 IST")
+    end_of_jan = Time.zone.parse("January 31st 2021 23:59:59 IST")
+    beg_of_feb = Time.zone.parse("February 1st 2021 00:00:00 IST")
 
     create(:blood_pressure, facility: facility, recorded_at: end_of_jan, user: user_1)
     create(:blood_pressure, facility: facility, recorded_at: beg_of_feb, user: user_2)


### PR DESCRIPTION
...and no registered or assigned patients

**Story card:** [sc-6496](https://app.shortcut.com/simpledotorg/story/6496/follow-up-data-not-visible-in-district-details-but-visible-in-facility-details)

Fix issue where a facility has no registered or assigned patients, but does have follow up numbers.