### PR TITLE
Report current month for progress tab

### DIFF
--- a/app/controllers/api/v3/analytics/user_analytics_controller.rb
+++ b/app/controllers/api/v3/analytics/user_analytics_controller.rb
@@ -7,7 +7,7 @@ class Api::V3::Analytics::UserAnalyticsController < Api::V3::AnalyticsController
   layout false
 
   def show
-    @period = Period.month(@for_end_of_month)
+    @period = Period.month(Date.current)
     @user_analytics = UserAnalyticsPresenter.new(current_facility)
     @achievements = Reports::FacilityProgressAchievementService.new(current_facility)
     @service = Reports::FacilityProgressService.new(current_facility, @period)


### PR DESCRIPTION
hotfix for bug report from the field - we need to use current month for the current @period, not `for_end_of_moth`, to make sure we report the correct numbers.