### PR TITLE
Consistentize drug stock timestamp with other facilities pages

### DIFF
--- a/app/controllers/my_facilities_controller.rb
+++ b/app/controllers/my_facilities_controller.rb
@@ -67,7 +67,7 @@ class MyFacilitiesController < AdminController
       if last_updated_at.nil?
         "unknown"
       else
-        last_updated_at.in_time_zone(Rails.application.config.country[:time_zone]).strftime("%d-%^b-%Y %I:%M%p")
+        last_updated_at.in_time_zone(Rails.application.config.country[:time_zone]).to_s(:day_mon_year_time)
       end
   end
 

--- a/app/views/my_facilities/drug_stocks/_drug_stock_nav.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_stock_nav.html.erb
@@ -18,6 +18,6 @@
   <div class="d-flex actions order-1 mb-24px order-lg-2 mb-lg-0 text-grey">
     <% if @facilities.present? %>
       Last updated on <%= @report&.fetch(:last_updated_at)&.to_s(:day_mon_year_time) %>
-  <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/my_facilities/drug_stocks/_drug_stock_nav.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_stock_nav.html.erb
@@ -17,7 +17,7 @@
   </div>
   <div class="d-flex actions order-1 mb-24px order-lg-2 mb-lg-0 text-grey">
     <% if @facilities.present? %>
-      Last updated on <%= @report&.fetch(:last_updated_at).to_s(:day_mon_year_time) %>
+      Last updated on <%= @report&.fetch(:last_updated_at)&.to_s(:day_mon_year_time) %>
   <% end %>
   </div>
 </div>

--- a/app/views/my_facilities/drug_stocks/_drug_stock_nav.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_stock_nav.html.erb
@@ -17,7 +17,7 @@
   </div>
   <div class="d-flex actions order-1 mb-24px order-lg-2 mb-lg-0 text-grey">
     <% if @facilities.present? %>
-      Last updated: <%= @report&.fetch(:last_updated_at) %>
+      Last updated on <%= @report&.fetch(:last_updated_at).to_s(:day_mon_year_time) %>
   <% end %>
   </div>
 </div>

--- a/config/initializers/time_and_date_formats.rb
+++ b/config/initializers/time_and_date_formats.rb
@@ -19,6 +19,8 @@ Date::DATE_FORMATS[:cohort] = lambda { |value| "#{value.prev_month.strftime("%b"
 Time::DATE_FORMATS[:day_mon_year] = "%-d-%b-%Y"
 Date::DATE_FORMATS[:day_mon_year] = "%-d-%b-%Y"
 
+Time::DATE_FORMATS[:day_mon_year_time] = "%d-%^b-%Y %I:%M%p"
+
 # DHIS2 has its own period string formats
 # https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/introduction.html#webapi_date_perid_format
 Time::DATE_FORMATS[:dhis2] = "%Y%m"


### PR DESCRIPTION
**Story card:** https://app.shortcut.com/simpledotorg/story/7733/fix-drug-stock-timestamp-format

This PR makes the "Last update" timestamp on the drug stock page match the format we use on other My Facilities pages.

Before: `Last updated: 2022-03-24 17:35:58 +0400`
After: `Last updated on 24-MAR-2022 05:35PM`