### PR TITLE
Refresh daily follow up matviews throughout the day

### DIFF
--- a/app/services/refresh_reporting_views.rb
+++ b/app/services/refresh_reporting_views.rb
@@ -44,6 +44,9 @@ class RefreshReportingViews
     new(views: ["Reports::DailyFollowUp"]).call
   end
 
+  def self.refresh_v2
+    new(views: V2_REPORTING_VIEWS).call
+  end
 
   attr_reader :logger
   delegate :tz, :set_last_updated_at, to: self

--- a/app/services/refresh_reporting_views.rb
+++ b/app/services/refresh_reporting_views.rb
@@ -36,6 +36,8 @@ class RefreshReportingViews
     Rails.cache.write(REPORTING_VIEW_REFRESH_TIME_KEY, Time.current.in_time_zone(tz))
   end
 
+  # Refreshes all views by default, or can take an Array of class names if you want to
+  # specifically refresh certain matviews.
   def self.call(views: :all)
     new(views: views).call
   end

--- a/app/services/refresh_reporting_views.rb
+++ b/app/services/refresh_reporting_views.rb
@@ -3,45 +3,6 @@ class RefreshReportingViews
   include ActiveSupport::Benchmarkable
   REPORTING_VIEW_REFRESH_TIME_KEY = "last_reporting_view_refresh_time".freeze
 
-  def self.last_updated_at
-    Rails.cache.fetch(REPORTING_VIEW_REFRESH_TIME_KEY)
-  end
-
-  def self.set_last_updated_at
-    Rails.cache.write(REPORTING_VIEW_REFRESH_TIME_KEY, Time.current.in_time_zone(tz))
-  end
-
-  def self.call
-    new.call
-  end
-
-  attr_reader :logger
-  delegate :tz, :set_last_updated_at, to: self
-
-  def initialize
-    @logger = Rails.logger.child(class: self.class.name)
-    if Rails.env.development?
-      stdout_logger = Ougai::Logger.new($stdout)
-      @logger.extend(Ougai::Logger.broadcast(stdout_logger))
-    end
-  end
-
-  def call
-    logger.info "Beginning full reporting view refresh"
-    benchmark_and_statsd("all_v1") do
-      refresh_v1
-    end
-    benchmark_and_statsd("all_v2") do
-      refresh_v2
-    end
-    set_last_updated_at
-    logger.info "Completed full reporting view refresh"
-  end
-
-  def self.tz
-    Rails.application.config.country[:time_zone]
-  end
-
   # Keep the views below in the order as defined, as they have dependencies on earlier matviews in the lists
   V1_REPORTING_VIEWS = %w[
     LatestBloodPressuresPerPatientPerMonth
@@ -67,25 +28,64 @@ class RefreshReportingViews
     Reports::FacilityStateDimension
   ].freeze
 
-  def refresh_v1
-    V1_REPORTING_VIEWS.each do |name|
-      benchmark_and_statsd(name) do
-        klass = name.constantize
-        klass.refresh
-      end
+  def self.last_updated_at
+    Rails.cache.fetch(REPORTING_VIEW_REFRESH_TIME_KEY)
+  end
+
+  def self.set_last_updated_at
+    Rails.cache.write(REPORTING_VIEW_REFRESH_TIME_KEY, Time.current.in_time_zone(tz))
+  end
+
+  def self.call(views: :all)
+    new(views: views).call
+  end
+
+  def self.refresh_daily_follow_ups
+    new(views: ["Reports::DailyFollowUp"]).call
+  end
+
+
+  attr_reader :logger
+  delegate :tz, :set_last_updated_at, to: self
+
+  def initialize(views:)
+    @logger = Rails.logger.child(class: self.class.name)
+    @views = if views == :all
+      V1_REPORTING_VIEWS + V2_REPORTING_VIEWS
+    else
+      views
+    end
+    if Rails.env.development?
+      stdout_logger = Ougai::Logger.new($stdout)
+      @logger.extend(Ougai::Logger.broadcast(stdout_logger))
     end
   end
 
-  def refresh_v2
-    V2_REPORTING_VIEWS.each do |name|
-      benchmark_and_statsd(name) do
-        klass = name.constantize
-        klass.refresh
-      end
+  def call
+    logger.info "Beginning full reporting view refresh"
+    benchmark_and_statsd("all") do
+      refresh
     end
+    set_last_updated_at
+    logger.info "Completed full reporting view refresh"
+  end
+
+  def self.tz
+    Rails.application.config.country[:time_zone]
   end
 
   private
+
+  attr_reader :views
+
+  def refresh
+    views.each do |name|
+      benchmark_and_statsd(name) do
+        klass = name.constantize
+        klass.refresh
+      end
+    end
+  end
 
   def benchmark_and_statsd(operation)
     name = "refresh_reporting_views.#{operation}"

--- a/app/services/refresh_reporting_views.rb
+++ b/app/services/refresh_reporting_views.rb
@@ -45,7 +45,6 @@ class RefreshReportingViews
     Rails.cache.write(REPORTING_VIEW_DAILY_REFRESH_KEY, Time.current.in_time_zone(tz))
   end
 
-
   # Refreshes all views by default, or can take an Array of class names if you want to
   # specifically refresh certain matviews.
   def self.call(views: :all)
@@ -96,7 +95,6 @@ class RefreshReportingViews
   def all_views_refreshed?
     @all == true
   end
-
 
   attr_reader :views
 

--- a/app/services/refresh_reporting_views.rb
+++ b/app/services/refresh_reporting_views.rb
@@ -33,9 +33,18 @@ class RefreshReportingViews
     Rails.cache.fetch(REPORTING_VIEW_REFRESH_TIME_KEY)
   end
 
+  def self.last_updated_at_daily_follow_ups
+    Rails.cache.fetch(REPORTING_VIEW_DAILY_REFRESH_KEY)
+  end
+
   def self.set_last_updated_at
     Rails.cache.write(REPORTING_VIEW_REFRESH_TIME_KEY, Time.current.in_time_zone(tz))
   end
+
+  def self.set_last_updated_at_daily_follow_ups
+    Rails.cache.write(REPORTING_VIEW_DAILY_REFRESH_KEY, Time.current.in_time_zone(tz))
+  end
+
 
   # Refreshes all views by default, or can take an Array of class names if you want to
   # specifically refresh certain matviews.
@@ -74,7 +83,7 @@ class RefreshReportingViews
       refresh
     end
     set_last_updated_at if all_views_refreshed?
-    self.class.set_daily_last_updated_at if views.include?(/Daily/)
+    self.class.set_last_updated_at_daily_follow_ups if views.include?(/Daily/)
     logger.info "Completed full reporting view refresh"
   end
 
@@ -86,10 +95,6 @@ class RefreshReportingViews
 
   def all_views_refreshed?
     @all == true
-  end
-
-  def self.set_daily_last_updated_at
-    Rails.cache.write(REPORTING_VIEW_DAILY_REFRESH_KEY, Time.current.in_time_zone(tz))
   end
 
 

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -16,7 +16,7 @@ module Reports
     # probably matters the most health care workers as they see patients 
     # throughout the day and expect to see those reflected in the daily counts.
     def last_updated_at
-
+      RefreshReportingViews.last_updated_at_daily_follow_ups
     end
 
     def daily_registrations(date)

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -11,6 +11,14 @@ module Reports
       @diabetes_enabled = facility.enable_diabetes_management
     end
 
+    # we use the daily timestamp for the purposes of the last updated at,
+    # even though monthly numbers may lag behind the daily.  The update time
+    # probably matters the most health care workers as they see patients 
+    # throughout the day and expect to see those reflected in the daily counts.
+    def last_updated_at
+
+    end
+
     def daily_registrations(date)
       daily_registrations_grouped_by_day[date.to_date] || 0
     end

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -13,7 +13,7 @@ module Reports
 
     # we use the daily timestamp for the purposes of the last updated at,
     # even though monthly numbers may lag behind the daily.  The update time
-    # probably matters the most health care workers as they see patients 
+    # probably matters the most health care workers as they see patients
     # throughout the day and expect to see those reflected in the daily counts.
     def last_updated_at
       RefreshReportingViews.last_updated_at_daily_follow_ups

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -17,7 +17,7 @@
       <div class="progress-contents">
         <p class="updated-date">
           <span>
-            <%= raw t("analytics.updated", time: @user_analytics.last_updated_at) %>
+            <%= raw t("analytics.updated", time: @service.last_updated_at) %>
           </span>
         </p>
 

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -19,10 +19,11 @@
           <span>
             <% if current_user.feature_enabled?(:follow_ups_v2_progress_tab) %>
               <%= @service.last_updated_at %>
+              <%= raw t("analytics.updated", time: @service.last_updated_at) %>
             <% else %>
               <%= @user_analytics.last_updated_at %>
+              <%= raw t("analytics.updated", time: @user_analytics.last_updated_at) %>
             <% end %>
-            <%= raw t("analytics.updated", time: @service.last_updated_at) %>
           </span>
         </p>
 

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -17,6 +17,11 @@
       <div class="progress-contents">
         <p class="updated-date">
           <span>
+            <% if current_user.feature_enabled?(:follow_ups_v2_progress_tab) %>
+              <%= @service.last_updated_at %>
+            <% else %>
+              <%= @user_analytics.last_updated_at %>
+            <% end %>
             <%= raw t("analytics.updated", time: @service.last_updated_at) %>
           </span>
         </p>

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -18,10 +18,8 @@
         <p class="updated-date">
           <span>
             <% if current_user.feature_enabled?(:follow_ups_v2_progress_tab) %>
-              <%= @service.last_updated_at %>
               <%= raw t("analytics.updated", time: @service.last_updated_at) %>
             <% else %>
-              <%= @user_analytics.last_updated_at %>
               <%= raw t("analytics.updated", time: @user_analytics.last_updated_at) %>
             <% end %>
           </span>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -27,7 +27,7 @@ every :day, at: local("12:30am"), roles: [:cron] do
   rake "db:refresh_reporting_views"
 end
 
-FOLLOW_UP_TIMES = ["09:00 am", "11:00 am", "01:00 pm", "03:00 pm", "05:00 pm", "07:00 pm"].map { |t| local(t) }
+FOLLOW_UP_TIMES = ["08:00 am", "09:00 am", "11:00 am", "01:00 pm", "03:00 pm", "05:00 pm", "07:00 pm"].map { |t| local(t) }
 
 every :day, at: FOLLOW_UP_TIMES, roles: [:cron] do
   rake "db:refresh_daily_follow_ups"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -27,7 +27,9 @@ every :day, at: local("12:30am"), roles: [:cron] do
   rake "db:refresh_reporting_views"
 end
 
-every :day, at: [local("09:00 am"), local("11:00 am"), local("01:00 pm"), local("03:00 pm"), local("05:00 pm")] roles: [:cron] do
+FOLLOW_UP_TIMES = ["09:00 am", "11:00 am", "01:00 pm", "03:00 pm", "05:00 pm", "07:00 pm"].map { |t| local(t) }
+
+every :day, at: FOLLOW_UP_TIMES, roles: [:cron] do
   rake "db:refresh_dailly_follow_ups"
 end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -30,7 +30,7 @@ end
 FOLLOW_UP_TIMES = ["09:00 am", "11:00 am", "01:00 pm", "03:00 pm", "05:00 pm", "07:00 pm"].map { |t| local(t) }
 
 every :day, at: FOLLOW_UP_TIMES, roles: [:cron] do
-  rake "db:refresh_dailly_follow_ups"
+  rake "db:refresh_daily_follow_ups"
 end
 
 every :day, at: local("01:00 am"), roles: [:cron] do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -27,6 +27,10 @@ every :day, at: local("12:30am"), roles: [:cron] do
   rake "db:refresh_reporting_views"
 end
 
+every :day, at: [local("09:00 am"), local("11:00 am"), local("01:00 pm"), local("03:00 pm"), local("05:00 pm")] roles: [:cron] do
+  rake "db:refresh_dailly_follow_ups"
+end
+
 every :day, at: local("01:00 am"), roles: [:cron] do
   runner "MarkPatientMobileNumbers.call"
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -7,6 +7,12 @@ namespace :db do
 
   task refresh_matviews: :refresh_reporting_views
 
+  desc "Refresh matviews for daily follow ups"
+  task refresh_daily_follow_ups: :environment do
+    RefreshReportingViews.refresh_daily_follow_ups
+    puts "Daily follow ups have been refreshed"
+  end
+
   desc "Generate fake Patient data"
   task seed_patients: :environment do
     abort "Can't run this task in env:#{ENV["SIMPLE_SERVER_ENV"]}!" if ENV["SIMPLE_SERVER_ENV"] == "production"

--- a/spec/controllers/my_facilities/drug_stocks_controller_spec.rb
+++ b/spec/controllers/my_facilities/drug_stocks_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe MyFacilities::DrugStocksController, type: :controller do
     context "as power_user" do
       it "returns a success response" do
         create(:patient, registration_facility: facilities_with_stock_tracked.first)
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         sign_in(power_user.email_authentication)
         get :drug_stocks, params: {}
@@ -43,7 +43,7 @@ RSpec.describe MyFacilities::DrugStocksController, type: :controller do
         skip "failing on CI"
         patient = create(:patient, :hypertension, recorded_at: 2.months.ago, registration_facility: facilities_with_stock_tracked.first, assigned_facility: facilities_with_stock_tracked.second)
         create(:blood_pressure, patient: patient, recorded_at: 1.month.ago, facility: facilities_with_stock_tracked.third)
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         sign_in(power_user.email_authentication)
         get :drug_stocks, params: {facility_group: facility_group_with_stock_tracked.slug}
@@ -56,7 +56,7 @@ RSpec.describe MyFacilities::DrugStocksController, type: :controller do
     context "as manager" do
       it "only include facilities with tracked protocol drugs and patients, and manager has access" do
         create(:patient, registration_facility: allowed_facility_for_manager)
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         sign_in(manager.email_authentication)
         get :drug_stocks, params: {}
@@ -69,7 +69,7 @@ RSpec.describe MyFacilities::DrugStocksController, type: :controller do
       it "only include facilities with tracked protocol drugs and patients, and viewer has access" do
         create(:patient, registration_facility: facilities_with_stock_tracked.first)
         create(:patient, registration_facility: facilities_with_stock_tracked.second)
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
         sign_in(report_viewer.email_authentication)
         get :drug_stocks, params: {}
 

--- a/spec/exporters/drug_stocks_report_exporter_spec.rb
+++ b/spec/exporters/drug_stocks_report_exporter_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe DrugStocksReportExporter do
     end
 
     def refresh_views
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
     end
 
     it "renders the csv" do

--- a/spec/exporters/monthly_district_report/district_data_spec.rb
+++ b/spec/exporters/monthly_district_report/district_data_spec.rb
@@ -82,7 +82,7 @@ describe MonthlyDistrictReport::DistrictData do
         end
       end
 
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
 
       rows = described_class.new(district[:region], month).content_rows
       expect(rows[0].count).to eq 76

--- a/spec/models/experimentation/stale_patient_experiment_spec.rb
+++ b/spec/models/experimentation/stale_patient_experiment_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Experimentation::StalePatientExperiment do
       create(:experiment, experiment_type: "stale_patients")
       allow(Experimentation::NotificationsExperiment).to receive(:eligible_patients).and_call_original
       expect(Experimentation::NotificationsExperiment).to receive(:eligible_patients)
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
 
       described_class.first.eligible_patients(Date.today)
     end
@@ -17,7 +17,7 @@ RSpec.describe Experimentation::StalePatientExperiment do
       create(:bp_with_encounter, patient: young_patient, device_created_at: 100.days.ago)
       old_patient = create(:patient, age: 18)
       create(:bp_with_encounter, patient: old_patient, device_created_at: 100.days.ago)
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
 
       result = described_class.first.eligible_patients(Date.today)
 
@@ -30,7 +30,7 @@ RSpec.describe Experimentation::StalePatientExperiment do
       create(:bp_with_encounter, patient: hypertensive, device_created_at: 100.days.ago)
       non_hypertensive = create(:patient, :without_hypertension, age: 80)
       create(:bp_with_encounter, patient: non_hypertensive, device_created_at: 100.days.ago)
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
 
       result = described_class.first.eligible_patients(Date.today)
 
@@ -46,7 +46,7 @@ RSpec.describe Experimentation::StalePatientExperiment do
 
       patient_with_phone = create(:patient, age: 80)
       create(:bp_with_encounter, patient: patient_with_phone, device_created_at: 100.days.ago)
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
 
       result = described_class.first.eligible_patients(Date.today)
 
@@ -69,7 +69,7 @@ RSpec.describe Experimentation::StalePatientExperiment do
       create(:bp_with_encounter, patient: ineligible_3, device_created_at: 100.days.ago)
       create(:bp_with_encounter, patient: ineligible_3, device_created_at: 10.days.ago)
 
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
 
       result = described_class.first.eligible_patients(Date.today)
 
@@ -85,7 +85,7 @@ RSpec.describe Experimentation::StalePatientExperiment do
       patient_with_past_appt = create(:patient, age: 80)
       create(:bp_with_encounter, patient: patient_with_past_appt, device_created_at: 40.days.ago)
       create(:appointment, patient: patient_with_past_appt, device_created_at: 70.days.ago, scheduled_date: 40.days.ago)
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
 
       result = described_class.first.eligible_patients(Date.today)
 
@@ -112,7 +112,7 @@ RSpec.describe Experimentation::StalePatientExperiment do
         patient: patient_without_future_remind_on,
         device_created_at: 70.days.ago,
         scheduled_date: 40.days.ago)
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
 
       result = described_class.first.eligible_patients(Date.today)
 
@@ -124,7 +124,7 @@ RSpec.describe Experimentation::StalePatientExperiment do
       patient = create(:patient, age: 80)
       create(:bp_with_encounter, patient: patient, device_created_at: 90.days.ago)
       create(:appointment, patient: patient, device_created_at: 120.days.ago, scheduled_date: 90.days.ago, status: "scheduled")
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
 
       result = described_class.first.eligible_patients(Date.today)
 

--- a/spec/models/reports/facility_appointment_scheduled_days_spec.rb
+++ b/spec/models/reports/facility_appointment_scheduled_days_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Reports::FacilityAppointmentScheduledDays, {type: :model, reporti
     create(:appointment, patient: follow_up_patient, facility: facility, scheduled_date: 10.days.from_now, device_created_at: Time.current)
     create(:appointment, patient: registered_patient, facility: facility, scheduled_date: 10.days.from_now, device_created_at: Time.current)
 
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
 
     expect(described_class.find_by(month_date: Period.current, facility: facility).appts_scheduled_0_to_14_days).to eq 1
   end
@@ -38,7 +38,7 @@ RSpec.describe Reports::FacilityAppointmentScheduledDays, {type: :model, reporti
         patient: create(:patient, recorded_at: 1.month.ago))
     end
 
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
 
     expect(described_class.find_by(month_date: Period.current, facility: facility).appts_scheduled_0_to_14_days).to eq 2
     expect(described_class.find_by(month_date: Period.current, facility: facility).appts_scheduled_15_to_31_days).to eq 2
@@ -54,7 +54,7 @@ RSpec.describe Reports::FacilityAppointmentScheduledDays, {type: :model, reporti
     _appointment_created_1_month_ago = create(:appointment, patient: patient, facility: facility, scheduled_date: Date.today, device_created_at: 31.days.ago)
     _appointment_created_2_month_ago = create(:appointment, patient: patient, facility: facility, scheduled_date: Date.today, device_created_at: 62.days.ago)
 
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
 
     expect(described_class.find_by(month_date: Period.current, facility: facility).appts_scheduled_0_to_14_days).to eq 1
     expect(described_class.find_by(month_date: Period.month(32.days.ago), facility: facility).appts_scheduled_15_to_31_days).to eq 1
@@ -83,7 +83,7 @@ RSpec.describe Reports::FacilityAppointmentScheduledDays, {type: :model, reporti
       scheduled_date: third_appointment_date + 70.days,
       device_created_at: third_appointment_date)
 
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
 
     expect(described_class.find_by(month_date: Period.current, facility: facility).appts_scheduled_more_than_62_days).to eq 1
   end
@@ -95,7 +95,7 @@ RSpec.describe Reports::FacilityAppointmentScheduledDays, {type: :model, reporti
     _appointment_created_6_months_ago = create(:appointment, facility: facility, patient: patient, scheduled_date: Date.today, device_created_at: 6.month.ago)
     _appointment_created_7_months_ago = create(:appointment, facility: facility, patient: patient, scheduled_date: Date.today, device_created_at: 7.month.ago)
 
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
 
     expect(described_class.find_by(month_date: Period.current, facility: facility).appts_scheduled_0_to_14_days).to eq 1
     expect(described_class.find_by(month_date: Period.month(6.month.ago), facility: facility).appts_scheduled_more_than_62_days).to eq 1
@@ -110,7 +110,7 @@ RSpec.describe Reports::FacilityAppointmentScheduledDays, {type: :model, reporti
       scheduled_date: Date.yesterday,
       device_created_at: Time.current)
 
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
 
     expect(described_class.find_by(month_date: Period.current, facility: facility)).to be_nil
   end
@@ -133,7 +133,7 @@ RSpec.describe Reports::FacilityAppointmentScheduledDays, {type: :model, reporti
       scheduled_date: Date.tomorrow,
       device_created_at: Time.current)
 
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
 
     expect(described_class.find_by(month_date: Period.current, facility: facility).appts_scheduled_0_to_14_days).to eq 2
   end
@@ -149,7 +149,7 @@ RSpec.describe Reports::FacilityAppointmentScheduledDays, {type: :model, reporti
         patient: create(:patient, recorded_at: 2.months.ago),
         deleted_at: Time.current)
 
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
 
     expect(described_class.find_by(month_date: Period.current, facility: facility)).to be_nil
   end
@@ -165,7 +165,7 @@ RSpec.describe Reports::FacilityAppointmentScheduledDays, {type: :model, reporti
         device_created_at: Time.current)
     end
 
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
 
     expect(described_class.find_by(month_date: Period.current, facility: facility).appts_scheduled_0_to_14_days).to eq 1
   end

--- a/spec/models/reports/facility_state_spec.rb
+++ b/spec/models/reports/facility_state_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Reports::FacilityState, {type: :model, reporting_spec: true} do
         two_years_ago = june_2021[:now] - 2.years
         create_list(:patient, 6, registration_facility: facility, recorded_at: two_years_ago)
         create_list(:patient, 3, registration_facility: facility, recorded_at: june_2021[:under_three_months_ago])
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
         with_reporting_time_zone do
           expect(described_class
             .where(facility_id: facility.id)
@@ -46,7 +46,7 @@ RSpec.describe Reports::FacilityState, {type: :model, reporting_spec: true} do
         month_2020_07 = "2020-07-01"
         month_2021_04 = "2021-04-01"
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
         with_reporting_time_zone do
           expect(described_class
             .where(facility_id: facility.id)
@@ -82,7 +82,7 @@ RSpec.describe Reports::FacilityState, {type: :model, reporting_spec: true} do
         _different_facility_patient = create(:patient, recorded_at: june_2021[:long_ago])
         create_list(:patient, 3, recorded_at: june_2021[:long_ago], assigned_facility: facility, status: "dead")
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
         with_reporting_time_zone do
           expect(described_class.find_by(month_date: june_2021[:now], facility: facility).lost_to_follow_up).to eq 1
           expect(described_class.find_by(month_date: june_2021[:now], facility: facility).under_care).to eq 2
@@ -100,7 +100,7 @@ RSpec.describe Reports::FacilityState, {type: :model, reporting_spec: true} do
         create(:patient, assigned_facility: facility, recorded_at: june_2021[:end_of_month])
         create_list(:patient, 3, recorded_at: june_2021[:long_ago], assigned_facility: facility, status: "dead")
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
         with_reporting_time_zone do
           expect(described_class.find_by(facility: facility, month_date: june_2021[:now] - 2.years).cumulative_assigned_patients).to eq 1
           expect(described_class.find_by(facility: facility, month_date: june_2021[:under_12_months_ago]).cumulative_assigned_patients).to eq 2
@@ -142,7 +142,7 @@ RSpec.describe Reports::FacilityState, {type: :model, reporting_spec: true} do
         create(:blood_pressure, patient: patient, recorded_at: june_2021[:over_3_months_ago])
       end
 
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
       with_reporting_time_zone do
         facility_state_june_2021 = described_class.find_by(facility: facility, month_date: june_2021[:now])
 
@@ -171,7 +171,7 @@ RSpec.describe Reports::FacilityState, {type: :model, reporting_spec: true} do
         user: patient_visited_no_bp.registration_user)
       create(:blood_pressure, patient: patient_visited_no_bp, recorded_at: june_2021[:over_12_months_ago])
 
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
       with_reporting_time_zone do
         facility_state_june_2021 = described_class.find_by(facility: facility, month_date: june_2021[:now])
 
@@ -214,7 +214,7 @@ RSpec.describe Reports::FacilityState, {type: :model, reporting_spec: true} do
         create(:blood_pressure, patient: patient, recorded_at: june_2021[:over_3_months_ago])
       end
 
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
       with_reporting_time_zone do
         facility_state_june_2021 = described_class.find_by(facility: facility, month_date: june_2021[:now])
 
@@ -248,7 +248,7 @@ RSpec.describe Reports::FacilityState, {type: :model, reporting_spec: true} do
             scheduled_date: Date.today,
             device_created_at: 63.days.ago)
 
-          RefreshReportingViews.new.refresh_v2
+          RefreshReportingViews.refresh_v2
 
           expect(described_class.find_by(month_date: Period.current, facility: facility).appts_scheduled_0_to_14_days).to eq 2
           expect(described_class.find_by(month_date: Period.current, facility: facility).total_appts_scheduled).to eq 2

--- a/spec/models/reports/patient_state_spec.rb
+++ b/spec/models/reports/patient_state_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
         patient_registered_13m_ago = Timecop.freeze(13.months.ago) { create(:patient) }
         Timecop.freeze(13.months.ago) { create(:blood_pressure, patient: patient_registered_13m_ago) }
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
         with_reporting_time_zone do
           expect(described_class
             .where(htn_care_state: "lost_to_follow_up", month_date: Date.current.beginning_of_month)
@@ -66,7 +66,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
         patient_registered_12m_ago = Timecop.freeze(12.months.ago) { create(:patient) }
         patient_registered_11m_ago = Timecop.freeze(11.months.ago) { create(:patient) }
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
         with_reporting_time_zone do
           expect(described_class
             .where(htn_care_state: "lost_to_follow_up", month_date: Date.current.beginning_of_month)
@@ -88,7 +88,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
         patient_with_recent_bp = Timecop.freeze(13.months.ago) { create(:patient) }
         Timecop.freeze(11.months.ago) { create(:blood_pressure, patient: patient_with_recent_bp) }
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
         with_reporting_time_zone do
           expect(described_class
             .where(htn_care_state: "lost_to_follow_up", month_date: Date.current.beginning_of_month)
@@ -107,7 +107,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
           create(:blood_pressure, patient: under_care_patient, recorded_at: june_2021[:under_12_months_ago])
           create(:blood_pressure, patient: ltfu_patient, recorded_at: june_2021[:over_12_months_ago])
 
-          RefreshReportingViews.new.refresh_v2
+          RefreshReportingViews.refresh_v2
 
           with_reporting_time_zone do
             expect(described_class
@@ -132,7 +132,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
           create(:blood_pressure, patient: under_care_patient, recorded_at: june_2021[:end_of_month] - 1.minute)
           create(:blood_pressure, patient: ltfu_patient, recorded_at: june_2021[:end_of_month] + 1.minute)
 
-          RefreshReportingViews.new.refresh_v2
+          RefreshReportingViews.refresh_v2
 
           with_reporting_time_zone do
             expect(described_class
@@ -154,7 +154,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
           under_care_patient = create(:patient, recorded_at: june_2021[:under_12_months_ago])
           ltfu_patient = create(:patient, recorded_at: june_2021[:over_12_months_ago])
 
-          RefreshReportingViews.new.refresh_v2
+          RefreshReportingViews.refresh_v2
           with_reporting_time_zone do
             expect(described_class
               .where(htn_care_state: "lost_to_follow_up", month_date: june_2021[:beginning_of_month])
@@ -180,7 +180,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
         patient_2 = create(:patient, recorded_at: june_2021[:long_ago])
         create(:encounter, patient: patient_2, encountered_on: june_2021[:under_3_months_ago])
         patient_3 = create(:patient, recorded_at: june_2021[:long_ago])
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           expect(described_class.where(htn_treatment_outcome_in_last_3_months: "missed_visit", month_date: june_2021[:now]).pluck(:patient_id))
@@ -213,7 +213,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
           facility: patient_with_no_bp.registration_facility,
           patient: patient_with_no_bp,
           user: patient_with_no_bp.registration_user)
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           expect(described_class.where(htn_treatment_outcome_in_last_3_months: "visited_no_bp", month_date: june_2021[:now]).pluck(:patient_id))
@@ -230,7 +230,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
         patient_bp_over_3_months = create(:patient, recorded_at: june_2021[:long_ago])
         create(:bp_with_encounter, patient: patient_bp_over_3_months, recorded_at: june_2021[:over_3_months_ago])
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           expect(described_class.where(htn_treatment_outcome_in_last_3_months: "controlled", month_date: june_2021[:now]).pluck(:patient_id))
@@ -247,7 +247,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
         patient_bp_over_3_months = create(:patient, recorded_at: june_2021[:long_ago])
         create(:bp_with_encounter, patient: patient_bp_over_3_months, recorded_at: june_2021[:over_3_months_ago])
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           expect(described_class.where(htn_treatment_outcome_in_last_3_months: "uncontrolled", month_date: june_2021[:now]).pluck(:patient_id))
@@ -265,7 +265,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
         patient_2 = create(:patient, recorded_at: june_2021[:long_ago])
         create(:encounter, patient: patient_2, encountered_on: june_2021[:now] - 1.month)
         patient_3 = create(:patient, recorded_at: june_2021[:long_ago])
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           expect(described_class.where(htn_treatment_outcome_in_last_2_months: "missed_visit", month_date: june_2021[:now]).pluck(:patient_id))
@@ -298,7 +298,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
           facility: patient_with_no_bp.registration_facility,
           patient: patient_with_no_bp,
           user: patient_with_no_bp.registration_user)
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           expect(described_class.where(htn_treatment_outcome_in_last_2_months: "visited_no_bp", month_date: june_2021[:now]).pluck(:patient_id))
@@ -315,7 +315,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
         patient_bp_over_2_months = create(:patient, recorded_at: june_2021[:long_ago])
         create(:bp_with_encounter, patient: patient_bp_over_2_months, recorded_at: june_2021[:now] - 2.months)
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           expect(described_class.where(htn_treatment_outcome_in_last_2_months: "controlled", month_date: june_2021[:now]).pluck(:patient_id))
@@ -332,7 +332,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
         patient_bp_over_2_months = create(:patient, recorded_at: june_2021[:long_ago])
         create(:bp_with_encounter, patient: patient_bp_over_2_months, recorded_at: june_2021[:now] - 2.months)
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           expect(described_class.where(htn_treatment_outcome_in_last_2_months: "uncontrolled", month_date: june_2021[:now]).pluck(:patient_id))
@@ -353,7 +353,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
         patient_2 = create(:patient, recorded_at: june_2021[:long_ago])
         create(:encounter, patient: patient_2, encountered_on: one_quarter_ago)
         patient_3 = create(:patient, recorded_at: june_2021[:long_ago])
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           expect(described_class.where(htn_treatment_outcome_in_quarter: "missed_visit", month_date: this_quarter).pluck(:patient_id))
@@ -386,7 +386,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
           facility: patient_with_no_bp.registration_facility,
           patient: patient_with_no_bp,
           user: patient_with_no_bp.registration_user)
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           expect(described_class.where(htn_treatment_outcome_in_quarter: "visited_no_bp", month_date: june_2021[:now]).pluck(:patient_id))
@@ -403,7 +403,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
         patient_bp_in_last_quarter = create(:patient, recorded_at: june_2021[:long_ago])
         create(:bp_with_encounter, patient: patient_bp_in_last_quarter, recorded_at: june_2021[:now] - 3.months)
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           expect(described_class.where(htn_treatment_outcome_in_quarter: "controlled", month_date: june_2021[:now]).pluck(:patient_id))
@@ -420,7 +420,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
         patient_bp_in_last_quarter = create(:patient, recorded_at: june_2021[:long_ago])
         create(:bp_with_encounter, patient: patient_bp_in_last_quarter, recorded_at: june_2021[:now] - 3.months)
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           expect(described_class.where(htn_treatment_outcome_in_quarter: "uncontrolled", month_date: june_2021[:now]).pluck(:patient_id))
@@ -438,7 +438,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
         patient_3 = create(:patient, recorded_at: june_2021[:now])
         patient_4 = create(:patient, recorded_at: june_2021[:over_3_months_ago])
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
         with_reporting_time_zone do
           expect(described_class.find_by(patient_id: patient_1.id, month_string: june_2021[:month_string]).months_since_registration).to eq 11
           expect(described_class.find_by(patient_id: patient_2.id, month_string: june_2021[:month_string]).months_since_registration).to eq 12
@@ -455,7 +455,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
         patient_3 = create(:patient, recorded_at: june_2021[:now] - 4.months)
         patient_4 = create(:patient, recorded_at: june_2021[:now])
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
         with_reporting_time_zone do
           expect(described_class.find_by(patient_id: patient_1.id, month_string: june_2021[:month_string]).quarters_since_registration).to eq 7
           expect(described_class.find_by(patient_id: patient_2.id, month_string: june_2021[:month_string]).quarters_since_registration).to eq 4
@@ -478,7 +478,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
 
         patient = create(:patient, registration_facility: registration_facility, assigned_facility: assigned_facility)
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           patient_state = described_class.find_by(patient_id: patient.id, month_string: june_2021[:month_string])
@@ -510,7 +510,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
 
         patient = create(:patient, registration_facility: registration_facility, assigned_facility: assigned_facility)
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           patient_state = described_class.find_by(patient_id: patient.id, month_string: june_2021[:month_string])
@@ -541,7 +541,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
 
         patient_no_bp = create(:patient, recorded_at: june_2021[:long_ago])
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           controlled_state = described_class.find_by(patient_id: patient_controlled.id, month_string: june_2021[:month_string])
@@ -586,7 +586,7 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
             create(:prescription_drug, patient: patient, device_created_at: eight_months_ago)
             create(:bp_with_encounter, :hypertensive, patient: patient, recorded_at: five_months_ago)
 
-            RefreshReportingViews.new.refresh_v2
+            RefreshReportingViews.refresh_v2
 
             # NOTE: we have to run some of these assertions for a range of up until the "current" frozen timestamp, because we build this matview
             # off a join with the reporting_months view, which uses now() and so will always have records up until

--- a/spec/models/reports/quarterly_facility_state_spec.rb
+++ b/spec/models/reports/quarterly_facility_state_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Reports::QuarterlyFacilityState, {type: :model, reporting_spec: t
     create(:patient, assigned_facility: facility, recorded_at: q4_2020)
     create(:patient, assigned_facility: facility, recorded_at: q1_2021)
 
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
     with_reporting_time_zone do
       expect(
         described_class.where(facility: facility)
@@ -71,7 +71,7 @@ RSpec.describe Reports::QuarterlyFacilityState, {type: :model, reporting_spec: t
         create(:blood_pressure, patient: patient, recorded_at: previous_quarter)
       end
 
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
       with_reporting_time_zone do
         quarterly_facility_state_2021_q2 = described_class.find_by(facility: facility, quarter_string: "2021-2")
 

--- a/spec/models/reports/region_summary_schema_spec.rb
+++ b/spec/models/reports/region_summary_schema_spec.rb
@@ -14,7 +14,7 @@ describe Reports::RegionSummarySchema, type: :model do
   let(:june_2020) { Period.month("June 1 2020") }
 
   def refresh_views
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
   end
 
   it "returns data correctly grouped when passed mixed region types" do

--- a/spec/models/reports/region_summary_spec.rb
+++ b/spec/models/reports/region_summary_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
   end
 
   def refresh_views
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
   end
 
   context "API contract" do
@@ -261,7 +261,7 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
       range = Period.month(2.years.ago)..Period.current
       create(:patient, assigned_facility: facility, recorded_at: Date.today)
 
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
 
       expect(described_class.new(facility, range: range).for_regions.where("month_date < ?", Period.current.to_date)).to be_empty
       expect(described_class.new(facility, range: range).for_regions.where("month_date = ?", Period.current.to_date)).not_to be_empty

--- a/spec/queries/drug_stocks_query_spec.rb
+++ b/spec/queries/drug_stocks_query_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DrugStocksQuery do
   }
 
   def refresh_views
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
   end
 
   context "drug stock report" do

--- a/spec/queries/overdue_calls_query_spec.rb
+++ b/spec/queries/overdue_calls_query_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe OverdueCallsQuery do
         Period.month("March 2021") => 1
       }
 
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
       expect(described_class.new.count(facility.region, :month)).to eq(expected)
     end
   end
@@ -33,7 +33,7 @@ RSpec.describe OverdueCallsQuery do
     create(:call_result, appointment: appointment_1, device_created_at: end_of_jan, user: user_1)
     create(:call_result, appointment: appointment_2, device_created_at: beg_of_feb, user: user_2)
 
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
     with_reporting_time_zone do
       expected = {
         Period.month("January 2021") => 1,
@@ -62,7 +62,7 @@ RSpec.describe OverdueCallsQuery do
 
       }
 
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
       expect(described_class.new.count(facility.region, :month, group_by: :user_id)).to eq(expected)
     end
   end

--- a/spec/services/cohort_service_spec.rb
+++ b/spec/services/cohort_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CohortService, type: :model do
   end
 
   def refresh_views
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
   end
 
   it "sorts periods from most recent to earliest" do

--- a/spec/services/facility_stats_service_spec.rb
+++ b/spec/services/facility_stats_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FacilityStatsService do
   let(:user) { create(:admin, :manager, :with_access, resource: organization, organization: organization) }
 
   def refresh_views
-    RefreshReportingViews.new.refresh_v2
+    RefreshReportingViews.refresh_v2
   end
 
   def facilities_data(facilities)

--- a/spec/services/medication_dispensation_service_spec.rb
+++ b/spec/services/medication_dispensation_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MedicationDispensationService, type: :model do
       _appointment_created_1_month_ago = create(:appointment, patient: patient, facility: facility, scheduled_date: Date.today, device_created_at: 32.days.ago)
       _appointment_created_2_month_ago = create(:appointment, patient: patient, facility: facility, scheduled_date: Date.today, device_created_at: 63.days.ago)
 
-      RefreshReportingViews.new.refresh_v2
+      RefreshReportingViews.refresh_v2
 
       medications_dispensation_service = MedicationDispensationService.new(region: facility, period: period)
       last_3_months = (Period.month(2.months.ago)..Period.current).to_a

--- a/spec/services/monthly_district_data_service_spec.rb
+++ b/spec/services/monthly_district_data_service_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe MonthlyDistrictDataService, reporting_spec: true do
         ltfu_patient
         medications_dispensed_patients
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         result = service.report
         csv = CSV.parse(result)
@@ -146,7 +146,7 @@ RSpec.describe MonthlyDistrictDataService, reporting_spec: true do
         ltfu_patient
         medications_dispensed_patients
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         result = service.report
         csv = CSV.parse(result)
@@ -180,7 +180,7 @@ RSpec.describe MonthlyDistrictDataService, reporting_spec: true do
         ltfu_patient
         medications_dispensed_patients
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         result = service.report
         csv = CSV.parse(result)
@@ -303,7 +303,7 @@ RSpec.describe MonthlyDistrictDataService, reporting_spec: true do
         ltfu_patient
         medications_dispensed_patients
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         result = service.report
         csv = CSV.parse(result)
@@ -341,7 +341,7 @@ RSpec.describe MonthlyDistrictDataService, reporting_spec: true do
         ltfu_patient
         medications_dispensed_patients
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         result = service.report
         csv = CSV.parse(result)
@@ -378,7 +378,7 @@ RSpec.describe MonthlyDistrictDataService, reporting_spec: true do
         ltfu_patient
         medications_dispensed_patients
 
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         result = service.report
         csv = CSV.parse(result)

--- a/spec/services/monthly_state_data_service_spec.rb
+++ b/spec/services/monthly_state_data_service_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe MonthlyStateDataService, reporting_spec: true do
         follow_up_patient
         patient_without_hypertension
         ltfu_patient
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         result = service.report
         csv = CSV.parse(result)
@@ -124,7 +124,7 @@ RSpec.describe MonthlyStateDataService, reporting_spec: true do
         missed_visit_patient
         patient_without_hypertension
         ltfu_patient
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         result = service.report
         csv = CSV.parse(result)
@@ -241,7 +241,7 @@ RSpec.describe MonthlyStateDataService, reporting_spec: true do
         patient_without_hypertension
         ltfu_patient
         medications_dispensed_patients
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         result = service.report
         csv = CSV.parse(result)
@@ -276,7 +276,7 @@ RSpec.describe MonthlyStateDataService, reporting_spec: true do
         patient_without_hypertension
         medications_dispensed_patients
         ltfu_patient
-        RefreshReportingViews.new.refresh_v2
+        RefreshReportingViews.refresh_v2
 
         result = service.report
         csv = CSV.parse(result)

--- a/spec/services/refresh_reporting_views_spec.rb
+++ b/spec/services/refresh_reporting_views_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe RefreshReportingViews do
       .and change { Reports::PatientFollowUp.count }.by(1)
   end
 
-  it "updates only the specified view when argument is passed in" do
+  it "updates only the specified view when views are passed in" do
     time = Time.current
     expect {
       Timecop.freeze(time) do

--- a/spec/services/refresh_reporting_views_spec.rb
+++ b/spec/services/refresh_reporting_views_spec.rb
@@ -53,4 +53,18 @@ RSpec.describe RefreshReportingViews do
       .and change { Reports::PatientVisit.count }.by(4)
       .and change { Reports::PatientFollowUp.count }.by(1)
   end
+
+  it "updates only the specified view when argument is passed in" do
+    time = Time.current
+    expect {
+      Timecop.freeze(time) do
+        patient = create(:patient, recorded_at: 1.month.ago)
+        create(:blood_pressure, patient: patient, recorded_at: 2.days.ago)
+        create(:appointment, patient: patient, recorded_at: 1.day.ago)
+
+        RefreshReportingViews.call(views: ["Reports::DailyFollowUp"])
+      end
+    }.to change { Reports::DailyFollowUp.count }.by(2)
+    expect(Reports::PatientState.count).to eq(0)
+  end
 end


### PR DESCRIPTION
**Story card:** [sc-7317](https://app.shortcut.com/simpledotorg/story/7317/increase-refresh-time-of-daily-follow-ups)

## Because

We need to refresh daily numbers more frequently for progress tab - this bumps it up to every other hour during the day IST time.

