### PR TITLE
Extract out a FacilityProgressService

### DIFF
--- a/app/components/reports/monthly_progress_component.rb
+++ b/app/components/reports/monthly_progress_component.rb
@@ -7,11 +7,11 @@ class Reports::MonthlyProgressComponent < ViewComponent::Base
   attr_reader :monthly_counts
   attr_reader :total_counts
 
-  def initialize(dimension, range:, total_counts:, monthly_counts:)
+  def initialize(dimension, service:)
     @dimension = dimension
-    @monthly_counts = monthly_counts
-    @total_counts = total_counts
-    @range = range
+    @monthly_counts = service.monthly_counts
+    @total_counts = service.total_counts
+    @range = service.range
   end
 
   def diagnosis_group_class

--- a/app/controllers/api/v3/analytics/user_analytics_controller.rb
+++ b/app/controllers/api/v3/analytics/user_analytics_controller.rb
@@ -10,9 +10,7 @@ class Api::V3::Analytics::UserAnalyticsController < Api::V3::AnalyticsController
     @user_analytics = UserAnalyticsPresenter.new(current_facility)
     @period = Period.month(@for_end_of_month)
     if current_user.feature_enabled?(:follow_ups_v2_progress_tab)
-      @range = Range.new(@period.advance(months: -5), @period)
-      @total_counts = Reports::FacilityStateGroup.totals(current_facility)
-      @monthly_counts = Reports::FacilityStateGroup.where(facility_region_id: current_facility.region.id, month_date: @range).to_a
+      @service = Reports::FacilityProgressService.new(current_facility, @period)
     end
 
     respond_to_html_or_json(@user_analytics.statistics)

--- a/app/controllers/reports/progress_controller.rb
+++ b/app/controllers/reports/progress_controller.rb
@@ -9,7 +9,7 @@ class Reports::ProgressController < AdminController
   def show
     @current_facility = @region
     @user_analytics = UserAnalyticsPresenter.new(@region)
-    @service = FacilityProgressService.new(current_facility, @period)
+    @service = Reports::FacilityProgressService.new(current_facility, @period)
     @range = Range.new(@period.advance(months: -5), @period)
     render "api/v3/analytics/user_analytics/show"
   end

--- a/app/controllers/reports/progress_controller.rb
+++ b/app/controllers/reports/progress_controller.rb
@@ -9,9 +9,8 @@ class Reports::ProgressController < AdminController
   def show
     @current_facility = @region
     @user_analytics = UserAnalyticsPresenter.new(@region)
+    @service = FacilityProgressService.new(current_facility, @period)
     @range = Range.new(@period.advance(months: -5), @period)
-    @total_counts = Reports::FacilityStateGroup.totals(current_facility)
-    @monthly_counts = Reports::FacilityStateGroup.where(facility_region_id: current_facility.region.id, month_date: @range).to_a
     render "api/v3/analytics/user_analytics/show"
   end
 

--- a/app/controllers/reports/progress_controller.rb
+++ b/app/controllers/reports/progress_controller.rb
@@ -10,7 +10,6 @@ class Reports::ProgressController < AdminController
     @current_facility = @region
     @user_analytics = UserAnalyticsPresenter.new(@region)
     @service = Reports::FacilityProgressService.new(current_facility, @period)
-    @range = Range.new(@period.advance(months: -5), @period)
     render "api/v3/analytics/user_analytics/show"
   end
 

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -9,6 +9,14 @@ module Reports
       @range = Range.new(@period.advance(months: -5), @period)
     end
 
+    def total_counts
+      @total_counts ||= Reports::FacilityStateGroup.totals(facility)
+    end
+
+    def monthly_counts
+      @monthly_counts ||= Reports::FacilityStateGroup.where(facility_region_id: facility.region.id, month_date: @range).to_a
+    end
+
     # Returns all possible combinations of FacilityProgressDimensions for displaying 
     # the different slices of progress data.
     def dimension_combinations_for(indicator)
@@ -22,16 +30,11 @@ module Reports
       dimensions
     end
 
+    private
+
     def create_dimension(*args)
       Reports::FacilityProgressDimension.new(*args)
     end
 
-    def total_counts
-      @total_counts ||= Reports::FacilityStateGroup.totals(facility)
-    end
-
-    def monthly_counts
-      @monthly_counts ||= Reports::FacilityStateGroup.where(facility_region_id: facility.region.id, month_date: @range).to_a
-    end
   end
 end

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -17,12 +17,12 @@ module Reports
       @monthly_counts ||= Reports::FacilityStateGroup.where(facility_region_id: facility.region.id, month_date: @range).to_a
     end
 
-    # Returns all possible combinations of FacilityProgressDimensions for displaying 
+    # Returns all possible combinations of FacilityProgressDimensions for displaying
     # the different slices of progress data.
     def dimension_combinations_for(indicator)
       dimensions = [create_dimension(indicator, diagnosis: :all, gender: :all)] # special case first
       combinations = [indicator].product([:diabetes, :hypertension]).product([:all, :male, :female, :transgender])
-      combinations.each_with_object([]) do |c|
+      combinations.each do |c|
         indicator, diagnosis = *c.first
         gender = c.last
         dimensions << create_dimension(indicator, diagnosis: diagnosis, gender: gender)
@@ -35,6 +35,5 @@ module Reports
     def create_dimension(*args)
       Reports::FacilityProgressDimension.new(*args)
     end
-
   end
 end

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -9,16 +9,21 @@ module Reports
       @range = Range.new(@period.advance(months: -5), @period)
     end
 
-    def dimensions(indicator)
-      # handle the special case of any diagnosis and all genders first
-      dimensions = [Reports::FacilityProgressDimension.new(indicator, diagnosis: :all, gender: :all)]
+    # Returns all possible combinations of FacilityProgressDimensions for displaying 
+    # the different slices of progress data.
+    def dimension_combinations_for(indicator)
+      dimensions = [create_dimension(indicator, diagnosis: :all, gender: :all)] # special case first
       combinations = [indicator].product([:diabetes, :hypertension]).product([:all, :male, :female, :transgender])
       combinations.each_with_object([]) do |c|
         indicator, diagnosis = *c.first
         gender = c.last
-        dimensions << Reports::FacilityProgressDimension.new(indicator, diagnosis: diagnosis, gender: gender)
+        dimensions << create_dimension(indicator, diagnosis: diagnosis, gender: gender)
       end
       dimensions
+    end
+
+    def create_dimension(*args)
+      Reports::FacilityProgressDimension.new(*args)
     end
 
     def total_counts

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -9,6 +9,18 @@ module Reports
       @range = Range.new(@period.advance(months: -5), @period)
     end
 
+    def dimensions(indicator)
+      # handle the special case of any diagnosis and all genders first
+      dimensions = [Reports::FacilityProgressDimension.new(indicator, diagnosis: :all, gender: :all)]
+      combinations = [indicator].product([:diabetes, :hypertension]).product([:all, :male, :female, :transgender])
+      combinations.each_with_object([]) do |c|
+        indicator, diagnosis = *c.first
+        gender = c.last
+        dimensions << Reports::FacilityProgressDimension.new(indicator, diagnosis: diagnosis, gender: gender)
+      end
+      dimensions
+    end
+
     def total_counts
       @total_counts ||= Reports::FacilityStateGroup.totals(facility)
     end

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -1,0 +1,21 @@
+module Reports
+  class FacilityProgressService
+
+    attr_reader :facility
+    attr_reader :range
+
+    def initialize(facility, period)
+      @facility = facility
+      @period = period
+      @range = Range.new(@period.advance(months: -5), @period)
+    end
+
+    def total_counts
+      @total_counts ||= Reports::FacilityStateGroup.totals(facility)
+    end
+
+    def monthly_counts
+      @monthly_counts ||= Reports::FacilityStateGroup.where(facility_region_id: facility.region.id, month_date: @range).to_a
+    end
+  end
+end

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -1,6 +1,5 @@
 module Reports
   class FacilityProgressService
-
     attr_reader :facility
     attr_reader :range
 

--- a/app/views/api/v3/analytics/user_analytics/_monthly_breakdown.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_monthly_breakdown.html.erb
@@ -11,6 +11,6 @@ combinations.each_with_object([]) do |c|
 end
 %>
 <% dimensions.each do |dimension| %>
-  <%= render(Reports::MonthlyProgressComponent.new(dimension, range: @range, total_counts: @total_counts, monthly_counts: @monthly_counts)) %>
+  <%= render(Reports::MonthlyProgressComponent.new(dimension, service: @service)) %>
 <% end %>
 

--- a/app/views/api/v3/analytics/user_analytics/_monthly_breakdown.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_monthly_breakdown.html.erb
@@ -1,3 +1,3 @@
-<% @service.dimensions(indicator).each do |dimension| %>
+<% @service.dimension_combinations_for(indicator).each do |dimension| %>
   <%= render(Reports::MonthlyProgressComponent.new(dimension, service: @service)) %>
 <% end %>

--- a/app/views/api/v3/analytics/user_analytics/_monthly_breakdown.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_monthly_breakdown.html.erb
@@ -1,16 +1,3 @@
-
-<% 
-# handle the special case of any diagnosis and all genders first
-dimensions = [Reports::FacilityProgressDimension.new(indicator, diagnosis: :all, gender: :all)]
-# then do all the combinations
-combinations = [indicator].product([:diabetes, :hypertension]).product([:all, :male, :female, :transgender])
-combinations.each_with_object([]) do |c|
-  indicator, diagnosis = *c.first
-  gender = c.last
-  dimensions << Reports::FacilityProgressDimension.new(indicator, diagnosis: diagnosis, gender: gender)
-end
-%>
-<% dimensions.each do |dimension| %>
+<% @service.dimensions(indicator).each do |dimension| %>
   <%= render(Reports::MonthlyProgressComponent.new(dimension, service: @service)) %>
 <% end %>
-

--- a/spec/components/reports/monthly_progress_component_spec.rb
+++ b/spec/components/reports/monthly_progress_component_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe Reports::MonthlyProgressComponent, type: :component do
     end
     Timecop.freeze(jan_2022) do
       refresh_views
-      counts = Reports::FacilityStateGroup.where(facility_region_id: facility.region.id, month_date: date_range)
       male = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :hypertension, gender: :male)
       male_component = described_class.new(male, service: service)
       expect(male_component.monthly_count(november_2021_period)).to eq(0)

--- a/spec/components/reports/monthly_progress_component_spec.rb
+++ b/spec/components/reports/monthly_progress_component_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Reports::MonthlyProgressComponent, type: :component do
   let(:date_range) { range.map(&:to_date) }
   let(:counts) { Reports::FacilityStateGroup.where(facility_region_id: facility.region.id, month_date: date_range).to_a }
   let(:total_counts) { Reports::FacilityStateGroup.totals(facility) }
+  let(:service) { Reports::FacilityProgressService.new(facility, december_2021_period) }
 
   it "returns totals based the dimension" do
     create(:patient, :hypertension, recorded_at: 2.years.ago, gender: :male, registration_user: user, registration_facility: facility)
@@ -20,10 +21,10 @@ RSpec.describe Reports::MonthlyProgressComponent, type: :component do
     refresh_views
 
     dimension = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :all, gender: :all)
-    component = described_class.new(dimension, monthly_counts: counts, total_counts: total_counts, range: range)
+    component = described_class.new(dimension, service: service)
     expect(component.total_count).to eq(2)
     dimension = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :hypertension, gender: :female)
-    component = described_class.new(dimension, monthly_counts: counts, total_counts: total_counts, range: range)
+    component = described_class.new(dimension, service: service)
     expect(component.total_count).to eq(1)
   end
 
@@ -34,9 +35,7 @@ RSpec.describe Reports::MonthlyProgressComponent, type: :component do
     Timecop.freeze(jan_2022) do
       refresh_views
       dimension = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :all, gender: :all)
-      counts = Reports::FacilityStateGroup.where(facility_region_id: facility.region.id, month_date: date_range)
-
-      component = described_class.new(dimension, monthly_counts: counts, total_counts: total_counts, range: range)
+      component = described_class.new(dimension, service: service)
 
       expect(component.total_count).to eq(1)
       expect(component.monthly_count(november_2021_period)).to eq(1)
@@ -51,12 +50,12 @@ RSpec.describe Reports::MonthlyProgressComponent, type: :component do
       refresh_views
       counts = Reports::FacilityStateGroup.where(facility_region_id: facility.region.id, month_date: date_range)
       male = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :hypertension, gender: :male)
-      male_component = described_class.new(male, monthly_counts: counts, total_counts: total_counts, range: range)
+      male_component = described_class.new(male, service: service)
       expect(male_component.monthly_count(november_2021_period)).to eq(0)
       expect(male_component.monthly_count(december_2021_period)).to be_nil
 
       female = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :hypertension, gender: :female)
-      female_component = described_class.new(female, monthly_counts: counts, total_counts: total_counts, range: range)
+      female_component = described_class.new(female, service: service)
       expect(female_component.monthly_count(november_2021_period)).to eq(1)
       expect(female_component.monthly_count(december_2021_period)).to be_nil
     end
@@ -64,11 +63,11 @@ RSpec.describe Reports::MonthlyProgressComponent, type: :component do
 
   it "returns valid diagnosis gender classes" do
     dimension = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :hypertension, gender: :male)
-    component = described_class.new(dimension, monthly_counts: counts, total_counts: total_counts, range: range)
+    component = described_class.new(dimension, service: service)
     expect(component.diagnosis_group_class).to eq("hypertension:male")
 
     dimension = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :diabetes, gender: :all)
-    component = described_class.new(dimension, monthly_counts: counts, total_counts: total_counts, range: range)
+    component = described_class.new(dimension, service: service)
     expect(component.diagnosis_group_class).to eq("diabetes:all")
   end
 end

--- a/spec/services/reports/facility_progress_service_spec.rb
+++ b/spec/services/reports/facility_progress_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Reports::FacilityProgressService, type: :model do
     facility = build(:facility)
     service = described_class.new(facility, Period.current)
     dimensions = service.dimension_combinations_for(:registrations)
-     # (2 diagnosis options) * (4 gender options) + 1 special case of all / all
+    # (2 diagnosis options) * (4 gender options) + 1 special case of all / all
     expect(dimensions.size).to eq(9)
     expect(dimensions.all? { |d| d.indicator == :registrations }).to be true
     expect(dimensions.count { |d| d.diagnosis == :diabetes }).to eq(4)

--- a/spec/services/reports/facility_progress_service_spec.rb
+++ b/spec/services/reports/facility_progress_service_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Reports::FacilityProgressService, type: :model do
+  it "returns all dimension combinations" do
+    facility = build(:facility)
+    service = described_class.new(facility, Period.current)
+    dimensions = service.dimension_combinations_for(:registrations)
+     # (2 diagnosis options) * (4 gender options) + 1 special case of all / all
+    expect(dimensions.size).to eq(9)
+    expect(dimensions.all? { |d| d.indicator == :registrations }).to be true
+    expect(dimensions.count { |d| d.diagnosis == :diabetes }).to eq(4)
+    expect(dimensions.count { |d| d.diagnosis == :hypertension }).to eq(4)
+    expect(dimensions.count { |d| d.diagnosis == :all }).to eq(1)
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-3822](https://app.shortcut.com/simpledotorg/story/3822/change-follow-ups-to-track-visits-in-progress-tab)

The code we need for the new follow ups in the progress tab is now required in two places - ProgressController and UserAnalyticsController.  We can keep things in one spot by extracting to a service, which also adds one nice spot for the counts and creating the possible dimensions.

Testing is the same as the previous follow ups PR - https://app.shortcut.com/simpledotorg/story/3822/change-follow-ups-to-track-visits-in-progress-tab