### PR TITLE
Updated Ethiopia DHIS2 data element ID

### DIFF
--- a/config/initializers/country_config.rb
+++ b/config/initializers/country_config.rb
@@ -51,7 +51,7 @@ class CountryConfig
       patient_line_list_show_zone: false,
       dhis2_data_elements: {
         cumulative_assigned: "nrK3Yj6ELl0",
-        cumulative_assigned_adjusted: "DxHkdQjTpXC",
+        cumulative_assigned_adjusted: "YKsRrnjBiVE",
         controlled: "ZCkeHFQETzb",
         uncontrolled: "z4mVPviB8OH",
         missed_visits: "tNRBsYt0ZOK",


### PR DESCRIPTION
**Story card:** n/a

## Because

The Ethiopia MoH provided an updated data element ID for `cumulative assigned patients (excluding new registrations)`
