### PR TITLE
Create January 2022 IHCI Experiment 

### DIFF
--- a/db/data/20220105113547_create_january2022_ihci_experiment2.rb
+++ b/db/data/20220105113547_create_january2022_ihci_experiment2.rb
@@ -1,0 +1,22 @@
+class CreateJanuary2022IhciExperiment2 < ActiveRecord::Migration[5.2]
+  def up
+    return unless CountryConfig.current_country?("India") && SimpleServer.env.production?
+
+    Seed::Experiment2Seeder.create_current_experiment(
+      experiment_name: "Current Patient January 2022",
+      start_time: Date.parse("Jan 6, 2022").beginning_of_day,
+      end_time: Date.parse("Feb 5, 2022").end_of_day,
+      max_patients_per_day: 20000
+    )
+    Seed::Experiment2Seeder.create_stale_experiment(
+      experiment_name: "Stale Patient January 2022",
+      start_time: Date.parse("Jan 6, 2022").beginning_of_day,
+      end_time: Date.parse("Feb 5, 2022").end_of_day,
+      max_patients_per_day: 15000
+    )
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-6538](https://app.shortcut.com/simpledotorg/story/6538/setup-sms-only-experiment)

## Because

We cancelled the previous experiment because we decided not to use WhatsApp for sending out messages further in the experimentation. One of the reasons for not using WhatsApp was it had a daily limit of 10000 messages.

## This addresses

- Created a new experiment that will be only using SMS to send out messages. 
- This also increases the number of messages send out daily because we are not using WhatsApp
   -  Current Patient Experiment can now enrol 20k patients daily 
   -  Stale Patient Experiment can now enrol 15k patients daily