### PR TITLE
Progress tab fixes

### DIFF
--- a/app/assets/javascripts/standalone/progress_tab.js
+++ b/app/assets/javascripts/standalone/progress_tab.js
@@ -71,27 +71,29 @@ function handleBarTouchEnd(event) {
 }
 
 // Card header tooltip interactions
-const helpCircles = document.querySelectorAll("[data-element-type='help-circle']");
-helpCircles.forEach(helpCircle => {
-  helpCircle.addEventListener("touchstart", handleHelpCircleTouchStart, false);
-  helpCircle.addEventListener("touchend", handleHelpCircleTouchEnd, false);
+const headerTitles = document.querySelectorAll("[data-element-type='header-title']");
+headerTitles.forEach(headerTitle => {
+  headerTitle.addEventListener("touchstart", handleHeaderTitleTouchStart, false);
+  headerTitle.addEventListener("touchend", handleHeaderTitleTouchEnd, false);
 });
 
-function handleHelpCircleTouchStart(event) {
+function handleHeaderTitleTouchStart(event) {
   event.preventDefault();
 
   const header = event.target.parentElement;
+  const headerTitle = header.querySelector("[data-element-type='header-title']");
   const helpCircle = header.querySelector("[data-element-type='help-circle']");
   const tooltip = header.querySelector("[data-element-type='tooltip']");
   const tooltipTip = header.querySelector("[data-element-type='tip']");
 
   tooltip.classList.remove("o-0");
-  tooltip.style.top = `${helpCircle.offsetTop + helpCircle.offsetHeight + tooltipTip.offsetHeight + 4}px`;
+  tooltip.style.top = `${headerTitle.offsetTop - tooltip.offsetHeight - 8}px`;
+  tooltip.style.left = `${headerTitle.offsetLeft}px`;
 
-  tooltipTip.style.left = `${helpCircle.offsetLeft + 2}px`;
+  tooltipTip.style.left = `${helpCircle.offsetLeft}px`;
 }
 
-function handleHelpCircleTouchEnd(event) {
+function handleHeaderTitleTouchEnd(event) {
   event.preventDefault();
 
   const header = event.target.parentElement.parentElement;

--- a/app/assets/stylesheets/partials/_variables.scss
+++ b/app/assets/stylesheets/partials/_variables.scss
@@ -70,6 +70,7 @@ $transparent-blue-30: rgba(0, 117, 235, 0.3);
 $green-new: #729c26;
 $yellow-new: #ffc93f;
 $yellow-dark-new: #efac00;
+$brown-new: #886b00;
 $orange-new: #e77d27;
 $red-new: #bd3838;
 $blue-new: #0c3966;

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -865,7 +865,6 @@ footer p {
 .fw-bold { font-weight: 700; } 
 .fw-medium { font-weight: 500; }
 .fw-regular { font-weight: 400; }
-.fs-10px { font-size: 10px; }
 .fs-12px { font-size: 12px; }
 .fs-14px { font-size: 14px; }
 .fs-16px { font-size: 16px; }

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -950,8 +950,12 @@ footer p {
 /* BOX SHADOWS */
 .bs-card { box-shadow: 0px 2px 4px $transparent-black-10; }
 .bs-fixed-card { box-shadow: 0px -2px 8px $transparent-black-10; }
-.bs-primary-button { box-shadow: 0px 4px 0px $blue-dark; }
-.bs-secondary-button { box-shadow: 0px 4px 0px $blue-mid; }
+.bs-primary-button {
+  box-shadow: 0 2px 2px $transparent-black-5, 0px 2px 0px $blue-dark;
+}
+.bs-secondary-button {
+  box-shadow: 0 2px 2px $transparent-black-5, 0px 2px 0px $blue-mid;
+}
 .bs-tooltip { box-shadow: 0px 2px 8px $transparent-black-10; }
 /* FORM FIELDS */
 .bs-border-box { box-sizing: border-box; }

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -806,6 +806,7 @@ footer p {
 .w-40px { width: 40px; }
 .w-48px { width: 48px; }
 .w-56px { width: 56px; }
+.w-76px { width: 76px; }
 .w-96px { width: 96px; }
 .w-95 { width: 95%; }
 .w-100 { width: 100%; }
@@ -823,6 +824,7 @@ footer p {
 .h-40px { height: 40px; }
 .h-48px { height: 48px; }
 .h-64px { height: 64px; }
+.h-76px { height: 76px; }
 .h-96px { height: 96px; }
 .h-160px { height: 160px; }
 /* SPACING */

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -771,7 +771,7 @@ footer p {
 .ai-flex-start { align-items: flex-start; }
 .jc-space-between { justify-content: space-between; }
 .jc-center { justify-content: center; }
-.jc-end { justify-content: end; }
+.jc-flex-end { justify-content: flex-end; }
 .f-1 { flex: 1; }
 .f-2 { flex: 2; }
 /* POSITION */

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -831,6 +831,7 @@ footer p {
 .mt-6px { margin-top: 6px; }
 .mt-16px { margin-top: 16px; }
 .mt-24px { margin-top: 24px; }
+.mt-48px { margin-top: 48px; }
 .mr-1px { margin-right: 1px; }
 .mr-2px { margin-right: 2px; }
 .mr-8px { margin-right: 8px; }

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -817,6 +817,7 @@ footer p {
 .h-6px { height: 6px; }
 .h-8px { height: 4px; }
 .h-16px { height: 16px; }
+.h-24px { height: 24px; }
 .h-32px { height: 32px; }
 .h-40px { height: 40px; }
 .h-64px { height: 64px; }

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -897,6 +897,7 @@ footer p {
 .c-grey-darkest { color: $grey-darkest; }
 .c-white { color: $white; }
 .c-black { color: $black; }
+.c-brown-new { color:$brown-new; }
 /* BACKGROUND COLORS */
 .bgc-grey-light { background: $grey-light; }
 .bgc-white { background-color: $white; }
@@ -935,6 +936,7 @@ footer p {
 .bl-8px-transparent { border-left: 8px solid $transparent-black-0; }
 .bt-8px-black { border-top: 8px solid $black; }
 .bb-8px-black { border-bottom: 8px solid $black; }
+.br-1px { border-radius: 1px; }
 .br-2px { border-radius: 2px; }
 .br-4px { border-radius: 4px; }
 .br-8px { border-radius: 8px; }
@@ -951,10 +953,10 @@ footer p {
 .bs-card { box-shadow: 0px 2px 4px $transparent-black-10; }
 .bs-fixed-card { box-shadow: 0px -2px 8px $transparent-black-10; }
 .bs-primary-button {
-  box-shadow: 0 2px 2px $transparent-black-5, 0px 2px 0px $blue-dark;
+  box-shadow: 0 2px 2px $transparent-black-16;
 }
 .bs-secondary-button {
-  box-shadow: 0 2px 2px $transparent-black-5, 0px 2px 0px $blue-mid;
+  box-shadow: 0 2px 2px $transparent-black-16;
 }
 .bs-tooltip { box-shadow: 0px 2px 8px $transparent-black-10; }
 /* FORM FIELDS */

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -885,6 +885,8 @@ footer p {
 .c-green { color: $green; }
 .c-green-new { color: $green-new; }
 .c-yellow { color: $yellow; }
+.c-yellow-dark-new { color: $yellow-dark-new; }
+.c-orange-new { color: $orange-new; }
 .c-red { color: $red; }
 .c-red-new { color: $red-new; }
 .c-lavander { color: $lavander; }

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -804,6 +804,7 @@ footer p {
 .w-24px { width: 24px; }
 .w-32px { width: 32px; }
 .w-40px { width: 40px; }
+.w-48px { width: 48px; }
 .w-56px { width: 56px; }
 .w-96px { width: 96px; }
 .w-95 { width: 95%; }
@@ -820,6 +821,7 @@ footer p {
 .h-24px { height: 24px; }
 .h-32px { height: 32px; }
 .h-40px { height: 40px; }
+.h-48px { height: 48px; }
 .h-64px { height: 64px; }
 .h-96px { height: 96px; }
 .h-160px { height: 160px; }
@@ -842,6 +844,7 @@ footer p {
 .pt-4px { padding-top: 4px; }
 .pt-16px { padding-top: 16px; }
 .pr-16px { padding-right: 16px; }
+.pr-48px { padding-right: 48px; }
 .pb-3px { padding-bottom: 3px; }
 .pb-4px { padding-bottom: 4px; }
 .pb-12px { padding-bottom: 12px; }

--- a/app/helpers/my_facilities_helper.rb
+++ b/app/helpers/my_facilities_helper.rb
@@ -19,14 +19,14 @@ module MyFacilitiesHelper
     end
   end
 
-  def patient_days_css_class(patient_days, prefix: "bg")
+  def patient_days_css_class(patient_days, prefix: "bgc")
     return if patient_days.nil?
     color = if patient_days == "error" then :red
     elsif patient_days < 30 then "red-new"
     elsif patient_days < 60 then "orange-new"
     elsif patient_days < 90 then "yellow-dark-new"
     else
-      :green
+      "green-new"
     end
     "#{prefix}-#{color}"
   end

--- a/app/helpers/my_facilities_helper.rb
+++ b/app/helpers/my_facilities_helper.rb
@@ -22,9 +22,9 @@ module MyFacilitiesHelper
   def patient_days_css_class(patient_days, prefix: "bg")
     return if patient_days.nil?
     color = if patient_days == "error" then :red
-    elsif patient_days < 30 then :red
-    elsif patient_days < 60 then :orange
-    elsif patient_days < 90 then "yellow-dark"
+    elsif patient_days < 30 then "red-new"
+    elsif patient_days < 60 then "orange-new"
+    elsif patient_days < 90 then "yellow-dark-new"
     else
       :green
     end

--- a/app/views/api/v3/analytics/user_analytics/_achievement_badge.erb
+++ b/app/views/api/v3/analytics/user_analytics/_achievement_badge.erb
@@ -1,12 +1,12 @@
-<div class="d-inline-flex fd-column ai-center jc-center w-56px h-64px <% if is_goal_completed %>bgc-<%= badge_color %>-light<% else %>bgc-white b-grey-mid<% end %> br-10px">
-  <div class="p-relative t--3px d-flex ai-center jc-center w-40px h-40px br-100 <% if is_goal_completed %>bgc-<%= badge_color %><% else %>bgc-white b-grey-mid<% end %>">
+<div class="d-inline-flex fd-column ai-center jc-center w-56px h-64px <% if is_goal_completed %><%= badge_color %><% else %>bgc-white b-grey-mid<% end %> br-10px">
+  <div class="p-relative t--3px d-flex ai-center jc-center w-40px h-40px br-100 <% if is_goal_completed %><%= circle_color %><% else %>bgc-white b-grey-mid<% end %>">
     <% if is_goal_completed %>
       <%= inline_file(icon_completed) %>
     <% else %>
       <%= inline_file(icon_goal) %>
     <% end %>
   </div>
-  <p class="m-0px p-0px ta-center ff-fredoka-one <% if value >= 100000 %>fs-12px<% elsif value >= 10000 %>fs-16px<% else %>fs-18px<% end %> <% if is_goal_completed %>c-<%= badge_color %><% else %>c-grey-mid<% end %>">
+  <p class="m-0px p-0px ta-center ff-fredoka-one <% if value >= 100000 %>fs-12px<% elsif value >= 10000 %>fs-16px<% else %>fs-18px<% end %> <% if is_goal_completed %><%= text_color %><% else %>c-grey-mid<% end %>">
     <%= number_with_delimiter(value) %>
   </p>
 </div>

--- a/app/views/api/v3/analytics/user_analytics/_data_bar_graph.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_data_bar_graph.html.erb
@@ -33,7 +33,7 @@
   </div>
   <div class="d-flex ai-center jc-space-between pt-12px bt-grey-mid">
     <% data.each do |data_point| %>
-      <p class="f-1 m-0px p-0px ta-center fw-bold fs-10px c-grey-dark">
+      <p class="f-1 m-0px p-0px ta-center fw-medium fs-12px c-grey-dark">
         <%= data_point["month"] %>
       </p>
     <% end %>

--- a/app/views/api/v3/analytics/user_analytics/_data_bar_graph.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_data_bar_graph.html.erb
@@ -4,7 +4,7 @@
 <div class="d-flex fd-column h-160px">
   <div class="p-relative f-1 d-flex" data-graph-type="bar-chart" data-with-tooltip="<%= show_tooltip %>">
     <% data.each_with_index do |data_point, index| %>
-      <div class="f-1 d-flex fd-column ai-center jc-end" data-graph-element="bar">
+      <div class="f-1 d-flex fd-column ai-center jc-flex-end" data-graph-element="bar">
         <p class="m-0px mb-8px p-0px ta-center fw-medium fs-16px c-black ttf-ease-in-out td-0_25s tp-color" data-element-type="text">
           <%= data_point["value"] %><% if data_type == "percentage" %>%<% end %>
         </p>

--- a/app/views/api/v3/analytics/user_analytics/_diagnosis_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_diagnosis_report.html.erb
@@ -65,7 +65,7 @@
     <%= render partial: "api/v3/analytics/user_analytics/data_bar_graph", locals: { data: diagnosis_data["monthly_follow_up_patients"]["breakdown"], data_type: diagnosis_data["monthly_follow_up_patients"]["data_type"], graph_css_color: "bgc-blue-new", show_tooltip: false } %>
   </div>
   <div class="mt-24px mb-8px pr-16px pl-16px">
-    <h3 class="m-0px p-0px ta-left fw-bold fs-20px c-grey">
+    <h3 class="m-0px p-0px ta-left fw-bold fs-20px c-grey-dark">
       <%= t("progress_tab.diagnosis_report.patient_treatment_outcomes.section_title") %>
     </h3>
   </div>
@@ -215,7 +215,7 @@
   </div>
   <% if report_diagnosis == "Hypertension" %>
     <div class="mt-24px mb-8px pr-16px pl-16px">
-      <h3 class="m-0px p-0px ta-left fw-bold fs-20px c-grey">
+      <h3 class="m-0px p-0px ta-left fw-bold fs-20px c-grey-dark">
         <%= t("progress_tab.diagnosis_report.drug_stock_report.section_title") %>
       </h3>
     </div>
@@ -244,7 +244,7 @@
       <h3 class="m-0px mb-2px p-0px ta-left fw-medium fs-20px c-black">
         <%= diagnosis_data["arb_tablets"]["name"] %>
       </h3>
-      <p class="m-0px mb-16px p-0px ta-left fw-regular fs-16px lh-150 c-yellow <%= patient_days_css_class(diagnosis_data['arb_tablets']['days_of_drugs_left'], prefix: 'c') %>">
+      <p class="m-0px mb-16px p-0px ta-left fw-regular fs-16px lh-150 c-yellow-dark-new <%= patient_days_css_class(diagnosis_data['arb_tablets']['days_of_drugs_left'], prefix: 'c') %>">
         <%= diagnosis_data["arb_tablets"]["days_of_drugs_left"] %> <%= "day".pluralize(diagnosis_data["arb_tablets"]["days_of_drugs_left"]) %> of tablets in stock
       </p>
       <% diagnosis_data["arb_tablets"]["breakdown"].each_with_index do |drug, index| %>
@@ -283,7 +283,7 @@
       <% end %>
     </div>
     <div class="mt-24px mb-8px pr-16px pl-16px">
-      <h3 class="m-0px p-0px ta-left fw-bold fs-20px c-grey">
+      <h3 class="m-0px p-0px ta-left fw-bold fs-20px c-grey-dark">
         <%= t("progress_tab.diagnosis_report.cohort_report.section_title") %>
       </h3>
     </div>

--- a/app/views/api/v3/analytics/user_analytics/_diagnosis_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_diagnosis_report.html.erb
@@ -64,7 +64,7 @@
     </p>
     <%= render partial: "api/v3/analytics/user_analytics/data_bar_graph", locals: { data: diagnosis_data["monthly_follow_up_patients"]["breakdown"], data_type: diagnosis_data["monthly_follow_up_patients"]["data_type"], graph_css_color: "bgc-blue-new", show_tooltip: false } %>
   </div>
-  <div class="mt-24px mb-8px pr-16px pl-16px">
+  <div class="mt-48px mb-8px pr-16px pl-16px">
     <h3 class="m-0px p-0px ta-left fw-bold fs-20px c-grey-dark">
       <%= t("progress_tab.diagnosis_report.patient_treatment_outcomes.section_title") %>
     </h3>
@@ -214,7 +214,7 @@
     <%= render partial: "api/v3/analytics/user_analytics/data_bar_graph", locals: { data: diagnosis_data["missed_visits"]["breakdown"], data_type: diagnosis_data["missed_visits"]["data_type"], graph_css_color: "bgc-red-new", show_tooltip: true, threshold: t("progress_tab.diagnosis_report.diagnosis_thresholds.missed_visits_long") } %>
   </div>
   <% if report_diagnosis == "Hypertension" %>
-    <div class="mt-24px mb-8px pr-16px pl-16px">
+    <div class="mt-48px mb-8px pr-16px pl-16px">
       <h3 class="m-0px p-0px ta-left fw-bold fs-20px c-grey-dark">
         <%= t("progress_tab.diagnosis_report.drug_stock_report.section_title") %>
       </h3>
@@ -282,7 +282,7 @@
         <% end %>
       <% end %>
     </div>
-    <div class="mt-24px mb-8px pr-16px pl-16px">
+    <div class="mt-48px mb-8px pr-16px pl-16px">
       <h3 class="m-0px p-0px ta-left fw-bold fs-20px c-grey-dark">
         <%= t("progress_tab.diagnosis_report.cohort_report.section_title") %>
       </h3>

--- a/app/views/api/v3/analytics/user_analytics/_diagnosis_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_diagnosis_report.html.erb
@@ -1,6 +1,10 @@
 <div id="<%= page_id %>" class="d-none">
   <div class="mb-8px pt-16px pb-16px bgc-white bs-card">
-    <a class="d-block pl-16px mb-24px" href="#" onclick="goToPage('<%= page_id %>', 'home-page'); return false;">
+    <a
+      class="d-block w-24px h-24px mb-24px pl-16px"
+      href="#"
+      onclick="goToPage('<%= page_id %>', 'home-page'); return false;"
+    >
       <div class="d-inline-block">
         <%= inline_file("chevron-left.svg") %>
       </div>

--- a/app/views/api/v3/analytics/user_analytics/_diagnosis_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_diagnosis_report.html.erb
@@ -71,21 +71,18 @@
   </div>
   <div class="mb-8px p-16px bgc-white bs-card">
     <div class="p-relative d-flex ai-center mb-8px" data-element-type="header">
-      <h2 class="m-0px mr-8px p-0px ta-left fw-medium fs-18px c-black">
-        <%= controlled_title = report_diagnosis == "Hypertension" ? t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_controlled_short") : t("progress_tab.diagnosis_report.diagnosis_thresholds.diabetes_controlled_short") %>
-      </h2>
-      <div class="d-flex ai-center w-16px h-16px" data-element-type="help-circle">
-        <%= inline_file("help-circle.svg") %>
+      <div class="d-flex ai-center" data-element-type="header-title">
+        <h2 class="m-0px mr-8px p-0px ta-left fw-medium fs-18px c-black pe-none">
+          <%= controlled_title = report_diagnosis == "Hypertension" ? t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_controlled_short") : t("progress_tab.diagnosis_report.diagnosis_thresholds.diabetes_controlled_short") %>
+        </h2>
+        <div class="d-flex ai-center w-16px h-16px pe-none" data-element-type="help-circle">
+          <%= inline_file("help-circle.svg") %>
+        </div>
       </div>
       <div
         class="o-0 pe-none p-absolute l-0 zi-100 d-flex fd-column w-100 bs-tooltip ttf-ease-in-out td-0_25s tp-opacity" 
         data-element-type="tooltip"
       >
-        <div
-          class="p-absolute t--8px l-8px w-0px h-0px br-8px-transparent bl-8px-transparent bb-8px-black"
-          data-element-type="tip"
-        >
-        </div>
         <div class="p-8px bgc-black br-4px">
           <% controlled_threshold_long = report_diagnosis == "Hypertension" ? t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_controlled_long") : t("progress_tab.diagnosis_report.diagnosis_thresholds.diabetes_controlled_long") %>
           <p class="m-0px mb-4px p-0px ta-left fw-regular fs-14px lh-150 c-white">
@@ -94,6 +91,11 @@
           <p class="m-0px p-0px ta-left fw-regular fs-14px lh-150 c-white">
             <span class="fw-bold">Denominator:</span> <%= t("progress_tab.diagnosis_report.patient_treatment_outcomes.controlled_card.help_tooltip.denominator", facility_name: current_facility.name, diagnosis: report_diagnosis) %>
           </p>
+        </div>
+        <div
+          class="p-absolute b--8px w-0px h-0px br-8px-transparent bl-8px-transparent bt-8px-black"
+          data-element-type="tip"
+        >
         </div>
       </div>
     </div>
@@ -106,21 +108,18 @@
   </div>
   <div class="mb-8px p-16px bgc-white bs-card">
     <div class="p-relative d-flex ai-center mb-8px" data-element-type="header">
-      <h2 class="m-0px mr-8px p-0px ta-left fw-medium fs-18px c-black">
-        <%= uncontrolled_title = report_diagnosis == "Hypertension" ? t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_short") : t("progress_tab.diagnosis_report.diagnosis_thresholds.diabetes_uncontrolled_short") %>
-      </h2>
-      <div class="d-flex ai-center w-16px h-16px" data-element-type="help-circle">
-        <%= inline_file("help-circle.svg") %>
+      <div class="d-flex ai-center" data-element-type="header-title">
+        <h2 class="m-0px mr-8px p-0px ta-left fw-medium fs-18px c-black pe-none">
+          <%= uncontrolled_title = report_diagnosis == "Hypertension" ? t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_short") : t("progress_tab.diagnosis_report.diagnosis_thresholds.diabetes_uncontrolled_short") %>
+        </h2>
+        <div class="d-flex ai-center w-16px h-16px pe-none" data-element-type="help-circle">
+          <%= inline_file("help-circle.svg") %>
+        </div>
       </div>
       <div
         class="o-0 pe-none p-absolute l-0 zi-100 d-flex fd-column w-100 bs-tooltip ttf-ease-in-out td-0_25s tp-opacity"
         data-element-type="tooltip"
       >
-        <div
-          class="p-absolute t--8px l-8px w-0px h-0px br-8px-transparent bl-8px-transparent bb-8px-black"
-          data-element-type="tip"
-        >
-        </div>
         <div class="p-8px bgc-black br-4px">
           <% uncontrolled_threshold_long = report_diagnosis == "Hypertension" ? t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_long") : t("progress_tab.diagnosis_report.diagnosis_thresholds.diabetes_uncontrolled_long") %>
           <p class="m-0px mb-4px p-0px ta-left fw-regular fs-14px lh-150 c-white">
@@ -129,6 +128,11 @@
           <p class="m-0px p-0px ta-left fw-regular fs-14px lh-150 c-white">
             <span class="fw-bold">Denominator:</span> <%= t("progress_tab.diagnosis_report.patient_treatment_outcomes.uncontrolled_card.help_tooltip.denominator", facility_name: current_facility.name, diagnosis: report_diagnosis) %>
           </p>
+        </div>
+        <div
+          class="p-absolute b--8px w-0px h-0px br-8px-transparent bl-8px-transparent bt-8px-black"
+          data-element-type="tip"
+        >
         </div>
       </div>
     </div>
@@ -142,21 +146,18 @@
   <% if report_diagnosis == "Diabetes" %>
     <div class="mb-8px p-16px bgc-white bs-card">
       <div class="p-relative d-flex ai-center mb-8px" data-element-type="header">
-        <h2 class="m-0px mr-8px p-0px ta-left fw-medium fs-18px c-black">
-          <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.diabetes_very_uncontrolled_short") %>
-        </h2>
-        <div class="d-flex ai-center w-16px h-16px" data-element-type="help-circle">
-          <%= inline_file("help-circle.svg") %>
+        <div class="d-flex ai-center" data-element-type="header-title">
+          <h2 class="m-0px mr-8px p-0px ta-left fw-medium fs-18px c-black pe-none">
+            <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.diabetes_very_uncontrolled_short") %>
+          </h2>
+          <div class="d-flex ai-center w-16px h-16px pe-none" data-element-type="help-circle">
+            <%= inline_file("help-circle.svg") %>
+          </div>
         </div>
         <div
           class="o-0 pe-none p-absolute l-0 zi-100 d-flex fd-column w-100 bs-tooltip ttf-ease-in-out td-0_25s tp-opacity"
           data-element-type="tooltip"
         >
-          <div
-            class="p-absolute t--8px l-8px w-0px h-0px br-8px-transparent bl-8px-transparent bb-8px-black"
-            data-element-type="tip"
-          >
-          </div>
           <div class="p-8px bgc-black br-4px">
             <p class="m-0px mb-4px p-0px ta-left fw-regular fs-14px lh-150 c-white">
               <span class="fw-bold">Numerator:</span> <%= t("progress_tab.diagnosis_report.patient_treatment_outcomes.very_uncontrolled_card.help_tooltip.numerator", very_uncontrolled_threshold: t("progress_tab.diagnosis_report.diagnosis_thresholds.diabetes_very_uncontrolled_long")) %>
@@ -164,6 +165,11 @@
             <p class="m-0px p-0px ta-left fw-regular fs-14px lh-150 c-white">
               <span class="fw-bold">Denominator:</span> <%= t("progress_tab.diagnosis_report.patient_treatment_outcomes.very_uncontrolled_card.help_tooltip.denominator", facility_name: current_facility.name) %>
             </p>
+          </div>
+          <div
+            class="p-absolute b--8px w-0px h-0px br-8px-transparent bl-8px-transparent bt-8px-black"
+            data-element-type="tip"
+          >
           </div>
         </div>
       </div>
@@ -175,21 +181,18 @@
   <% end %>
   <div class="mb-8px p-16px bgc-white bs-card">
     <div class="p-relative d-flex ai-center mb-8px" data-element-type="header">
-      <h2 class="m-0px mr-8px p-0px ta-left fw-medium fs-18px c-black">
-        <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.missed_visits_short") %>
-      </h2>
-      <div class="d-flex ai-center w-16px h-16px" data-element-type="help-circle">
-        <%= inline_file("help-circle.svg") %>
+      <div class="d-flex ai-center" data-element-type="header-title">
+        <h2 class="m-0px mr-8px p-0px ta-left fw-medium fs-18px c-black pe-none">
+          <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.missed_visits_short") %>
+        </h2>
+        <div class="d-flex ai-center w-16px h-16px pe-none" data-element-type="help-circle">
+          <%= inline_file("help-circle.svg") %>
+        </div>
       </div>
       <div
         class="o-0 pe-none p-absolute l-0 zi-100 d-flex fd-column w-100 bs-tooltip ttf-ease-in-out td-0_25s tp-opacity"
         data-element-type="tooltip"
       >
-        <div
-          class="p-absolute t--8px l-8px w-0px h-0px br-8px-transparent bl-8px-transparent bb-8px-black"
-          data-element-type="tip"
-        >
-        </div>
         <div class="p-8px bgc-black br-4px">
           <p class="m-0px mb-4px p-0px ta-left fw-regular fs-14px lh-150 c-white">
             <span class="fw-bold">Numerator:</span> <%= t("progress_tab.diagnosis_report.patient_treatment_outcomes.missed_visits_card.help_tooltip.numerator", diagnosis: report_diagnosis) %>
@@ -197,6 +200,11 @@
           <p class="m-0px p-0px ta-left fw-regular fs-14px lh-150 c-white">
             <span class="fw-bold">Denominator:</span> <%= t("progress_tab.diagnosis_report.patient_treatment_outcomes.missed_visits_card.help_tooltip.denominator", facility_name: current_facility.name, diagnosis: report_diagnosis) %>
           </p>
+        </div>
+        <div
+          class="p-absolute b--8px w-0px h-0px br-8px-transparent bl-8px-transparent bt-8px-black"
+          data-element-type="tip"
+        >
         </div>
       </div>
     </div>

--- a/app/views/api/v3/analytics/user_analytics/_diagnosis_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_diagnosis_report.html.erb
@@ -74,7 +74,7 @@
       <h2 class="m-0px mr-8px p-0px ta-left fw-medium fs-18px c-black">
         <%= controlled_title = report_diagnosis == "Hypertension" ? t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_controlled_short") : t("progress_tab.diagnosis_report.diagnosis_thresholds.diabetes_controlled_short") %>
       </h2>
-      <div class="d-flex ai-center" data-element-type="help-circle">
+      <div class="d-flex ai-center w-16px h-16px" data-element-type="help-circle">
         <%= inline_file("help-circle.svg") %>
       </div>
       <div
@@ -109,7 +109,7 @@
       <h2 class="m-0px mr-8px p-0px ta-left fw-medium fs-18px c-black">
         <%= uncontrolled_title = report_diagnosis == "Hypertension" ? t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_short") : t("progress_tab.diagnosis_report.diagnosis_thresholds.diabetes_uncontrolled_short") %>
       </h2>
-      <div class="d-flex ai-center" data-element-type="help-circle">
+      <div class="d-flex ai-center w-16px h-16px" data-element-type="help-circle">
         <%= inline_file("help-circle.svg") %>
       </div>
       <div
@@ -145,7 +145,7 @@
         <h2 class="m-0px mr-8px p-0px ta-left fw-medium fs-18px c-black">
           <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.diabetes_very_uncontrolled_short") %>
         </h2>
-        <div class="d-flex ai-center" data-element-type="help-circle">
+        <div class="d-flex ai-center w-16px h-16px" data-element-type="help-circle">
           <%= inline_file("help-circle.svg") %>
         </div>
         <div
@@ -178,7 +178,7 @@
       <h2 class="m-0px mr-8px p-0px ta-left fw-medium fs-18px c-black">
         <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.missed_visits_short") %>
       </h2>
-      <div class="d-flex ai-center" data-element-type="help-circle">
+      <div class="d-flex ai-center w-16px h-16px" data-element-type="help-circle">
         <%= inline_file("help-circle.svg") %>
       </div>
       <div

--- a/app/views/api/v3/analytics/user_analytics/_period_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_period_report.html.erb
@@ -67,13 +67,13 @@
   </div>
   <% if CountryConfig.current_country?("India") %>
     <div class="p-relative mb-8px p-16px bgc-yellow-lightest br-4px bs-card">
-      <h1 class="m-0px mb-8px p-0px ta-left fw-medium fs-18px lh-135 c-black">
+      <h1 class="m-0px mb-8px p-0px pr-48px ta-left fw-medium fs-18px lh-135 c-black">
         <%= t("progress_tab.period_report.patients_initiated_on_treatment_card.title") %>
       </h1>
       <p class="m-0px p-0px ta-left fw-normal fs-16px lh-165 c-black">
         <%= t("progress_tab.period_report.patients_initiated_on_treatment_card.main_text") %>
       </p>
-      <div class="p-absolute t-8px r-8px">
+      <div class="p-absolute t-8px r-8px w-48px h-48px">
         <%= inline_svg("exclamation-mark.svg") %>
       </div>
     </div>

--- a/app/views/api/v3/analytics/user_analytics/_period_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_period_report.html.erb
@@ -18,7 +18,7 @@
           <%= subtitle %>
         </p>
       <% end %>
-      <%= select_tag "periods", options_for_select(periods, periods.first), class: "w-100 mt-16px p-12px fw-medium fs-18px c-blue bgc-blue-light b-none br-4px bs-secondary-button o-none a-none chevron-down-icon" %>
+      <%= select_tag "periods", options_for_select(periods, periods.first), class: "w-100 mt-16px p-12px fw-bold fs-16px c-blue bgc-blue-light b-none br-2px bs-secondary-button o-none a-none chevron-down-icon" %>
     </div>
   </div>
   <div class="mb-8px p-16px bgc-white br-4px bs-card">

--- a/app/views/api/v3/analytics/user_analytics/_period_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_period_report.html.erb
@@ -9,7 +9,7 @@
         <%= inline_file("chevron-left.svg") %>
       </div>
     </a>
-    <div class="mb-12px pr-16px pl-16px">
+    <div class="pr-16px pl-16px">
       <h1 class="m-0px mb-8px fw-bold fs-24px">
         <%= title %> report
       </h1>
@@ -18,7 +18,7 @@
           <%= subtitle %>
         </p>
       <% end %>
-      <%= select_tag "periods", options_for_select(periods, periods.first), class: "w-100 mt-16px p-12px fw-bold fs-16px c-blue bgc-blue-light b-none br-2px bs-secondary-button o-none a-none chevron-down-icon" %>
+      <%= select_tag "periods", options_for_select(periods, periods.first), class: "w-100 mt-16px p-12px fw-medium fs-16px ls-1_25px tt-uppercase c-blue bgc-blue-light b-none br-1px bs-secondary-button o-none a-none chevron-down-icon" %>
     </div>
   </div>
   <div class="mb-8px p-16px bgc-white br-4px bs-card">

--- a/app/views/api/v3/analytics/user_analytics/_period_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_period_report.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= page_id %>" class="d-none">
   <div class="mb-8px pt-16px pb-16px bgc-white br-4px bs-card">
     <a
-      class="d-block pl-16px mb-24px"
+      class="d-block w-24px h-24px mb-24px pl-16px"
       href="#"
       onclick="goToPage('<%= page_id %>', 'home-page'); return false;"
     >

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -79,7 +79,7 @@
               access_token: current_user.access_token,
               facility_id: current_facility.id),
               style: "font-weight: 700;",
-              class: "d-block p-16px ta-center fs-16px tt-uppercase ls-1_25px c-blue b-none bb-blue-mid br-2px bgc-blue-light bs-secondary-button"
+              class: "d-block p-16px ta-center fs-16px fw-regular tt-uppercase ls-1_25px c-blue b-none bb-blue-mid br-2px bgc-blue-light bs-secondary-button"
             %>
           </div>
         <% end %>

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -78,8 +78,8 @@
             <%= link_to "Enter drug stock", new_webview_drug_stock_url(user_id: current_user.id,
               access_token: current_user.access_token,
               facility_id: current_facility.id),
-              style: "font-weight: 700;",
-              class: "d-block p-16px ta-center fs-16px fw-regular tt-uppercase ls-1_25px c-blue b-none bb-blue-mid br-2px bgc-blue-light bs-secondary-button"
+              style: "font-weight: 500;",
+              class: "d-block p-16px ta-center fs-16px fw-regular tt-uppercase ls-1_25px c-blue b-none bb-blue-mid br-1px bgc-blue-light bs-secondary-button"
             %>
           </div>
         <% end %>

--- a/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
@@ -99,8 +99,8 @@
         <%= link_to t("progress_tab.drug_stock_report_card.button_title"), new_webview_drug_stock_url(user_id: current_user.id,
           access_token: current_user.access_token,
           facility_id: current_facility.id),
-          style: "font-weight: 700;",
-          class: "d-block p-16px ta-center fs-16px fw-regular tt-uppercase ls-1_25px c-blue b-none bb-blue-mid br-2px bgc-blue-light bs-secondary-button"
+          style: "font-weight: 500;",
+          class: "d-block p-16px ta-center fs-16px fw-regular tt-uppercase ls-1_25px c-blue b-none br-1px bgc-blue-light bs-secondary-button"
         %>
       </div>
       <div class="mb-8px pt-16px pb-16px bgc-white bs-card">
@@ -117,7 +117,9 @@
               <%= render partial: "api/v3/analytics/user_analytics/achievement_badge",
                 locals: { value: badge["goal_value"],
                           is_goal_completed: badge["is_goal_completed"],
-                          badge_color: "lavander",
+                          text_color: "c-lavander",
+                          circle_color: "bgc-lavander",
+                          badge_color: "bgc-lavander-light",
                           icon_completed: "refresh-arrow-white.svg",
                           icon_goal: "refresh-arrow-grey.svg"
               } %>
@@ -134,7 +136,9 @@
               <%= render partial: "api/v3/analytics/user_analytics/achievement_badge",
                 locals: { value: badge["goal_value"],
                           is_goal_completed: badge["is_goal_completed"],
-                          badge_color: "baby-blue",
+                          text_color: "c-baby-blue",
+                          circle_color: "bgc-baby-blue",
+                          badge_color: "bgc-baby-blue-light",
                           icon_completed: "phone-white.svg",
                           icon_goal: "phone-grey.svg"
               } %>
@@ -151,7 +155,9 @@
               <%= render partial: "api/v3/analytics/user_analytics/achievement_badge",
                 locals: { value: badge["goal_value"],
                           is_goal_completed: badge["is_goal_completed"],
-                          badge_color: "yellow",
+                          text_color: "c-yellow-dark-new",
+                          circle_color: "bgc-yellow-new",
+                          badge_color: "bgc-yellow-light",
                           icon_completed: "face-yellow-darkest.svg",
                           icon_goal: "face-grey.svg"
               } %>

--- a/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
@@ -100,7 +100,7 @@
           access_token: current_user.access_token,
           facility_id: current_facility.id),
           style: "font-weight: 700;",
-          class: "d-block p-16px ta-center fs-16px tt-uppercase ls-1_25px c-blue b-none bb-blue-mid br-2px bgc-blue-light bs-secondary-button"
+          class: "d-block p-16px ta-center fs-16px fw-regular tt-uppercase ls-1_25px c-blue b-none bb-blue-mid br-2px bgc-blue-light bs-secondary-button"
         %>
       </div>
       <div class="mb-8px pt-16px pb-16px bgc-white bs-card">

--- a/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
@@ -109,10 +109,10 @@
         </h1>
         <div class="mb-24px">
           <p class="m-0px mb-8px p-0px pl-16px ta-left fw-normal fs-16px c-black">
-            <span class="fw-bold">7,051</span> <%= t("progress_tab.achievements_card.follow_up_visits_section_title", visit_or_visits: "visit".pluralize(7051)) %>
+            <span class="fw-bold">4,124</span> <%= t("progress_tab.achievements_card.follow_up_visits_section_title", visit_or_visits: "visit".pluralize(4124)) %>
           </p>
           <div class="d-flex ai-center jc-space-between pt-4px pb-4px pr-16px pl-16px">
-            <% follow_up_badge_goals = create_badge_array(7051) %>
+            <% follow_up_badge_goals = create_badge_array(4124) %>
             <% follow_up_badge_goals.each do |badge| %>
               <%= render partial: "api/v3/analytics/user_analytics/achievement_badge",
                 locals: { value: badge["goal_value"],
@@ -126,10 +126,10 @@
         </div>
         <div class="mb-24px">
           <p class="m-0px mb-8px p-0px pl-16px ta-left fw-normal fs-16px c-black">
-            <span class="fw-bold">2,501</span> <%= t("progress_tab.achievements_card.overdue_patients_section_title", call_or_calls: "call".pluralize(2501)) %>
+            <span class="fw-bold">8,716</span> <%= t("progress_tab.achievements_card.overdue_patients_section_title", call_or_calls: "call".pluralize(8716)) %>
           </p>
           <div class="d-flex ai-center jc-space-between pt-4px pb-4px pr-16px pl-16px">
-            <% overdue_call_badge_goals = create_badge_array(2501) %>
+            <% overdue_call_badge_goals = create_badge_array(8716) %>
             <% overdue_call_badge_goals.each do |badge| %>
               <%= render partial: "api/v3/analytics/user_analytics/achievement_badge",
                 locals: { value: badge["goal_value"],

--- a/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
@@ -92,7 +92,7 @@
               <%= t("progress_tab.drug_stock_report_card.subtitle", facility_name: current_facility.name, period: @period.to_s(:mon_year)) %>
             </p>
           </div>
-          <div>
+          <div class="w-76px h-76px">
             <%= inline_svg("drug-stock.svg") %>
           </div>
         </div>

--- a/app/views/webview/drug_stocks/new.html.erb
+++ b/app/views/webview/drug_stocks/new.html.erb
@@ -62,7 +62,7 @@
             <div class="mb-24px">
               <% choices = last_n_months(n: 6, inclusive: @show_current_month).map { |d| [d.to_date.to_s(:mon_year), d.to_date.to_s(:mon_year)] }
               %>
-              <%= form.select :for_end_of_month, choices, { label_class: "d-block mb-8px fw-medium fs-18px c-black", selected: @for_end_of_month.to_date.to_s(:mon_year) }, { id: "for_end_of_month", class: "w-100 p-12px fw-medium fs-18px c-blue bgc-blue-light b-none br-4px bs-secondary-button o-none a-none chevron-down-icon" } %>
+              <%= form.select :for_end_of_month, choices, { label_class: "d-block mb-8px fw-medium fs-18px c-black", selected: @for_end_of_month.to_date.to_s(:mon_year) }, { id: "for_end_of_month", class: "w-100 p-12px fw-regular fs-16px c-blue bgc-blue-light b-none br-2px bs-secondary-button o-none a-none chevron-down-icon" } %>
             </div>
             <% @protocol_drugs.each_with_index do |protocol_drug, index| %>
               <%= form.fields_for "drug_stocks[#{index}]", DrugStock.new do |drug_stock_form| %>
@@ -117,7 +117,7 @@
               <% end %>
             </div>
             <div class="p-fixed b-0 l-0 zi-100 w-100 p-8px bgc-blue-light bs-border-box bs-fixed-card" style="padding-bottom: 12px;">
-              <%= form.button "SAVE", class: "d-block w-100 p-16px ta-center bgc-blue tt-uppercase ls-1_25px br-4px fs-16px b-none bs-primary-button bs-border-box", style: "font-weight: 700; color: #ffffff;" %>
+              <%= form.button "SAVE", class: "d-block w-100 p-16px ta-center bgc-blue tt-uppercase ls-1_25px br-2px fs-16px b-none bs-primary-button bs-border-box", style: "font-weight: 700; color: #ffffff;" %>
             </div>
           <% end %>
         </div>

--- a/app/views/webview/drug_stocks/new.html.erb
+++ b/app/views/webview/drug_stocks/new.html.erb
@@ -62,7 +62,7 @@
             <div class="mb-24px">
               <% choices = last_n_months(n: 6, inclusive: @show_current_month).map { |d| [d.to_date.to_s(:mon_year), d.to_date.to_s(:mon_year)] }
               %>
-              <%= form.select :for_end_of_month, choices, { label_class: "d-block mb-8px fw-medium fs-18px c-black", selected: @for_end_of_month.to_date.to_s(:mon_year) }, { id: "for_end_of_month", class: "w-100 p-12px fw-regular fs-16px c-blue bgc-blue-light b-none br-2px bs-secondary-button o-none a-none chevron-down-icon" } %>
+              <%= form.select :for_end_of_month, choices, { label_class: "d-block mb-8px fw-medium fs-18px c-black", selected: @for_end_of_month.to_date.to_s(:mon_year) }, { id: "for_end_of_month", class: "w-100 p-12px fw-regular fs-16px c-blue bgc-blue-light tt-uppercase ls-1_25px b-none br-1px bs-secondary-button o-none a-none chevron-down-icon" } %>
             </div>
             <% @protocol_drugs.each_with_index do |protocol_drug, index| %>
               <%= form.fields_for "drug_stocks[#{index}]", DrugStock.new do |drug_stock_form| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,8 +124,8 @@ en:
         title: "Follow-up patients"
         subtitle: "Patients that had a BP taken, a blood sugar taken, an appointment scheduled, or their medications updated at %{facility_name}."
       patients_initiated_on_treatment_card:
-        title: "Where is the patients initiated on treatment data?"
-        main_text: "Use registered patients, it will always equal patients initiated on treatment for patients registered on Simple."
+        title: "Where is the \"Patients initiated on treatment\" data?"
+        main_text: "Use registered patients, it will always equal \"Patients initiated on treatment\" for patients registered on Simple."
     diagnosis_report:
       diagnosis_thresholds:
         hypertension_controlled_short: "BP controlled"
@@ -151,7 +151,7 @@ en:
           transferred_out_patients: "Transferred-out"
       total_registered_patients:
         title: "Total registered patients"
-        subtitle: "All %{diagnosis} patients registered in %{facility_name}."
+        subtitle: "All %{diagnosis} patients registered at %{facility_name}."
       monthly_follow_up_patients:
         title: "Monthly follow-up patients"
         subtitle: "%{diagnosis} patients with a BP taken, a blood sugar taken, an appointment scheduled, or a medication updated at %{facility_name} during a month."
@@ -159,22 +159,22 @@ en:
         section_title: "Patient treatment outcomes"
         chart_tooltip: "%{number_of_patients} %{patient_or_patients} with %{threshold} between %{start_period} and %{end_period} of %{number_of_registered_patients} %{patient_or_patients} registered till %{registration_period}."
         controlled_card:
-          subtitle: "%{diagnosis} patients in %{facility_name} registered >3 months ago with %{controlled_threshold} at their last visit in the last 3 months."
+          subtitle: "%{diagnosis} patients at %{facility_name} registered >3 months ago with %{controlled_threshold} at their last visit in the last 3 months."
           help_tooltip:
             numerator: "Patients with %{controlled_threshold} at their last visit in the last 3 months."
             denominator: "%{diagnosis} patients assigned to %{facility_name}, registered before the last 3 months. Dead and lost to follow-up patients are excluded."
         uncontrolled_card:
-          subtitle: "%{diagnosis} patients in %{facility_name} registered >3 months ago with %{uncontrolled_threshold} at their last visit in the last 3 months."
+          subtitle: "%{diagnosis} patients at %{facility_name} registered >3 months ago with %{uncontrolled_threshold} at their last visit in the last 3 months."
           help_tooltip:
             numerator: "Patients with %{uncontrolled_threshold} at their last visit in the last 3 months."
             denominator: "%{diagnosis} patients assigned to %{facility_name}, registered before the last 3 months. Dead and lost to follow-up patients are excluded."
         very_uncontrolled_card:
-          subtitle: "Diabetes patients in %{facility_name} registered >3 months ago with %{very_uncontrolled_threshold} at their last visit in the last 3 months."
+          subtitle: "Diabetes patients at %{facility_name} registered >3 months ago with %{very_uncontrolled_threshold} at their last visit in the last 3 months."
           help_tooltip:
             numerator: "Diabetes patients in %{very_uncontrolled_threshold} at their last visit in the last 3 months."
             denominator: "Diabetes patients assigned to %{facility_name}, registered before the last 3 months. Dead and lost to follow-up patients are excluded."
         missed_visits_card:
-          subtitle: "%{diagnosis} patients in %{facility_name} registered >3 months ago with no visit in the last 3 months."
+          subtitle: "%{diagnosis} patients at %{facility_name} registered >3 months ago with no visit in the last 3 months."
           help_tooltip:
             numerator: "%{diagnosis} patients with no visit in the last 3 months."
             denominator: "%{diagnosis} patients assigned to %{facility_name}, registered before the last 3 months. Dead and lost to follow-up patients are excluded."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,7 +125,7 @@ en:
         subtitle: "Patients that had a BP taken, a blood sugar taken, an appointment scheduled, or their medications updated at %{facility_name}."
       patients_initiated_on_treatment_card:
         title: "Where is the \"Patients initiated on treatment\" data?"
-        main_text: "Use registered patients, it will always equal \"Patients initiated on treatment\" for patients registered on Simple."
+        main_text: "Use \"Registered patients\", it will always equal \"Patients initiated on treatment\" for patients registered on Simple."
     diagnosis_report:
       diagnosis_thresholds:
         hypertension_controlled_short: "BP controlled"

--- a/spec/helpers/my_facilities_helper_spec.rb
+++ b/spec/helpers/my_facilities_helper_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe MyFacilitiesHelper, type: :helper do
       expect(patient_days_css_class(nil)).to be_nil
     end
 
-    it "returns red if < 30" do
+    it "returns red-new if < 30" do
       expect(patient_days_css_class(29)).to eq("bgc-red-new")
     end
 
-    it "is orange for 30 to < 60" do
+    it "is orange-new for 30 to < 60" do
       expect(patient_days_css_class(35)).to eq("bgc-orange-new")
     end
 
-    it "is yellow for 60 to < 90" do
+    it "is yellow-dark-new for 60 to < 90" do
       expect(patient_days_css_class(66)).to eq("bgc-yellow-dark-new")
     end
 
-    it "is green for more than 90" do
-      expect(patient_days_css_class(91)).to eq("bgc-green")
+    it "is green-new for more than 90" do
+      expect(patient_days_css_class(91)).to eq("bgc-green-new")
     end
 
     it "can change the prefix for the css class" do

--- a/spec/helpers/my_facilities_helper_spec.rb
+++ b/spec/helpers/my_facilities_helper_spec.rb
@@ -7,24 +7,24 @@ RSpec.describe MyFacilitiesHelper, type: :helper do
     end
 
     it "returns red if < 30" do
-      expect(patient_days_css_class(29)).to eq("bg-red")
+      expect(patient_days_css_class(29)).to eq("bgc-red-new")
     end
 
     it "is orange for 30 to < 60" do
-      expect(patient_days_css_class(35)).to eq("bg-orange")
+      expect(patient_days_css_class(35)).to eq("bgc-orange-new")
     end
 
     it "is yellow for 60 to < 90" do
-      expect(patient_days_css_class(66)).to eq("bg-yellow-dark")
+      expect(patient_days_css_class(66)).to eq("bgc-yellow-dark-new")
     end
 
     it "is green for more than 90" do
-      expect(patient_days_css_class(91)).to eq("bg-green")
+      expect(patient_days_css_class(91)).to eq("bgc-green")
     end
 
     it "can change the prefix for the css class" do
-      expect(patient_days_css_class(29, prefix: "text")).to eq("text-red")
-      expect(patient_days_css_class(200, prefix: "text")).to eq("text-green")
+      expect(patient_days_css_class(29, prefix: "c")).to eq("c-red-new")
+      expect(patient_days_css_class(200, prefix: "c")).to eq("c-green-new")
     end
   end
 


### PR DESCRIPTION
**Story card:** [sc-7512](https://app.shortcut.com/simpledotorg/story/7512/test-new-ui-on-local-device)

## Because

This PR includes a bunch of small fixes and polishes after testing on my iPhone's Safari/Chrome browsers.

## This addresses

* Fixes the sizing of all `svg` elements (Drug stock image, Help circle icon, Exclamation mark image, Back arrow icon)
* Moves the treatment outcome title tooltip _above_ the title so that the user can see the tooltip on touch
* Sets the right flex direction for the graph bar charts (were floating top before)

**Daniel's fix list**
![image](https://user-images.githubusercontent.com/16785131/156936100-2ed669b4-b467-4158-a742-4ad2210cd49f.png)
* Matched the secondary button style with Simple App secondary buttons.
* Using a darker yellow color for the registered patient badge text.

## Test instructions

Please test this PR on your mobile device.

Enable the `new_progress_tab` Flipper flag.

**How to view your local on your phone**
1. Open your Mac's `System Preferences` > `Sharing` and select the "Internet Sharing" option. Make sure it's **not** checked.
2. Within the "Internet Sharing" menu, make sure the "iPhone USB" option is selected.
3. Now go to `System Preferences` > `Network`, select the "Wi-Fi" menu option and take note of your IP address (shown under the "Status" label).
4. Open your terminal and `git checkout progress-tab-mobile-fixes`
5. Then, `git pull`, `bundle install`, and start the server using this command: `rails server -b 0.0.0.0`
6. Open your browser on your phone and enter your IP address and port on the URL address bar (example, `192.168.17.17:3000`)

**What to look out for**
1. Typos or wrong tooltips/subtitles for key indicator cards
2. Home page buttons and sub-page back arrows link to the right pages
3. Charts are interactive and intuitive
4. Spacing and color looks good