### PR TITLE
Rename schema_v2 to RegionSummarySchema

### DIFF
--- a/app/models/reports/region_summary_schema.rb
+++ b/app/models/reports/region_summary_schema.rb
@@ -1,5 +1,5 @@
 module Reports
-  class SchemaV2
+  class RegionSummarySchema
     include BustCache
     include Memery
     include RegionCaching

--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -23,7 +23,7 @@ module Reports
       @period_type = @periods.first.type
       @follow_ups_v2 = follow_ups_v2
       raise ArgumentError, "Quarter periods not supported" if @period_type != :month
-      @schema = SchemaV2.new(@regions, periods: @periods)
+      @schema = RegionSummarySchema.new(@regions, periods: @periods)
       @bp_measures_query = BPMeasuresQuery.new
       @follow_ups_query = FollowUpsQuery.new
       @registered_patients_query = RegisteredPatientsQuery.new

--- a/doc/wiki/feature-flags.md
+++ b/doc/wiki/feature-flags.md
@@ -23,7 +23,6 @@ to facility the launch of a new feature, and may reference the Simple team's int
 | imo_messaging | Yes | When enabled, patient reminder messages will be attempted via Imo first, before falling back to SMS. |
 | notifications | Yes | When enabled, Simple Server will send patient reminder messages. |
 | organization_reports | Yes | When enabled, the Simple Dashboard will allow users to view a top-level report for the whole organization. |
-| reporting_schema_v2 | Yes | Feature flag to launch [Reporting Pipeline](https://app.shortcut.com/simpledotorg/epic/2422/reporting-pipeline-etl) |
 | skip_api_validation | Yes | When enabled, Simple Server will not perform JSON validation of incoming API requests. This makes the API endpoints much more performant, but should only be enabled if all API clients are trusted (Simple app only). |
 | sync_encounters | Yes | When enabled, encounters can be synced between app and server like any other standard sync resource. |
 | weekly_telemed_report | Yes | When enabled, a weekly report on telemedicine activity in Simple will be sent via email to the configured recipients. |

--- a/spec/models/reports/region_summary_schema_spec.rb
+++ b/spec/models/reports/region_summary_schema_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Reports::SchemaV2, type: :model do
+describe Reports::RegionSummarySchema, type: :model do
   let(:organization) { create(:organization, name: "org-1") }
   let(:user) { create(:admin, :manager, :with_access, resource: organization, organization: organization) }
 
@@ -65,7 +65,7 @@ describe Reports::SchemaV2, type: :model do
     schema = described_class.new([facility.region], periods: range)
     entries = schema.cache_entries(:earliest_patient_recorded_at)
     entries.each do |entry|
-      expect(entry.to_s).to include("schema_v2")
+      expect(entry.to_s).to include("region_summary_schema")
       expect(entry.to_s).to include(facility.region.id)
       expect(entry.to_s).to include(schema.cache_version)
     end


### PR DESCRIPTION
all of these methods pull back data from the RegionSummary model, which
in turn uses the FacilityState (reporting_facility_states) reporting matview. So renaming to better match what it does.

No story, this came up as an area of clean up in a recent server devs meeting.