### PR TITLE
Demo country in production

### DIFF
--- a/public/manifest/demo.json
+++ b/public/manifest/demo.json
@@ -25,9 +25,9 @@
       "isd_code": "94"
     },
     {
-      "country_code": "IN",
+      "country_code": "DEMO",
       "endpoint": "https://api-sandbox.simple.org/api/",
-      "display_name": "Sandbox",
+      "display_name": "Demo Country",
       "isd_code": "91"
     }
   ],

--- a/public/manifest/production.json
+++ b/public/manifest/production.json
@@ -23,7 +23,13 @@
       "endpoint": "https://api.lk.simple.org/api/",
       "display_name": "Sri Lanka",
       "isd_code": "94"
-    }
+    },
+    {
+      "country_code": "DEMO",
+      "endpoint": "https://api-sandbox.simple.org/api/",
+      "display_name": "Demo Country",
+      "isd_code": "91"
+    }    
   ],
   "v2": {
     "countries": [
@@ -68,6 +74,17 @@
           {
             "display_name": "Sri Lanka",
             "endpoint": "https://api.lk.simple.org/api/"
+          }
+        ]
+      },
+      {
+        "country_code": "DEMO",
+        "display_name": "Demo Country",
+        "isd_code": "91",
+        "deployments": [
+          {
+            "display_name": "Demo Country",
+            "endpoint": "https://api-sandbox.simple.org/api/"
           }
         ]
       }


### PR DESCRIPTION
**Story card:** [sc-6861](https://app.shortcut.com/simpledotorg/story/6861/fix-google-play-policy-issue)

## Because

We need to make the production app browsable in a "demo" mode for Google Play app reviewers to give us the 👍 Without this approval, we cannot make any releases to the production Simple app.

## This addresses

Add a "Demo" country to the production manifest that points at Sandbox. Users who select this country (eg. Google Play reviewers) can self sign-up and connect to Sandbox. Upon re-sign-in, they can use the fixed OTP of 000000, since Sandbox has fixed OTPs.

This approach avoids the following, which is good:

* Introducing conditional OTP logic into the application
* Adding test data to a production server
* Introducing any "demo mode" into the app that can be switched to, resulting in confusion for real users.

This is a follow-up PR to #3340 and #3332 