### PR TITLE
Send validation errors to logs instead of Sentry

### DIFF
--- a/app/controllers/api/v3/sync_controller.rb
+++ b/app/controllers/api/v3/sync_controller.rb
@@ -70,12 +70,10 @@ class Api::V3::SyncController < APIController
   def capture_errors(params, errors)
     return unless errors.present?
 
-    Sentry.capture_message("Validation Error",
-      extra: {
-        params_with_errors: params_with_errors(params, errors),
-        errors: errors
-      },
-      tags: {type: "validation"})
+    Rails.logger.info(
+      params_with_errors: params_with_errors(params, errors),
+      errors: errors
+    )
   end
 
   def process_token


### PR DESCRIPTION
**Story card:** [sc-5177](https://app.shortcut.com/simpledotorg/story/5177/sync-validation-error-move-exception-to-datadog)

## Because

We don't want to send these no-action-required incidents to Sentry, we want to send them to logs to be parsed in DD if necessary.