### PR TITLE
Require facility size

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -93,7 +93,7 @@ class Facility < ApplicationRecord
   validates :facility_size,
     inclusion: {
       in: facility_sizes.values,
-      message: "not in #{facility_sizes.values.join(", ")}",
+      message: "not in #{facility_sizes.values.join(", ")}"
     }
   validates :enable_teleconsultation, inclusion: {in: [true, false]}
   validates :teleconsultation_medical_officers,

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -94,7 +94,6 @@ class Facility < ApplicationRecord
     inclusion: {
       in: facility_sizes.values,
       message: "not in #{facility_sizes.values.join(", ")}",
-      allow_blank: true
     }
   validates :enable_teleconsultation, inclusion: {in: [true, false]}
   validates :teleconsultation_medical_officers,

--- a/db/data/20220112012521_add_default_facility_size.rb
+++ b/db/data/20220112012521_add_default_facility_size.rb
@@ -1,0 +1,9 @@
+class AddDefaultFacilitySize < ActiveRecord::Migration[5.2]
+  def up
+    Facility.where(facility_size: nil).update_all(facility_size: :community)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20211227141152)
+DataMigrate::Data.define(version: 20220112012521)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -165,7 +165,7 @@ CREATE TABLE public.facilities (
     slug character varying,
     zone character varying,
     enable_diabetes_management boolean DEFAULT false NOT NULL,
-    facility_size character varying,
+    facility_size character varying NOT NULL,
     monthly_estimated_opd_load integer,
     enable_teleconsultation boolean DEFAULT false NOT NULL
 );
@@ -4884,9 +4884,11 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20211209110618'),
 ('20211210152751'),
 ('20211210152752'),
+('20211214014913'),
 ('20211215192748'),
 ('20211216144440'),
 ('20211216154413'),
-('20220106075216');
+('20220106075216'),
+('20220112142707');
 
 

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -235,6 +235,9 @@ RSpec.describe Facility, type: :model do
     it { is_expected.to validate_presence_of(:country) }
     it { is_expected.to validate_numericality_of(:pin) }
 
+    valid_sizes = Facility.facility_sizes.values
+    it { is_expected.to validate_inclusion_of(:facility_size).in_array(valid_sizes).with_message("not in #{valid_sizes.join(", ")}") }
+
     describe "valid_block" do
       let!(:organization) { create(:organization, name: "OrgTwo") }
       let!(:facility_group) { create(:facility_group, name: "FGThree", organization_id: organization.id) }


### PR DESCRIPTION
**Story card:** [sc-6568](https://app.shortcut.com/simpledotorg/story/6568/not-able-to-download-monthly-facility-data-from-dashboard)

## Because

Monthly facility download doesn't work if facilities are missing facility sizes.

## This addresses

 Since missing sizes also make facilities disappear from some reports, we're making them mandatory.