### PR TITLE
Fix meds specs failing in US time

### DIFF
--- a/spec/models/reports/facility_appointment_scheduled_days_spec.rb
+++ b/spec/models/reports/facility_appointment_scheduled_days_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Reports::FacilityAppointmentScheduledDays, {type: :model, reporti
     RefreshReportingViews.new.refresh_v2
 
     expect(described_class.find_by(month_date: Period.current, facility: facility).appts_scheduled_0_to_14_days).to eq 1
-    expect(described_class.find_by(month_date: Period.month(1.month.ago), facility: facility).appts_scheduled_15_to_31_days).to eq 1
-    expect(described_class.find_by(month_date: Period.month(2.month.ago), facility: facility).appts_scheduled_32_to_62_days).to eq 1
+    expect(described_class.find_by(month_date: Period.month(32.days.ago), facility: facility).appts_scheduled_15_to_31_days).to eq 1
+    expect(described_class.find_by(month_date: Period.month(63.days.ago), facility: facility).appts_scheduled_32_to_62_days).to eq 1
   end
 
   it "considers only the latest appointment of a patient in a month" do

--- a/spec/models/reports/facility_state_spec.rb
+++ b/spec/models/reports/facility_state_spec.rb
@@ -252,8 +252,8 @@ RSpec.describe Reports::FacilityState, {type: :model, reporting_spec: true} do
 
           expect(described_class.find_by(month_date: Period.current, facility: facility).appts_scheduled_0_to_14_days).to eq 2
           expect(described_class.find_by(month_date: Period.current, facility: facility).total_appts_scheduled).to eq 2
-          expect(described_class.find_by(month_date: Period.month(1.month.ago), facility: facility).appts_scheduled_32_to_62_days).to eq 1
-          expect(described_class.find_by(month_date: Period.month(2.month.ago), facility: facility).appts_scheduled_more_than_62_days).to eq 1
+          expect(described_class.find_by(month_date: Period.month(32.days.ago), facility: facility).appts_scheduled_32_to_62_days).to eq 1
+          expect(described_class.find_by(month_date: Period.month(63.days.ago), facility: facility).appts_scheduled_more_than_62_days).to eq 1
         end
       end
     end

--- a/spec/models/reports/facility_state_spec.rb
+++ b/spec/models/reports/facility_state_spec.rb
@@ -229,31 +229,33 @@ RSpec.describe Reports::FacilityState, {type: :model, reporting_spec: true} do
 
   context "medication dispensed in last 3 months" do
     it "counts the latest appointments scheduled per patient by days scheduled by bucket" do
-      skip "failing Feb 4th 2022 afternoon time US"
       Timecop.return do
-        facility = create(:facility)
-        patients = create_list(:patient, 2, recorded_at: 3.months.ago, assigned_facility: facility)
-        _current_month_appointments = patients.each do |patient|
-          create(:appointment, facility: facility, patient: patient, scheduled_date: 10.days.from_now, device_created_at: Time.current)
+        Timecop.freeze("#{Date.today.end_of_month} 23:00 IST") do
+          facility = create(:facility)
+          patients = create_list(:patient, 2, recorded_at: 3.months.ago, assigned_facility: facility)
+          _current_month_appointments = patients.each do |patient|
+            create(:appointment, facility: facility, patient: patient, scheduled_date: 10.days.from_now, device_created_at: Time.current)
+          end
+
+          _appointment_1_month_ago = create(:appointment,
+            facility: facility,
+            patient: patients.first,
+            scheduled_date: Date.today,
+            device_created_at: 32.days.ago)
+          _appointment_2_month_ago = create(:appointment,
+            facility: facility,
+            patient: patients.first,
+            scheduled_date: Date.today,
+            device_created_at: 63.days.ago)
+
+          RefreshReportingViews.new.refresh_v2
+
+          expect(described_class.find_by(month_date: Period.current, facility: facility).appts_scheduled_0_to_14_days).to eq 2
+          expect(described_class.find_by(month_date: Period.current, facility: facility).total_appts_scheduled).to eq 2
+          expect(described_class.find_by(month_date: Period.month(1.month.ago), facility: facility).appts_scheduled_15_to_31_days).to eq 1
+          expect(described_class.find_by(month_date: Period.month(1.month.ago), facility: facility).appts_scheduled_32_to_62_days).to eq 1
+          expect(described_class.find_by(month_date: Period.month(2.month.ago), facility: facility).appts_scheduled_more_than_62_days).to eq 1
         end
-
-        _appointment_1_month_ago = create(:appointment,
-          facility: facility,
-          patient: patients.first,
-          scheduled_date: Date.today,
-          device_created_at: 32.days.ago)
-        _appointment_2_month_ago = create(:appointment,
-          facility: facility,
-          patient: patients.first,
-          scheduled_date: Date.today,
-          device_created_at: 63.days.ago)
-
-        RefreshReportingViews.new.refresh_v2
-
-        expect(described_class.find_by(month_date: Period.current, facility: facility).appts_scheduled_0_to_14_days).to eq 2
-        expect(described_class.find_by(month_date: Period.current, facility: facility).total_appts_scheduled).to eq 2
-        expect(described_class.find_by(month_date: Period.month(1.month.ago), facility: facility).appts_scheduled_32_to_62_days).to eq 1
-        expect(described_class.find_by(month_date: Period.month(2.month.ago), facility: facility).appts_scheduled_more_than_62_days).to eq 1
       end
     end
   end

--- a/spec/models/reports/facility_state_spec.rb
+++ b/spec/models/reports/facility_state_spec.rb
@@ -252,7 +252,6 @@ RSpec.describe Reports::FacilityState, {type: :model, reporting_spec: true} do
 
           expect(described_class.find_by(month_date: Period.current, facility: facility).appts_scheduled_0_to_14_days).to eq 2
           expect(described_class.find_by(month_date: Period.current, facility: facility).total_appts_scheduled).to eq 2
-          expect(described_class.find_by(month_date: Period.month(1.month.ago), facility: facility).appts_scheduled_15_to_31_days).to eq 1
           expect(described_class.find_by(month_date: Period.month(1.month.ago), facility: facility).appts_scheduled_32_to_62_days).to eq 1
           expect(described_class.find_by(month_date: Period.month(2.month.ago), facility: facility).appts_scheduled_more_than_62_days).to eq 1
         end

--- a/spec/services/medication_dispensation_service_spec.rb
+++ b/spec/services/medication_dispensation_service_spec.rb
@@ -2,39 +2,40 @@ require "rails_helper"
 
 RSpec.describe MedicationDispensationService, type: :model do
   it "returns bucketed days of medications data" do
-    skip "failing February 3rd 2022 in the afternoon US time"
-    facility = create(:facility)
-    period = Period.current
-    patient = create(:patient, recorded_at: 1.year.ago)
-    _appointment_created_today = create(:appointment, patient: patient, facility: facility, scheduled_date: 10.days.from_now, device_created_at: Date.today)
-    _appointment_created_1_month_ago = create(:appointment, patient: patient, facility: facility, scheduled_date: Date.today, device_created_at: 32.days.ago)
-    _appointment_created_2_month_ago = create(:appointment, patient: patient, facility: facility, scheduled_date: Date.today, device_created_at: 63.days.ago)
+    Timecop.freeze("#{Date.today.end_of_month} 23:00 IST") do
+      facility = create(:facility)
+      period = Period.current
+      patient = create(:patient, recorded_at: 1.year.ago)
+      _appointment_created_today = create(:appointment, patient: patient, facility: facility, scheduled_date: 10.days.from_now, device_created_at: Date.today)
+      _appointment_created_1_month_ago = create(:appointment, patient: patient, facility: facility, scheduled_date: Date.today, device_created_at: 32.days.ago)
+      _appointment_created_2_month_ago = create(:appointment, patient: patient, facility: facility, scheduled_date: Date.today, device_created_at: 63.days.ago)
 
-    RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.new.refresh_v2
 
-    medications_dispensation_service = MedicationDispensationService.new(region: facility, period: period)
-    last_3_months = (Period.month(2.months.ago)..Period.current).to_a
-    current_month = last_3_months.last
-    one_month_ago = last_3_months.second
-    two_months_ago = last_3_months.first
-    expected_data_structure = {
-      "0-14 days" => {color: "#BD3838",
-                      counts: {two_months_ago => 0, one_month_ago => 0, current_month => 1},
-                      totals: {two_months_ago => 1, one_month_ago => 1, current_month => 1},
-                      percentages: {two_months_ago => 0, one_month_ago => 0, current_month => 100}},
-      "1 month (15-31 days)" => {color: "#E77D27",
-                                 counts: {two_months_ago => 0, one_month_ago => 0, current_month => 0},
-                                 totals: {two_months_ago => 1, one_month_ago => 1, current_month => 1},
-                                 percentages: {two_months_ago => 0, one_month_ago => 0, current_month => 0}},
-      "2 months (32-62 days)" => {color: "#729C26",
-                                  counts: {two_months_ago => 0, one_month_ago => 1, current_month => 0},
-                                  totals: {two_months_ago => 1, one_month_ago => 1, current_month => 1},
-                                  percentages: {two_months_ago => 0, one_month_ago => 100, current_month => 0}},
-      ">2 months" => {color: "#007AA6",
-                      counts: {two_months_ago => 1, one_month_ago => 0, current_month => 0},
-                      totals: {two_months_ago => 1, one_month_ago => 1, current_month => 1},
-                      percentages: {two_months_ago => 100, one_month_ago => 0, current_month => 0}}
-    }
-    expect(medications_dispensation_service.call).to eq(expected_data_structure)
+      medications_dispensation_service = MedicationDispensationService.new(region: facility, period: period)
+      last_3_months = (Period.month(2.months.ago)..Period.current).to_a
+      current_month = last_3_months.last
+      one_month_ago = last_3_months.second
+      two_months_ago = last_3_months.first
+      expected_data_structure = {
+        "0-14 days" => {color: "#BD3838",
+                        counts: {two_months_ago => 0, one_month_ago => 0, current_month => 1},
+                        totals: {two_months_ago => 1, one_month_ago => 1, current_month => 1},
+                        percentages: {two_months_ago => 0, one_month_ago => 0, current_month => 100}},
+        "1 month (15-31 days)" => {color: "#E77D27",
+                                   counts: {two_months_ago => 0, one_month_ago => 0, current_month => 0},
+                                   totals: {two_months_ago => 1, one_month_ago => 1, current_month => 1},
+                                   percentages: {two_months_ago => 0, one_month_ago => 0, current_month => 0}},
+        "2 months (32-62 days)" => {color: "#729C26",
+                                    counts: {two_months_ago => 0, one_month_ago => 1, current_month => 0},
+                                    totals: {two_months_ago => 1, one_month_ago => 1, current_month => 1},
+                                    percentages: {two_months_ago => 0, one_month_ago => 100, current_month => 0}},
+        ">2 months" => {color: "#007AA6",
+                        counts: {two_months_ago => 1, one_month_ago => 0, current_month => 0},
+                        totals: {two_months_ago => 1, one_month_ago => 1, current_month => 1},
+                        percentages: {two_months_ago => 100, one_month_ago => 0, current_month => 0}}
+      }
+      expect(medications_dispensation_service.call).to eq(expected_data_structure)
+    end
   end
 end


### PR DESCRIPTION
**Story card:** [sc-7058](https://app.shortcut.com/simpledotorg/story/7058/fix-calculation-for-days-until-next-appointment)

## Because

Some specs were failing due to timezone issues. 

## This addresses

The specs failed in US time afternoon because the data was created in US time but the view was being refreshed in `Asia/Kolkata` time. This freezes time to IST similar to the other specs. 

Note to reviewer: Ignore whitespace while reviewing.
