### PR TITLE
Add a check to handle the cases when next_scheduled_appointment' and 'current_prescription_drugs are nil

### DIFF
--- a/app/models/materialized_patient_summary.rb
+++ b/app/models/materialized_patient_summary.rb
@@ -29,7 +29,7 @@ class MaterializedPatientSummary < ActiveRecord::Base
     recorded_at < Patient::LTFU_TIME.ago &&
       (latest_blood_pressure_recorded_at.nil? || latest_blood_pressure_recorded_at < Patient::LTFU_TIME.ago) &&
       (latest_blood_sugar_recorded_at.nil? || latest_blood_sugar_recorded_at < Patient::LTFU_TIME.ago) &&
-      (next_scheduled_appointment.nil? || next_scheduled_appointment.device_created_at < Patient::LTFU_TIME.ago) &&
-      (prescription_drugs.empty? || current_prescription_drugs.first.device_created_at < Patient::LTFU_TIME.ago)
+      (next_scheduled_appointment&.device_created_at.nil? || next_scheduled_appointment.device_created_at < Patient::LTFU_TIME.ago) &&
+      (current_prescription_drugs.first&.device_created_at.nil? || current_prescription_drugs.first.device_created_at < Patient::LTFU_TIME.ago)
   end
 end


### PR DESCRIPTION
**Story card:** [sc-7642](https://app.shortcut.com/simpledotorg/story/7642/add-check-for-edge-cases-in-ltfu-function)

## Because

`ltfu?` method throws an error when there is no `next_scheduled_appointment' and 'current_prescription_drugs`
> [NoMethodError](https://sentry.io/organizations/resolve-to-save-lives/issues/3101764995/?referrer=slack)
undefined method `device_created_at' for nil:NilClass

## This addresses

Add a check to handle the cases when `next_scheduled_appointment' and 'current_prescription_drugs` are `nil`