### PR TITLE
Correct qa address

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,1 +1,1 @@
-server "ec2-13-232-139-143.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db sidekiq cron]
+server "ec2-3-108-62-212.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db sidekiq cron]


### PR DESCRIPTION
It appears we put in the wrong address for the qa server in https://github.com/simpledotorg/simple-server/pull/3160, this fixes it