### PR TITLE
Reports details: Fix links to add estimated hypertension population

### DIFF
--- a/app/views/reports/regions/_hypertension_patient_coverage.html.erb
+++ b/app/views/reports/regions/_hypertension_patient_coverage.html.erb
@@ -71,8 +71,8 @@
       </span>
     <% else %>
       <% if @region.district_region? && accessible_region?(@region, :manage) %>
-        <%= link_to "+ Add population", edit_admin_facility_group_path(@region) %>
-      <% elsif @region.state_region? && accessible_region?(@region, :view_reports) %>
+        <%= link_to "+ Add population", edit_admin_facility_group_path(@region.source) %>
+      <% elsif @region.state_region? && accessible_region?(@region, :manage) %>
         <%= link_to "+ Add district populations", "/admin/facilities" %>
       <% else %>
         <span class="fw-bold">


### PR DESCRIPTION
**Story card:** [sc-6800](https://app.shortcut.com/simpledotorg/story/6800/the-link-in-the-reports-details-page-to-add-estimated-htn-population-for-a-district-is-broken)

## Because

- The link to add estimated hypertension population for districts was using the `district region` instead of the `facility_group`.
- The link to add estimated hypertension population for states was checking the `view_reports` permission instead of `manage`. Users with a `view_reports` permission can't actually set the estimated hypertension population.