### PR TITLE
Add 'Visited but no BP taken' to progress tab quarterly cohort reports

### DIFF
--- a/app/assets/stylesheets/partials/_variables.scss
+++ b/app/assets/stylesheets/partials/_variables.scss
@@ -70,6 +70,7 @@ $transparent-blue-30: rgba(0, 117, 235, 0.3);
 $green-new: #729c26;
 $yellow-new: #ffc93f;
 $yellow-dark-new: #efac00;
+$orange-new: #e77d27;
 $red-new: #bd3838;
 $blue-new: #0c3966;
 $purple-new: #60419a; 

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -915,6 +915,7 @@ footer p {
 .bgc-yellow { background-color: $yellow; }
 .bgc-yellow-new { background-color: $yellow-new; }
 .bgc-yellow-dark-new { background-color: $yellow-dark-new; }
+.bgc-orange-new { background-color: $orange-new; }
 /* BORDERS */
 .b-none { border: none; }
 .b-grey-mid { border: 1px solid $grey-mid; }

--- a/app/helpers/reports/reports_fake_facility_progress_service.rb
+++ b/app/helpers/reports/reports_fake_facility_progress_service.rb
@@ -366,8 +366,10 @@ module Reports
             "total_patients" => 227,
             "bp_controlled_rate" => 42,
             "bp_controlled_patients" => 95,
-            "bp_not_controlled_rate" => 28,
-            "bp_not_controlled_patients" => 64,
+            "bp_not_controlled_rate" => 24,
+            "bp_not_controlled_patients" => 54,
+            "visited_but_no_bp_taken_rate" => 4,
+            "visited_but_no_bp_taken_patients" => 9,
             "missed_visits_rate" => 29,
             "missed_visits_patients" => 67
           },
@@ -378,8 +380,10 @@ module Reports
             "total_patients" => 207,
             "bp_controlled_rate" => 50,
             "bp_controlled_patients" => 104,
-            "bp_not_controlled_rate" => 48,
-            "bp_not_controlled_patients" => 99,
+            "bp_not_controlled_rate" => 40,
+            "bp_not_controlled_patients" => 83,
+            "visited_but_no_bp_taken_rate" => 8,
+            "visited_but_no_bp_taken_patients" => 8,
             "missed_visits_rate" => 2,
             "missed_visits_patients" => 4
           },
@@ -392,8 +396,10 @@ module Reports
             "bp_controlled_patients" => 104,
             "bp_not_controlled_rate" => 26,
             "bp_not_controlled_patients" => 64,
-            "missed_visits_rate" => 31,
-            "missed_visits_patients" => 79
+            "visited_but_no_bp_taken_rate" => 4,
+            "visited_but_no_bp_taken_patients" => 10,
+            "missed_visits_rate" => 27,
+            "missed_visits_patients" => 67
           },
           {
             "start_period" => "Q1-2021",
@@ -404,8 +410,10 @@ module Reports
             "bp_controlled_patients" => 73,
             "bp_not_controlled_rate" => 24,
             "bp_not_controlled_patients" => 48,
-            "missed_visits_rate" => 39,
-            "missed_visits_patients" => 77
+            "visited_but_no_bp_taken_rate" => 5,
+            "visited_but_no_bp_taken_patients" => 10,
+            "missed_visits_rate" => 32,
+            "missed_visits_patients" => 63
           }
         ]
       }

--- a/app/views/api/v3/analytics/user_analytics/_data_stacked_bar_graph.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_data_stacked_bar_graph.html.erb
@@ -25,7 +25,7 @@
       </div>
       <div class="p-absolute l-0 w-auto mw-100 p-8px bgc-black br-4px" data-element-type="tooltip-copy">
         <p class="m-0px p-0px ta-left fw-regular fs-14px lh-150 c-white">
-          <%= data["bp_controlled_patients"] %> <%= "patient".pluralize(data["bp_controlled_patients"]) %> with <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_controlled_long") %>
+          <%= t("progress_tab.diagnosis_report.cohort_report.cohort_bar_tooltip", total_patients: data["bp_controlled_patioents"], patient_or_patients: "patient".pluralize(data["bp_controlled_patients"]), threshold: t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_controlled_long")) %>
         </p>
       </div>
     </div>
@@ -51,7 +51,7 @@
       </div>
       <div class="p-absolute l-0 w-auto mw-100 p-8px bgc-black br-4px" data-element-type="tooltip-copy">
         <p class="m-0px p-0px ta-left fw-regular fs-14px lh-150 c-white">
-          <%= data["bp_not_controlled_patients"] %> <%= "patient".pluralize(data["bp_not_controlled_patients"]) %> with <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_long") %>
+          <%= t("progress_tab.diagnosis_report.cohort_report.cohort_bar_tooltip", total_patients: data["bp_not_controlled_patioents"], patient_or_patients: "patient".pluralize(data["bp_not_controlled_patients"]), threshold: t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_long")) %>
         </p>
       </div>
     </div>
@@ -77,7 +77,7 @@
       </div>
       <div class="p-absolute l-0 w-auto mw-100 p-8px bgc-black br-4px" data-element-type="tooltip-copy">
         <p class="m-0px p-0px ta-left fw-regular fs-14px lh-150 c-white">
-          <%= data["visited_but_no_bp_taken_patients"] %> <%= "patient".pluralize(data["visited_but_no_bp_taken_patients"]) %> with <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_visited_but_no_bp_taken_long") %>
+          <%= t("progress_tab.diagnosis_report.cohort_report.cohort_bar_tooltip", total_patients: data["visited_but_no_bp_taken_patients"], patient_or_patients: "patient".pluralize(data["visited_but_no_bp_taken_patients"]), threshold: t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_visited_but_no_bp_taken_long")) %>
         </p>
       </div>
     </div>
@@ -103,7 +103,7 @@
       </div>
       <div class="p-absolute l-0 w-auto mw-100 p-8px bgc-black br-4px" data-element-type="tooltip-copy">
         <p class="m-0px p-0px ta-left fw-regular fs-14px lh-150 c-white">
-          <%= data["missed_visits_patients"] %> <%= "patient".pluralize(data["missed_visits_patients"]) %> with <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.missed_visits_long") %>
+          <%= t("progress_tab.diagnosis_report.cohort_report.cohort_bar_tooltip", total_patients: data["missed_visits_patients"], patient_or_patients: "patient".pluralize(data["missed_visits_patients"]), threshold: t("progress_tab.diagnosis_report.diagnosis_thresholds.missed_visits_long")) %>
         </p>
       </div>
     </div>

--- a/app/views/api/v3/analytics/user_analytics/_data_stacked_bar_graph.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_data_stacked_bar_graph.html.erb
@@ -1,10 +1,11 @@
 <% min_width = 5 %>
 <% bp_controlled = [data["bp_controlled_rate"], min_width].max %>
 <% bp_not_controlled = [data["bp_not_controlled_rate"], min_width].max %>
+<% visited_but_no_bp_taken = [data["visited_but_no_bp_taken_rate"], min_width].max %>
 <% missed_visits = [data["missed_visits_rate"], min_width].max %>
 <div class="p-relative d-flex br-4px" data-graph-type="stacked-bar-chart">
   <div
-    class="d-flex ai-center jc-center mr-2px p-16px bgc-green-new btlr-4px bblr-4px ttf-ease-in-out td-0_25s tp-opacity"
+    class="d-flex ai-center jc-center mr-1px p-16px bgc-green-new btlr-4px bblr-4px ttf-ease-in-out td-0_25s tp-opacity"
     style="width: <%= bp_controlled %>%;"
     data-graph-element="stacked-bar"
   >
@@ -24,7 +25,7 @@
       </div>
       <div class="p-absolute l-0 w-auto mw-100 p-8px bgc-black br-4px" data-element-type="tooltip-copy">
         <p class="m-0px p-0px ta-left fw-regular fs-14px lh-150 c-white">
-          <%= data["bp_controlled_patients"] %> patients with BP &lt;140/90
+          <%= data["bp_controlled_patients"] %> <%= "patient".pluralize(data["bp_controlled_patients"]) %> with <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_controlled_long") %>
         </p>
       </div>
     </div>
@@ -50,13 +51,39 @@
       </div>
       <div class="p-absolute l-0 w-auto mw-100 p-8px bgc-black br-4px" data-element-type="tooltip-copy">
         <p class="m-0px p-0px ta-left fw-regular fs-14px lh-150 c-white">
-          <%= data["bp_not_controlled_patients"] %> patients with &ge;140/90
+          <%= data["bp_not_controlled_patients"] %> <%= "patient".pluralize(data["bp_not_controlled_patients"]) %> with <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_long") %>
         </p>
       </div>
     </div>
   </div>
   <div
-    class="d-flex ai-center jc-center ml-2px p-16px bgc-red-new btrr-4px bbrr-4px ttf-ease-in-out td-0_25s tp-opacity"
+    class="d-flex ai-center jc-center ml-1px mr-1px p-16px bgc-orange-new ttf-ease-in-out td-0_25s tp-opacity"
+    style="width: <%= visited_but_no_bp_taken %>%;"
+    data-graph-element="stacked-bar"
+  >
+    <p class="m-0px p-0px ta-center fw-bold fs-16px c-white pe-none">
+      <%= data["visited_but_no_bp_taken_rate"] %>%
+    </p>
+    <div
+      class="o-0 pe-none p-absolute l-0 zi-100 d-flex fd-column w-100 bs-tooltip ttf-ease-in-out td-0_25s tp-opacity"
+      data-element-type="tooltip"
+      data-tooltip-index="1"
+      data-tooltip-length="3"
+    >
+      <div
+        class="p-absolute b--8px w-0px h-0px br-8px-transparent bl-8px-transparent bt-8px-black"
+        data-element-type="tooltip-tip"
+      >
+      </div>
+      <div class="p-absolute l-0 w-auto mw-100 p-8px bgc-black br-4px" data-element-type="tooltip-copy">
+        <p class="m-0px p-0px ta-left fw-regular fs-14px lh-150 c-white">
+          <%= data["visited_but_no_bp_taken_patients"] %> <%= "patient".pluralize(data["visited_but_no_bp_taken_patients"]) %> with <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_visited_but_no_bp_taken_long") %>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    class="d-flex ai-center jc-center ml-1px p-16px bgc-red-new btrr-4px bbrr-4px ttf-ease-in-out td-0_25s tp-opacity"
     style="width: <%= missed_visits %>%;"
     data-graph-element="stacked-bar"
   >
@@ -76,7 +103,7 @@
       </div>
       <div class="p-absolute l-0 w-auto mw-100 p-8px bgc-black br-4px" data-element-type="tooltip-copy">
         <p class="m-0px p-0px ta-left fw-regular fs-14px lh-150 c-white">
-          <%= data["missed_visits_patients"] %> patients with no visit
+          <%= data["missed_visits_patients"] %> <%= "patient".pluralize(data["missed_visits_patients"]) %> with <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.missed_visits_long") %>
         </p>
       </div>
     </div>

--- a/app/views/api/v3/analytics/user_analytics/_diagnosis_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_diagnosis_report.html.erb
@@ -295,6 +295,12 @@
             <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_short") %>
           </p>
         </div>
+        <div class="d-flex ai-center jc-center mb-8px">
+          <div class="w-16px h-16px mr-8px br-4px bgc-orange-new"></div>
+          <p class="f-1 m-0px p-0px ta-left fw-regular fs-14px c-black">
+            <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_visited_but_no_bp_taken_short") %>
+          </p>
+        </div>
         <div class="d-flex ai-center jc-center">
           <div class="w-16px h-16px mr-8px br-4px bgc-red-new"></div>
           <p class="f-1 m-0px p-0px ta-left fw-regular fs-14px c-black">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,8 @@ en:
         diabetes_uncontrolled_long: "RBS/PPBS 200-99, FBS 126-199, or HbA1c 7.0-8.9"
         diabetes_very_uncontrolled_short: "BS ≥300"
         diabetes_very_uncontrolled_long: "RBS/PPBS ≥300, FBS ≥200, or HbA1c ≥9.0"
+        hypertension_visited_but_no_bp_taken_short: "Visited but no BP taken"
+        hypertension_visited_but_no_bp_taken_long: "no BP taken"
         missed_visits_short: "Missed visits"
         missed_visits_long: "no visit"
       assigned_patients_card:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -185,6 +185,7 @@ en:
         card_subtitle: "The result for all assigned hypertensive patients registered in a quarter at their follow-up visit in the following two quarters."
         cohort_title: "Result from last visit in %{start_period}/%{end_period}"
         cohort_subtitle: "%{number_of_patients} %{patient_or_patients} registered in %{registration_period}"
+        cohort_bar_tooltip: "%{total_patients} %{patient_or_patients} with %{threshold}"
 
   admin:
     reset_otp_alert: 'Are you sure you want to reset the OTP? This will invalidate the previous OTP and a SMS will be sent to the user with the new OTP'


### PR DESCRIPTION
**Story card:** [sc-7455](https://app.shortcut.com/simpledotorg/story/7455/add-visited-but-no-bp-taken-stacked-bar-chart-to-quarterly-cohort-reports?vc_group_by=day&cf_workflow=500000031&ct_workflow=all)

## Because

We are now showing "Visited but no BP taken" on the Dashboard.

## This addresses

![image](https://user-images.githubusercontent.com/16785131/156068329-bb6f7310-89b3-4056-857c-717396e34e2f.png)
Adds a new "Visited but no BP taken" bar chart to the quarterly cohort reports and adds a new legend item.

## Test instructions

1. Add the `new_progress_tab` Flipper flag to your local
2. Go to any facility report page on the Dashboard and click the "Progress report" tab
3. Open your inspector tools and view the page on a mobile device
4. Click the "Hypertension" report, scroll down to the cohort reports section and click around the bars. Make sure the copy is accurate and the tooltips work.