### PR TITLE
Include facilities with followups in the drug stock report pages and downloads

### DIFF
--- a/app/controllers/my_facilities/drug_stocks_controller.rb
+++ b/app/controllers/my_facilities/drug_stocks_controller.rb
@@ -127,7 +127,7 @@ class MyFacilities::DrugStocksController < AdminController
     # and have stock tracking enabled and at least one registered or assigned patient
     active_facility_ids = filter_facilities
       .joins("INNER JOIN reporting_facility_states on reporting_facility_states.facility_id = facilities.id")
-      .where("cumulative_registrations > 0 OR cumulative_assigned_patients > 0")
+      .where("cumulative_registrations > 0 OR cumulative_assigned_patients > 0 OR monthly_follow_ups > 0")
       .pluck("facilities.id")
 
     filter_facilities


### PR DESCRIPTION


**Story card:** [sc-6743](https://app.shortcut.com/simpledotorg/story/6743/show-facilities-with-at-least-1-followup-in-the-drug-stock-reporting-pages)

## Because

We want to include facilities that may not have any assigned or registered patients in drug stock reports, as long as they have at least one follow up
