### PR TITLE
allow <a> tags to wrap

### DIFF
--- a/app/assets/stylesheets/partials/_dashboard.scss
+++ b/app/assets/stylesheets/partials/_dashboard.scss
@@ -209,6 +209,10 @@ th sup {
       text-overflow: ellipsis;
       overflow: hidden;
     }
+
+    a.allow-wrap {
+      white-space: normal !important;
+    }
   }
 
   col { border-left: 1px solid $grey-lightest; }

--- a/app/views/my_facilities/drug_stocks/_drug_consumption_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_consumption_table.html.erb
@@ -1,4 +1,5 @@
-<table class="mt-3 table table-compact table-responsive-md table-hover analytics-table">
+<div class="table-responsive">
+  <table class="mt-4 table table-compact table-hover analytics-table">
   <colgroup>
     <col>
     <% @drugs_by_category.map do |_drug_category, drugs| %>
@@ -234,3 +235,4 @@
   <% end %>
   </tbody>
 </table>
+</div>

--- a/app/views/my_facilities/drug_stocks/_drug_consumption_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_consumption_table.html.erb
@@ -83,7 +83,7 @@
     <% report = @report[:district_drug_consumption] %>
     <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
         data-original-title='District: <%= "#{@report[:district_patient_count]} patients" %>'>
-      <%= link_to(reports_region_path(@district_region, report_scope: "district")) do %>
+      <%= link_to(reports_region_path(@district_region, report_scope: "district"), class: "allow-wrap") do %>
         <%= drug_stock_region_label(@district_region).titleize %>
       <% end %>
     </td>
@@ -123,7 +123,7 @@
       <% block_report = @report[:drug_consumption_by_block_id][block.id] %>
       <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click" title=""
           data-original-title='<%= "#{block.name}: #{@report[:patient_count_by_block_id][block.id]} patients" %>'>
-        <%= link_to(reports_region_path(block, report_scope: "block")) do %>
+        <%= link_to(reports_region_path(block, report_scope: "block"), class: "allow-wrap") do %>
           <%= block.name %>
         <% end %>
       </td>
@@ -197,7 +197,7 @@
       <% facility_report = @report[:drug_consumption_by_facility_id][facility.id] %>
       <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click" title=""
           data-original-title='<%= "#{facility.name}: #{@report[:patient_count_by_facility_id][facility.id]} patients" %>'>
-        <%= link_to(reports_region_path(facility, report_scope: "facility")) do %>
+        <%= link_to(reports_region_path(facility, report_scope: "facility"), class: "allow-wrap") do %>
           <%= facility.name %>
         <% end %>
       </td>

--- a/app/views/my_facilities/drug_stocks/_drug_stocks_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_stocks_table.html.erb
@@ -69,7 +69,7 @@
     <tr data-sort-method="none">
       <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
           data-original-title='District: <%= "#{@report[:district_patient_count]} patients" %>'>
-        <%= link_to(reports_region_path(@district_region, report_scope: "district")) do %>
+        <%= link_to(reports_region_path(@district_region, report_scope: "district"), class: "allow-wrap") do %>
           <%= drug_stock_region_label(@district_region).titleize %>
         <% end %>
       </td>
@@ -112,7 +112,7 @@
         <% block_patient_days_report = @report[:patient_days_by_block_id][block.id] %>
         <td class="type-title" colspan="2" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
             data-original-title='<%= "#{block.name}: #{@report[:patient_count_by_block_id][block.id]} patients" %>'>
-          <%= link_to(reports_region_path(block, report_scope: "block")) do %>
+          <%= link_to(reports_region_path(block, report_scope: "block"), class: "allow-wrap") do %>
             <%= block.name %>
           <% end %>
         </td>
@@ -179,7 +179,7 @@
         <% facility_patient_days_report = @report[:patient_days_by_facility_id][facility.id] %>
         <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
             data-original-title='<%= "#{facility.name}: #{@report[:patient_count_by_facility_id][facility.id]} patients" %>'>
-          <%= link_to(reports_region_path(facility, report_scope: "facility")) do %>
+          <%= link_to(reports_region_path(facility, report_scope: "facility"), class: "allow-wrap") do %>
             <%= facility.name %>
           <% end %>
         </td>


### PR DESCRIPTION
**Story card:** [sc-5567](https://app.shortcut.com/simpledotorg/story/5567/fix-overflow-on-drug-consumption-screen)

## Because

Blocks and facilities with long names break styling on the drug consumption page

## This addresses

Adds a css class to allow anchor tags to wrap
