### PR TITLE
Show comma-separated numbers in the graph tooltips

### DIFF
--- a/app/assets/javascripts/common/medications_dispensation.js
+++ b/app/assets/javascripts/common/medications_dispensation.js
@@ -106,7 +106,7 @@ MedicationsDispensationGraph = function () {
         label: function(tooltipItem, data) {
             let numerators = Object.values(data.datasets[tooltipItem.datasetIndex].numerators);
             let denominators = Object.values(data.datasets[tooltipItem.datasetIndex].denominators);
-          return numerators[tooltipItem.index].toLocaleString() + " of " + denominators[tooltipItem.index].toLocaleString() + " follow-up patients";
+          return reports.formatNumberWithCommas(numerators[tooltipItem.index]) + " of " + reports.formatNumberWithCommas(denominators[tooltipItem.index]) + " follow-up patients";
         },
       }
     }

--- a/app/assets/javascripts/common/medications_dispensation.js
+++ b/app/assets/javascripts/common/medications_dispensation.js
@@ -104,9 +104,9 @@ MedicationsDispensationGraph = function () {
           return ""
         },
         label: function(tooltipItem, data) {
-            let numerators = Object.values(data.datasets[tooltipItem.datasetIndex].numerators)
-            let denominators = Object.values(data.datasets[tooltipItem.datasetIndex].denominators)
-          return numerators[tooltipItem.index] + " of "  + denominators[tooltipItem.index] + " follow-up patients";
+            let numerators = Object.values(data.datasets[tooltipItem.datasetIndex].numerators);
+            let denominators = Object.values(data.datasets[tooltipItem.datasetIndex].denominators);
+          return numerators[tooltipItem.index].toLocaleString() + " of " + denominators[tooltipItem.index].toLocaleString() + " follow-up patients";
         },
       }
     }


### PR DESCRIPTION
**Story card:** [sc-7351](https://app.shortcut.com/simpledotorg/story/7351/uqzpnk78w-can-we-show-comma-separate-numbers-in-the-graph-tooltips)

## Because

Days of medication graph tooltips don't show comma-separated numbers

## This addresses
Used `number.toLocaleString()` to comma-separate the numbers
(Follows the international system of numeration)

Before:

<img width="572" alt="Screenshot 2022-02-16 at 6 14 29 PM" src="https://user-images.githubusercontent.com/32141642/154267195-c6fc9628-22d4-401c-8591-3c3606031d28.png">

After:

<img width="572" alt="Screenshot 2022-02-16 at 6 10 36 PM" src="https://user-images.githubusercontent.com/32141642/154266527-8ec543a2-8cbf-4e27-b155-17615b399924.png">