### PR TITLE
Update country code to DEMO

### DIFF
--- a/public/manifest/demo.json
+++ b/public/manifest/demo.json
@@ -78,12 +78,12 @@
         ]
       },
       {
-        "country_code": "IN",
-        "display_name": "Sandbox",
+        "country_code": "DEMO",
+        "display_name": "Demo Country",
         "isd_code": "91",
         "deployments": [
           {
-            "display_name": "Sandbox",
+            "display_name": "Demo Country",
             "endpoint": "https://api-sandbox.simple.org/api/"
           }
         ]


### PR DESCRIPTION
Follow-up to #3332 

We need a unique country code, so the app can show a unique country name in the selection screen.

This is still a test. If this works, we'll update the production manifest.