### PR TITLE
Bump up open dependabot PRs to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "bundler"
+    open-pull-requests-limit: 10
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
the default is 5.  It would be  helpful to see more of the outdated gem updates needed to get things ready for Rails 6.