### PR TITLE
Remove check for currently overdue patients on the download link

### DIFF
--- a/app/views/layouts/overdue.html.erb
+++ b/app/views/layouts/overdue.html.erb
@@ -33,7 +33,7 @@
       </label>
     <% end %>
   </section>
-  <% if @selected_facility && @patient_summaries.present? && current_admin.accessible_facilities(:manage_overdue_list).include?(@selected_facility) %>
+  <% if @selected_facility && current_admin.accessible_facilities(:manage_overdue_list).include?(@selected_facility) %>
     <section class="mb-5">
       <h4>
         Download


### PR DESCRIPTION
**Story card:** [sc-7047](https://app.shortcut.com/simpledotorg/story/7047/allow-downloading-overdue-lists-even-when-there-aren-t-any-currently-overdue-patients)

## Because

We don't show the overdue list download link for facilities that have removed all their overdue patients from the overdue list 

## This addresses

Show the download link even if a facility doesn't have any currently overdue patients