### PR TITLE
Add derailed_benchmarks and configure for dynamic benchmarks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,11 @@ group :development, :test do
   gem "standard", "1.5.0", require: false
 end
 
+group :development, :test, :profiling do
+  gem "derailed_benchmarks"
+  gem "memory_profiler", require: false
+end
+
 group :development do
   gem "guard-rspec", require: false
   gem "listen"
@@ -116,7 +121,6 @@ group :development do
   gem "spring", "3.1.1"
   gem "spring-commands-rspec"
   gem "web-console", ">= 3.3.0"
-  gem "memory_profiler"
   gem "flamegraph"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
     autoprefixer-rails (9.7.6)
       execjs
     bcrypt (3.1.16)
+    benchmark-ips (2.9.2)
     bindex (0.8.1)
     bootsnap (1.7.2)
       msgpack (~> 1.0)
@@ -136,6 +137,19 @@ GEM
     ddtrace (0.53.0)
       ffi (~> 1.0)
       msgpack
+    dead_end (3.1.0)
+    derailed_benchmarks (2.1.1)
+      benchmark-ips (~> 2)
+      dead_end
+      get_process_mem (~> 0)
+      heapy (~> 0)
+      memory_profiler (>= 0, < 2)
+      mini_histogram (>= 0.3.0)
+      rack (>= 1)
+      rack-test
+      rake (> 10, < 14)
+      ruby-statistics (>= 2.1)
+      thor (>= 0.19, < 2)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -236,6 +250,8 @@ GEM
     generator_spec (0.9.4)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
+    get_process_mem (0.2.7)
+      ffi (~> 1.0)
     github-ds (0.5.0)
       activerecord (>= 3.2)
     globalid (0.4.2)
@@ -259,6 +275,8 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     hashdiff (1.0.1)
     hashie (4.1.0)
+    heapy (0.2.0)
+      thor
     http (5.0.4)
       addressable (~> 2.8)
       http-cookie (~> 1.0)
@@ -324,6 +342,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
+    mini_histogram (0.3.1)
     mini_mime (1.1.2)
     mini_portile2 (2.6.1)
     minitest (5.15.0)
@@ -507,6 +526,7 @@ GEM
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.11.0)
+    ruby-statistics (3.0.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)
@@ -664,6 +684,7 @@ DEPENDENCIES
   data-anonymization
   data_migrate
   ddtrace (~> 0.51)
+  derailed_benchmarks
   devise (>= 4.7.1)
   devise_invitable (~> 1.7.0)
   dhis2

--- a/config/environments/profiling.rb
+++ b/config/environments/profiling.rb
@@ -1,10 +1,10 @@
 Rails.application.configure do
-  # NOTE: for profiling purposes, you may wish to change both the below values to _true_ if you are
+  # NOTE: for profiling purposes, you want below values to _true_ if you are
   # running scripted benchmarks and would like more reliable results.  However, if you are analyzing lower level
   # performance (with flamegraphs for example), and want to see the results of changes interactively, you'll
-  # probably want to keep them both to false. Otherwise any code changes require a full restart of yoru server.
-  config.cache_classes = false
-  config.eager_load = false
+  # probably want them both to be false. Otherwise any code changes require a full restart of yoru server.
+  config.cache_classes = true
+  config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local = false
@@ -26,7 +26,7 @@ Rails.application.configure do
   config.assets.compile = true
 
   # Set this to :info to truly match production; debug will show each SQL statement in logs
-  config.log_level = :debug
+  config.log_level = :info
 
   # Use a different cache store in production.
   config.cache_store = if ENV["RAILS_CACHE_REDIS_URL"].present?

--- a/config/initializers/00_datadog.rb
+++ b/config/initializers/00_datadog.rb
@@ -4,7 +4,7 @@ require "datadog/statsd"
 
 # Allow running via an ENV var (for development usage, for example) ...otherwise
 # exclude some envs by default
-DATADOG_ENABLED = ENV["DATADOG_ENABLED"] || !(Rails.env.development? || Rails.env.test? || SimpleServer.env.review? || SimpleServer.env.android_review?)
+DATADOG_ENABLED = ENV["DATADOG_ENABLED"] || !(Rails.env.development? || Rails.env.test? || Rails.env.profiling? || SimpleServer.env.review? || SimpleServer.env.android_review?)
 
 # Trying out Ruby code profiling in selected environments
 ENABLE_DD_PROFILING = SimpleServer.env.sandbox?

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -2,10 +2,12 @@
 if ENV["RACK_MINI_PROFILER"] && !ENV["DATADOG_ENABLED"]
   Rails.logger.info "Initializing rack-mini-profiler"
   require "stackprof"
+  require "memory_profiler"
   require "rack-mini-profiler"
 
   # initialization is skipped so we do it manually
   Rack::MiniProfilerRails.initialize!(Rails.application)
+  Rack::MiniProfiler.config.enable_advanced_debugging_tools = true
   Rack::MiniProfiler.config.skip_paths = [%r{/webview/}, %r{/api}]
   if Rails.env.profiling? # we want to disable any authorization for the profiling env, as this would only be run locally
     Rack::MiniProfiler.config.authorization_mode = :allow_all

--- a/perf.rake
+++ b/perf.rake
@@ -1,0 +1,26 @@
+require 'bundler'
+Bundler.setup
+
+require 'derailed_benchmarks'
+require 'derailed_benchmarks/tasks'
+
+class DerailedAuth < DerailedBenchmarks::AuthHelper
+  def setup
+    require 'devise'
+    require 'warden'
+    extend ::Warden::Test::Helpers
+    extend ::Devise::TestHelpers
+    Warden.test_mode!
+  end
+
+  def user
+    @user = User.find_by_email("admin@simple.org")
+  end
+
+  def call(env)
+    login_as(user.email_authentication)
+    app.call(env)
+  end
+end
+
+DerailedBenchmarks.auth = DerailedAuth.new

--- a/perf.rake
+++ b/perf.rake
@@ -1,13 +1,13 @@
-require 'bundler'
+require "bundler"
 Bundler.setup
 
-require 'derailed_benchmarks'
-require 'derailed_benchmarks/tasks'
+require "derailed_benchmarks"
+require "derailed_benchmarks/tasks"
 
 class DerailedAuth < DerailedBenchmarks::AuthHelper
   def setup
-    require 'devise'
-    require 'warden'
+    require "devise"
+    require "warden"
     extend ::Warden::Test::Helpers
     extend ::Devise::TestHelpers
     Warden.test_mode!

--- a/script/bench_region_details
+++ b/script/bench_region_details
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Note that the vars below will be overridden by preexisting values.
 # The path to hit will depend upon your local seed data.
 : "${PATH_TO_HIT=/reports/regions/state/diamond-islands/details}"
 : "${TEST_COUNT=10}"

--- a/script/bench_region_details
+++ b/script/bench_region_details
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# The path to hit will depend upon your local seed data.
+export PATH_TO_HIT=/reports/regions/state/diamond-islands/details
+export TEST_COUNT=10
+export USE_AUTH=true
+
+# See https://github.com/zombocom/derailed_benchmarks#running-derailed-exec for 
+# detailed docs on all the tools derailed provides.
+RAILS_ENV=profiling bundle exec derailed exec perf:test

--- a/script/bench_region_details
+++ b/script/bench_region_details
@@ -1,9 +1,13 @@
 #!/bin/bash
 
 # The path to hit will depend upon your local seed data.
-export PATH_TO_HIT=/reports/regions/state/diamond-islands/details
-export TEST_COUNT=10
-export USE_AUTH=true
+: "${PATH_TO_HIT=/reports/regions/state/diamond-islands/details}"
+: "${TEST_COUNT=10}"
+: "${USE_AUTH=true}"
+
+export PATH_TO_HIT
+export TEST_COUNT
+export USE_AUTH
 
 # See https://github.com/zombocom/derailed_benchmarks#running-derailed-exec for 
 # detailed docs on all the tools derailed provides.

--- a/script/bench_web
+++ b/script/bench_web
@@ -3,7 +3,7 @@
 # Note that the vars below will be overridden by preexisting values.
 # The path to hit will depend upon your local seed data.
 : "${PATH_TO_HIT=/reports/regions/state/diamond-islands/details}"
-: "${TEST_COUNT=10}"
+: "${TEST_COUNT=25}"
 : "${USE_AUTH=true}"
 # See https://github.com/zombocom/derailed_benchmarks#running-derailed-exec for 
 # detailed docs on all the tasks derailed provides.

--- a/script/bench_web
+++ b/script/bench_web
@@ -5,11 +5,13 @@
 : "${PATH_TO_HIT=/reports/regions/state/diamond-islands/details}"
 : "${TEST_COUNT=10}"
 : "${USE_AUTH=true}"
+# See https://github.com/zombocom/derailed_benchmarks#running-derailed-exec for 
+# detailed docs on all the tasks derailed provides.
+: "${DR_TASK=perf:test}"
 
 export PATH_TO_HIT
 export TEST_COUNT
 export USE_AUTH
+export DR_TASK
 
-# See https://github.com/zombocom/derailed_benchmarks#running-derailed-exec for 
-# detailed docs on all the tools derailed provides.
-RAILS_ENV=profiling bundle exec derailed exec perf:test
+RAILS_ENV=profiling bundle exec derailed exec $DR_TASK


### PR DESCRIPTION
**Story card:** [sc-6531](https://app.shortcut.com/simpledotorg/story/6531/region-details-is-slow-for-large-regions)

## Because

We need a way to have repeatable, logged in, scripted benchmarks for perf and scaling work

## This addresses

Adds https://github.com/zombocom/derailed_benchmarks for local memory profiling and benchmarking. 
Adds an auth adapter to login as admin for local benchmarks.
Tweaks profiling env to be more like prod.

## Test instructions

First, you'll need your `profiling` env setup locally for this. You can do this via:

```
RAILS_ENV=profiling rails db:reset
```
to set things up.  

Or get a dataset much more like prod (recommended) with:

```
SEED_TYPE=profiling RAILS_ENV=profiling rails db:reset
```

Note that this seed size will take between 30 mins to over an hour depending on your local machine and your DB setup.

Then, you can run `script/bench_web`, which provides a small harness for running tasks provided by derailed.  See also https://github.com/zombocom/derailed_benchmarks for docs about all the different tasks this provides.