### PR TITLE
Localize and enable monthly downloads everywhere

### DIFF
--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -196,6 +196,11 @@ class Region < ApplicationRecord
     I18n.t("region_type.#{region_type}")
   end
 
+  def localized_child_region_type
+    return nil if child_region_type.nil?
+    I18n.t("region_type.#{child_region_type}")
+  end
+
   def log_payload
     attrs = attributes.slice("name", "slug", "path")
     attrs["id"] = id.presence

--- a/app/services/monthly_district_data_service.rb
+++ b/app/services/monthly_district_data_service.rb
@@ -10,7 +10,7 @@ class MonthlyDistrictDataService
 
   def report
     CSV.generate(headers: true) do |csv|
-      csv << ["Monthly facility data for #{region.name} #{period.to_date.strftime("%B %Y")}"]
+      csv << ["Monthly #{localized_facility} data for #{region.name} #{period.to_date.strftime("%B %Y")}"]
       csv << section_row
       csv << header_row
       csv << district_row
@@ -29,13 +29,25 @@ class MonthlyDistrictDataService
 
   private
 
+  def localized_district
+     I18n.t("region_type.district")
+  end
+
+  def localized_block
+     I18n.t("region_type.block")
+  end
+
+  def localized_facility
+     I18n.t("region_type.facility")
+  end
+
   def region_headers
     [
       "#",
-      "Block",
-      "Facility",
-      "Facility type",
-      "Facility size"
+      localized_block.capitalize,
+      localized_facility.capitalize,
+      "#{localized_facility.capitalize} type",
+      "#{localized_facility.capitalize} size"
     ]
   end
 
@@ -100,7 +112,7 @@ class MonthlyDistrictDataService
 
   def district_row
     row_data = {
-      index: "All facilities",
+      index: "All #{localized_facility.pluralize}",
       block: nil,
       facility: nil,
       facility_type: nil,
@@ -124,7 +136,7 @@ class MonthlyDistrictDataService
 
     size_data.sort.map do |size, summed_data|
       row_data = {
-        index: "#{size.capitalize} facilities",
+        index: "#{size.capitalize} #{localized_facility.pluralize}",
         block: nil,
         facility: nil,
         facility_type: nil,

--- a/app/services/monthly_district_data_service.rb
+++ b/app/services/monthly_district_data_service.rb
@@ -30,15 +30,15 @@ class MonthlyDistrictDataService
   private
 
   def localized_district
-     I18n.t("region_type.district")
+    I18n.t("region_type.district")
   end
 
   def localized_block
-     I18n.t("region_type.block")
+    I18n.t("region_type.block")
   end
 
   def localized_facility
-     I18n.t("region_type.facility")
+    I18n.t("region_type.facility")
   end
 
   def region_headers

--- a/app/services/monthly_state_data_service.rb
+++ b/app/services/monthly_state_data_service.rb
@@ -22,11 +22,19 @@ class MonthlyStateDataService
 
   private
 
+  def localized_state
+     I18n.t("region_type.state")
+  end
+
+  def localized_district
+     I18n.t("region_type.district")
+  end
+
   def region_headers
     [
       "#",
-      "State",
-      "District"
+      localized_state.capitalize,
+      localized_district.capitalize
     ]
   end
 
@@ -91,7 +99,7 @@ class MonthlyStateDataService
 
   def state_row
     row_data = {
-      index: "All",
+      index: "All #{localized_district.pluralize}",
       state: region.name,
       district: nil
     }.merge(region_data(region))

--- a/app/services/monthly_state_data_service.rb
+++ b/app/services/monthly_state_data_service.rb
@@ -23,11 +23,11 @@ class MonthlyStateDataService
   private
 
   def localized_state
-     I18n.t("region_type.state")
+    I18n.t("region_type.state")
   end
 
   def localized_district
-     I18n.t("region_type.district")
+    I18n.t("region_type.district")
   end
 
   def region_headers

--- a/app/views/reports/regions/_downloads.html.erb
+++ b/app/views/reports/regions/_downloads.html.erb
@@ -26,14 +26,14 @@
       <% end %>
     <% end %>
 
-    <% if @region.district_region? && CountryConfig.current_country?("India") %>
+    <% if @region.district_region? && current_admin.feature_enabled?(:monthly_district_data_download) %>
       <%= link_to(reports_region_monthly_district_data_path(@region, report_scope: params[:report_scope], period: params.dig(:period, :value), format: :csv), class: "dropdown-item") do %>
         <i class="far fa-file w-16px ta-center mr-4px c-grey-medium"></i>
         Monthly <%= I18n.t("region_type.facility") %> data
       <% end %>
     <% end %>
 
-    <% if @region.state_region? && CountryConfig.current_country?("India") %>
+    <% if @region.state_region? && current_admin.feature_enabled?(:monthly_state_data_download) %>
       <%= link_to(reports_region_monthly_state_data_path(@region, report_scope: params[:report_scope], period: params.dig(:period, :value), format: :csv), class: "dropdown-item") do %>
         <i class="far fa-file w-16px ta-center mr-4px c-grey-medium"></i>
         Monthly <%= I18n.t("region_type.#{@region.child_region_type}") %> data

--- a/app/views/reports/regions/_downloads.html.erb
+++ b/app/views/reports/regions/_downloads.html.erb
@@ -36,7 +36,7 @@
     <% if @region.state_region? && current_admin.feature_enabled?(:monthly_state_data_download) %>
       <%= link_to(reports_region_monthly_state_data_path(@region, report_scope: params[:report_scope], period: params.dig(:period, :value), format: :csv), class: "dropdown-item") do %>
         <i class="far fa-file w-16px ta-center mr-4px c-grey-medium"></i>
-        Monthly <%= I18n.t("region_type.#{@region.child_region_type}") %> data
+        Monthly <%= @region.localized_child_region_type %> data
       <% end %>
     <% end %>
 

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -81,6 +81,45 @@ RSpec.describe Region, type: :model do
     end
   end
 
+  describe "localized_child_region_type" do
+    it "returns country specific names" do
+      state = build(:region, region_type: :state)
+      district = build(:region, region_type: :district)
+      block = build(:region, region_type: :block)
+      facility = build(:region, region_type: :facility)
+      I18n.with_locale(:en_IN) do
+        expect(state.localized_child_region_type).to eq("district")
+        expect(district.localized_child_region_type).to eq("block")
+        expect(block.localized_child_region_type).to eq("facility")
+        expect(facility.localized_child_region_type).to be_nil
+      end
+      I18n.with_locale(:en_BD) do
+        expect(state.localized_child_region_type).to eq("district")
+        expect(district.localized_child_region_type).to eq("upazila")
+        expect(block.localized_child_region_type).to eq("facility")
+        expect(facility.localized_child_region_type).to be_nil
+      end
+      I18n.with_locale(:en_ET) do
+        expect(state.localized_child_region_type).to eq("zone")
+        expect(district.localized_child_region_type).to eq("woreda")
+        expect(block.localized_child_region_type).to eq("facility")
+        expect(facility.localized_child_region_type).to be_nil
+      end
+    end
+
+    it "has a fallback for default locale (which is the same as the India region_types)" do
+      state = build(:region, region_type: :state)
+      district = build(:region, region_type: :district)
+      block = build(:region, region_type: :block)
+      facility = build(:region, region_type: :facility)
+      expect(I18n.locale).to eq(:en)
+      expect(state.localized_child_region_type).to eq("district")
+      expect(district.localized_child_region_type).to eq("block")
+      expect(block.localized_child_region_type).to eq("facility")
+      expect(facility.localized_child_region_type).to be_nil
+    end
+  end
+
   describe "region_type" do
     it "has question methods for determining type" do
       region_1 = Region.create!(name: "New York", region_type: "state", reparent_to: Region.root)

--- a/spec/services/monthly_state_data_service_spec.rb
+++ b/spec/services/monthly_state_data_service_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe MonthlyStateDataService do
       csv = CSV.parse(result)
       region_row_index = 3
 
-      expect(find_in_csv(csv, region_row_index, "#")).to eq("All")
+      expect(find_in_csv(csv, region_row_index, "#")).to eq("All districts")
       expect(find_in_csv(csv, region_row_index, "State")).to eq(state.name)
       expect(csv[region_row_index][2..3].uniq).to eq([nil])
       expect(find_in_csv(csv, region_row_index, "Total registrations")).to eq("3")


### PR DESCRIPTION
**Story cards:**
- [sc-6598](https://app.shortcut.com/simpledotorg/story/6598/translate-state-district-facility-etc-in-report-downloads)
- [sc-6688](https://app.shortcut.com/simpledotorg/story/6688/turn-off-india-only-filter-in-navigation-views)

## Because

Monthly district and facility summary data are useful downloads, and we want them available everywhere.

## This addresses

This translates all region names in the downloads (and links), enables them outside of India, and adds a feature flag in case something goes wrong.