### PR TITLE
Remove registration buffer from daily follow ups matview

### DIFF
--- a/db/migrate/20220217202441_update_reporting_daily_follow_ups_to_version_2.rb
+++ b/db/migrate/20220217202441_update_reporting_daily_follow_ups_to_version_2.rb
@@ -1,0 +1,8 @@
+class UpdateReportingDailyFollowUpsToVersion2 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :reporting_daily_follow_ups,
+      version: 2,
+      revert_to_version: 1,
+      materialized: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1430,7 +1430,7 @@ CREATE MATERIALIZED VIEW public.reporting_daily_follow_ups AS
             bp.recorded_at AS visited_at,
             (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bp.recorded_at))))::integer AS day_of_year
            FROM (public.patients p
-             JOIN public.blood_pressures bp ON (((p.id = bp.patient_id) AND (date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bp.recorded_at))) > date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
+             JOIN public.blood_pressures bp ON ((p.id = bp.patient_id)))
           WHERE ((p.deleted_at IS NULL) AND (bp.recorded_at > (CURRENT_TIMESTAMP - '30 days'::interval)))
         ), follow_up_blood_sugars AS (
          SELECT DISTINCT ON (p.id, bs.facility_id, ((date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at))))::integer)) p.id AS patient_id,
@@ -1442,7 +1442,7 @@ CREATE MATERIALIZED VIEW public.reporting_daily_follow_ups AS
             bs.recorded_at AS visited_at,
             (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at))))::integer AS day_of_year
            FROM (public.patients p
-             JOIN public.blood_sugars bs ON (((p.id = bs.patient_id) AND (date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at))) > date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
+             JOIN public.blood_sugars bs ON ((p.id = bs.patient_id)))
           WHERE ((p.deleted_at IS NULL) AND (bs.recorded_at > (CURRENT_TIMESTAMP - '30 days'::interval)))
         ), follow_up_prescription_drugs AS (
          SELECT DISTINCT ON (p.id, pd.facility_id, ((date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at))))::integer)) p.id AS patient_id,
@@ -1454,7 +1454,7 @@ CREATE MATERIALIZED VIEW public.reporting_daily_follow_ups AS
             pd.device_created_at AS visited_at,
             (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at))))::integer AS day_of_year
            FROM (public.patients p
-             JOIN public.prescription_drugs pd ON (((p.id = pd.patient_id) AND (date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at))) > date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
+             JOIN public.prescription_drugs pd ON ((p.id = pd.patient_id)))
           WHERE ((p.deleted_at IS NULL) AND (pd.device_created_at > (CURRENT_TIMESTAMP - '30 days'::interval)))
         ), follow_up_appointments AS (
          SELECT DISTINCT ON (p.id, app.creation_facility_id, ((date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at))))::integer)) p.id AS patient_id,
@@ -1466,7 +1466,7 @@ CREATE MATERIALIZED VIEW public.reporting_daily_follow_ups AS
             app.device_created_at AS visited_at,
             (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at))))::integer AS day_of_year
            FROM (public.patients p
-             JOIN public.appointments app ON (((p.id = app.patient_id) AND (date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at))) > date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
+             JOIN public.appointments app ON ((p.id = app.patient_id)))
           WHERE ((p.deleted_at IS NULL) AND (app.device_created_at > (CURRENT_TIMESTAMP - '30 days'::interval)))
         ), all_follow_ups AS (
          SELECT follow_up_blood_pressures.patient_id,
@@ -5552,6 +5552,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220202091240'),
 ('20220203073617'),
 ('20220204224734'),
-('20220209233034');
+('20220209233034'),
+('20220217202441');
 
 

--- a/db/views/reporting_daily_follow_ups_v02.sql
+++ b/db/views/reporting_daily_follow_ups_v02.sql
@@ -1,0 +1,86 @@
+WITH follow_up_blood_pressures AS (
+  SELECT DISTINCT ON (patient_id, facility_id, day_of_year)
+    p.id AS patient_id,
+    p.gender::gender_enum as patient_gender,
+    bp.id as visit_id,
+    'BloodPressure' AS visit_type,
+    bp.facility_id,
+    bp.user_id,
+    bp.recorded_at AS visited_at,
+    cast(EXTRACT(DOY FROM bp.recorded_at AT TIME ZONE 'UTC' at time zone (SELECT current_setting('TIMEZONE'))) as integer) AS day_of_year
+ FROM patients p
+    INNER JOIN blood_pressures bp
+      ON p.id = bp.patient_id
+  WHERE p.deleted_at IS NULL
+    AND bp.recorded_at > current_timestamp - interval '30 day'
+),
+follow_up_blood_sugars AS (
+  SELECT DISTINCT ON (patient_id, facility_id, day_of_year)
+    p.id AS patient_id,
+    p.gender::gender_enum as patient_gender,
+    bs.id as visit_id,
+   'BloodSugar' AS visit_type,
+    bs.facility_id,
+    bs.user_id,
+    bs.recorded_at AS visited_at,
+    cast(EXTRACT(DOY FROM bs.recorded_at AT TIME ZONE 'UTC' at time zone (SELECT current_setting('TIMEZONE'))) as integer) AS day_of_year
+
+  FROM patients p
+  INNER JOIN blood_sugars bs ON p.id = bs.patient_id
+  WHERE p.deleted_at IS NULL
+    AND bs.recorded_at > current_timestamp - interval '30 day'
+),
+follow_up_prescription_drugs AS (
+  SELECT DISTINCT ON (patient_id, facility_id, day_of_year)
+    p.id AS patient_id,
+    p.gender::gender_enum as patient_gender,
+    pd.id as visit_id,
+    'PrescriptionDrug' AS visit_type,
+    pd.facility_id,
+    pd.user_id,
+    pd.device_created_at AS visited_at,
+    cast(EXTRACT(DOY FROM pd.device_created_at AT TIME ZONE 'UTC' at time zone (SELECT current_setting('TIMEZONE'))) as integer) AS day_of_year
+  FROM patients p
+  INNER JOIN prescription_drugs pd ON p.id = pd.patient_id
+  WHERE p.deleted_at IS NULL
+    AND pd.device_created_at > current_timestamp - interval '30 day'
+),
+follow_up_appointments AS (
+  SELECT DISTINCT ON (patient_id, facility_id, day_of_year)
+    p.id AS patient_id,
+    p.gender::gender_enum as patient_gender,
+    app.id as visit_id,
+    'Appointment' AS visit_type,
+    app.creation_facility_id AS facility_id,
+    app.user_id,
+    app.device_created_at as visited_at,
+    cast(EXTRACT(DOY FROM app.device_created_at AT TIME ZONE 'UTC' at time zone (SELECT current_setting('TIMEZONE'))) as integer) AS day_of_year
+FROM patients p
+  INNER JOIN appointments app ON p.id = app.patient_id
+  WHERE p.deleted_at IS NULL
+    AND app.device_created_at > current_timestamp - interval '30 day'
+),
+all_follow_ups AS (
+  SELECT *
+  FROM
+    follow_up_blood_pressures
+    UNION (select * FROM follow_up_blood_sugars)
+    UNION (select * FROM follow_up_prescription_drugs)
+    UNION (select * FROM follow_up_appointments)
+)
+SELECT DISTINCT ON (all_follow_ups.day_of_year, all_follow_ups.facility_id, all_follow_ups.patient_id)
+  all_follow_ups.patient_id,
+  all_follow_ups.patient_gender,
+  all_follow_ups.facility_id,
+  mh.diabetes,
+  mh.hypertension,
+  all_follow_ups.user_id,
+  all_follow_ups.visit_id,
+  all_follow_ups.visit_type,
+  all_follow_ups.visited_at,
+  all_follow_ups.day_of_year
+FROM
+  all_follow_ups
+  INNER JOIN medical_histories mh
+     ON all_follow_ups.patient_id = mh.patient_id
+


### PR DESCRIPTION
I realized we don't want this exclusion of patients registered in the past month, as it will not show follow ups for recently registered patients...which the progress tab **should** show.

**Story card:** [sc-7115](https://app.shortcut.com/simpledotorg/story/7115/rollout-v2-numbers-follow-ups-in-progress-tab-follow-ups-v2-progress-tab)
