### PR TITLE
Cohort Report quick fixes

### DIFF
--- a/app/assets/stylesheets/partials/_dashboard.scss
+++ b/app/assets/stylesheets/partials/_dashboard.scss
@@ -317,6 +317,8 @@ th sup {
 .split-bars {
   font-family: $font-condensed;
   height: 40px;
+  border-radius: 4px;
+  overflow: hidden;
 }
 
 .split-bars table {

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -39,7 +39,9 @@ Custom formatting for printable elements
 
 .split-bars {
     border-collapse: separate;
+    border-radius: 4px;
     border-spacing: 4px;
+    overflow: hidden;
 }
 
 .split-bars .bar-1 { }

--- a/app/views/reports/regions/cohort.html.erb
+++ b/app/views/reports/regions/cohort.html.erb
@@ -58,7 +58,7 @@
                     title="<%= number_with_delimiter(cohort["no_bp"]) %> <%= "patient".pluralize(cohort["no_bp"]) %> didn't have a BP taken"
                     style="width: <%= no_bp_percent %>%;"
                   >
-                    <%= (cohort["no_bp"] > 0 && no_bp_percent == 0) ? "< 1" : no_bp_percent %>
+                    <%= (cohort["no_bp"] > 0 && no_bp_percent == 0) ? "< 1" : no_bp_percent %>%
                   </td>
                   <td
                     class="bar bar-2"
@@ -68,7 +68,7 @@
                     title="<%= number_with_delimiter(cohort["uncontrolled"]) %> <%= "patient".pluralize(cohort["uncontrolled"]) %> visited with BP not controlled"
                     style="width: <%= uncontrolled_percent %>%;"
                   >
-                    <%= (cohort["uncontrolled"] > 1 && uncontrolled_percent == 0) ? "< 1" : uncontrolled_percent %>
+                    <%= (cohort["uncontrolled"] > 1 && uncontrolled_percent == 0) ? "< 1" : uncontrolled_percent %>%
                   </td>
                   <td
                     class="bar bar-3"
@@ -78,7 +78,7 @@
                     title="<%= number_with_delimiter(cohort["controlled"]) %> <%= "patient".pluralize(cohort["controlled"]) %> visited with BP controlled"
                     style="<%= controlled_percent %>%;"
                   >
-                    <%= (cohort["controlled"] > 0 && controlled_percent == 0) ? "< 1" : controlled_percent %>
+                    <%= (cohort["controlled"] > 0 && controlled_percent == 0) ? "< 1" : controlled_percent %>%
                   </td>
                   <td
                     class="bar bar-4"
@@ -88,7 +88,7 @@
                     title="<%= number_with_delimiter(cohort["missed_visits"]) %> <%= "patient".pluralize(cohort["missed_visits"]) %> missed visit"
                     style="width: <%= missed_visits_percent %>%;"
                   >
-                    <%= (cohort["missed_visits"] > 0 && missed_visits_percent == 0) ? "< 1" : missed_visits_percent %>
+                    <%= (cohort["missed_visits"] > 0 && missed_visits_percent == 0) ? "< 1" : missed_visits_percent %>%
                   </td>
                 <% else %>
                   <td class="bar bar-none w-100pt">


### PR DESCRIPTION
**Story card:** [sc-7571](https://app.shortcut.com/simpledotorg/story/7571/show-a-percentage-sign-next-to-the-cohort-report-bar-chart-values)

## Because

The cohort report bar charts should display the `%` symbol next to each value. Also, the border radius of the first cohort report bar chart isn't rendering (it's bugging me).

## This addresses
**Before fix**
![image](https://user-images.githubusercontent.com/16785131/157259948-fef5c40b-b1eb-426b-b687-3f7b7664b131.png)
1. Bar charts not showing `%` symbol
2. The first cohort report bar isn't properly rendering the border radius

**After fix**
![image](https://user-images.githubusercontent.com/16785131/157259549-28aaf1db-a2f3-4c28-833a-c24405301af1.png)
1. Showing `%` sign within bar charts
2. The first cohort report is now showing the proper `4px` radius :)

## Test instructions

1. Go to any cohort report report tab and checkout the monthly and quarterly cohort reports.
2. The `%` sign should display in all bars.
3. The first bar chart should have a border radius of `4px` (like the rest of the bar charts).