### PR TITLE
Remove Sidekiq servermiddleware

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -24,10 +24,6 @@ SIDEKIQ_STATS_PREFIX = "#{SimpleServer.env}.#{CountryConfig.current[:abbreviatio
 Sidekiq.configure_server do |config|
   config.on(:shutdown) { Statsd.instance.close }
   config.server_middleware do |chain|
-    # The env and prefix are used to create keys in the format of env.prefix.worker_name.[stat_name]
-    # We want 'sidekiq' to be the top level, and then have our env specific information,
-    # which is we pass in a static string to `env` and the actual server env to `prefix`.
-    chain.add Sidekiq::Statsd::ServerMiddleware, env: SIDEKIQ_STATS_KEY, prefix: SIDEKIQ_STATS_PREFIX, statsd: Statsd.instance.statsd
     chain.add SidekiqMiddleware::SetLocalTimeZone
     chain.add SidekiqMiddleware::FlushMetrics
   end


### PR DESCRIPTION
Removes [https://github.com/phstc/sidekiq-statsd] from our Sidekiq middlewares.

I don't think we need this anymore, and I believe this may be causing
https://app.shortcut.com/simpledotorg/story/5139/argumenterror-start-sender-first

**Story card:** [sc-5139](https://app.shortcut.com/simpledotorg/story/5139/argumenterror-start-sender-first)

After merging this we will have to see if we still get the right visibility into Sidekiq in Datadog...but given how many jobs it seems to be impacting it seems worth to try removing.