### PR TITLE
Add memoization to facility progress service

### DIFF
--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -1,5 +1,7 @@
 module Reports
   class FacilityProgressService
+    include Memery
+
     MONTHS = -5
     CONTROL_MONTHS = -12
     attr_reader :control_range
@@ -80,12 +82,12 @@ module Reports
 
     attr_reader :diabetes_enabled
 
-    def daily_registrations_grouped_by_day
+    memoize def daily_registrations_grouped_by_day
       diagnosis = diabetes_enabled ? :all : :hypertension
       RegisteredPatientsQuery.new.count_daily(facility, diagnosis: diagnosis, last: 30)
     end
 
-    def daily_follow_ups_grouped_by_day
+    memoize def daily_follow_ups_grouped_by_day
       scope = Reports::DailyFollowUp.with_hypertension
       scope = scope.or(Reports::DailyFollowUp.with_diabetes) if diabetes_enabled
       scope.where(facility: facility).group_by_day(:visited_at, last: 30).count


### PR DESCRIPTION
These methods were earlier memoized. We removed it due to confusion
around when the progress tab gets updated, as the memoization was acting
like a secondary caching layer.

But, removing the memoization, increased the latency of the API and
conflicts with our SLAs. Hence we are adding this back

Co-authored-by: Priyanga P Kini <priyangapkini99@gmail.com>