### PR TITLE
"Recent updates" card: Show last 3 months of updates

### DIFF
--- a/app/views/my_facilities/_recent_updates.html.erb
+++ b/app/views/my_facilities/_recent_updates.html.erb
@@ -50,41 +50,4 @@
       </p>
     </li>
   </ul>
-  <h5 class="font-weight-bold mt-2">
-    December 2021
-  </h5>
-  <ul class="mt-3 mb-0">
-    <li>
-      <p>
-        <strong>Dashboard:</strong> You can now find data for the number of overdue patients contacted by healthcare workers in the report "Details" page.
-      </p>
-    </li>
-    <li>
-      <p>
-        <strong>Simple App:</strong> Downloading and sharing of overdue lists patients from Simple app is available.
-      </p>
-    </li>
-  </ul>
-  <h5 class="font-weight-bold mt-2">
-    October 2021
-  </h5>
-  <ul class="mt-3 mb-0">
-    <li>
-      <p>
-        <strong>Simple App:</strong> Patients who have been marked as dead show 'Died' status.
-      </p>
-    </li>
-    <li>
-      <p>
-        <strong>Simple App:</strong> Users can now add custom medications for a patient by using 'Add another medicine' button.
-      </p>
-    </li>
-    <% if CountryConfig.current[:name] == "Ethiopia" %>
-      <li>
-        <p>
-          <strong>Simple App:</strong> We show a personal health number field to add information like hospital ID.
-        </p>
-      </li>
-    <% end %>
-  </ul>
 </div>


### PR DESCRIPTION
## Because

We were showing updates for the last _8 months_. Not necessary. Let's show the updates for the last 3 months.

## This addresses

Removes monthly updates in the "Recent updates" card from 2021.

## Test instructions

Open the "Home" page and checkout the "Recent updates" card. It should only show updates for months in 2022.