### PR TITLE
Rack attack fix: Use dig to avoid errors if params are malformed

### DIFF
--- a/config/initializers/rate_limiter.rb
+++ b/config/initializers/rate_limiter.rb
@@ -46,7 +46,7 @@ unless SimpleServer.env.sandbox? || SimpleServer.env.qa? || SimpleServer.env.and
 
     throttle("throttle_user_activate", RateLimit.auth_api_options) do |req|
       if req.post? && req.path.start_with?("/api/v4/users/activate") && SimpleServer.env.production?
-        r = req.params.dig("user", "id")
+        req.params.dig("user", "id")
       end
     end
 

--- a/config/initializers/rate_limiter.rb
+++ b/config/initializers/rate_limiter.rb
@@ -46,7 +46,7 @@ unless SimpleServer.env.sandbox? || SimpleServer.env.qa? || SimpleServer.env.and
 
     throttle("throttle_user_activate", RateLimit.auth_api_options) do |req|
       if req.post? && req.path.start_with?("/api/v4/users/activate") && SimpleServer.env.production?
-        req.params["user"]["id"]
+        req.params.dig("user", "id")
       end
     end
 

--- a/config/initializers/rate_limiter.rb
+++ b/config/initializers/rate_limiter.rb
@@ -46,7 +46,7 @@ unless SimpleServer.env.sandbox? || SimpleServer.env.qa? || SimpleServer.env.and
 
     throttle("throttle_user_activate", RateLimit.auth_api_options) do |req|
       if req.post? && req.path.start_with?("/api/v4/users/activate") && SimpleServer.env.production?
-        req.params.dig("user", "id")
+        r = req.params.dig("user", "id")
       end
     end
 

--- a/spec/initializers/rate_limiter_spec.rb
+++ b/spec/initializers/rate_limiter_spec.rb
@@ -180,6 +180,17 @@ describe "RateLimiter", type: :controller do
         allow(RequestOtpSmsJob).to receive_message_chain("set.perform_later")
       end
 
+      it "returns 400 bad request when params are malformed" do
+        stub_const("SIMPLE_SERVER_ENV", "production")
+        limit.times do |i|
+          post "/api/v4/users/activate", {}
+          if i > limit
+            expect(i > limit).to eq(true)
+            expect(last_response.status).to eq(400)
+          end
+        end
+      end
+
       it "does not change the request status when the number of requests is lower than the limit" do
         stub_const("SIMPLE_SERVER_ENV", "production")
         user = create(:user, password: "1234")


### PR DESCRIPTION
Trying a quick fix for [sc7150](https://app.shortcut.com/simpledotorg/story/7150/nomethoderror-undefined-method-for-nil-nilclass)

We need to handle malformed params, as we are getting quite a few sentry errors where params do not have `[:user][:id]`:

https://sentry.io/organizations/resolve-to-save-lives/issues/2993018371/events/506518eaccc247d3930ff3cdba91711e/events/?project=1217715&referrer=Shortcut