### PR TITLE
Tweak dependabot settings:

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "23:30" # check for updates at 23:30 UTC / 5 AM IST to avoid main working hours
+    # Only create pull requests to update lockfiles. Ignore any new versions that would require package manifest changes.
+    versioning-strategy: "lockfile-only"
+


### PR DESCRIPTION
* only check for updates at 23:30 UTC / 5 AM IST / 5:30 CT
* only do version updates that involve bumping the lockfile for
  now...otherwise we get updates that are quite a bit out of scope, at
least for now

(no story, just trying to get dependabot dialed in)