### PR TITLE
Setup daily RAILS_NEXT (i.e. 6.x) build

### DIFF
--- a/.semaphore/rails_next.yml
+++ b/.semaphore/rails_next.yml
@@ -40,7 +40,6 @@ blocks:
           value: "1"
       secrets:
         - name: sentry-release-auth-token
-        - name: semaphore-deploy-key
       jobs:
         - name: StandardRB
           commands:

--- a/.semaphore/rails_next.yml
+++ b/.semaphore/rails_next.yml
@@ -1,12 +1,12 @@
 version: v1.0
-name: Test simple-server
+name: Test simple-server on RAILS_NEXT
 agent:
   machine:
     type: e1-standard-8
     os_image: ubuntu1804
 auto_cancel:
   running:
-    when: "true"
+    when: "false"
 blocks:
   - name: Cache dependencies
     task:

--- a/.semaphore/rails_next.yml
+++ b/.semaphore/rails_next.yml
@@ -1,0 +1,71 @@
+version: v1.0
+name: Test simple-server
+agent:
+  machine:
+    type: e1-standard-8
+    os_image: ubuntu1804
+auto_cancel:
+  running:
+    when: "true"
+blocks:
+  - name: Cache dependencies
+    task:
+      env_vars:
+        - name: DD_PROFILING_NO_EXTENSION
+          value: "true"
+      jobs:
+        - name: Cache everything
+          commands:
+            - sem-version ruby 2.7.4
+            - checkout
+            # - cache clear
+            - cache restore
+            - bundle config set deployment 'true'
+            - bundle config set path 'vendor/bundle'
+            - bundle install
+            - yarn install
+            - cache store
+  - name: Tests
+    task:
+      env_vars:
+        - name: DATABASE_URL
+          value: "postgresql://postgres:@0.0.0.0:5432/myapp_test"
+        - name: RAILS_ENV
+          value: "test"
+        - name: TB_RSPEC_OPTIONS
+          value: "--profile --format RspecJunitFormatter --out junit.xml"
+      secrets:
+        - name: sentry-release-auth-token
+        - name: semaphore-deploy-key
+      jobs:
+        - name: StandardRB
+          commands:
+            - checkout
+            - cache restore
+            - bundle config set deployment 'true'
+            - bundle config set path 'vendor/bundle'
+            - bundle install
+            - "bundle exec standardrb"
+        - name: RSpec
+          parallelism: 8
+          commands:
+            - checkout
+            - script/semaphore_setup
+            - rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT
+      epilogue:
+        always:
+          commands:
+            - "[[ -f junit.xml ]] && test-results publish junit.xml"
+
+after_pipeline:
+  task:
+    jobs:
+      - name: Publish Results
+        commands:
+          - test-results gen-pipeline-report
+
+promotions:
+  - name: Deploy
+    pipeline_file: deploy.yml
+    auto_promote:
+      when: (branch = 'master' AND result = 'passed') OR (tag =~ '^release-.*' AND result = 'passed')

--- a/.semaphore/rails_next.yml
+++ b/.semaphore/rails_next.yml
@@ -13,6 +13,8 @@ blocks:
       env_vars:
         - name: DD_PROFILING_NO_EXTENSION
           value: "true"
+        - name: RAILS_NEXT
+          value: "1"
       jobs:
         - name: Cache everything
           commands:
@@ -34,6 +36,8 @@ blocks:
           value: "test"
         - name: TB_RSPEC_OPTIONS
           value: "--profile --format RspecJunitFormatter --out junit.xml"
+        - name: RAILS_NEXT
+          value: "1"
       secrets:
         - name: sentry-release-auth-token
         - name: semaphore-deploy-key
@@ -63,9 +67,3 @@ after_pipeline:
       - name: Publish Results
         commands:
           - test-results gen-pipeline-report
-
-promotions:
-  - name: Deploy
-    pipeline_file: deploy.yml
-    auto_promote:
-      when: (branch = 'master' AND result = 'passed') OR (tag =~ '^release-.*' AND result = 'passed')


### PR DESCRIPTION
**Story card:** [sc-7113](https://app.shortcut.com/simpledotorg/story/7113/run-a-regular-rails-6-x-build-every-day-to-see-how-close-we-are-to-a-passing-build)

## Because

We want a daily build running with RAILS_NEXT set so that it runs rails 6.x on CI to start getting feedback on how the upgrade is tracking.

## This addresses

Adds a `rails_next.yml` pipeline file. The scheduler is configured in Semaphore's admin UI, as that is a project level config that you can't setup in the yaml.

## Test instructions

View and verify the nightly build setup to run at 02:00 UTC.