### PR TITLE
Add Sandbox to the Demo manifest

### DIFF
--- a/public/manifest/demo.json
+++ b/public/manifest/demo.json
@@ -23,6 +23,12 @@
       "endpoint": "https://api-demo.lk.simple.org/api/",
       "display_name": "Sri Lanka",
       "isd_code": "94"
+    },
+    {
+      "country_code": "IN",
+      "endpoint": "https://api-sandbox.simple.org/api/",
+      "display_name": "Sandbox",
+      "isd_code": "91"
     }
   ],
   "v2": {
@@ -68,6 +74,17 @@
           {
             "display_name": "Sri Lanka",
             "endpoint": "https://api-demo.lk.simple.org/api/"
+          }
+        ]
+      },
+      {
+        "country_code": "IN",
+        "display_name": "Sandbox",
+        "isd_code": "91",
+        "deployments": [
+          {
+            "display_name": "Sandbox",
+            "endpoint": "https://api-sandbox.simple.org/api/"
           }
         ]
       }


### PR DESCRIPTION
**Story card:** [sc-6861](https://app.shortcut.com/simpledotorg/story/6861)

## Because

We want to allow google play reviewers to test the full production app in "demo mode".

## This addresses

Adding a "Sandbox" country to the demo manifest. This is a trial run for adding a "Sandbox" country to the production manifest, thereby allowing Google Play reviewers to select it and do all the review they need in a test environment.