### PR TITLE
Include current day's data in daily follow ups

### DIFF
--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -1,6 +1,5 @@
 module Reports
   class FacilityProgressService
-    include Memery
     MONTHS = -5
     CONTROL_MONTHS = -12
     attr_reader :control_range
@@ -81,15 +80,15 @@ module Reports
 
     attr_reader :diabetes_enabled
 
-    memoize def daily_registrations_grouped_by_day
+    def daily_registrations_grouped_by_day
       diagnosis = diabetes_enabled ? :all : :hypertension
       RegisteredPatientsQuery.new.count_daily(facility, diagnosis: diagnosis, last: 30)
     end
 
-    memoize def daily_follow_ups_grouped_by_day
+    def daily_follow_ups_grouped_by_day
       scope = Reports::DailyFollowUp.with_hypertension
       scope = scope.or(Reports::DailyFollowUp.with_diabetes) if diabetes_enabled
-      scope.where(facility: facility).group_by_day(:visited_at, last: 30, current: false).count
+      scope.where(facility: facility).group_by_day(:visited_at, last: 30).count
     end
 
     def create_dimension(*args)


### PR DESCRIPTION
**Story card:** [sc-7469](https://app.shortcut.com/simpledotorg/story/7469/issue-with-real-time-data-of-follow-up-entries)

## Because

Daily follow ups do not include the current days data when displaying the daily follow ups.

## This addresses
Inclusion of current days data in calculating the daily follow ups.

This change also removes memoization from the methods that calculate the
daily follow ups and registration statistics due to the following
reasons:
1. The memoization along with material view refreshes makes it tricky to
   know when was the data updated. The material views may have been
   updated but there is a chance that the memoization is returning stale
   data.
2. The data is a simple query on a materialized view with no ruby
   computation. So the memoization may not be very useful here.

## Test instructions

1. Get user test credentials using `bundle exec rails get_user_credentials`
2. Visit `api/v3/analytics/user_analytics.html` by setting `X-User-Id`, `X-Facility-Id` and `Authorization` headers from step 1. 
3. Create a new blood pressure for a hypertensive patient for the above facility and user
4. Refresh the daily follow ups materialized view using `bundle exec rake db:refresh_daily_follow_ups` 
5. Refresh the progress tab
6. You should see the follow ups number increase by 1. 