### PR TITLE
Shouldn't allow to delete a facility having assigned_patients

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -219,6 +219,7 @@ class Facility < ApplicationRecord
 
   def records_preventing_discard
     {
+      "assigned_patients" => assigned_patients,
       "registered patient" => registered_patients,
       "blood pressure" => blood_pressures,
       "blood sugar" => blood_sugars,

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -405,8 +405,13 @@ RSpec.describe Facility, type: :model do
     let!(:facility) { create(:facility) }
 
     context "isn't discardable if data exists" do
-      it "has patients" do
+      it "has registered patients" do
         create(:patient, registration_facility: facility)
+        expect(facility.discardable?).to be false
+      end
+
+      it "has assigned patients" do
+        create(:patient, assigned_facility: facility)
         expect(facility.discardable?).to be false
       end
 


### PR DESCRIPTION
**Story card:** [sc-6032](https://app.shortcut.com/simpledotorg/story/6032/don-t-allow-deleting-a-facility-if-it-has-assigned-patients)

## Because

`Facility#discardable?` doesn't check for assigned patients. 

## This addresses

- Added `assigned_patients` to `Facility#records_preventing_discard`

## Test instructions

- Wrote unit test to ensure that a facility isn't discardable if it has assigned_patients.