### PR TITLE
Fix authz check for adding population data

### DIFF
--- a/app/views/reports/regions/_hypertension_patient_coverage.html.erb
+++ b/app/views/reports/regions/_hypertension_patient_coverage.html.erb
@@ -69,16 +69,16 @@
       <span class="fw-bold">
         <%= number_with_delimiter(@region.estimated_population&.population) %>
       </span>
-    <% elsif accessible_region?(@region, :manage) %>
-      <% if @region.district_region? %>
-        <%= link_to "+ Add population", edit_admin_facility_group_path(@region) %>
-      <% elsif @region.state_region? %>
-        <%= link_to "+ Add district populations", "/admin/facilities" %>
-      <% end %>
     <% else %>
-      <span class="fw-bold">
-        N/A
-      </span>
+      <% if @region.district_region? && accessible_region?(@region, :manage) %>
+        <%= link_to "+ Add population", edit_admin_facility_group_path(@region) %>
+      <% elsif @region.state_region? && accessible_region?(@region, :view_reports) %>
+        <%= link_to "+ Add district populations", "/admin/facilities" %>
+      <% else %>
+        <span class="fw-bold">
+          N/A
+        </span>
+      <% end %>
     <% end %>
   </p>
 </div>


### PR DESCRIPTION
**Story card:** [sc-6548](https://app.shortcut.com/simpledotorg/story/6548/actionview-template-error-states-only-support-view-reports-authorization-requests)

We can't check if a user has manage access to a state (as that authz condition doesn't exist right now in our system) - currently for state regions the authz check will blow up for users who have this feature turned on.

So we can check the authz conditions after we check the region type, and also just use `view_reports` for state regions.