### PR TITLE
Remove bootboot from Gemfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "bundler"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     directory: "/"
     schedule:
       interval: "daily"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
-plugin "bootboot", "~> 0.1.1"
-Plugin.send(:load_plugin, "bootboot") if Plugin.installed?("bootboot")
-
 source "https://rubygems.org"
 
 ruby "2.7.4"


### PR DESCRIPTION
This is breaking deploys, because the path returned for the gem is a fully qualified path from a release that has been cleaned up.

see https://github.com/rubygems/rubygems/issues/3304
and https://github.com/rubygems/rubygems/issues/3340

**Story card:** [sc-6351](https://app.shortcut.com/simpledotorg/story/6351/setup-dual-dependency-approach-to-prepare-for-rails-6-and-beyond)
