### PR TITLE
Don't schedule a fallback when message delivery fails

### DIFF
--- a/app/controllers/api/v3/twilio_sms_delivery_controller.rb
+++ b/app/controllers/api/v3/twilio_sms_delivery_controller.rb
@@ -12,13 +12,6 @@ class Api::V3::TwilioSmsDeliveryController < ApplicationController
     event = [communication_type, twilio_message.result].join(".")
     metrics.increment(event)
 
-    notification = twilio_message.communication.notification
-
-    if twilio_message.unsuccessful? && notification&.next_communication_type
-      notification.status_scheduled!
-      AppointmentNotification::Worker.perform_at(Communication.next_messaging_time, notification.id)
-    end
-
     head :ok
   end
 

--- a/app/jobs/appointment_notification/worker.rb
+++ b/app/jobs/appointment_notification/worker.rb
@@ -29,7 +29,7 @@ class AppointmentNotification::Worker
   private
 
   def send_message(notification, recipient_number)
-    communication_type = notification.next_communication_type
+    communication_type = "sms"
     logger.info "send_message for notification #{notification.id} communication_type=#{communication_type}"
     context = {
       calling_class: self.class.name,
@@ -112,12 +112,6 @@ class AppointmentNotification::Worker
   end
 
   def valid_notification?(notification)
-    unless notification.next_communication_type
-      logger.info "skipping notification #{notification.id}, no next communication type"
-      metrics.increment("skipped.no_next_communication_type")
-      return
-    end
-
     unless notification.status_scheduled?
       logger.info "skipping notification #{notification.id}, scheduled already"
       metrics.increment("skipped.not_scheduled")

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -155,14 +155,6 @@ class Appointment < ApplicationRecord
      remind_on: remind_on}
   end
 
-  def previously_communicated_via?(communication_type)
-    latest_notification = notifications.includes(:communications)
-      .where(communications: {communication_type: communication_type})
-      .order(created_at: :desc)
-      .first
-    latest_notification&.communications&.any? { |c| c.attempted? }
-  end
-
   private
 
   def cancel_reason_is_present_if_cancelled

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -97,28 +97,4 @@ class Notification < ApplicationRecord
       :failed
     end
   end
-
-  def next_communication_type
-    return nil if status_cancelled?
-    if preferred_communication_method && !previously_communicated_by?(preferred_communication_method)
-      return preferred_communication_method
-    end
-    return backup_communication_method unless previously_communicated_by?(backup_communication_method)
-    nil
-  end
-
-  private
-
-  def previously_communicated_by?(method)
-    communications.any? { |communication| communication.communication_type == method }
-  end
-
-  def preferred_communication_method
-    return "whatsapp" if Flipper.enabled?(:whatsapp_appointment_reminders)
-    nil
-  end
-
-  def backup_communication_method
-    "sms"
-  end
 end

--- a/spec/controllers/api/v3/twilio_sms_delivery_controller_spec.rb
+++ b/spec/controllers/api/v3/twilio_sms_delivery_controller_spec.rb
@@ -147,9 +147,8 @@ RSpec.describe Api::V3::TwilioSmsDeliveryController, type: :controller do
           post :create, params: params
         end
 
-        it "logs failure and schedules a new attempt if the first attempt failed and there is a next communication type" do
+        it "logs failure if the attempt failed" do
           session_id = SecureRandom.uuid
-          fallback_time = 5.minutes.from_now
           notification = create(:notification)
           communication = create(:communication, :whatsapp, notification: notification)
           create(:twilio_sms_delivery_detail, session_id: session_id, result: "queued", communication: communication)
@@ -160,16 +159,9 @@ RSpec.describe Api::V3::TwilioSmsDeliveryController, type: :controller do
           )
           set_twilio_signature_header(callback_url, params)
 
-          allow(Communication).to receive(:next_messaging_time).and_return(fallback_time)
-          expect(AppointmentNotification::Worker).to receive(:perform_at).with(
-            fallback_time,
-            communication.notification.id
-          )
           expect(Statsd.instance).to receive(:increment).with("twilio_callback.whatsapp.failed")
 
           post :create, params: params
-
-          expect(communication.notification.reload.status).to eq("scheduled")
         end
 
         context "For communication with no appointment" do

--- a/spec/jobs/appointment_notification/worker_spec.rb
+++ b/spec/jobs/appointment_notification/worker_spec.rb
@@ -64,47 +64,6 @@ RSpec.describe AppointmentNotification::Worker, type: :job do
       }.to change { Communication.count }.by(1)
     end
 
-    it "sends a whatsapp message when notification's next_communication_type is whatsapp" do
-      mock_successful_delivery
-      allow_any_instance_of(Notification).to receive(:next_communication_type).and_return("whatsapp")
-
-      expect(Statsd.instance).to receive(:increment).with("appointment_notification.worker.sent.whatsapp")
-      expect_any_instance_of(TwilioApiService).to receive(:send_whatsapp)
-      described_class.perform_async(notification.id)
-      described_class.drain
-    end
-
-    it "sends sms when notification's next_communication_type is sms" do
-      mock_successful_delivery
-      allow_any_instance_of(Notification).to receive(:next_communication_type).and_return("sms")
-
-      expect(Statsd.instance).to receive(:increment).with("appointment_notification.worker.sent.sms")
-      expect_any_instance_of(TwilioApiService).to receive(:send_sms)
-      described_class.perform_async(notification.id)
-      described_class.drain
-    end
-
-    it "does not send a communication when notification's next_communication_type is nil" do
-      mock_successful_delivery
-      allow_any_instance_of(Notification).to receive(:next_communication_type).and_return(nil)
-
-      expect(Statsd.instance).to receive(:increment).with("appointment_notification.worker.skipped.no_next_communication_type")
-      expect {
-        described_class.perform_async(notification.id)
-        described_class.drain
-      }.not_to change { Communication.count }
-    end
-
-    it "raises an error when next_communication_type is not supported" do
-      allow_any_instance_of(Notification).to receive(:next_communication_type).and_return("aol_instant_messenger")
-
-      expect {
-        described_class.perform_async(notification.id)
-        described_class.drain
-      }.to raise_error(StandardError)
-        .with_message("AppointmentNotification::Worker is not configured to handle communication type aol_instant_messenger")
-    end
-
     it "creates a Communication with twilio response status and sid" do
       mock_successful_delivery
 
@@ -225,7 +184,6 @@ RSpec.describe AppointmentNotification::Worker, type: :job do
         allow(ENV).to receive(:fetch).and_call_original
         allow(ENV).to receive(:fetch).with("TWILIO_APPOINTMENT_REMINDER_NUMBERS", "").and_return("+testnumber111,+testnumber222,+testnumber333")
         experiment = create(:experiment)
-        allow_any_instance_of(Notification).to receive(:next_communication_type).and_return("sms")
         allow_any_instance_of(Notification).to receive(:experiment).and_return(experiment)
 
         expect(TwilioApiService).to receive(:new).with(sms_sender: /testnumber/).and_call_original
@@ -239,7 +197,6 @@ RSpec.describe AppointmentNotification::Worker, type: :job do
         allow(ENV).to receive(:fetch).and_call_original
         allow(ENV).to receive(:fetch).with("TWILIO_APPOINTMENT_REMINDER_NUMBERS", "").and_return("")
         experiment = create(:experiment, experiment_type: "medication_reminder")
-        allow_any_instance_of(Notification).to receive(:next_communication_type).and_return("sms")
         allow_any_instance_of(Notification).to receive(:experiment).and_return(experiment)
 
         expect(TwilioApiService).to receive(:new).with(sms_sender: nil).and_call_original

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -315,49 +315,6 @@ describe Appointment, type: :model do
     end
   end
 
-  describe "#previously_communicated_via" do
-    let(:overdue_appointment) do
-      create(:appointment,
-        scheduled_date: 31.days.ago,
-        status: :scheduled)
-    end
-
-    it "returns falsey if there are no communications for the appointment" do
-      expect(overdue_appointment.previously_communicated_via?(:sms)).to be_falsey
-    end
-
-    it "returns falsey if there are non sms communications for the appointment" do
-      notification = create(:notification, subject: overdue_appointment)
-      create(:communication,
-        communication_type: :voip_call,
-        appointment: overdue_appointment,
-        notification: notification)
-
-      expect(overdue_appointment.previously_communicated_via?(:sms)).to be_falsey
-    end
-
-    it "returns true if followup reminder SMS for the appointment was unsuccessful" do
-      notification = create(:notification, subject: overdue_appointment)
-      notification.communications << create(:communication,
-        :sms,
-        appointment: overdue_appointment,
-        detailable: create(:twilio_sms_delivery_detail, :undelivered))
-
-      expect(overdue_appointment.previously_communicated_via?(:sms)).to eq(false)
-    end
-
-    it "returns false if followup reminder SMS for the appointment were successful" do
-      notification = create(:notification, subject: overdue_appointment)
-      notification.communications << create(:communication,
-        :sms,
-        appointment_id: overdue_appointment.id,
-        notification: notification,
-        detailable: create(:twilio_sms_delivery_detail, :delivered))
-
-      expect(overdue_appointment.reload.previously_communicated_via?(:sms)).to eq(true)
-    end
-  end
-
   context "anonymised data for appointments" do
     describe "anonymized_data" do
       it "correctly retrieves the anonymised data for an appointment" do

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -59,43 +59,6 @@ describe Notification, type: :model do
     end
   end
 
-  describe "#next_communication_type" do
-    context "when WhatsApp flag is on" do
-      before { Flipper.enable(:whatsapp_appointment_reminders) }
-
-      it "returns whatsapp if it has no whatsapp communications" do
-        expect(notification.next_communication_type).to eq("whatsapp")
-      end
-
-      it "returns sms if it has a whatsapp communication but no sms communication" do
-        create(:communication, communication_type: "whatsapp", notification: notification)
-        expect(notification.next_communication_type).to eq("sms")
-      end
-
-      it "returns nil if it has both a whatsapp and sms communication" do
-        create(:communication, communication_type: "whatsapp", notification: notification)
-        create(:communication, communication_type: "sms", notification: notification)
-        expect(notification.next_communication_type).to eq(nil)
-      end
-    end
-
-    context "when WhatsApp flag is off" do
-      it "returns sms if it has no sms communication" do
-        expect(notification.next_communication_type).to eq("sms")
-      end
-
-      it "returns nil if it has an sms communication" do
-        create(:communication, communication_type: "sms", notification: notification)
-        expect(notification.next_communication_type).to eq(nil)
-      end
-    end
-
-    it "returns nil when notification is cancelled" do
-      notification.status_cancelled!
-      expect(notification.next_communication_type).to eq(nil)
-    end
-  end
-
   describe "#delivery_result" do
     it "is failed if no successful deliveries are present" do
       notification = create(:notification)


### PR DESCRIPTION
**Story card:** [sc-7503](https://app.shortcut.com/simpledotorg/story/7503/remove-fallback-for-failed-messages)

## Because
We don't use whatsapp for sending reminders at the moment

## This addresses
Removes code that scheduled fallback SMSes for failed whatsapp messages 