### PR TITLE
Patient list export for NHF Study

### DIFF
--- a/app/exporters/patients_with_history_exporter.rb
+++ b/app/exporters/patients_with_history_exporter.rb
@@ -1,7 +1,10 @@
 require "csv"
 
 class PatientsWithHistoryExporter < PatientsExporter
-  def csv(patients, display_blood_pressures: 3, display_medication_columns: 5)
+  DEFAULT_DISPLAY_BLOOD_PRESSURES = 3
+  DEFAULT_DISPLAY_MEDICATION_COLUMNS = 5
+
+  def csv(patients, display_blood_pressures:, display_medication_columns:)
     @display_blood_pressures = display_blood_pressures
     @display_medication_columns = display_medication_columns
     super(patients)
@@ -43,7 +46,7 @@ class PatientsWithHistoryExporter < PatientsExporter
       "Diagnosed with Diabetes",
       "Risk Level",
       "Days Overdue For Next Follow-up",
-      (1..@display_blood_pressures).map do |i|
+      (1..display_blood_pressures).map do |i|
         [
           "BP #{i} Date",
           "BP #{i} Quarter",
@@ -79,7 +82,7 @@ class PatientsWithHistoryExporter < PatientsExporter
   def csv_fields(patient_summary)
     latest_bps = patient_summary
       .latest_blood_pressures
-      .first(@display_blood_pressures + 1)
+      .first(display_blood_pressures + 1)
 
     all_medications = fetch_medication_history(patient_summary, latest_bps.map(&:recorded_at))
     zone_column_index = csv_headers.index(zone_column)
@@ -114,7 +117,7 @@ class PatientsWithHistoryExporter < PatientsExporter
       patient_summary.diabetes,
       ("High" if patient_summary.risk_level > 0),
       patient_summary.days_overdue.to_i,
-      (1..@display_blood_pressures).map do |i|
+      (1..display_blood_pressures).map do |i|
         bp = latest_bps[i - 1]
         previous_bp = latest_bps[i]
         appointment = appointment_created_on(patient_appointments, bp&.recorded_at)
@@ -144,6 +147,14 @@ class PatientsWithHistoryExporter < PatientsExporter
 
   private
 
+  def display_blood_pressures
+    @display_blood_pressures || DEFAULT_DISPLAY_BLOOD_PRESSURES
+  end
+
+  def display_medication_columns
+    @display_medication_columns || DEFAULT_DISPLAY_MEDICATION_COLUMNS
+  end
+
   def appointment_created_on(appointments, date)
     date && appointments.find { |a| date.all_day.cover?(a.device_created_at) }
   end
@@ -167,10 +178,10 @@ class PatientsWithHistoryExporter < PatientsExporter
     medications = medications_on(all_medications, date)
 
     initial_medications =
-      (0...@display_medication_columns).flat_map { |i| [medications[i]&.name, medications[i]&.dosage] }
+      (0...display_medication_columns).flat_map { |i| [medications[i]&.name, medications[i]&.dosage] }
 
     other_medications =
-      medications[@display_medication_columns..medications.length]
+      medications[display_medication_columns..medications.length]
         &.map { |medication| "#{medication.name}-#{medication.dosage}" }
         &.join(", ")
 

--- a/app/exporters/patients_with_history_exporter.rb
+++ b/app/exporters/patients_with_history_exporter.rb
@@ -4,7 +4,7 @@ class PatientsWithHistoryExporter < PatientsExporter
   DEFAULT_DISPLAY_BLOOD_PRESSURES = 3
   DEFAULT_DISPLAY_MEDICATION_COLUMNS = 5
 
-  def csv(patients, display_blood_pressures:, display_medication_columns:)
+  def csv(patients, display_blood_pressures: DEFAULT_DISPLAY_BLOOD_PRESSURES, display_medication_columns: DEFAULT_DISPLAY_MEDICATION_COLUMNS)
     @display_blood_pressures = display_blood_pressures
     @display_medication_columns = display_medication_columns
     super(patients)

--- a/app/exporters/patients_with_history_exporter.rb
+++ b/app/exporters/patients_with_history_exporter.rb
@@ -1,7 +1,7 @@
 require "csv"
 
 class PatientsWithHistoryExporter < PatientsExporter
-  def csv(patients, display_blood_pressures = 3, display_medication_columns = 5)
+  def csv(patients, display_blood_pressures: 3, display_medication_columns: 5)
     @display_blood_pressures = display_blood_pressures
     @display_medication_columns = display_medication_columns
     super(patients)

--- a/app/exporters/patients_with_history_exporter.rb
+++ b/app/exporters/patients_with_history_exporter.rb
@@ -1,8 +1,11 @@
 require "csv"
 
 class PatientsWithHistoryExporter < PatientsExporter
-  DISPLAY_BLOOD_PRESSURES = 3
-  DISPLAY_MEDICATION_COLUMNS = 5
+  def csv(patients, display_blood_pressures = 3, display_medication_columns = 5)
+    @display_blood_pressures = display_blood_pressures
+    @display_medication_columns = display_medication_columns
+    super(patients)
+  end
 
   def load_batch(batch)
     super(batch)
@@ -40,7 +43,7 @@ class PatientsWithHistoryExporter < PatientsExporter
       "Diagnosed with Diabetes",
       "Risk Level",
       "Days Overdue For Next Follow-up",
-      (1..DISPLAY_BLOOD_PRESSURES).map do |i|
+      (1..@display_blood_pressures).map do |i|
         [
           "BP #{i} Date",
           "BP #{i} Quarter",
@@ -76,7 +79,7 @@ class PatientsWithHistoryExporter < PatientsExporter
   def csv_fields(patient_summary)
     latest_bps = patient_summary
       .latest_blood_pressures
-      .first(DISPLAY_BLOOD_PRESSURES + 1)
+      .first(@display_blood_pressures + 1)
 
     all_medications = fetch_medication_history(patient_summary, latest_bps.map(&:recorded_at))
     zone_column_index = csv_headers.index(zone_column)
@@ -111,7 +114,7 @@ class PatientsWithHistoryExporter < PatientsExporter
       patient_summary.diabetes,
       ("High" if patient_summary.risk_level > 0),
       patient_summary.days_overdue.to_i,
-      (1..DISPLAY_BLOOD_PRESSURES).map do |i|
+      (1..@display_blood_pressures).map do |i|
         bp = latest_bps[i - 1]
         previous_bp = latest_bps[i]
         appointment = appointment_created_on(patient_appointments, bp&.recorded_at)
@@ -164,10 +167,10 @@ class PatientsWithHistoryExporter < PatientsExporter
     medications = medications_on(all_medications, date)
 
     initial_medications =
-      (0...DISPLAY_MEDICATION_COLUMNS).flat_map { |i| [medications[i]&.name, medications[i]&.dosage] }
+      (0...@display_medication_columns).flat_map { |i| [medications[i]&.name, medications[i]&.dosage] }
 
     other_medications =
-      medications[DISPLAY_MEDICATION_COLUMNS..medications.length]
+      medications[@display_medication_columns..medications.length]
         &.map { |medication| "#{medication.name}-#{medication.dosage}" }
         &.join(", ")
 

--- a/lib/data_scripts/nhf_study_export_script.rb
+++ b/lib/data_scripts/nhf_study_export_script.rb
@@ -13,7 +13,7 @@ class NhfStudyExportScript < DataScript
   end
 
   def call
-    patients = Patient.where("full_name ILIKE ? OR full_name ILIKE ?", "%XYZ", "%XYX")
+    patients = Patient.where("full_name ILIKE ? OR full_name ILIKE ?", "%XYZ%", "%XYX%")
 
     csv = PatientsWithHistoryExporter.csv(patients, display_blood_pressures: 12)
 

--- a/lib/data_scripts/nhf_study_export_script.rb
+++ b/lib/data_scripts/nhf_study_export_script.rb
@@ -17,8 +17,6 @@ class NhfStudyExportScript < DataScript
 
     csv = PatientsWithHistoryExporter.csv(patients, display_blood_pressures: 12)
 
-    File.open(File.join(Rails.root, "nhf_study_line_list.csv"), "w") do |f|
-      f.write(csv)
-    end
+    File.write(File.join(Rails.root, "nhf_study_line_list.csv"), csv)
   end
 end

--- a/lib/data_scripts/nhf_study_export_script.rb
+++ b/lib/data_scripts/nhf_study_export_script.rb
@@ -1,0 +1,24 @@
+class NhfStudyExportScript < DataScript
+  attr_reader :logger
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def initialize(dry_run: true)
+    super(dry_run: dry_run)
+
+    fields = {module: :data_script, class: self.class}
+    @logger = Rails.logger.child(fields)
+  end
+
+  def call
+    patients = Patient.where("full_name ILIKE ? OR full_name ILIKE ?", "%XYZ", "%XYX")
+
+    csv = PatientsWithHistoryExporter.csv(patients, display_blood_pressures: 12)
+
+    File.open(File.join(Rails.root, "nhf_study_line_list.csv"), "w") do |f|
+      f.write(csv)
+    end
+  end
+end

--- a/spec/lib/data_scripts/nhf_study_export_script_spec.rb
+++ b/spec/lib/data_scripts/nhf_study_export_script_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
- require_relative "../../../lib/data_scripts/nhf_study_export_script"
+require_relative "../../../lib/data_scripts/nhf_study_export_script"
 
 describe NhfStudyExportScript do
   it "runs" do

--- a/spec/lib/data_scripts/nhf_study_export_script_spec.rb
+++ b/spec/lib/data_scripts/nhf_study_export_script_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+ require_relative "../../../lib/data_scripts/nhf_study_export_script"
+
+describe NhfStudyExportScript do
+  it "runs" do
+    described_class.call
+  end
+
+  it "enables readonly mode when in dry run mode" do
+    described_class.call(dry_run: true)
+    expect(User.new).to be_readonly
+  end
+
+  it "changes nothing in dry run mode" do
+    expect {
+      described_class.call
+    }.to_not change {
+      Patient.count
+    }
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-6887](https://app.shortcut.com/simpledotorg/story/6887/nhf-study-report)

## Because

The NHF needs full patient records for patients in their study. These patient names end in 'XYZ' or 'XYX'.

## This addresses

This allows our patient line list w/ history to include a variable number of BPs and meds, allowing us to export the full patient history.