### PR TITLE
Localize Estimated HTN population banner copy

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -74,6 +74,10 @@ module DashboardHelper
 
   def total_estimated_hypertensive_population_copy(region)
     region_copy = "#{region.region_type}_copy"
-    t("total_estimated_hypertensive_population.#{region_copy}", region_name: region.name)
+    t("total_estimated_hypertensive_population.#{region_copy}",
+      region_name: region.name,
+      child_region_type: region.child_region_type,
+      child_region_type_plural: region.child_region_type.pluralize
+    )
   end
 end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -77,7 +77,6 @@ module DashboardHelper
     t("total_estimated_hypertensive_population.#{region_copy}",
       region_name: region.name,
       child_region_type: region.child_region_type,
-      child_region_type_plural: region.child_region_type.pluralize
-    )
+      child_region_type_plural: region.child_region_type.pluralize)
   end
 end

--- a/app/views/reports/regions/_hypertension_patient_coverage.html.erb
+++ b/app/views/reports/regions/_hypertension_patient_coverage.html.erb
@@ -31,7 +31,7 @@
       <% if accessible_region?(@region, :manage) %>
         <div class="mb-16px p-12px br-4px bg-blue-light">
           <p class="m-0px fs-14px c-black">
-            Add the est. hypertensive population to see the coverage rate.
+            Add the estimated hypertensive population to see the coverage rate.
           </p>
           <%= link_to "+ Add population", edit_admin_facility_group_path(@region.source), :class => "fs-14px" %>
         </div>
@@ -46,9 +46,9 @@
       <% if current_admin.accessible_district_regions(:manage).to_set.superset?(@region.district_regions.to_set) %>
         <div class="mb-16px p-12px br-4px bg-blue-light">
           <p class="m-0px fs-14px c-black">
-            Add the est. hypertensive population for all districts to see the coverage rate.
+            Add the estimated hypertensive population for all <%= @region.child_region_type.pluralize %> to see the coverage rate.
           </p>
-          <%= link_to "+ Add district populations", "/admin/facilities", :class => "fs-14px" %>
+          <%= link_to "+ Add #{@region.child_region_type} populations", "/admin/facilities", :class => "fs-14px" %>
         </div>
         <% else %>
         <div class="mb-16px p-12px br-4px bg-yellow-light">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,7 +80,7 @@ en:
   hypertension_patient_coverage_copy: "Total registered patients diagnosed with hypertension divided by the region's estimated hypertensive population."
   total_estimated_hypertensive_population:
     district_copy: "The approximate number of people in %{region_name} with hypertension."
-    state_copy: "The sum of %{region_name}'s district populations entered on the Dashboard. This number is only displayed if all districts have a population."
+    state_copy: "The sum of %{region_name}'s %{child_region_type} populations entered on the Dashboard. This number is only displayed if all %{child_region_type_plural} have a population."
   medications_dispensation_copy:
     numerator: "Number of days till a patient's next scheduled appointment."
     denominator: "Total appointments scheduled for follow-up patients during a month."


### PR DESCRIPTION
**Story card:** [sc-7324](https://app.shortcut.com/simpledotorg/story/7324/localize-estimated-htn-population-banner-copy)

## Because

The banner's copy and the "Total est. hypertensive population" tooltip use static names for the use of the word "district".

## This addresses

Localizes the use of the word "district" in the banner and tooltip

![image](https://user-images.githubusercontent.com/16785131/153901160-e86439cc-e26c-46f6-b88b-00a1e9220786.png)


## Test instructions

Enter detailed instructions for how to test this PR...