### PR TITLE
Update progress tab home page

### DIFF
--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -821,6 +821,7 @@ footer p {
 .h-40px { height: 40px; }
 .h-64px { height: 64px; }
 .h-96px { height: 96px; }
+.h-112px { height: 112px; }
 .h-160px { height: 160px; }
 /* SPACING */
 .mt-6px { margin-top: 6px; }

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -821,7 +821,6 @@ footer p {
 .h-40px { height: 40px; }
 .h-64px { height: 64px; }
 .h-96px { height: 96px; }
-.h-112px { height: 112px; }
 .h-160px { height: 160px; }
 /* SPACING */
 .mt-6px { margin-top: 6px; }

--- a/app/helpers/progress_tab_helper.rb
+++ b/app/helpers/progress_tab_helper.rb
@@ -27,6 +27,6 @@ module ProgressTabHelper
       "is_goal_completed" => false
     })
 
-    badges.reverse
+    badges.last(5)
   end
 end

--- a/app/views/api/v3/analytics/user_analytics/_achievement_badge.erb
+++ b/app/views/api/v3/analytics/user_analytics/_achievement_badge.erb
@@ -1,4 +1,4 @@
-<div class="d-inline-flex fd-column ai-center jc-center w-56px h-64px mr-16px <% if is_goal_completed %>bgc-<%= badge_color %>-light<% else %>bgc-white b-grey-mid<% end %> br-10px">
+<div class="d-inline-flex fd-column ai-center jc-center w-56px h-64px <% if is_goal_completed %>bgc-<%= badge_color %>-light<% else %>bgc-white b-grey-mid<% end %> br-10px">
   <div class="p-relative t--3px d-flex ai-center jc-center w-40px h-40px br-100 <% if is_goal_completed %>bgc-<%= badge_color %><% else %>bgc-white b-grey-mid<% end %>">
     <% if is_goal_completed %>
       <%= inline_file(icon_completed) %>
@@ -6,7 +6,7 @@
       <%= inline_file(icon_goal) %>
     <% end %>
   </div>
-  <p class="m-0px p-0px ta-center ff-fredoka-one <% if value >= 10000 %>fs-16px<% else %>fs-18px<% end %> <% if is_goal_completed %>c-<%= badge_color %><% else %>c-grey-mid<% end %>">
+  <p class="m-0px p-0px ta-center ff-fredoka-one <% if value >= 100000 %>fs-12px<% elsif value >= 10000 %>fs-16px<% else %>fs-18px<% end %> <% if is_goal_completed %>c-<%= badge_color %><% else %>c-grey-mid<% end %>">
     <%= number_with_delimiter(value) %>
   </p>
 </div>

--- a/app/views/api/v3/analytics/user_analytics/_diagnosis_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_diagnosis_report.html.erb
@@ -5,9 +5,9 @@
         <%= inline_file("chevron-left.svg") %>
       </div>
     </a>
-    <div class="mb-12px pr-16px pl-16px">
+    <div class="pr-16px pl-16px">
       <h1 class="m-0px mb-8px fw-bold fs-24px">
-        <%= title %>
+        <%= title %> report
       </h1>
       <% if subtitle %>
         <p class="m-0px p-0px ta-left fw-normal fs-16px c-grey-dark">

--- a/app/views/api/v3/analytics/user_analytics/_period_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_period_report.html.erb
@@ -11,7 +11,7 @@
     </a>
     <div class="mb-12px pr-16px pl-16px">
       <h1 class="m-0px mb-8px fw-bold fs-24px">
-        <%= title %>
+        <%= title %> report
       </h1>
       <% if subtitle %>
         <p class="m-0px p-0px ta-left fw-normal fs-16px c-grey-dark">

--- a/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
@@ -18,12 +18,9 @@
   <body>
     <div id="home-page">
       <div class="mb-8px p-16px bgc-white bs-card">
-        <h1 class="m-0px mb-4px fw-bold fs-24px c-black">
-          <%= t("progress_tab.progress_reports_card.title") %>
+        <h1 class="m-0px mb-16px fw-bold fs-24px c-black">
+          <%= t("progress_tab.registrations_and_follow_ups_card.title") %>
         </h1>
-        <p class="m-0px mb-16px p-0px ta-left fw-normal fs-16px lh-150 c-grey-dark">
-          <%= t("progress_tab.progress_reports_card.subtitle") %>
-        </p>
         <div class="d-flex ai-center jc-space-between">
           <a class="f-1 d-flex fd-column ai-center jc-center td-none mr-10px p-12px bgc-blue-green-light br-8px" href="#" onclick="goToPage('home-page', 'daily-report-page'); return false;">
             <div class="p-relative d-flex ai-center jc-center w-32px h-32px mb-8px bgc-white br-8px o-hidden">
@@ -62,10 +59,10 @@
       </div>
       <div class="mb-8px p-16px bgc-white bs-card">
         <h1 class="m-0px mb-4px fw-bold fs-24px c-black">
-          <%= t("progress_tab.diagnosis_reports_card.title") %>
+          <%= t("progress_tab.reports_card.title") %>
         </h1>
         <p class="m-0px mb-16px p-0px ta-left fw-normal fs-16px lh-150 c-grey-dark">
-          <%= t("progress_tab.diagnosis_reports_card.subtitle") %>
+          <%= t("progress_tab.reports_card.subtitle", facility_name: current_facility.name) %>
         </p>
         <div class="d-flex ai-center jc-space-between">
           <a
@@ -176,7 +173,7 @@
                locals: {
                  page_id: "daily-report-page",
                  title: t("progress_tab.daily_report_title"),
-                 subtitle: false,
+                 subtitle: t("progress_tab.last_updated_at", date: DateTime.parse(@user_analytics.last_updated_at).to_date.strftime("%d-%b-%y at %I:%M %P")),
                  periods: @period_reports_data["daily_periods"],
                  registered_patients: @period_reports_data["daily_registered_patients"],
                  follow_up_patients: @period_reports_data["daily_follow_up_patients"]
@@ -186,7 +183,7 @@
                locals: {
                  page_id: "monthly-report-page",
                  title: t("progress_tab.monthly_report_title"),
-                 subtitle: false,
+                 subtitle: t("progress_tab.last_updated_at", date: DateTime.parse(@user_analytics.last_updated_at).to_date.strftime("%d-%b-%y at %I:%M %P")),
                  periods: @period_reports_data["monthly_periods"],
                  registered_patients: @period_reports_data["monthly_registered_patients"],
                  follow_up_patients: @period_reports_data["monthly_follow_up_patients"]
@@ -196,7 +193,7 @@
                locals: {
                  page_id: "yearly-report-page",
                  title: t("progress_tab.yearly_report_title"),
-                 subtitle: "Apr-2021 to Mar-2022",
+                 subtitle: t("progress_tab.last_updated_at", date: DateTime.parse(@user_analytics.last_updated_at).to_date.strftime("%d-%b-%y at %I:%M %P")),
                  periods: @period_reports_data["yearly_periods"],
                  registered_patients: @period_reports_data["yearly_registered_patients"],
                  follow_up_patients: @period_reports_data["yearly_follow_up_patients"]
@@ -207,7 +204,7 @@
                  page_id: "hypertension-report",
                  report_diagnosis: t("progress_tab.diagnoses.hypertension"),
                  title: t("progress_tab.hypertension_report_title"),
-                 subtitle: t("progress_tab.reports_card.subtitle", date: DateTime.parse(@user_analytics.last_updated_at).to_date.strftime("%d-%b-%y at %I:%M %P")),
+                 subtitle: t("progress_tab.last_updated_at", date: DateTime.parse(@user_analytics.last_updated_at).to_date.strftime("%d-%b-%y at %I:%M %P")),
                  diagnosis_data: @hypertension_reports_data
                }
     
@@ -217,7 +214,7 @@
                  page_id: "diabetes-report",
                  report_diagnosis: t("progress_tab.diagnoses.diabetes"),
                  title: t("progress_tab.diabetes_report_title"),
-                 subtitle: t("progress_tab.reports_card.subtitle", date: DateTime.parse(@user_analytics.last_updated_at).to_date.strftime("%d-%b-%y at %I:%M %P")),
+                 subtitle: t("progress_tab.last_updated_at", date: DateTime.parse(@user_analytics.last_updated_at).to_date.strftime("%d-%b-%y at %I:%M %P")),
                  diagnosis_data: @diabetes_reports_data
                }
     

--- a/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
@@ -22,34 +22,25 @@
           <%= t("progress_tab.registrations_and_follow_ups_card.title") %>
         </h1>
         <div class="d-flex ai-center jc-space-between">
-          <a class="f-1 d-flex fd-column ai-center jc-center td-none mr-10px p-12px bgc-blue-green-light br-8px" href="#" onclick="goToPage('home-page', 'daily-report-page'); return false;">
+          <a class="f-1 d-flex fd-column ai-center jc-center td-none h-96px mr-10px p-12px bgc-blue-green-light br-8px" href="#" onclick="goToPage('home-page', 'daily-report-page'); return false;">
             <div class="p-relative d-flex ai-center jc-center w-32px h-32px mb-8px bgc-white br-8px o-hidden">
               <div class="p-absolute t-0 l-0 w-100 h-6px bgc-blue-green"></div>
-              <p class="m-0px mt-6px p-0px ta-center fw-bold fs-14px c-blue-green">
-                <%= Date.today.strftime("%d") %> 
-              </p>
             </div>
             <p class="m-0px p-0px ta-center fw-medium fs-16px c-blue-green">
               <%= t("progress_tab.daily_report_title") %>
             </p>
           </a>
-          <a class="f-1 d-flex fd-column ai-center jc-center td-none mr-4px ml-4px p-12px bgc-blue-light br-8px" href="#" onclick="goToPage('home-page', 'monthly-report-page'); return false;">
+          <a class="f-1 d-flex fd-column ai-center jc-center td-none h-96px mr-4px ml-4px p-12px bgc-blue-light br-8px" href="#" onclick="goToPage('home-page', 'monthly-report-page'); return false;">
             <div class="p-relative d-flex ai-center jc-center w-32px h-32px mb-8px bgc-white br-8px o-hidden">
               <div class="p-absolute t-0 l-0 w-100 h-6px bgc-blue"></div>
-              <p class="m-0px mt-6px p-0px ta-center tt-uppercase fw-bold ls-0_4px fs-12px c-blue">
-                <%= Date.today.strftime("%b") %> 
-              </p>
             </div>
             <p class="m-0px p-0px ta-center fw-medium fs-16px c-blue">
               <%= t("progress_tab.monthly_report_title") %>
             </p>
           </a>
-          <a class="f-1 d-flex fd-column ai-center jc-center td-none ml-10px p-12px bgc-navy-light br-8px" href="#" onclick="goToPage('home-page', 'yearly-report-page'); return false;">
+          <a class="f-1 d-flex fd-column ai-center jc-center td-none h-96px ml-10px p-12px bgc-navy-light br-8px" href="#" onclick="goToPage('home-page', 'yearly-report-page'); return false;">
             <div class="p-relative d-flex ai-center jc-center w-32px h-32px mb-8px bgc-white br-8px o-hidden">
               <div class="p-absolute t-0 l-0 w-100 h-6px bgc-navy"></div>
-              <p class="m-0px mt-6px p-0px ta-center fw-bold fs-10px c-navy">
-                <%= Date.today.strftime("%Y") %> 
-              </p>
             </div>
             <p class="m-0px p-0px ta-center fw-medium fs-16px c-navy">
               <%= t("progress_tab.yearly_report_title") %>
@@ -66,7 +57,7 @@
         </p>
         <div class="d-flex ai-center jc-space-between">
           <a
-            class="f-1 d-flex fd-column ai-center mr-8px p-12px td-none bgc-red-light br-8px"
+            class="f-1 d-flex fd-column ai-center jc-center h-96px mr-8px p-12px td-none bgc-red-light br-8px"
             href="#"
             onclick="goToPage('home-page', 'hypertension-report'); return false;"
           >
@@ -78,7 +69,7 @@
             </p>
           </a>
           <a
-            class="f-1 d-flex fd-column ai-center ml-8px p-12px td-none bgc-purple-light br-8px"
+            class="f-1 d-flex fd-column ai-center jc-center h-96px ml-8px p-12px td-none bgc-purple-light br-8px"
             href="#"
             onclick="goToPage('home-page', 'diabetes-report'); return false;"
           >

--- a/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
@@ -19,12 +19,12 @@
     <div id="home-page">
       <div class="mb-8px p-16px bgc-white bs-card">
         <h1 class="m-0px mb-4px fw-bold fs-24px c-black">
-          <%= t("progress_tab.reports_card.title") %>
+          <%= t("progress_tab.progress_reports_card.title") %>
         </h1>
         <p class="m-0px mb-16px p-0px ta-left fw-normal fs-16px lh-150 c-grey-dark">
-          <%= t("progress_tab.reports_card.subtitle", date: DateTime.parse(@user_analytics.last_updated_at).to_date.strftime("%d-%b-%y at %I:%M %P")) %>
+          <%= t("progress_tab.progress_reports_card.subtitle") %>
         </p>
-        <div class="d-flex ai-center jc-space-between mb-16px">
+        <div class="d-flex ai-center jc-space-between">
           <a class="f-1 d-flex fd-column ai-center jc-center td-none mr-10px p-12px bgc-blue-green-light br-8px" href="#" onclick="goToPage('home-page', 'daily-report-page'); return false;">
             <div class="p-relative d-flex ai-center jc-center w-32px h-32px mb-8px bgc-white br-8px o-hidden">
               <div class="p-absolute t-0 l-0 w-100 h-6px bgc-blue-green"></div>
@@ -59,30 +59,40 @@
             </p>
           </a>
         </div>
-        <a
-          class="d-flex ai-center mb-16px p-12px td-none bgc-red-light br-8px"
-          href="#"
-          onclick="goToPage('home-page', 'hypertension-report'); return false;"
-        >
-          <div class="d-flex ai-center jc-center w-32px h-32px mr-12px bgc-white br-8px">
-            <%= inline_file("graph-red.svg") %>
-          </div>
-          <p class="m-0px p-0px ta-left fw-medium fs-16px c-red">
-            <%= t("progress_tab.hypertension_report_title") %>
-          </p>
-        </a>
-        <a
-          class="d-flex ai-center p-12px td-none bgc-purple-light br-8px"
-          href="#"
-          onclick="goToPage('home-page', 'diabetes-report'); return false;"
-        >
-          <div class="d-flex ai-center jc-center w-32px h-32px mr-12px bgc-white br-8px">
-            <%= inline_file("graph-purple.svg") %>
-          </div>
-          <p class="m-0px p-0px ta-left fw-medium fs-16px c-purple">
-            <%= t("progress_tab.diabetes_report_title") %>
-          </p>
-        </a>
+      </div>
+      <div class="mb-8px p-16px bgc-white bs-card">
+        <h1 class="m-0px mb-4px fw-bold fs-24px c-black">
+          <%= t("progress_tab.diagnosis_reports_card.title") %>
+        </h1>
+        <p class="m-0px mb-16px p-0px ta-left fw-normal fs-16px lh-150 c-grey-dark">
+          <%= t("progress_tab.diagnosis_reports_card.subtitle") %>
+        </p>
+        <div class="d-flex ai-center jc-space-between">
+          <a
+            class="f-1 d-flex fd-column ai-center mr-8px p-12px td-none bgc-red-light br-8px"
+            href="#"
+            onclick="goToPage('home-page', 'hypertension-report'); return false;"
+          >
+            <div class="d-flex ai-center jc-center w-32px h-32px mb-8px bgc-white br-8px">
+              <%= inline_file("graph-red.svg") %>
+            </div>
+            <p class="m-0px p-0px ta-left fw-medium fs-16px c-red">
+              <%= t("progress_tab.hypertension_report_title") %>
+            </p>
+          </a>
+          <a
+            class="f-1 d-flex fd-column ai-center ml-8px p-12px td-none bgc-purple-light br-8px"
+            href="#"
+            onclick="goToPage('home-page', 'diabetes-report'); return false;"
+          >
+            <div class="d-flex ai-center jc-center w-32px h-32px mb-8px bgc-white br-8px">
+              <%= inline_file("graph-purple.svg") %>
+            </div>
+            <p class="m-0px p-0px ta-left fw-medium fs-16px c-purple">
+              <%= t("progress_tab.diabetes_report_title") %>
+            </p>
+          </a>
+        </div>
       </div>
       <div class="mb-8px p-16px bgc-white bs-card">
         <div class="d-flex ai-flex-start jc-space-between mb-16px">
@@ -106,19 +116,14 @@
         %>
       </div>
       <div class="mb-8px pt-16px pb-16px bgc-white bs-card">
-        <div class="pr-16px pl-16px">
-          <h1 class="m-0px mb-8px fw-bold fs-24px">
-            <%= t("progress_tab.achievements_card.title") %>
-          </h1>
-          <p class="m-0px mb-24px p-0px ta-left fw-normal fs-16px lh-150 c-grey-dark">
-            <%= t("progress_tab.achievements_card.subtitle", facility_name: current_facility.name) %>
-          </p>
-        </div>
+        <h1 class="m-0px mb-24px pr-16px pl-16px fw-bold fs-24px">
+          <%= t("progress_tab.achievements_card.title") %>
+        </h1>
         <div class="mb-24px">
           <p class="m-0px mb-8px p-0px pl-16px ta-left fw-normal fs-16px c-black">
             <span class="fw-bold">7,051</span> <%= t("progress_tab.achievements_card.follow_up_visits_section_title", visit_or_visits: "visit".pluralize(7051)) %>
           </p>
-          <div class="ws-nowrap ox-scroll pt-4px pb-4px pl-16px d-none-scrollbar">
+          <div class="d-flex ai-center jc-space-between pt-4px pb-4px pr-16px pl-16px">
             <% follow_up_badge_goals = create_badge_array(7051) %>
             <% follow_up_badge_goals.each do |badge| %>
               <%= render partial: "api/v3/analytics/user_analytics/achievement_badge",
@@ -135,7 +140,7 @@
           <p class="m-0px mb-8px p-0px pl-16px ta-left fw-normal fs-16px c-black">
             <span class="fw-bold">2,501</span> <%= t("progress_tab.achievements_card.overdue_patients_section_title", call_or_calls: "call".pluralize(2501)) %>
           </p>
-          <div class="ws-nowrap ox-scroll pt-4px pb-4px pl-16px d-none-scrollbar">
+          <div class="d-flex ai-center jc-space-between pt-4px pb-4px pr-16px pl-16px">
             <% overdue_call_badge_goals = create_badge_array(2501) %>
             <% overdue_call_badge_goals.each do |badge| %>
               <%= render partial: "api/v3/analytics/user_analytics/achievement_badge",
@@ -152,7 +157,7 @@
           <p class="m-0px mb-8px p-0px pl-16px ta-left fw-normal fs-16px c-black">
             <span class="fw-bold">1,512</span> <%= t("progress_tab.achievements_card.registered_patients_title", patient_or_patients: "patient".pluralize(1512)) %>
           </p>
-          <div class="ws-nowrap ox-scroll pt-4px pb-4px pl-16px d-none-scrollbar">
+          <div class="d-flex ai-center jc-space-between pt-4px pb-4px pr-16px pl-16px">
             <% registered_patients_badge_goals = create_badge_array(1512) %>
             <% registered_patients_badge_goals.each do |badge| %>
               <%= render partial: "api/v3/analytics/user_analytics/achievement_badge",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,16 +101,18 @@ en:
       male: "Male"
       female: "Female"
       transgender: "Transgender"
-    reports_card:
-      title: "Reports"
-      subtitle: "Data last updated on %{date}."
+    progress_reports_card:
+      title: "Progress reports"
+      subtitle: "Data for registrations and follow-ups."
+    diagnosis_reports_card:
+      title: "Diagnosis reports"
+      subtitle: "6-month trends for registrations, follow-ups, and treatment outcomes."
     drug_stock_report_card:
       title: "Drug stock report"
       subtitle: "Submit %{facility_name}'s drug stock report for %{period}."
       button_title: "Enter drug stock"
     achievements_card:
       title: "Achievements"
-      subtitle: "%{facility_name}'s all-time progress."
       follow_up_visits_section_title: "follow-up %{visit_or_visits} recorded"
       overdue_patients_section_title: "%{call_or_calls} to overdue patients"
       registered_patients_title: "registered %{patient_or_patients}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,6 +91,7 @@ en:
     yearly_report_title: "Yearly"
     hypertension_report_title: "Hypertension"
     diabetes_report_title: "Diabetes"
+    last_updated_at: "Data last updated on %{date}"
     diagnoses:
       hypertension: "Hypertension"
       diabetes: "Diabetes"
@@ -101,12 +102,11 @@ en:
       male: "Male"
       female: "Female"
       transgender: "Transgender"
-    progress_reports_card:
-      title: "Progress reports"
-      subtitle: "Data for registrations and follow-ups."
-    diagnosis_reports_card:
-      title: "Diagnosis reports"
-      subtitle: "6-month trends for registrations, follow-ups, and treatment outcomes."
+    registrations_and_follow_ups_card:
+      title: "Registrations and follow-ups"
+    reports_card:
+      title: "Reports"
+      subtitle: "How %{facility_name} is helping patients treat their hypertension and diabetes."
     drug_stock_report_card:
       title: "Drug stock report"
       subtitle: "Submit %{facility_name}'s drug stock report for %{period}."


### PR DESCRIPTION
**Story card:** [sc-7395](https://app.shortcut.com/simpledotorg/story/7395/update-home-page)

## Because

Aarti did some user testing and there are a few UI changes to make the page easier to understand for users.

## This addresses

![image](https://user-images.githubusercontent.com/16785131/156057018-76ea8391-9cc3-4fe9-9c64-00aa21a90463.png)
Make the following UI updates to the home page:

1. Remove "Progress reports" card subtitle and rename card to "Registrations and follow-ups"
2. Create a new "Reports" card
3. Increase the height of the report card buttons "Daily, Monthly, Yearly, Hypertension, and Diabetes" to `96px`
4. Remove the inner content of the calendar icons for the "Daily, Monthly, and Yearly" buttons
5. Delete the Achievements card subtitle
6. Update the achievement badges so that only the last 5 badges appear per row
7. Update the "Daily, Monthly, Yearly, Hypertension, and Diabetes" page titles and subtitles

## Test instructions

1. Go to your local and enable the `new_progress_tab` Flipper flag
2. Go to any facility report on the Dashboard and click the "Progress report" tab
3. Use [this Figma file](https://www.figma.com/file/vmZlmlFSCOrEYzTMkqsNB8/Simple-(Production)?node-id=23263%3A39910) and make sure the home page designs and copy match the designs on your local.