### PR TITLE
Hotfix for facility group updates when no population is set

### DIFF
--- a/app/models/facility_group_region_sync.rb
+++ b/app/models/facility_group_region_sync.rb
@@ -22,7 +22,7 @@ class FacilityGroupRegionSync < SimpleDelegator
     region.name = name
     if district_estimated_population
       if district_estimated_population.blank?
-        region.estimated_population.mark_for_destruction
+        region&.estimated_population&.mark_for_destruction
       else
         population = region.estimated_population || region.build_estimated_population
         population.population = district_estimated_population

--- a/spec/controllers/admin/facility_groups_controller_spec.rb
+++ b/spec/controllers/admin/facility_groups_controller_spec.rb
@@ -148,6 +148,18 @@ RSpec.describe Admin::FacilityGroupsController, type: :controller do
       expect(facility_group.state).to eq("New York")
     end
 
+    fit "updates when population is blank and no population exists" do
+      facility_group = create(:facility_group, valid_attributes)
+      new_attributes = {
+        name: "New Name",
+        district_estimated_population: "",
+        description: "New Description",
+        state: "New York"
+
+      }
+      put :update, params: {id: facility_group.to_param, facility_group: new_attributes, organization_id: organization.id}
+    end
+
     it "can turn on diabetes management for all facilities inside a facility group" do
       facility_group = create(:facility_group, valid_attributes)
       facilities = create_list(:facility, 2, facility_group: facility_group, enable_diabetes_management: false)

--- a/spec/controllers/admin/facility_groups_controller_spec.rb
+++ b/spec/controllers/admin/facility_groups_controller_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Admin::FacilityGroupsController, type: :controller do
       expect(facility_group.state).to eq("New York")
     end
 
-    fit "updates when population is blank and no population exists" do
+    it "updates when population is blank and no population exists" do
       facility_group = create(:facility_group, valid_attributes)
       new_attributes = {
         name: "New Name",
@@ -158,6 +158,10 @@ RSpec.describe Admin::FacilityGroupsController, type: :controller do
 
       }
       put :update, params: {id: facility_group.to_param, facility_group: new_attributes, organization_id: organization.id}
+      facility_group.reload
+      expect(facility_group.name).to eq("New Name")
+      expect(facility_group.description).to eq("New Description")
+      expect(facility_group.state).to eq("New York")
     end
 
     it "can turn on diabetes management for all facilities inside a facility group" do


### PR DESCRIPTION
**Story card:** [sc-6569](https://app.shortcut.com/simpledotorg/story/6569/nomethoderror-undefined-method-mark-for-destruction-for-nil-nilclass)
