### PR TITLE
Clean Est. HTN Population

### DIFF
--- a/app/assets/stylesheets/partials/_reports.scss
+++ b/app/assets/stylesheets/partials/_reports.scss
@@ -74,6 +74,7 @@
 .mr-4px { margin-right: 4px; }
 .mr-6px { margin-right: 6px; }
 .mr-8px { margin-right: 8px; }
+.p-12px { padding: 12px; }
 .pb-8px { padding-bottom: 8px; }
 .pb-16px { padding-bottom: 16px; }
 .pl-16px { padding-left: 16px; }
@@ -147,6 +148,7 @@
 .bg-green { background-color: $green }
 .bg-green-dark { background-color: $green-dark; }
 .bg-green-medium { background-color: $green-mid; }
+.bg-blue-light { background-color: $blue-light; }
 .bg-purple-medium { background-color: $purple-mid; }
 .bg-purple-light { background-color: $purple-light; }
 .bg-yellow-light { background-color: $yellow-light; }

--- a/app/views/admin/facilities/index.html.erb
+++ b/app/views/admin/facilities/index.html.erb
@@ -34,16 +34,14 @@
               </span>
               <%= facility_group.name %>
             </h3>
-            <% if current_admin.feature_enabled?(:estimated_population) %>
-              <p class="subtitle">
-                Estimated hypertensive population:
-                <% if facility_group.region.estimated_population&.population %>
-                  <%= number_with_delimiter(facility_group.region.estimated_population.population) %>
-                <% else %>
-                  <%= link_to "+ Add population", edit_admin_facility_group_path(facility_group) %>
-                <% end %>
-              </p>
-            <% end %>
+            <p class="subtitle">
+              Estimated hypertensive population:
+              <% if facility_group.region.estimated_population&.population %>
+                <%= number_with_delimiter(facility_group.region.estimated_population.population) %>
+              <% else %>
+                <%= link_to "+ Add population", edit_admin_facility_group_path(facility_group) %>
+              <% end %>
+            </p>
           </div>
           <% if current_admin.accessible_facility_groups(:manage).find_by_id(facility_group) %>
             <div class="col-4 text-right">

--- a/app/views/admin/facility_groups/_form.html.erb
+++ b/app/views/admin/facility_groups/_form.html.erb
@@ -37,10 +37,8 @@
         <%= form.select(:protocol_id, protocols.order(:name).map { |protocol| [protocol.name, protocol.id] }) %>
       <% end %>
 
-      <% if current_admin.feature_enabled?(:estimated_population) %>
-        <%= form.number_field :district_estimated_population, value: @facility_group&.estimated_population&.population, label: "Estimated hypertensive population", autocomplete: "off", 
-          help: "Leave blank if unknown" %>
-      <% end %>
+      <%= form.number_field :district_estimated_population, value: @facility_group&.estimated_population&.population, label: "Estimated hypertensive population", autocomplete: "off", 
+        help: "Leave blank if unknown" %>
 
       <div class="mt-3">
         <label><%= I18n.t("region_type.block").pluralize.capitalize %></label>

--- a/app/views/reports/regions/_details_footnotes.html.erb
+++ b/app/views/reports/regions/_details_footnotes.html.erb
@@ -81,7 +81,7 @@
       </div>
     </div>
   <% end %>
-  <% if current_admin.feature_enabled?(:estimated_population) && @region.supports_htn_population_coverage %>
+  <% if @region.supports_htn_population_coverage %>
     <div class="mb-24px">
       <p class="mb-8px fs-16px fw-bold c-grey-dark">
         Hypertension patient coverage

--- a/app/views/reports/regions/_hypertension_patient_coverage.html.erb
+++ b/app/views/reports/regions/_hypertension_patient_coverage.html.erb
@@ -1,34 +1,35 @@
+<div class="mb-8px d-lg-flex align-lg-center">
+  <p class="mb-0px fs-32px fw-bold <% if @region.estimated_population&.show_coverage %>c-green-dark<% else %>c-black<% end %> mr-lg-12px" id="<%= @region.estimated_population&.show_coverage %>">
+    <% if @region.estimated_population&.show_coverage %>
+      <%= number_to_percentage(@region.estimated_population.hypertension_patient_coverage_rate, precision: 0) %>
+    <% else %>
+      N/A
+    <% end %>
+  </p>
+  <div>
+    <% if @region.estimated_population&.show_coverage %>
+      <p class="m-0px c-black">
+        <span>
+          <%= number_with_delimiter(@chart_data[:patient_breakdown][:total_patients]) %>
+        </span>
+        <%= "patient".pluralize(@chart_data[:patient_breakdown][:total_patients]) %> registered
+      </p>
+      <p class="m-0px c-grey-dark c-print-black">
+        of
+        <span>
+          <%= number_with_delimiter(@region.estimated_population.population) %>
+        </span>
+        estimated hypertensive people in <%= @region.name %>
+      </p>
+    <% end %>
+  </div>
+</div>
 <div class="d-flex h-24px mb-16px o-hidden <% if @region.estimated_population&.hypertension_patient_coverage_rate == 100.0 %>br-4px<% end %>">
   <div
     class="br-tl-4px br-bl-4px <% if @region.estimated_population&.show_coverage %>bg-green-dark<% else %>bg-grey-light<% end %>"
     style="width: <% if @region.estimated_population&.show_coverage %><%= number_to_percentage(@region.estimated_population.hypertension_patient_coverage_rate, precision: 0) %><% else %>5%<% end %>;"
   ></div>
   <div class="flex-1 br-tr-4px br-br-4px bg-grey-light"></div>
-</div>
-<div class="d-flex ai-center jc-between">
-  <p class="mb-8px">
-    Hypertension patient coverage
-    <span class="p-relative t-1px">
-      <i
-        class="fas fa-question-circle fs-14px c-grey-dark"
-        data-toggle="tooltip"
-        data-placement="right"
-        data-trigger="hover click"
-        data-html="true"
-        title="<%= t('hypertension_patient_coverage_copy') %>"
-      >
-      </i>
-    </span>
-  </p>
-  <p class="mb-8px fw-bold">
-    <% if @region.estimated_population&.show_coverage %>
-      <span class="c-green-dark" id="<%= @region.estimated_population.show_coverage %>">
-        <%= number_to_percentage(@region.estimated_population.hypertension_patient_coverage_rate, precision: 0) %>
-      </span>
-    <% else %>
-      N/A
-    <% end %>
-  </p>
 </div>
 <div class="d-flex ai-center jc-between">
   <p class="mb-8px">

--- a/app/views/reports/regions/_hypertension_patient_coverage.html.erb
+++ b/app/views/reports/regions/_hypertension_patient_coverage.html.erb
@@ -1,13 +1,9 @@
-<div class="mb-8px d-lg-flex align-lg-center">
-  <p class="mb-0px fs-32px fw-bold <% if @region.estimated_population&.show_coverage %>c-green-dark<% else %>c-black<% end %> mr-lg-12px" id="<%= @region.estimated_population&.show_coverage %>">
-    <% if @region.estimated_population&.show_coverage %>
+<% if @region.estimated_population&.show_coverage %>
+  <div class="mb-8px d-lg-flex align-lg-center">
+    <p class="mb-0px fs-32px fw-bold c-green-dark mr-lg-12px" id="<%= @region.estimated_population&.show_coverage %>">
       <%= number_to_percentage(@region.estimated_population.hypertension_patient_coverage_rate, precision: 0) %>
-    <% else %>
-      N/A
-    <% end %>
-  </p>
-  <div>
-    <% if @region.estimated_population&.show_coverage %>
+    </p>
+    <div>
       <p class="m-0px c-black">
         <span>
           <%= number_with_delimiter(@chart_data[:patient_breakdown][:total_patients]) %>
@@ -21,16 +17,30 @@
         </span>
         estimated hypertensive people in <%= @region.name %>
       </p>
+    </div>
+  </div>
+  <div class="d-flex h-24px mb-16px o-hidden <% if @region.estimated_population&.hypertension_patient_coverage_rate == 100.0 %>br-4px<% end %>">
+    <div
+      class="br-tl-4px br-bl-4px <% if @region.estimated_population&.show_coverage %>bg-green-dark<% else %>bg-grey-light<% end %>"
+      style="width: <% if @region.estimated_population&.show_coverage %><%= number_to_percentage(@region.estimated_population.hypertension_patient_coverage_rate, precision: 0) %><% else %>5%<% end %>;"
+    ></div>
+    <div class="flex-1 br-tr-4px br-br-4px bg-grey-light"></div>
+  </div>
+<% else %>
+  <div class="mb-16px p-12px br-4px bg-blue-light">
+    <% if @region.district_region? %>
+      <p class="m-0px fs-14px c-black">
+        Add the est. hypertensive population to see the coverage rate.
+      </p>
+      <%= link_to "+ Add population", edit_admin_facility_group_path(@region.source), :class => "fs-14px" %>
+    <% elsif @region.state_region? %>
+      <p class="m-0px fs-14px c-black">
+        Add the est. hypertensive population for all districts to see the coverage rate.
+      </p>
+      <%= link_to "+ Add district populations", "/admin/facilities", :class => "fs-14px" %>
     <% end %>
   </div>
-</div>
-<div class="d-flex h-24px mb-16px o-hidden <% if @region.estimated_population&.hypertension_patient_coverage_rate == 100.0 %>br-4px<% end %>">
-  <div
-    class="br-tl-4px br-bl-4px <% if @region.estimated_population&.show_coverage %>bg-green-dark<% else %>bg-grey-light<% end %>"
-    style="width: <% if @region.estimated_population&.show_coverage %><%= number_to_percentage(@region.estimated_population.hypertension_patient_coverage_rate, precision: 0) %><% else %>5%<% end %>;"
-  ></div>
-  <div class="flex-1 br-tr-4px br-br-4px bg-grey-light"></div>
-</div>
+<% end %>
 <div class="d-flex ai-center jc-between">
   <p class="mb-8px">
     Total registered patients
@@ -71,15 +81,9 @@
         <%= number_with_delimiter(@region.estimated_population&.population) %>
       </span>
     <% else %>
-      <% if @region.district_region? && accessible_region?(@region, :manage) %>
-        <%= link_to "+ Add population", edit_admin_facility_group_path(@region.source) %>
-      <% elsif @region.state_region? %>
-        <%= link_to "+ Add district populations", "/admin/facilities" %>
-      <% else %>
-        <span class="fw-bold">
-          N/A
-        </span>
-      <% end %>
+      <span class="fw-bold">
+        N/A
+      </span>
     <% end %>
   </p>
 </div>

--- a/app/views/reports/regions/_hypertension_patient_coverage.html.erb
+++ b/app/views/reports/regions/_hypertension_patient_coverage.html.erb
@@ -1,4 +1,4 @@
-<% if @region.estimated_population&.show_coverage %>
+<% if @region.estimated_population&.show_coverage && accessible_region?(@region, :manage) %>
   <div class="mb-8px d-lg-flex align-lg-center">
     <p class="mb-0px fs-32px fw-bold c-green-dark mr-lg-12px" id="<%= @region.estimated_population&.show_coverage %>">
       <%= number_to_percentage(@region.estimated_population.hypertension_patient_coverage_rate, precision: 0) %>
@@ -25,6 +25,18 @@
       style="width: <% if @region.estimated_population&.show_coverage %><%= number_to_percentage(@region.estimated_population.hypertension_patient_coverage_rate, precision: 0) %><% else %>5%<% end %>;"
     ></div>
     <div class="flex-1 br-tr-4px br-br-4px bg-grey-light"></div>
+  </div>
+<% elsif !(@region.estimated_population&.show_coverage) && !(accessible_region?(@region, :manage)) %>
+  <div class="mb-16px p-12px br-4px bg-yellow-light">
+    <% if @region.district_region? %>
+      <p class="m-0px fs-14px c-black">
+        Ask a Dashboard admin to add the est. hypertensive population for <%= @region.name %> to see the hypertension coverage rate.
+      </p>
+    <% elsif @region.state_region? %>
+      <p class="m-0px fs-14px c-black">
+        Ask a Dashboard admin to add the est. hypertensive population for all districts ine<%= @region.name %> to see the hypertension coverage rate.
+      </p>
+    <% end %>
   </div>
 <% else %>
   <div class="mb-16px p-12px br-4px bg-blue-light">

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -7,7 +7,7 @@
             Hypertension coverage
           </h3>
         </div>
-        <p class="mb-24px c-grey-dark mr-lg-12px">
+        <p class="mb-16px c-grey-dark mr-lg-12px">
           All hypertensive individuals and patients in <%= @region.name %>
         </p>
         <%= render "reports/regions/hypertension_patient_coverage" %>

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -1,7 +1,7 @@
 <div class="d-lg-flex flex-lg-wrap">
   <div class="d-lg-flex w-lg-50 pr-lg-2">
     <div id="patient-breakdown" data-period="<%= @period.to_s %>" class="mt-8px mx-0px mb-16px p-20px bg-white br-4px bs-small w-lg-full mt-lg-0 pb-inside-avoid b-print-black w-print-16cm">
-      <% if current_admin.feature_enabled?(:estimated_population) && @region.supports_htn_population_coverage %>
+      <% if @region.supports_htn_population_coverage %>
         <div class="d-flex flex-1 mb-8px">
           <h3 class="mb-0px mr-8px">
             Hypertension coverage


### PR DESCRIPTION
**Story card:** [sc-6849](https://app.shortcut.com/simpledotorg/story/6849/clean-codebase?vc_group_by=day&ct_workflow=all&cf_workflow=500000031)

## Because

We need to the feature flags and update the "Hypertension coverage" card's layout/styling.

## This addresses

* Removes all feature flags
* Updates the "Hypertension coverage" card's UI to make the coverage rate a bit more prominent

## Test instructions

Make sure you add the estimated hypertension population for all districts in a state. Then go to the state and district's report "Details" pages and check out the new UI. It should look like the screenshots below:

**Large screens**
![image](https://user-images.githubusercontent.com/16785131/150606176-cb6fc9ec-5f2c-4c3e-9553-8ea8f35cdb4a.png)

**Small screens**
![image](https://user-images.githubusercontent.com/16785131/150606216-75e31f5c-ec1e-4048-a588-d1d2b8130142.png)
