### PR TITLE
Add a small script to make it easier to run things in profiling

### DIFF
--- a/script/profile
+++ b/script/profile
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Run a rails commmand in profiling RAILS_ENV with Spring disabled
+RAILS_ENV=profiling DISABLE_SPRING=1 bin/rails "$1"


### PR DESCRIPTION
We always need to disable spring, so this makes things easier to run
server, console, etc in profiling RAILS_ENV

**Story card:** [sc-6531](https://app.shortcut.com/simpledotorg/story/6531/region-details-is-slow-for-large-regions)

