### PR TITLE
Revert "Rate limit OTPs from the same user ID (#3322)"

### DIFF
--- a/config/initializers/rate_limiter.rb
+++ b/config/initializers/rate_limiter.rb
@@ -7,6 +7,13 @@ unless SimpleServer.env.sandbox? || SimpleServer.env.qa? || SimpleServer.env.and
       {limit: limit_proc, period: period_proc}
     end
 
+    def self.user_api_options
+      limit_proc = proc { |_req| 5 }
+      period_proc = proc { |_req| 30.minutes }
+
+      {limit: limit_proc, period: period_proc}
+    end
+
     def self.patient_lookup_api_options
       limit_proc = proc { |_req| 5 }
       period_proc = proc { |_req| 5.second }
@@ -44,9 +51,9 @@ unless SimpleServer.env.sandbox? || SimpleServer.env.qa? || SimpleServer.env.and
       end
     end
 
-    throttle("throttle_user_activate", RateLimit.auth_api_options) do |req|
+    throttle("throttle_user_activate", RateLimit.user_api_options) do |req|
       if req.post? && req.path.start_with?("/api/v4/users/activate") && SimpleServer.env.production?
-        req.params["user"]["id"]
+        req.ip
       end
     end
 

--- a/spec/initializers/rate_limiter_spec.rb
+++ b/spec/initializers/rate_limiter_spec.rb
@@ -204,18 +204,6 @@ describe "RateLimiter", type: :controller do
         end
       end
 
-      it "does not rate limit across user ids" do
-        stub_const("SIMPLE_SERVER_ENV", "production")
-
-        (limit * 2).times do |i|
-          post "/api/v4/users/activate", {user: {id: SecureRandom.uuid, password: "1234"}}
-          if i > limit
-            expect(i > limit).to eq(true)
-            expect(last_response.status).to eq(401)
-          end
-        end
-      end
-
       it "does not rate limit in non production environments" do
         stub_const("SIMPLE_SERVER_ENV", "sandbox")
         user = create(:user, password: "1234")


### PR DESCRIPTION
This reverts commit a386799f888cea72000fbb5028bf21e593e7bf70.

**Story card:** [sc-XXXX](URL)

## Because

https://sentry.io/organizations/resolve-to-save-lives/issues/2993018371/?project=1217715&referrer=slack

## This addresses

Reverts #3322