### PR TITLE
MH DHIS2 Activation

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -100,3 +100,9 @@ every 1.month, at: local("4:00 am"), roles: [:cron] do
     rake "dhis2:export"
   end
 end
+
+every :day, at: local("4:00 am"), roles: [:cron] do
+  if Flipper.enabled?(:maharashtra_dhis2_export)
+    rake "dhis2:maharashtra_export"
+  end
+end

--- a/lib/tasks/dhis2.rake
+++ b/lib/tasks/dhis2.rake
@@ -3,4 +3,9 @@ namespace :dhis2 do
   task export: :environment do
     DHIS2Exporter.export
   end
+
+  desc "Export aggregate indicators for each facility to Maharashtra's DHIS2"
+  task maharashtra_export: :environment do
+    MaharashtraDHIS2Exporter.export
+  end
 end


### PR DESCRIPTION
**Story card:** [sc-5903](https://app.shortcut.com/simpledotorg/story/5903/turn-on-maharashtra-dhis2-export-flag-in-india-for-mahashtra)

This PR adds the MH DHIS2 export to our daily cron tasks. We choose to keep this as a daily task so we can quickly iterate with minimal code changes during the initial setup. Once this works, we can move this to a monthly cadence - maybe when we hook up to a production server.

For now, the data is being sent to a test server managed by the Maharashtra HISP. The following other dependencies have already been taken care of:
* [x] DHIS2 IDs added to the 10 Maharashtra facilities involved in the integration
* [x] The feature flag `maharashtra_dhis2_export` has been enabled in India production
* [x] The necessary code that exports gender-disaggregated data elements to Maharashtra has been merged
