### PR TITLE
Remove action_cable, as we don't use it

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,6 @@ require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
-require "action_cable/engine"
 require "sprockets/railtie"
 
 require_relative "../lib/extensions/logging_extensions"


### PR DESCRIPTION
No story card, just noticed we are loading this and do not use it at all.