### PR TITLE
Fix setting the updated timestamp for daily reports

### DIFF
--- a/app/services/refresh_reporting_views.rb
+++ b/app/services/refresh_reporting_views.rb
@@ -82,7 +82,7 @@ class RefreshReportingViews
       refresh
     end
     set_last_updated_at if all_views_refreshed?
-    self.class.set_last_updated_at_daily_follow_ups if views.include?(/Daily/)
+    self.class.set_last_updated_at_daily_follow_ups if views.any? { |view| view.match?(/Daily/) }
     logger.info "Completed full reporting view refresh"
   end
 

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -17,7 +17,7 @@
       <div class="progress-contents">
         <p class="updated-date">
           <span>
-            <%= raw t("analytics.updated", time: l(@service.last_updated_at)) %>
+            <%= raw t("analytics.updated", time: @service.last_updated_at ? l(@service.last_updated_at) : "") %>
           </span>
         </p>
 

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -17,7 +17,7 @@
       <div class="progress-contents">
         <p class="updated-date">
           <span>
-            <%= raw t("analytics.updated", time: @service.last_updated_at) %>
+            <%= raw t("analytics.updated", time: l(@service.last_updated_at)) %>
           </span>
         </p>
 


### PR DESCRIPTION
**Story card:** [sc-7378](https://app.shortcut.com/simpledotorg/story/7378/daily-progress-number-refresh-time-is-missing)

## Because

Earlier the check was trying to check if the regex is included in the
list of view names, instead of checking if any of the views contain the
string 'Daily'

## This addresses

Currently the progress has a missing `Updated:` timestamp. This fix adds the missing timestamp

## Test instructions

- Get credentials to access the webviews locally using `bundle exec rails get_user_credentials`
- Refresh daily follow up views using `bundle exec rails get_user_credentials` 
- Make an api call to `GET v3/analytics/user_analytics.html` using the credentials from about. This will return an html page. There should be a timestamp following the text `Updated:`. If you're using postman, you can also preview the page. The timestamp will look similar to the image below.

![Screenshot from 2022-02-28 14-29-48](https://user-images.githubusercontent.com/3933133/155954207-f4e125ea-e8b7-40d4-9604-ba5e1e9fe530.png)

**Update**
We've also added a fix to change formatting of the `Updated:` timestamp, it currently looks like:
![Screenshot from 2022-02-28 17-50-46](https://user-images.githubusercontent.com/3933133/155982836-a7d14010-35d7-40f3-84c3-afbd48718a67.png)

This matches the formatting that existed earlier.

Co-authored-by: Priyanga P Kini <priyangapkini99@gmail.com>