### PR TITLE
Convert Rack::Request to ActionDispatch::Request before parsing JSON params

### DIFF
--- a/config/initializers/rate_limiter.rb
+++ b/config/initializers/rate_limiter.rb
@@ -53,7 +53,8 @@ unless SimpleServer.env.sandbox? || SimpleServer.env.qa? || SimpleServer.env.and
 
     throttle("throttle_user_activate", RateLimit.user_api_options) do |req|
       if req.post? && req.path.start_with?("/api/v4/users/activate") && SimpleServer.env.production?
-        req.ip
+        request = ActionDispatch::Request.new(req.env)
+        request.params["user"]["id"]
       end
     end
 

--- a/spec/initializers/rate_limiter_spec.rb
+++ b/spec/initializers/rate_limiter_spec.rb
@@ -204,6 +204,18 @@ describe "RateLimiter", type: :controller do
         end
       end
 
+      it "does not rate limit across user ids" do
+        stub_const("SIMPLE_SERVER_ENV", "production")
+
+        (limit * 2).times do |i|
+          post "/api/v4/users/activate", {user: {id: SecureRandom.uuid, password: "1234"}}
+          if i > limit
+            expect(i > limit).to eq(true)
+            expect(last_response.status).to eq(401)
+          end
+        end
+      end
+
       it "does not rate limit in non production environments" do
         stub_const("SIMPLE_SERVER_ENV", "sandbox")
         user = create(:user, password: "1234")


### PR DESCRIPTION
**Story card:** [sc-7150](https://app.shortcut.com/simpledotorg/story/7150/nomethoderror-undefined-method-for-nil-nilclass)

This effectively reverts https://github.com/simpledotorg/simple-server/pull/3370.

## Because

`Rack::Attack` uses `Rack::Request` as the request object, which has the JSON params in the body of the request, which need to be parsed like so: `JSON.parse(req.body.string)["user"]["id"]`. Alternatively, we could just convert the request into an `ActionDispatch::request` as suggested in https://github.com/rack/rack-attack/issues/399.

**Note: This issue isn't currently reproducible in the tests. We should figure out a way to do this before we proceed with this solution.**

## This addresses

Parsing the request params correctly.

## Test instructions
- Consider enabling rate limiting on sandbox, just to try out this fix.
- Activate a user from the app, ensure it work successfully