### PR TITLE
Move rspec back to dev/test; update related gems

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,7 +18,7 @@ blocks:
           commands:
             - sem-version ruby 2.7.4
             - checkout
-            - cache clear
+            # - cache clear
             - cache restore
             - bundle config set deployment 'true'
             - bundle config set path 'vendor/bundle'

--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,8 @@ gem "render_async"
 gem "request_store-sidekiq"
 gem "request_store"
 gem "roo", "~> 2.8.0"
-gem "rswag", "~> 2.4.0"
+gem "rswag-api"
+gem "rswag-ui"
 gem "ruby-progressbar", require: false
 gem "rubyzip"
 gem "sassc-rails"
@@ -118,6 +119,8 @@ group :development, :test do
   gem "rails-controller-testing"
   gem "rb-readline"
   gem "rspec-rails", "~> 4"
+  gem "rswag-specs"
+
   gem "shoulda-matchers", "~> 5.0.0"
   gem "standard", "1.6.0", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ group :development, :test do
   gem "parallel_tests", group: %i[development test]
   gem "rails-controller-testing"
   gem "rb-readline"
-  gem "rspec-rails", "~> 4.0.1"
+  gem "rspec-rails", "~> 4"
   gem "shoulda-matchers", "~> 5.0.0"
   gem "standard", "1.6.0", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,6 @@ gem "render_async"
 gem "request_store-sidekiq"
 gem "request_store"
 gem "roo", "~> 2.8.0"
-gem "rspec-rails", "~> 4.0.1"
 gem "rswag", "~> 2.4.0"
 gem "ruby-progressbar", require: false
 gem "rubyzip"
@@ -118,6 +117,7 @@ group :development, :test do
   gem "parallel_tests", group: %i[development test]
   gem "rails-controller-testing"
   gem "rb-readline"
+  gem "rspec-rails", "~> 4.0.1"
   gem "shoulda-matchers", "~> 5.0.0"
   gem "standard", "1.6.0", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     dhis2 (3.3.1)
       dry-validation (= 0.11.1)
       rest-client
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     diffy (3.4.0)
     discard (1.2.0)
       activerecord (>= 4.2, < 7)
@@ -499,7 +499,7 @@ GEM
       rspec-expectations (~> 3.9)
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
-    rspec-sidekiq (3.0.3)
+    rspec-sidekiq (3.1.0)
       rspec-core (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.9.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -748,7 +748,7 @@ DEPENDENCIES
   request_store
   request_store-sidekiq
   roo (~> 2.8.0)
-  rspec-rails (~> 4.0.1)
+  rspec-rails (~> 4)
   rspec-sidekiq
   rswag (~> 2.4.0)
   ruby-progressbar

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -503,10 +503,6 @@ GEM
       rspec-core (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.9.4)
-    rswag (2.4.0)
-      rswag-api (= 2.4.0)
-      rswag-specs (= 2.4.0)
-      rswag-ui (= 2.4.0)
     rswag-api (2.4.0)
       railties (>= 3.1, < 7.0)
     rswag-specs (2.4.0)
@@ -750,7 +746,9 @@ DEPENDENCIES
   roo (~> 2.8.0)
   rspec-rails (~> 4)
   rspec-sidekiq
-  rswag (~> 2.4.0)
+  rswag-api
+  rswag-specs
+  rswag-ui
   ruby-progressbar
   rubyzip
   sassc-rails

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -764,7 +764,7 @@ DEPENDENCIES
   request_store
   request_store-sidekiq
   roo (~> 2.8.0)
-  rspec-rails (~> 4.0.1)
+  rspec-rails (~> 4)
   rspec-sidekiq
   rswag (~> 2.4.0)
   ruby-progressbar

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -177,7 +177,7 @@ GEM
     dhis2 (3.3.1)
       dry-validation (= 0.11.1)
       rest-client
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     diffy (3.4.0)
     discard (1.2.0)
       activerecord (>= 4.2, < 7)
@@ -514,7 +514,7 @@ GEM
       rspec-expectations (~> 3.9)
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
-    rspec-sidekiq (3.0.3)
+    rspec-sidekiq (3.1.0)
       rspec-core (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.9.4)

--- a/Gemfile_next.lock
+++ b/Gemfile_next.lock
@@ -518,10 +518,6 @@ GEM
       rspec-core (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.9.4)
-    rswag (2.4.0)
-      rswag-api (= 2.4.0)
-      rswag-specs (= 2.4.0)
-      rswag-ui (= 2.4.0)
     rswag-api (2.4.0)
       railties (>= 3.1, < 7.0)
     rswag-specs (2.4.0)
@@ -766,7 +762,9 @@ DEPENDENCIES
   roo (~> 2.8.0)
   rspec-rails (~> 4)
   rspec-sidekiq
-  rswag (~> 2.4.0)
+  rswag-api
+  rswag-specs
+  rswag-ui
   ruby-progressbar
   rubyzip
   sassc-rails


### PR DESCRIPTION
Small rspec fix/change - we shouldn't have this in our main bundle if we can help it.

I had to split up [rswag](https://github.com/rswag/rswag) gems to do this, since rswag depends on rspec-core for part of its functionality.

