### PR TITLE
[P1] Daily followups bug

### DIFF
--- a/db/migrate/20220315095931_update_reporting_daily_follow_ups_to_version_3.rb
+++ b/db/migrate/20220315095931_update_reporting_daily_follow_ups_to_version_3.rb
@@ -1,0 +1,8 @@
+class UpdateReportingDailyFollowUpsToVersion3 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :reporting_daily_follow_ups,
+      version: 3,
+      revert_to_version: 2,
+      materialized: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1380,7 +1380,7 @@ CREATE MATERIALIZED VIEW public.reporting_daily_follow_ups AS
             bp.recorded_at AS visited_at,
             (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bp.recorded_at))))::integer AS day_of_year
            FROM (public.patients p
-             JOIN public.blood_pressures bp ON ((p.id = bp.patient_id)))
+             JOIN public.blood_pressures bp ON (((p.id = bp.patient_id) AND (date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bp.recorded_at))) > date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
           WHERE ((p.deleted_at IS NULL) AND (bp.recorded_at > (CURRENT_TIMESTAMP - '30 days'::interval)))
         ), follow_up_blood_sugars AS (
          SELECT DISTINCT ON (p.id, bs.facility_id, ((date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at))))::integer)) p.id AS patient_id,
@@ -1392,7 +1392,7 @@ CREATE MATERIALIZED VIEW public.reporting_daily_follow_ups AS
             bs.recorded_at AS visited_at,
             (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at))))::integer AS day_of_year
            FROM (public.patients p
-             JOIN public.blood_sugars bs ON ((p.id = bs.patient_id)))
+             JOIN public.blood_sugars bs ON (((p.id = bs.patient_id) AND (date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at))) > date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
           WHERE ((p.deleted_at IS NULL) AND (bs.recorded_at > (CURRENT_TIMESTAMP - '30 days'::interval)))
         ), follow_up_prescription_drugs AS (
          SELECT DISTINCT ON (p.id, pd.facility_id, ((date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at))))::integer)) p.id AS patient_id,
@@ -1404,7 +1404,7 @@ CREATE MATERIALIZED VIEW public.reporting_daily_follow_ups AS
             pd.device_created_at AS visited_at,
             (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at))))::integer AS day_of_year
            FROM (public.patients p
-             JOIN public.prescription_drugs pd ON ((p.id = pd.patient_id)))
+             JOIN public.prescription_drugs pd ON (((p.id = pd.patient_id) AND (date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at))) > date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
           WHERE ((p.deleted_at IS NULL) AND (pd.device_created_at > (CURRENT_TIMESTAMP - '30 days'::interval)))
         ), follow_up_appointments AS (
          SELECT DISTINCT ON (p.id, app.creation_facility_id, ((date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at))))::integer)) p.id AS patient_id,
@@ -1416,7 +1416,7 @@ CREATE MATERIALIZED VIEW public.reporting_daily_follow_ups AS
             app.device_created_at AS visited_at,
             (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at))))::integer AS day_of_year
            FROM (public.patients p
-             JOIN public.appointments app ON ((p.id = app.patient_id)))
+             JOIN public.appointments app ON (((p.id = app.patient_id) AND (date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at))) > date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
           WHERE ((p.deleted_at IS NULL) AND (app.device_created_at > (CURRENT_TIMESTAMP - '30 days'::interval)))
         ), all_follow_ups AS (
          SELECT follow_up_blood_pressures.patient_id,
@@ -5497,6 +5497,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220217102418'),
 ('20220217102500'),
 ('20220217202441'),
-('20220223080958');
+('20220223080958'),
+('20220315095931');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1416,7 +1416,7 @@ CREATE MATERIALIZED VIEW public.reporting_daily_follow_ups AS
             app.device_created_at AS visited_at,
             (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at))))::integer AS day_of_year
            FROM (public.patients p
-             JOIN public.appointments app ON (((p.id = app.patient_id) AND (date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at))) > date_trunc('month'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
+             JOIN public.appointments app ON (((p.id = app.patient_id) AND (date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at))) > date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
           WHERE ((p.deleted_at IS NULL) AND (app.device_created_at > (CURRENT_TIMESTAMP - '30 days'::interval)))
         ), all_follow_ups AS (
          SELECT follow_up_blood_pressures.patient_id,

--- a/db/views/reporting_daily_follow_ups_v03.sql
+++ b/db/views/reporting_daily_follow_ups_v03.sql
@@ -66,8 +66,8 @@ follow_up_appointments AS (
 FROM patients p
   INNER JOIN appointments app
     ON p.id = app.patient_id
-    AND date_trunc('month', app.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
-      > date_trunc('month', p.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+    AND date_trunc('day', app.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+      > date_trunc('day', p.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
   WHERE p.deleted_at IS NULL
     AND app.device_created_at > current_timestamp - interval '30 day'
 ),

--- a/db/views/reporting_daily_follow_ups_v03.sql
+++ b/db/views/reporting_daily_follow_ups_v03.sql
@@ -1,0 +1,96 @@
+WITH follow_up_blood_pressures AS (
+  SELECT DISTINCT ON (patient_id, facility_id, day_of_year)
+    p.id AS patient_id,
+    p.gender::gender_enum as patient_gender,
+    bp.id as visit_id,
+    'BloodPressure' AS visit_type,
+    bp.facility_id,
+    bp.user_id,
+    bp.recorded_at AS visited_at,
+    cast(EXTRACT(DOY FROM bp.recorded_at AT TIME ZONE 'UTC' at time zone (SELECT current_setting('TIMEZONE'))) as integer) AS day_of_year
+ FROM patients p
+    INNER JOIN blood_pressures bp
+      ON p.id = bp.patient_id
+      AND date_trunc('day', bp.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+        > date_trunc('day', p.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+  WHERE p.deleted_at IS NULL
+    AND bp.recorded_at > current_timestamp - interval '30 day'
+),
+follow_up_blood_sugars AS (
+  SELECT DISTINCT ON (patient_id, facility_id, day_of_year)
+    p.id AS patient_id,
+    p.gender::gender_enum as patient_gender,
+    bs.id as visit_id,
+   'BloodSugar' AS visit_type,
+    bs.facility_id,
+    bs.user_id,
+    bs.recorded_at AS visited_at,
+    cast(EXTRACT(DOY FROM bs.recorded_at AT TIME ZONE 'UTC' at time zone (SELECT current_setting('TIMEZONE'))) as integer) AS day_of_year
+
+  FROM patients p
+  INNER JOIN blood_sugars bs
+    ON p.id = bs.patient_id
+    AND date_trunc('day', bs.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+      > date_trunc('day', p.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+  WHERE p.deleted_at IS NULL
+    AND bs.recorded_at > current_timestamp - interval '30 day'
+),
+follow_up_prescription_drugs AS (
+  SELECT DISTINCT ON (patient_id, facility_id, day_of_year)
+    p.id AS patient_id,
+    p.gender::gender_enum as patient_gender,
+    pd.id as visit_id,
+    'PrescriptionDrug' AS visit_type,
+    pd.facility_id,
+    pd.user_id,
+    pd.device_created_at AS visited_at,
+    cast(EXTRACT(DOY FROM pd.device_created_at AT TIME ZONE 'UTC' at time zone (SELECT current_setting('TIMEZONE'))) as integer) AS day_of_year
+  FROM patients p
+  INNER JOIN prescription_drugs pd
+    ON p.id = pd.patient_id
+    AND date_trunc('day', pd.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+      > date_trunc('day', p.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+  WHERE p.deleted_at IS NULL
+    AND pd.device_created_at > current_timestamp - interval '30 day'
+),
+follow_up_appointments AS (
+  SELECT DISTINCT ON (patient_id, facility_id, day_of_year)
+    p.id AS patient_id,
+    p.gender::gender_enum as patient_gender,
+    app.id as visit_id,
+    'Appointment' AS visit_type,
+    app.creation_facility_id AS facility_id,
+    app.user_id,
+    app.device_created_at as visited_at,
+    cast(EXTRACT(DOY FROM app.device_created_at AT TIME ZONE 'UTC' at time zone (SELECT current_setting('TIMEZONE'))) as integer) AS day_of_year
+FROM patients p
+  INNER JOIN appointments app
+    ON p.id = app.patient_id
+    AND date_trunc('month', app.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+      > date_trunc('month', p.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+  WHERE p.deleted_at IS NULL
+    AND app.device_created_at > current_timestamp - interval '30 day'
+),
+all_follow_ups AS (
+  SELECT *
+  FROM
+    follow_up_blood_pressures
+    UNION (select * FROM follow_up_blood_sugars)
+    UNION (select * FROM follow_up_prescription_drugs)
+    UNION (select * FROM follow_up_appointments)
+)
+SELECT DISTINCT ON (all_follow_ups.day_of_year, all_follow_ups.facility_id, all_follow_ups.patient_id)
+  all_follow_ups.patient_id,
+  all_follow_ups.patient_gender,
+  all_follow_ups.facility_id,
+  mh.diabetes,
+  mh.hypertension,
+  all_follow_ups.user_id,
+  all_follow_ups.visit_id,
+  all_follow_ups.visit_type,
+  all_follow_ups.visited_at,
+  all_follow_ups.day_of_year
+FROM
+  all_follow_ups
+  INNER JOIN medical_histories mh
+     ON all_follow_ups.patient_id = mh.patient_id

--- a/spec/models/reports/daily_follow_up_spec.rb
+++ b/spec/models/reports/daily_follow_up_spec.rb
@@ -144,4 +144,14 @@ RSpec.describe Reports::DailyFollowUp, {type: :model, reporting_spec: true} do
 
     expect(described_class.count).to eq(0)
   end
+
+  it "counts activity the day after registration as a follow up" do
+    now = Time.current
+    patient = create(:patient, recorded_at: now.advance(days: -1).beginning_of_day)
+    create(:blood_pressure, patient: patient, user: user, facility: facility, recorded_at: now.end_of_day)
+
+    described_class.refresh
+
+    expect(described_class.count).to eq(1)
+  end
 end

--- a/spec/models/reports/daily_follow_up_spec.rb
+++ b/spec/models/reports/daily_follow_up_spec.rb
@@ -134,4 +134,14 @@ RSpec.describe Reports::DailyFollowUp, {type: :model, reporting_spec: true} do
       expect(follow_up.day_of_year).to eq(now.yday)
     end
   end
+
+  it "does not count registration activity as a follow up" do
+    now = Time.current
+    patient = create(:patient, recorded_at: now.beginning_of_day)
+    create(:blood_pressure, patient: patient, user: user, facility: facility, recorded_at: now.end_of_day)
+
+    described_class.refresh
+
+    expect(described_class.count).to eq(0)
+  end
 end

--- a/spec/services/reports/facility_progress_service_spec.rb
+++ b/spec/services/reports/facility_progress_service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Reports::FacilityProgressService, type: :model do
 
   it "matches daily stats for including JSON in the view" do
     facility = create(:facility, enable_diabetes_management: true)
-    htn_patient1 = create(:patient, :hypertension, registration_facility: facility, registration_user: user, recorded_at: two_days_ago)
+    htn_patient1 = create(:patient, :hypertension, registration_facility: facility, registration_user: user, recorded_at: seven_days_ago)
     _htn_patient2 = create(:patient, :hypertension, registration_facility: facility, registration_user: user, recorded_at: two_days_ago)
     _dm_patient = create(:patient, :diabetes, registration_facility: facility, registration_user: user, recorded_at: two_days_ago)
     _htn_patient3 = create(:patient, :hypertension, registration_facility: facility, registration_user: user, recorded_at: 1.minute.ago)
@@ -43,9 +43,9 @@ RSpec.describe Reports::FacilityProgressService, type: :model do
 
       registrations = service.daily_statistics[:daily][:grouped_by_date][:registrations]
       follow_ups = service.daily_statistics[:daily][:grouped_by_date][:follow_ups]
-      expect(registrations[seven_days_ago.to_date]).to eq(0)
+      expect(registrations[seven_days_ago.to_date]).to eq(1)
       expect(follow_ups[seven_days_ago.to_date]).to eq(0)
-      expect(registrations[two_days_ago.to_date]).to eq(3)
+      expect(registrations[two_days_ago.to_date]).to eq(2)
       expect(follow_ups[two_days_ago.to_date]).to eq(1)
     end
   end


### PR DESCRIPTION
**Story card:** [sc-7641](https://app.shortcut.com/simpledotorg/story/7641/progress-tab-follow-ups-shouldn-t-include-fresh-registrations)

Here’s the timeline I’m seeing:

* We crafted a daily followups reporting view. This view excluded BPs that were recorded in the same month that the patient was registered - Check out the PR.
* We then realized that this month exclusion was wrong, and reverted the exclusion in another PR . Notice that the month exclusion is gone.
* The problem is: When we removed this exclusion, we didn’t introduce a “daily” exclusion. In other words, BPs or other visit activity that happened on the same day as the patient’s registration date should NOT be counted as a follow-up visit, but our view started counting them as followups.
* Proposed solution: Add a daily exclusion (similar to the monthly exclusion that existed) to our daily followups reporting view.