### PR TITLE
Help screen not properly showing/hiding subviews

### DIFF
--- a/app/assets/javascripts/standalone/help.js
+++ b/app/assets/javascripts/standalone/help.js
@@ -1,28 +1,16 @@
 // Hides and shows each page of Help
 
-function openWindow(id, parentId) {
-   const element = document.getElementById(id);
-   element.style.display = 'block';
+function goToPage(startPageId, endPageId) {
+  const startPage = document.getElementById(startPageId);
+  startPage.style.display = "none";
+  startPage.style.height = "0";
 
-   if (parentId) {
-     var parent = document.getElementById(parentId);
-     parent.style.display = 'none';
-     parent.style.height = '0';
-   }
+  const endPage = document.getElementById(endPageId);
+  endPage.style.display = "block";
+  endPage.style.height = "0";
 
-   document.body.scrollTop = 0; // For Safari
-   document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
-}
-
-function closeWindow(id, parentId) {
-   const element = document.getElementById(id);
-   element.style.display = 'none';
-
-   if (parentId) {
-     var parent = document.getElementById(parentId);
-     parent.style.display = 'block';
-     parent.style.height = 'auto';
-   }
+  document.body.scrollTop = 0;
+  document.documentElement.scrollTop = 0;
 }
 
 // FAQ hides and shows answers

--- a/app/views/api/v3/help/show.html.erb
+++ b/app/views/api/v3/help/show.html.erb
@@ -17,31 +17,31 @@
     <div id="help-section" class="help-body">
       <div class="help-contents">
         <nav class="help-nav">
-          <a href="#" onclick="openWindow('help-videos'); return false">
+          <a href="#" onclick="goToPage('help-section', 'help-videos'); return false">
           <%= t("help.menu.videos_html") %>
           <%= inline_svg('icon_chevron_right.svg') %>
           </a>
-          <a href="#" onclick="openWindow('help-start'); return false">
+          <a href="#" onclick="goToPage('help-section', 'help-start'); return false">
           <%= t("help.menu.start_html") %>
           <%= inline_svg('icon_chevron_right.svg') %>
           </a>
-          <a href="#" onclick="openWindow('help-register'); return false">
+          <a href="#" onclick="goToPage('help-section', 'help-register'); return false">
           <%= t("help.menu.register_html") %>
           <%= inline_svg('icon_chevron_right.svg') %>
           </a>
-          <a href="#" onclick="openWindow('help-search'); return false">
+          <a href="#" onclick="goToPage('help-section', 'help-search'); return false">
           <%= t("help.menu.search_html") %>
           <%= inline_svg('icon_chevron_right.svg') %>
           </a>
-          <a href="#" onclick="openWindow('help-record'); return false">
+          <a href="#" onclick="goToPage('help-section', 'help-record'); return false">
           <%= t("help.menu.record_html") %>
           <%= inline_svg('icon_chevron_right.svg') %>
           </a>
-          <a href="#" onclick="openWindow('help-overdue'); return false">
+          <a href="#" onclick="goToPage('help-section', 'help-overdue'); return false">
           <%= t("help.menu.overdue_html") %>
           <%= inline_svg('icon_chevron_right.svg') %>
           </a>
-          <a href="#" onclick="openWindow('help-faq'); return false">
+          <a href="#" onclick="goToPage('help-section', 'help-faq'); return false">
           <%= t("help.menu.faq_html") %>
           <%= inline_svg('icon_chevron_right.svg') %>
           </a>
@@ -60,12 +60,12 @@
           </div>
         <% end %>
         <div class="card">
-          <a href="#" onclick="openWindow('help-bp-passport-app'); return false" class="card-header" style="background: #FF3355 url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzQ0IiBoZWlnaHQ9IjI0MCIgdmlld0JveD0iMCAwIDM0NCAyNDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHg9IjEyMSIgeT0iMzAiIHdpZHRoPSIxMDkiIGhlaWdodD0iMTc5IiByeD0iOSIgZmlsbD0iIzAwNDc4RiIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSI2Ii8+CjxyZWN0IHg9IjE3OCIgeT0iODQiIHdpZHRoPSI2IiBoZWlnaHQ9Ijc1IiBmaWxsPSIjM0I3Q0JFIi8+CjxjaXJjbGUgY3g9IjE4MSIgY3k9Ijg0IiByPSIzIiBmaWxsPSIjRkYzMzU1Ii8+CjxjaXJjbGUgY3g9IjE4MSIgY3k9IjE1OSIgcj0iMyIgZmlsbD0iIzAwQjg0OSIvPgo8cmVjdCB4PSIxODciIHk9Ijk5IiB3aWR0aD0iNiIgaGVpZ2h0PSI3MiIgZmlsbD0iIzNCN0NCRSIvPgo8Y2lyY2xlIGN4PSIxOTAiIGN5PSI5OSIgcj0iMyIgZmlsbD0iI0ZGMzM1NSIvPgo8Y2lyY2xlIGN4PSIxOTAiIGN5PSIxNzEiIHI9IjMiIGZpbGw9IiMwMEI4NDkiLz4KPHJlY3QgeD0iMTk2IiB5PSI4NiIgd2lkdGg9IjYiIGhlaWdodD0iNjgiIGZpbGw9IiMzQjdDQkUiLz4KPGNpcmNsZSBjeD0iMTk5IiBjeT0iODYiIHI9IjMiIGZpbGw9IiNGRjMzNTUiLz4KPGNpcmNsZSBjeD0iMTk5IiBjeT0iMTU0IiByPSIzIiBmaWxsPSIjMDBCODQ5Ii8+CjxyZWN0IHg9IjIwNSIgeT0iOTIiIHdpZHRoPSI2IiBoZWlnaHQ9IjczIiBmaWxsPSIjM0I3Q0JFIi8+CjxjaXJjbGUgY3g9IjIwOCIgY3k9IjkyIiByPSIzIiBmaWxsPSIjRkYzMzU1Ii8+CjxjaXJjbGUgY3g9IjIwOCIgY3k9IjE2NSIgcj0iMyIgZmlsbD0iIzAwQjg0OSIvPgo8cmVjdCB4PSIyMTQiIHk9Ijk0IiB3aWR0aD0iNiIgaGVpZ2h0PSI2NSIgZmlsbD0iIzNCN0NCRSIvPgo8Y2lyY2xlIGN4PSIyMTciIGN5PSI5NCIgcj0iMyIgZmlsbD0iI0ZGMzM1NSIvPgo8Y2lyY2xlIGN4PSIyMTciIGN5PSIxNTkiIHI9IjMiIGZpbGw9IiMwMEI4NDkiLz4KPHJlY3QgeD0iMTMyIiB5PSI4NCIgd2lkdGg9IjYiIGhlaWdodD0iNzUiIGZpbGw9IiMzQjdDQkUiLz4KPGNpcmNsZSBjeD0iMTM1IiBjeT0iODQiIHI9IjMiIGZpbGw9IiNGRjMzNTUiLz4KPGNpcmNsZSBjeD0iMTM1IiBjeT0iMTU5IiByPSIzIiBmaWxsPSIjMDBCODQ5Ii8+CjxyZWN0IHg9IjE0MSIgeT0iOTkiIHdpZHRoPSI2IiBoZWlnaHQ9IjcyIiBmaWxsPSIjM0I3Q0JFIi8+CjxjaXJjbGUgY3g9IjE0NCIgY3k9Ijk5IiByPSIzIiBmaWxsPSIjRkYzMzU1Ii8+CjxjaXJjbGUgY3g9IjE0NCIgY3k9IjE3MSIgcj0iMyIgZmlsbD0iIzAwQjg0OSIvPgo8cmVjdCB4PSIxNTAiIHk9Ijg2IiB3aWR0aD0iNiIgaGVpZ2h0PSI2OCIgZmlsbD0iIzNCN0NCRSIvPgo8Y2lyY2xlIGN4PSIxNTMiIGN5PSI4NiIgcj0iMyIgZmlsbD0iI0ZGMzM1NSIvPgo8Y2lyY2xlIGN4PSIxNTMiIGN5PSIxNTQiIHI9IjMiIGZpbGw9IiMwMEI4NDkiLz4KPHJlY3QgeD0iMTU5IiB5PSI5MiIgd2lkdGg9IjYiIGhlaWdodD0iNzMiIGZpbGw9IiMzQjdDQkUiLz4KPGNpcmNsZSBjeD0iMTYyIiBjeT0iOTIiIHI9IjMiIGZpbGw9IiNGRjMzNTUiLz4KPGNpcmNsZSBjeD0iMTYyIiBjeT0iMTY1IiByPSIzIiBmaWxsPSIjMDBCODQ5Ii8+CjxyZWN0IHg9IjE2OCIgeT0iOTQiIHdpZHRoPSI2IiBoZWlnaHQ9IjY1IiBmaWxsPSIjM0I3Q0JFIi8+CjxjaXJjbGUgY3g9IjE3MSIgY3k9Ijk0IiByPSIzIiBmaWxsPSIjRkYzMzU1Ii8+CjxjaXJjbGUgY3g9IjE3MSIgY3k9IjE1OSIgcj0iMyIgZmlsbD0iIzAwQjg0OSIvPgo8cmVjdCB4PSI4NSIgeT0iMTI1IiB3aWR0aD0iNjMiIGhlaWdodD0iNjMiIHJ4PSI5IiBmaWxsPSIjMDAzNjZEIi8+CjxwYXRoIGQ9Ik0xMTUuNSAxNzZDMTIzLjUwOCAxNzYgMTMwIDE2OS40ODggMTMwIDE2MS40NTVDMTMwIDE1MC41NDUgMTE1LjUgMTM2IDExNS41IDEzNkMxMTUuNSAxMzYgMTAxIDE1MC41NDUgMTAxIDE2MS40NTVDMTAxIDE2OS40ODggMTA3LjQ5MiAxNzYgMTE1LjUgMTc2WiIgZmlsbD0iI0ZGMzM1NSIvPgo8cGF0aCBkPSJNMTA2LjQxNiAxNjcuODk5QzEwNS43NjEgMTY3LjEzIDEwNS44OTQgMTY2LjAwNyAxMDYuNzEzIDE2NS4zOTFDMTA3LjUzMyAxNjQuNzc1IDEwOC43MjggMTY0LjkgMTA5LjM4NCAxNjUuNjdDMTEyLjA4NiAxNjguODQyIDExNy4wMTUgMTY5LjM1NyAxMjAuMzkzIDE2Ni44MTlDMTIwLjg0NSAxNjYuNDc5IDEyMS4yNTUgMTY2LjA5NCAxMjEuNjE2IDE2NS42N0MxMjIuMjcyIDE2NC45IDEyMy40NjcgMTY0Ljc3NSAxMjQuMjg3IDE2NS4zOTFDMTI1LjEwNiAxNjYuMDA3IDEyNS4yMzkgMTY3LjEzIDEyNC41ODQgMTY3Ljg5OUMxMjQuMDQ3IDE2OC41MjkgMTIzLjQzOCAxNjkuMTAyIDEyMi43NjcgMTY5LjYwNkMxMTcuNzUgMTczLjM3NSAxMTAuNDMgMTcyLjYxMSAxMDYuNDE2IDE2Ny44OTlaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K) no-repeat 50% 50%; background-size: contain;">
+          <a href="#" onclick="goToPage('help-section', 'help-bp-passport-app'); return false" class="card-header" style="background: #FF3355 url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzQ0IiBoZWlnaHQ9IjI0MCIgdmlld0JveD0iMCAwIDM0NCAyNDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHg9IjEyMSIgeT0iMzAiIHdpZHRoPSIxMDkiIGhlaWdodD0iMTc5IiByeD0iOSIgZmlsbD0iIzAwNDc4RiIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSI2Ii8+CjxyZWN0IHg9IjE3OCIgeT0iODQiIHdpZHRoPSI2IiBoZWlnaHQ9Ijc1IiBmaWxsPSIjM0I3Q0JFIi8+CjxjaXJjbGUgY3g9IjE4MSIgY3k9Ijg0IiByPSIzIiBmaWxsPSIjRkYzMzU1Ii8+CjxjaXJjbGUgY3g9IjE4MSIgY3k9IjE1OSIgcj0iMyIgZmlsbD0iIzAwQjg0OSIvPgo8cmVjdCB4PSIxODciIHk9Ijk5IiB3aWR0aD0iNiIgaGVpZ2h0PSI3MiIgZmlsbD0iIzNCN0NCRSIvPgo8Y2lyY2xlIGN4PSIxOTAiIGN5PSI5OSIgcj0iMyIgZmlsbD0iI0ZGMzM1NSIvPgo8Y2lyY2xlIGN4PSIxOTAiIGN5PSIxNzEiIHI9IjMiIGZpbGw9IiMwMEI4NDkiLz4KPHJlY3QgeD0iMTk2IiB5PSI4NiIgd2lkdGg9IjYiIGhlaWdodD0iNjgiIGZpbGw9IiMzQjdDQkUiLz4KPGNpcmNsZSBjeD0iMTk5IiBjeT0iODYiIHI9IjMiIGZpbGw9IiNGRjMzNTUiLz4KPGNpcmNsZSBjeD0iMTk5IiBjeT0iMTU0IiByPSIzIiBmaWxsPSIjMDBCODQ5Ii8+CjxyZWN0IHg9IjIwNSIgeT0iOTIiIHdpZHRoPSI2IiBoZWlnaHQ9IjczIiBmaWxsPSIjM0I3Q0JFIi8+CjxjaXJjbGUgY3g9IjIwOCIgY3k9IjkyIiByPSIzIiBmaWxsPSIjRkYzMzU1Ii8+CjxjaXJjbGUgY3g9IjIwOCIgY3k9IjE2NSIgcj0iMyIgZmlsbD0iIzAwQjg0OSIvPgo8cmVjdCB4PSIyMTQiIHk9Ijk0IiB3aWR0aD0iNiIgaGVpZ2h0PSI2NSIgZmlsbD0iIzNCN0NCRSIvPgo8Y2lyY2xlIGN4PSIyMTciIGN5PSI5NCIgcj0iMyIgZmlsbD0iI0ZGMzM1NSIvPgo8Y2lyY2xlIGN4PSIyMTciIGN5PSIxNTkiIHI9IjMiIGZpbGw9IiMwMEI4NDkiLz4KPHJlY3QgeD0iMTMyIiB5PSI4NCIgd2lkdGg9IjYiIGhlaWdodD0iNzUiIGZpbGw9IiMzQjdDQkUiLz4KPGNpcmNsZSBjeD0iMTM1IiBjeT0iODQiIHI9IjMiIGZpbGw9IiNGRjMzNTUiLz4KPGNpcmNsZSBjeD0iMTM1IiBjeT0iMTU5IiByPSIzIiBmaWxsPSIjMDBCODQ5Ii8+CjxyZWN0IHg9IjE0MSIgeT0iOTkiIHdpZHRoPSI2IiBoZWlnaHQ9IjcyIiBmaWxsPSIjM0I3Q0JFIi8+CjxjaXJjbGUgY3g9IjE0NCIgY3k9Ijk5IiByPSIzIiBmaWxsPSIjRkYzMzU1Ii8+CjxjaXJjbGUgY3g9IjE0NCIgY3k9IjE3MSIgcj0iMyIgZmlsbD0iIzAwQjg0OSIvPgo8cmVjdCB4PSIxNTAiIHk9Ijg2IiB3aWR0aD0iNiIgaGVpZ2h0PSI2OCIgZmlsbD0iIzNCN0NCRSIvPgo8Y2lyY2xlIGN4PSIxNTMiIGN5PSI4NiIgcj0iMyIgZmlsbD0iI0ZGMzM1NSIvPgo8Y2lyY2xlIGN4PSIxNTMiIGN5PSIxNTQiIHI9IjMiIGZpbGw9IiMwMEI4NDkiLz4KPHJlY3QgeD0iMTU5IiB5PSI5MiIgd2lkdGg9IjYiIGhlaWdodD0iNzMiIGZpbGw9IiMzQjdDQkUiLz4KPGNpcmNsZSBjeD0iMTYyIiBjeT0iOTIiIHI9IjMiIGZpbGw9IiNGRjMzNTUiLz4KPGNpcmNsZSBjeD0iMTYyIiBjeT0iMTY1IiByPSIzIiBmaWxsPSIjMDBCODQ5Ii8+CjxyZWN0IHg9IjE2OCIgeT0iOTQiIHdpZHRoPSI2IiBoZWlnaHQ9IjY1IiBmaWxsPSIjM0I3Q0JFIi8+CjxjaXJjbGUgY3g9IjE3MSIgY3k9Ijk0IiByPSIzIiBmaWxsPSIjRkYzMzU1Ii8+CjxjaXJjbGUgY3g9IjE3MSIgY3k9IjE1OSIgcj0iMyIgZmlsbD0iIzAwQjg0OSIvPgo8cmVjdCB4PSI4NSIgeT0iMTI1IiB3aWR0aD0iNjMiIGhlaWdodD0iNjMiIHJ4PSI5IiBmaWxsPSIjMDAzNjZEIi8+CjxwYXRoIGQ9Ik0xMTUuNSAxNzZDMTIzLjUwOCAxNzYgMTMwIDE2OS40ODggMTMwIDE2MS40NTVDMTMwIDE1MC41NDUgMTE1LjUgMTM2IDExNS41IDEzNkMxMTUuNSAxMzYgMTAxIDE1MC41NDUgMTAxIDE2MS40NTVDMTAxIDE2OS40ODggMTA3LjQ5MiAxNzYgMTE1LjUgMTc2WiIgZmlsbD0iI0ZGMzM1NSIvPgo8cGF0aCBkPSJNMTA2LjQxNiAxNjcuODk5QzEwNS43NjEgMTY3LjEzIDEwNS44OTQgMTY2LjAwNyAxMDYuNzEzIDE2NS4zOTFDMTA3LjUzMyAxNjQuNzc1IDEwOC43MjggMTY0LjkgMTA5LjM4NCAxNjUuNjdDMTEyLjA4NiAxNjguODQyIDExNy4wMTUgMTY5LjM1NyAxMjAuMzkzIDE2Ni44MTlDMTIwLjg0NSAxNjYuNDc5IDEyMS4yNTUgMTY2LjA5NCAxMjEuNjE2IDE2NS42N0MxMjIuMjcyIDE2NC45IDEyMy40NjcgMTY0Ljc3NSAxMjQuMjg3IDE2NS4zOTFDMTI1LjEwNiAxNjYuMDA3IDEyNS4yMzkgMTY3LjEzIDEyNC41ODQgMTY3Ljg5OUMxMjQuMDQ3IDE2OC41MjkgMTIzLjQzOCAxNjkuMTAyIDEyMi43NjcgMTY5LjYwNkMxMTcuNzUgMTczLjM3NSAxMTAuNDMgMTcyLjYxMSAxMDYuNDE2IDE2Ny44OTlaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K) no-repeat 50% 50%; background-size: contain;">
           </a>
           <h3><span style="color: #FF3355; font-size: 90%; float: right;"><%= t("help.bp_passport_app_summary.new_html") %></span> <%= t("help.bp_passport_app_summary.heading_html") %></h3>
           <p><%= t("help.bp_passport_app_summary.contents_1_html") %></p>
           <p><%= t("help.bp_passport_app_summary.contents_2_html") %></p>
-          <p class="card-footer-button"><a href="#" onclick="openWindow('help-bp-passport-app'); return false"><%= t("help.bp_passport_app_summary.learn_more_html") %></a></p>
+          <p class="card-footer-button"><a href="#" onclick="goToPage('help-section', 'help-bp-passport-app'); return false"><%= t("help.bp_passport_app_summary.learn_more_html") %></a></p>
         </div>
         <p class="tos"><a href="https://simple.org/simple-privacy"><%= t("help.privacy_policy_html") %></a> <span class="divider">&nbsp;|&nbsp;</span> <a href="https://simple.org/terms"><%= t("help.terms_of_service_html") %></a></p>
       </div>
@@ -75,7 +75,7 @@
 
     <div id="help-videos" class="help-body" style="display: none;">
       <div class="help-contents">
-        <a href="#" onclick="closeWindow('help-videos'); return false" class="help-back">
+        <a href="#" onclick="goToPage('help-videos', 'help-section'); return false" class="help-back">
           <%= inline_svg('icon_back.svg') %>
         </a>
         <h2><%= t("help.videos.heading_html") %></h2>
@@ -157,7 +157,7 @@
 
     <div id="help-start" class="help-body" style="display: none;">
       <div class="help-contents">
-        <a href="#" onclick="closeWindow('help-start'); return false" class="help-back">
+        <a href="#" onclick="goToPage('help-start', 'help-section'); return false" class="help-back">
           <%= inline_svg('icon_back.svg') %>
         </a>
         <h2><%= t("help.start.heading_html") %></h2>
@@ -215,7 +215,7 @@
 
     <div id="help-register" class="help-body" style="display: none;">
       <div class="help-contents">
-        <a href="#" onclick="closeWindow('help-register'); return false" class="help-back">
+        <a href="#" onclick="goToPage('help-register', 'help-section'); return false" class="help-back">
           <%= inline_svg('icon_back.svg') %>
         </a>
         <h2><%= t("help.register.heading_html") %></h2>
@@ -269,7 +269,7 @@
 
     <div id="help-search" class="help-body" style="display: none;">
       <div class="help-contents">
-        <a href="#" onclick="closeWindow('help-search'); return false" class="help-back">
+        <a href="#" onclick="goToPage('help-search', 'help-section'); return false" class="help-back">
           <%= inline_svg('icon_back.svg') %>
         </a>
         <h2><%= t("help.search.heading_html") %></h2>
@@ -302,7 +302,7 @@
 
     <div id="help-record" class="help-body" style="display: none;">
       <div class="help-contents">
-        <a href="#" onclick="closeWindow('help-record'); return false" class="help-back">
+        <a href="#" onclick="goToPage('help-record', 'help-section'); return false" class="help-back">
           <%= inline_svg('icon_back.svg') %>
         </a>
         <h2><%= t("help.record.heading_html") %></h2>
@@ -372,7 +372,7 @@
 
     <div id="help-overdue" class="help-body" style="display: none;">
       <div class="help-contents">
-        <a href="#" onclick="closeWindow('help-overdue'); return false" class="help-back">
+        <a href="#" onclick="goToPage('help-overdue', 'help-section'); return false" class="help-back">
           <%= inline_svg('icon_back.svg') %>
         </a>
         <h2><%= t("help.overdue.heading_html") %></h2>
@@ -414,7 +414,7 @@
 
     <div id="help-faq" class="help-body" style="display: none;">
       <div class="help-contents">
-        <a href="#" onclick="closeWindow('help-faq'); return false" class="help-back">
+        <a href="#" onclick="goToPage('help-faq', 'help-section'); return false" class="help-back">
           <%= inline_svg('icon_back.svg') %>
         </a>
         <h2><%= t("help.faq.heading_html") %></h2>
@@ -481,7 +481,7 @@
 
     <div id="help-bp-passport-app" class="help-body" style="display: none;">
       <div class="help-contents">
-        <a href="#" onclick="closeWindow('help-bp-passport-app'); return false" class="help-back">
+        <a href="#" onclick="goToPage('help-bp-passport-app', 'help-section'); return false" class="help-back">
           <%= inline_svg('icon_back.svg') %>
         </a>
         <h2><%= t("help.bp_passport_app.heading_html") %></h2>


### PR DESCRIPTION
**Story card:** [sc-7526](https://app.shortcut.com/simpledotorg/story/7526/help-screen-text-cutting-off-in-common-questions)

## Because

When a user clicks one of the links to open a subpage, the content of the "Help" home screen still appears at the end (it should be hidden).

## This addresses

**Before**
![image](https://user-images.githubusercontent.com/16785131/157088632-f7371d93-914e-4c0e-afb5-17aa57a52a1d.png)
_The "Help" section subviews show content from the home page (the "App for your patients" card shouldn't be displayed because it's part of the home page)._

**After**
![image](https://user-images.githubusercontent.com/16785131/157088262-b3b2b1ef-68b4-49ad-a8e9-d162ec8a0de4.png)
_The "Help" section subviews don't show content from the home page._

1. Deleted the `closeWindow` and `openWindow` JS functions. Replaced with a single function, `goToPage`
2. Set the right element IDs in the HTML to open/close the home page and subviews on link click.

## Test instructions

1. Go to `localhost:3000/api/v3/help.html` on your local
2. Click the first "Help" page link, "Videos"
3. Scroll down to the end of the page and make sure only the "Videos" content is displayed. The "Help" home page content shouldn't display
4. Click the back arrow at the top of the page. Scroll down to the bottom of the home page and make sure only the home page content is displaying
5. Do this for every link