### PR TITLE
Max 100 facilities on HOME

### DIFF
--- a/app/views/shared/my_facilities/_inactive_facilities.html.erb
+++ b/app/views/shared/my_facilities/_inactive_facilities.html.erb
@@ -33,7 +33,7 @@
           </tr>
         </thead>
         <tbody>
-          <% @inactive_facilities.sort_by(&:name).each do |facility| %>
+          <% @inactive_facilities.sort_by(&:name).first(100).each do |facility| %>
             <tr>
               <td>
                 <%= link_to facility.name, reports_region_facility_path(facility) %>


### PR DESCRIPTION
**Story card:** NONE

## Because

We currently show ALL inactive facilities on the Home of the dashboard. This isn't at all helpful for Praveen or power users and it makes the homepage bonkers.

## This addresses

We never show an insane list on the Homepage.

## Test instructions

Load a large or small data set and make sure it truncates successfully.