### PR TITLE
Add a custom task to fix Bundler plugin path for bootboot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source "https://rubygems.org"
-
 ruby "2.7.4"
+
+plugin "bootboot", "~> 0.1.1"
+Bundler.settings.set_local("bootboot_env_prefix", "RAILS")
+Plugin.send(:load_plugin, "bootboot") if Plugin.installed?("bootboot")
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
@@ -8,6 +11,7 @@ git_source(:github) do |repo_name|
 end
 
 gem "dotenv-rails"
+
 if ENV["RAILS_NEXT"]
   enable_dual_booting if Plugin.installed?("bootboot")
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,7 +27,7 @@ set :sentry_repo, "simpledotorg/simple-server"
 # Fire off release notifications to Sentry after successful deploys
 before "deploy:starting", "sentry:validate_config"
 after "deploy:published", "sentry:notice_deployment"
-before "deploy:bundle", "deploy:fix_bundler_plugin_path"
+before "deploy:updated", "deploy:fix_bundler_plugin_path"
 
 append :linked_dirs, ".bundle"
 append :linked_files, ".env.production"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,7 +27,7 @@ set :sentry_repo, "simpledotorg/simple-server"
 # Fire off release notifications to Sentry after successful deploys
 before "deploy:starting", "sentry:validate_config"
 after "deploy:published", "sentry:notice_deployment"
-before "deploy:updated", "deploy:fix_bundler_plugin_path"
+after "deploy:symlink:linked_dirs", "deploy:fix_bundler_plugin_path"
 
 append :linked_dirs, ".bundle"
 append :linked_files, ".env.production"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,6 +27,7 @@ set :sentry_repo, "simpledotorg/simple-server"
 # Fire off release notifications to Sentry after successful deploys
 before "deploy:starting", "sentry:validate_config"
 after "deploy:published", "sentry:notice_deployment"
+before "deploy:bundle", "deploy:fix_bundler_plugin_path"
 
 append :linked_dirs, ".bundle"
 append :linked_files, ".env.production"

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -11,7 +11,6 @@ namespace :deploy do
   task :fix_bundler_plugin_path do
     on release_roles([:all]) do
       within shared_path do
-        # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
         execute "sed", "-i", '"s#/home/deploy/apps/simple-server/releases/[0-9]\+/#/home/deploy/apps/simple-server/shared/#g"', ".bundle/plugin/index"
       end
     end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -24,6 +24,17 @@ namespace :deploy do
     end
   end
 
+  desc "Run tmp:clear on all machines"
+  task clear_tmp: [:set_rails_env] do
+    on release_roles(:all) do
+      within current_path do
+        with rails_env: fetch(:rails_env) do
+          execute :rake, "tmp:clear"
+        end
+      end
+    end
+  end
+
   desc "Runs any runner task, example: cap deploy:runner task='RegionBackfill.call'"
   task runner: [:set_rails_env] do
     on release_roles([:app]) do

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -6,7 +6,7 @@ namespace :deploy do
   desc "Fix Bundler plugin path so it points to the shared path instead of a release path"
   task :fix_bundler_plugin_path do
     on release_roles([:all]) do
-      within current_path do
+      within shared_path do
         # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
         execute "sed", "-i", "'s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g'", ".bundle/plugin/index"
       end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -8,7 +8,7 @@ namespace :deploy do
     on release_roles([:all]) do
       within shared_path do
         # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
-        execute "sed", "-i", "--follow-symlinks", "--debug", 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g', ".bundle/plugin/index"
+        execute "sed", "-i", "--follow-symlinks", "--debug", 's#/home/deploy/apps/simple-server/releases/[0-9]+/#/home/deploy/apps/simple-server/shared/#g', ".bundle/plugin/index"
       end
     end
   end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -8,7 +8,7 @@ namespace :deploy do
     on release_roles(:all) do
       within release_path do
         # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
-        execute "sed", "-i", "''", "'s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g'", ".bundle/plugin/index"
+        execute "sed", "-i", "'s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g'", ".bundle/plugin/index"
       end
     end
   end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -8,7 +8,7 @@ namespace :deploy do
     on release_roles(:all) do
       within release_path do
         # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
-        execute "sed", "i", "s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g", ".bundle/plugin/index"
+        execute "sed", "i", "''", "s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g", ".bundle/plugin/index"
       end
     end
   end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -1,21 +1,10 @@
-namespace :bundler do
-  before :install, :fix_bundler_plugin_path do
-    on release_roles do
-      within release_path do
-        # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
-        execute "sed", "i", "s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g", ".bundle/plugin/index"
-      end
-    end
-  end
-end
-
 namespace :deploy do
   before :starting, :check_sidekiq_hooks do
     invoke "sidekiq:add_default_hooks"
   end
 
   desc "Fix Bundler plugin path so it points to the shared path instead of a release path"
-  after :updated, :fix_bundler_plugin_path do
+  task :fix_bundler_plugin_path do
     on release_roles do
       within release_path do
         # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -8,7 +8,7 @@ namespace :deploy do
     on release_roles(:all) do
       within release_path do
         # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
-        execute "sed", "i", "''", "s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g", ".bundle/plugin/index"
+        execute "sed", "-i", "''", "s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g", ".bundle/plugin/index"
       end
     end
   end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -8,7 +8,7 @@ namespace :deploy do
     on release_roles([:all]) do
       within shared_path do
         # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
-        execute "sed", "-i", "--follow-symlinks", "--debug", '"s#/home/deploy/apps/simple-server/releases/[0-9]\+/#/home/deploy/apps/simple-server/shared/#g"', ".bundle/plugin/index"
+        execute "sed", "-i", '"s#/home/deploy/apps/simple-server/releases/[0-9]\+/#/home/deploy/apps/simple-server/shared/#g"', ".bundle/plugin/index"
       end
     end
   end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -5,21 +5,10 @@ namespace :deploy do
 
   desc "Fix Bundler plugin path so it points to the shared path instead of a release path"
   task :fix_bundler_plugin_path do
-    on release_roles(:all) do
-      within release_path do
+    on release_roles([:all]) do
+      within current_path do
         # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
         execute "sed", "-i", "'s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g'", ".bundle/plugin/index"
-      end
-    end
-  end
-
-  desc "Runs any rake task, example: cap deploy:rake task=db:seed"
-  task rake: [:set_rails_env] do
-    on release_roles([:db]) do
-      within release_path do
-        with rails_env: fetch(:rails_env) do
-          execute :rake, ENV["task"]
-        end
       end
     end
   end
@@ -30,6 +19,17 @@ namespace :deploy do
       within current_path do
         with rails_env: fetch(:rails_env) do
           execute :rake, "tmp:clear"
+        end
+      end
+    end
+  end
+
+  desc "Runs any rake task, example: cap deploy:rake task=db:seed"
+  task rake: [:set_rails_env] do
+    on release_roles([:db]) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :rake, ENV["task"]
         end
       end
     end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -8,7 +8,7 @@ namespace :deploy do
     on release_roles([:all]) do
       within shared_path do
         # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
-        execute "sed", "-i", "--follow-symlinks", "--debug", 's#/home/deploy/apps/simple-server/releases/[0-9]+/#/home/deploy/apps/simple-server/shared/#g', ".bundle/plugin/index"
+        execute "sed", "-i", "--follow-symlinks", "--debug", '"s#/home/deploy/apps/simple-server/releases/[0-9]+/#/home/deploy/apps/simple-server/shared/#g"', ".bundle/plugin/index"
       end
     end
   end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -5,7 +5,7 @@ namespace :deploy do
 
   desc "Fix Bundler plugin path so it points to the shared path instead of a release path"
   task :fix_bundler_plugin_path do
-    on release_roles do
+    on release_roles(:all) do
       within release_path do
         # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
         execute "sed", "i", "s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g", ".bundle/plugin/index"

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -8,7 +8,7 @@ namespace :deploy do
     on release_roles(:all) do
       within release_path do
         # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
-        execute "sed", "-i", "''", "s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g", ".bundle/plugin/index"
+        execute "sed", "-i", "''", "'s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g'", ".bundle/plugin/index"
       end
     end
   end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -8,7 +8,7 @@ namespace :deploy do
     on release_roles([:all]) do
       within shared_path do
         # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
-        execute "sed", "-i", "--follow-symlinks", "--debug", "'s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g'", ".bundle/plugin/index"
+        execute "sed", "-i", "--follow-symlinks", "--debug", 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g', ".bundle/plugin/index"
       end
     end
   end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -8,7 +8,7 @@ namespace :deploy do
     on release_roles([:all]) do
       within shared_path do
         # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
-        execute "sed", "-i", "'s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g'", ".bundle/plugin/index"
+        execute "sed", "-i", "--follow-symlinks", "--debug", "'s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g'", ".bundle/plugin/index"
       end
     end
   end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -3,7 +3,11 @@ namespace :deploy do
     invoke "sidekiq:add_default_hooks"
   end
 
-  desc "Fix Bundler plugin path so it points to the shared path instead of a release path"
+  desc <<-EOL
+  Fix Bundler plugin path so it points to the shared path instead of a release path -- this fixes a deep, painful issue between Rubygems,
+  Bundler plugins, and bootboot. See https://github.com/simpledotorg/simple-server/pull/3268 for some related issues here and to see
+  if there are better fixes that happen upstream so we don't need this hack anymore.
+  EOL
   task :fix_bundler_plugin_path do
     on release_roles([:all]) do
       within shared_path do

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -1,3 +1,14 @@
+namespace :bundler do
+  before :install, :fix_bundler_plugin_path do
+    on release_roles do
+      within release_path do
+        # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
+        execute "sed", "i", "s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g", ".bundle/plugin/index"
+      end
+    end
+  end
+end
+
 namespace :deploy do
   before :starting, :check_sidekiq_hooks do
     invoke "sidekiq:add_default_hooks"

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -3,6 +3,16 @@ namespace :deploy do
     invoke "sidekiq:add_default_hooks"
   end
 
+  desc "Fix Bundler plugin path so it points to the shared path instead of a release path"
+  after :updated, :fix_bundler_plugin_path do
+    on release_roles do
+      within release_path do
+        # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
+        execute "sed", "i", "s#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g", ".bundle/plugin/index"
+      end
+    end
+  end
+
   desc "Runs any rake task, example: cap deploy:rake task=db:seed"
   task rake: [:set_rails_env] do
     on release_roles([:db]) do

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -8,7 +8,7 @@ namespace :deploy do
     on release_roles([:all]) do
       within shared_path do
         # sed -i 's#/home/deploy/apps/simple-server/releases/[0-9]\+/.bundle/#/home/deploy/apps/simple-server/shared/.bundle/#g' plugin/index
-        execute "sed", "-i", "--follow-symlinks", "--debug", '"s#/home/deploy/apps/simple-server/releases/[0-9]+/#/home/deploy/apps/simple-server/shared/#g"', ".bundle/plugin/index"
+        execute "sed", "-i", "--follow-symlinks", "--debug", '"s#/home/deploy/apps/simple-server/releases/[0-9]\+/#/home/deploy/apps/simple-server/shared/#g"', ".bundle/plugin/index"
       end
     end
   end


### PR DESCRIPTION
It turns out the bundler config for plugins is cached everywhere...so rather than trying to remove it and clean it up on every server, going to try to roll forward here and fix it.

This is a follow up to https://github.com/simpledotorg/simple-server/pull/3268.

**Story card:** [sc-6351](https://app.shortcut.com/simpledotorg/story/6351/setup-dual-dependency-approach-to-prepare-for-rails-6-and-beyond)

