### PR TITLE
Added colors back to cohort reports

### DIFF
--- a/app/assets/stylesheets/partials/_dashboard.scss
+++ b/app/assets/stylesheets/partials/_dashboard.scss
@@ -460,52 +460,55 @@ td.type-percent {
 .split-bars {
   font-family: $font-condensed;
   height: 40px;
-  border-radius: 4px;
+  border-radius: 10px;
   overflow: hidden;
-}
-
-.split-bars table {
   border-collapse: separate;
-  border-spacing: 0;
+
+  table {
+    border-collapse: separate;
+    border-spacing: 0;
+  }
+
+  td {
+    text-align: center;
+    line-height: 2; /* Sets height of bar */
+  }
+
+  .bar {
+    background: $grey-light;
+    vertical-align: middle;
+    padding: 4px 8px;
+    font-size: 110%;
+    position: relative;
+    white-space: nowrap;
+  }
+
+  .bar-none {
+    background: $grey-light;
+    color: $grey-dark;
+  }
+
+  .bar-1 {
+    background: $grey-mid;
+    color: $grey-darkest;
+  }
+
+  .bar-2 {
+    background: $red;
+    color: #fff;
+  }
+
+  .bar-3 {
+    background: $green;
+    color: $white;
+  }
+
+  .bar-4 {
+    background: $blue;
+    color: $white;
+  }
 }
 
-.split-bars td {
-  text-align: center;
-  line-height: 1.7; /* Sets height of bar */
-}
-
-.split-bars .bar {
-  background: #ddd;
-  vertical-align: middle;
-  padding: 4px 8px;
-  font-size: 110%;
-  position: relative;
-  white-space: nowrap;
-}
-
-.split-bars .bar-none {
-  background: $grey-light;
-  color: $grey-dark;
-  border-radius: 3px;
-}
-.split-bars .bar-1 {
-  background: $grey-mid;
-  color: $grey-darkest;
-  border-radius: 3px 0 0 3px;
-}
-.split-bars .bar-2 {
-  background: $red;
-  color: #fff;
-}
-.split-bars .bar-3 {
-  background: $green-dark;
-  color: $white;
-}
-.split-bars .bar-4 {
-  background: $blue;
-  border-radius: 0 3px 3px 0;
-  color: $white;
-}
 .split-row-first .split-bars .bar {
   background-image: asset-url("diagonal-stripe.png");
   background-size: 120px;
@@ -563,7 +566,7 @@ td.type-percent {
   background: $red;
 }
 .key div.controlled:after {
-  background: $green-dark;
+  background: $green;
 }
 
 .key div.didntattend {

--- a/app/views/reports/regions/cohort.html.erb
+++ b/app/views/reports/regions/cohort.html.erb
@@ -51,7 +51,7 @@
                     no_bp_percent = cohort["no_bp_rate"]
                   %>
                   <td
-                    class="bar bar-controlled"
+                    class="bar bar-3 bar-controlled"
                     data-toggle="tooltip"
                     data-placement="top"
                     data-trigger="hover focus click"
@@ -61,7 +61,7 @@
                     <%= (cohort["controlled"] > 0 && controlled_percent == 0) ? "< 1" : controlled_percent %>%
                   </td>
                   <td
-                    class="bar bar-uncontrolled"
+                    class="bar bar-2 bar-uncontrolled"
                     data-toggle="tooltip"
                     data-placement="top"
                     data-trigger="hover focus click"
@@ -71,7 +71,7 @@
                     <%= (cohort["uncontrolled"] > 1 && uncontrolled_percent == 0) ? "< 1" : uncontrolled_percent %>%
                   </td>
                   <td
-                    class="bar bar-missed-visits"
+                    class="bar bar-4 bar-missed-visits"
                     data-toggle="tooltip"
                     data-placement="top"
                     data-trigger="hover focus click"
@@ -103,7 +103,7 @@
     <% end %>
     <div class="mt-8px pt-24px bt-1px bt-grey-light d-lg-flex align-lg-center justify-lg-end mt-lg-0px pt-lg-16px">
       <p class="mb-8px c-black mr-lg-4 mb-lg-0">
-        <span class="p-relative t-1px d-inline-block w-12px h-12px mr-4px br-2px bg-green-dark"></span>
+        <span class="p-relative t-1px d-inline-block w-12px h-12px mr-4px br-2px bg-green"></span>
         BP controlled
       </p>
       <p class="mb-8px c-black mr-lg-4 mb-lg-0">


### PR DESCRIPTION
**Story card:** NONE

## Because

BUG reported that background colors are accidentally removed from cohort reports.

## This addresses

Instead of rolling back the previous change, I rewrote some html and css to be better than before.

## Test instructions

I clicked through cohort reports in Reports and also in Progress tab to ensure everything is working as expected.