### PR TITLE
Remove Config fallback code for Redis URLs

### DIFF
--- a/app/helpers/config.rb
+++ b/app/helpers/config.rb
@@ -5,14 +5,6 @@ module Config
     end
   end
 
-  def self.ensure_required_keys_have_fallbacks(required_keys: {})
-    required_keys.each do |key, fallback|
-      ENV.fetch(key)
-    rescue KeyError
-      ENV.fetch(fallback)
-    end
-  end
-
   def self.get_int(config_key_name, default_value)
     (ENV[config_key_name] || default_value).to_i
   end

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -31,9 +31,3 @@ Config.ensure_required_keys_are_present(required_keys: [
   "SIDEKIQ_CONCURRENCY",
   "ANALYTICS_DASHBOARD_CACHE_TTL"
 ])
-
-Config.ensure_required_keys_have_fallbacks(required_keys: {
-  "CALL_SESSION_REDIS_HOST" => "REDIS_URL",
-  "SIDEKIQ_REDIS_HOST" => "REDIS_URL",
-  "RAILS_CACHE_REDIS_URL" => "REDIS_URL"
-})


### PR DESCRIPTION
Redis will already try to connect to REDIS_URL when you call `Redis.new`
without any arguments...which we do when the specific Redis urls aren't
found in the enviornment.

We can't depend on a fallback ENV var, because in Heroku the REDIS_URL
isn't necessarily available at bundle time (Heroku looks to setup the
Redis env after bundling).

no story, just hopefully fixing a common Heroku review app failure mode that looks like [this](https://dashboard.heroku.com/apps/simple-review-pr-3377/activity/builds/421cd015-4642-4bd1-b7c2-19f44038f70b)

```
     rake aborted!
       KeyError: key not found: "REDIS_URL"
       /tmp/build_003741ab/lib/env_helper.rb:12:in `fetch'
       /tmp/build_003741ab/lib/env_helper.rb:12:in `rescue in block in ensure_required_keys_have_fallbacks'
       /tmp/build_003741ab/lib/env_helper.rb:10:in `block in ensure_required_keys_have_fallbacks'
       /tmp/build_003741ab/lib/env_helper.rb:9:in `each'
       /tmp/build_003741ab/lib/env_helper.rb:9:in `ensure_required_keys_have_fallbacks'
       /tmp/build_003741ab/config/initializers/config.rb:35:in `<main>'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:59:in `load'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:59:in `load'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/dependencies.rb:285:in `block in load'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/dependencies.rb:257:in `load_dependency'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/dependencies.rb:285:in `load'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/engine.rb:663:in `block in load_config_initializer'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/notifications.rb:170:in `instrument'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/engine.rb:662:in `load_config_initializer'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/engine.rb:620:in `block (2 levels) in <class:Engine>'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/engine.rb:619:in `each'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/engine.rb:619:in `block in <class:Engine>'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/initializable.rb:32:in `instance_exec'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/initializable.rb:32:in `run'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/initializable.rb:61:in `block in run_initializers'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/initializable.rb:50:in `each'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/initializable.rb:50:in `tsort_each_child'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/initializable.rb:60:in `run_initializers'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/application.rb:361:in `initialize!'
       /tmp/build_003741ab/config/environment.rb:5:in `<main>'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/dependencies.rb:291:in `block in require'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/dependencies.rb:257:in `load_dependency'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/dependencies.rb:291:in `require'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/application.rb:337:in `require_environment!'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/application.rb:520:in `block in run_tasks_blocks'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/sentry-ruby-core-4.8.3/lib/sentry/rake.rb:24:in `execute'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/sprockets-rails-3.2.2/lib/sprockets/rails/task.rb:61:in `block (2 levels) in define'
       /tmp/build_003741ab/vendor/bundle/ruby/2.7.0/gems/sentry-ruby-core-4.8.3/lib/sentry/rake.rb:24:in `execute'
       
       Caused by:
```