### PR TITLE
Cosmetic formatting of the reports and breadcrumbs

### DIFF
--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -2,7 +2,7 @@ Reports = function (withLtfu) {
   this.darkGreenColor = "rgba(0, 122, 49, 1)";
   this.mediumGreenColor = "rgba(0, 184, 73, 1)";
   this.lightGreenColor = "rgba(242, 248, 245, 0.9)";
-  this.darkRedColor = "rgba(184, 22, 49, 1)"
+  this.darkRedColor = "rgba(184, 22, 49, 1)";
   this.mediumRedColor = "rgba(255, 51, 85, 1)";
   this.lightRedColor = "rgba(255, 235, 238, 0.9)";
   this.darkPurpleColor = "rgba(83, 0, 224, 1)";
@@ -19,11 +19,11 @@ Reports = function (withLtfu) {
   this.initialize = () => {
     this.initializeCharts();
     this.initializeTables();
-  }
+  };
 
   this.getChartDataNode = () => {
     return document.getElementById("data-json");
-  }
+  };
 
   this.initializeCharts = () => {
     const data = this.getReportingData();
@@ -33,74 +33,83 @@ Reports = function (withLtfu) {
     this.setupMissedVisitsGraph(data);
     this.setupCumulativeRegistrationsGraph(data);
     this.setupVisitDetailsGraph(data);
-  }
+  };
 
   this.setupControlledGraph = (data) => {
-    const adjustedPatients = withLtfu ? data.adjustedPatientCountsWithLtfu : data.adjustedPatientCounts;
+    const adjustedPatients = withLtfu
+      ? data.adjustedPatientCountsWithLtfu
+      : data.adjustedPatientCounts;
     const controlledGraphNumerator = data.controlledPatients;
-    const controlledGraphRate = withLtfu ? data.controlWithLtfuRate : data.controlRate;
+    const controlledGraphRate = withLtfu
+      ? data.controlWithLtfuRate
+      : data.controlRate;
 
     const controlledGraphConfig = this.createBaseGraphConfig();
     controlledGraphConfig.data = {
       labels: Object.keys(controlledGraphRate),
-      datasets: [{
-        label: "BP controlled",
-        backgroundColor: this.lightGreenColor,
-        borderColor: this.mediumGreenColor,
-        borderWidth: 2,
-        pointBackgroundColor: this.whiteColor,
-        hoverBackgroundColor: this.whiteColor,
-        hoverBorderWidth: 2,
-        data: Object.values(controlledGraphRate),
-      }],
+      datasets: [
+        {
+          label: "BP controlled",
+          backgroundColor: this.lightGreenColor,
+          borderColor: this.mediumGreenColor,
+          borderWidth: 2,
+          pointBackgroundColor: this.whiteColor,
+          hoverBackgroundColor: this.whiteColor,
+          hoverBorderWidth: 2,
+          data: Object.values(controlledGraphRate),
+        },
+      ],
     };
     controlledGraphConfig.options.scales = {
-      xAxes: [{
-        stacked: true,
-        display: true,
-        gridLines: {
-          display: false,
-          drawBorder: true,
-        },
-        ticks: {
-          autoSkip: false,
-          fontColor: this.darkGreyColor,
-          fontSize: 12,
-          fontFamily: "Roboto Condensed",
-          padding: 8,
-          min: 0,
-          beginAtZero: true,
-        },
-      }],
-      yAxes: [{
-        stacked: false,
-        display: true,
-        gridLines: {
+      xAxes: [
+        {
+          stacked: true,
           display: true,
-          drawBorder: false,
+          gridLines: {
+            display: false,
+            drawBorder: true,
+          },
+          ticks: {
+            autoSkip: false,
+            fontColor: this.darkGreyColor,
+            fontSize: 12,
+            fontFamily: "Roboto Condensed",
+            padding: 8,
+            min: 0,
+            beginAtZero: true,
+          },
         },
-        ticks: {
-          autoSkip: false,
-          fontColor: this.darkGreyColor,
-          fontSize: 12,
-          fontFamily: "Roboto Condensed",
-          padding: 8,
-          min: 0,
-          beginAtZero: true,
-          stepSize: 25,
-          max: 100,
+      ],
+      yAxes: [
+        {
+          stacked: false,
+          display: true,
+          gridLines: {
+            display: true,
+            drawBorder: false,
+          },
+          ticks: {
+            autoSkip: false,
+            fontColor: this.darkGreyColor,
+            fontSize: 12,
+            fontFamily: "Roboto Condensed",
+            padding: 8,
+            min: 0,
+            beginAtZero: true,
+            stepSize: 25,
+            max: 100,
+          },
         },
-      }],
+      ],
     };
     controlledGraphConfig.options.tooltips = {
       enabled: false,
       custom: (tooltip) => {
-        let hoveredDatapoint = tooltip.dataPoints
-        if(hoveredDatapoint)
+        let hoveredDatapoint = tooltip.dataPoints;
+        if (hoveredDatapoint)
           populateControlledGraph(hoveredDatapoint[0].label);
-        else
-          populateControlledGraphDefault();
-      }
+        else populateControlledGraphDefault();
+      },
     };
 
     const populateControlledGraph = (period) => {
@@ -110,7 +119,9 @@ Reports = function (withLtfu) {
       const periodStartNode = cardNode.querySelector("[data-period-start]");
       const periodEndNode = cardNode.querySelector("[data-period-end]");
       const registrationsNode = cardNode.querySelector("[data-registrations]");
-      const registrationsPeriodEndNode = cardNode.querySelector("[data-registrations-period-end]");
+      const registrationsPeriodEndNode = cardNode.querySelector(
+        "[data-registrations-period-end]"
+      );
 
       const rate = this.formatPercentage(controlledGraphRate[period]);
       const periodInfo = data.periodInfo[period];
@@ -121,91 +132,105 @@ Reports = function (withLtfu) {
       totalPatientsNode.innerHTML = this.formatNumberWithCommas(totalPatients);
       periodStartNode.innerHTML = periodInfo.bp_control_start_date;
       periodEndNode.innerHTML = periodInfo.bp_control_end_date;
-      registrationsNode.innerHTML = this.formatNumberWithCommas(adjustedPatientCounts);
-      registrationsPeriodEndNode.innerHTML = periodInfo.bp_control_registration_date;
-    }
+      registrationsNode.innerHTML = this.formatNumberWithCommas(
+        adjustedPatientCounts
+      );
+      registrationsPeriodEndNode.innerHTML =
+        periodInfo.bp_control_registration_date;
+    };
 
     const populateControlledGraphDefault = () => {
       const cardNode = document.getElementById("bp-controlled");
       const mostRecentPeriod = cardNode.getAttribute("data-period");
 
       populateControlledGraph(mostRecentPeriod);
-    }
+    };
 
-    const controlledGraphCanvas = document.getElementById("controlledPatientsTrend");
+    const controlledGraphCanvas = document.getElementById(
+      "controlledPatientsTrend"
+    );
     if (controlledGraphCanvas) {
       new Chart(controlledGraphCanvas.getContext("2d"), controlledGraphConfig);
       populateControlledGraphDefault();
     }
-  }
+  };
 
   this.setupUncontrolledGraph = (data) => {
-    const adjustedPatients = withLtfu ? data.adjustedPatientCountsWithLtfu : data.adjustedPatientCounts;
+    const adjustedPatients = withLtfu
+      ? data.adjustedPatientCountsWithLtfu
+      : data.adjustedPatientCounts;
     const uncontrolledGraphNumerator = data.uncontrolledPatients;
-    const uncontrolledGraphRate = withLtfu ? data.uncontrolledWithLtfuRate : data.uncontrolledRate;
+    const uncontrolledGraphRate = withLtfu
+      ? data.uncontrolledWithLtfuRate
+      : data.uncontrolledRate;
 
     const uncontrolledGraphConfig = this.createBaseGraphConfig();
     uncontrolledGraphConfig.data = {
       labels: Object.keys(uncontrolledGraphRate),
-      datasets: [{
-        label: "BP uncontrolled",
-        backgroundColor: this.lightRedColor,
-        borderColor: this.mediumRedColor,
-        borderWidth: 2,
-        pointBackgroundColor: this.whiteColor,
-        hoverBackgroundColor: this.whiteColor,
-        hoverBorderWidth: 2,
-        data: Object.values(uncontrolledGraphRate),
-        type: "line",
-      }],
+      datasets: [
+        {
+          label: "BP uncontrolled",
+          backgroundColor: this.lightRedColor,
+          borderColor: this.mediumRedColor,
+          borderWidth: 2,
+          pointBackgroundColor: this.whiteColor,
+          hoverBackgroundColor: this.whiteColor,
+          hoverBorderWidth: 2,
+          data: Object.values(uncontrolledGraphRate),
+          type: "line",
+        },
+      ],
     };
     uncontrolledGraphConfig.options.scales = {
-      xAxes: [{
-        stacked: false,
-        display: true,
-        gridLines: {
-          display: false,
-          drawBorder: true,
-        },
-        ticks: {
-          autoSkip: false,
-          fontColor: this.darkGreyColor,
-          fontSize: 12,
-          fontFamily: "Roboto Condensed",
-          padding: 8,
-          min: 0,
-          beginAtZero: true,
-        },
-      }],
-      yAxes: [{
-        stacked: false,
-        display: true,
-        gridLines: {
+      xAxes: [
+        {
+          stacked: false,
           display: true,
-          drawBorder: false,
+          gridLines: {
+            display: false,
+            drawBorder: true,
+          },
+          ticks: {
+            autoSkip: false,
+            fontColor: this.darkGreyColor,
+            fontSize: 12,
+            fontFamily: "Roboto Condensed",
+            padding: 8,
+            min: 0,
+            beginAtZero: true,
+          },
         },
-        ticks: {
-          autoSkip: false,
-          fontColor: this.darkGreyColor,
-          fontSize: 12,
-          fontFamily: "Roboto Condensed",
-          padding: 8,
-          min: 0,
-          beginAtZero: true,
-          stepSize: 25,
-          max: 100,
+      ],
+      yAxes: [
+        {
+          stacked: false,
+          display: true,
+          gridLines: {
+            display: true,
+            drawBorder: false,
+          },
+          ticks: {
+            autoSkip: false,
+            fontColor: this.darkGreyColor,
+            fontSize: 12,
+            fontFamily: "Roboto Condensed",
+            padding: 8,
+            min: 0,
+            beginAtZero: true,
+            stepSize: 25,
+            max: 100,
+          },
         },
-      }],
+      ],
     };
     uncontrolledGraphConfig.options.tooltips = {
       enabled: false,
       custom: (tooltip) => {
-        let hoveredDatapoint = tooltip.dataPoints
-        if(hoveredDatapoint)
+        let hoveredDatapoint = tooltip.dataPoints;
+        if (hoveredDatapoint)
           populateUncontrolledGraph(hoveredDatapoint[0].label);
-        else
-          populateUncontrolledGraphDefault();
-      }
+        else populateUncontrolledGraphDefault();
+      },
     };
 
     const populateUncontrolledGraph = (period) => {
@@ -215,7 +240,9 @@ Reports = function (withLtfu) {
       const periodStartNode = cardNode.querySelector("[data-period-start]");
       const periodEndNode = cardNode.querySelector("[data-period-end]");
       const registrationsNode = cardNode.querySelector("[data-registrations]");
-      const registrationsPeriodEndNode = cardNode.querySelector("[data-registrations-period-end]")
+      const registrationsPeriodEndNode = cardNode.querySelector(
+        "[data-registrations-period-end]"
+      );
 
       const rate = this.formatPercentage(uncontrolledGraphRate[period]);
       const periodInfo = data.periodInfo[period];
@@ -226,91 +253,110 @@ Reports = function (withLtfu) {
       totalPatientsNode.innerHTML = this.formatNumberWithCommas(totalPatients);
       periodStartNode.innerHTML = periodInfo.bp_control_start_date;
       periodEndNode.innerHTML = periodInfo.bp_control_end_date;
-      registrationsNode.innerHTML = this.formatNumberWithCommas(adjustedPatientCounts);
-      registrationsPeriodEndNode.innerHTML = periodInfo.bp_control_registration_date;
-    }
+      registrationsNode.innerHTML = this.formatNumberWithCommas(
+        adjustedPatientCounts
+      );
+      registrationsPeriodEndNode.innerHTML =
+        periodInfo.bp_control_registration_date;
+    };
 
     const populateUncontrolledGraphDefault = () => {
       const cardNode = document.getElementById("bp-uncontrolled");
       const mostRecentPeriod = cardNode.getAttribute("data-period");
 
       populateUncontrolledGraph(mostRecentPeriod);
-    }
+    };
 
-    const uncontrolledGraphCanvas = document.getElementById("uncontrolledPatientsTrend");
+    const uncontrolledGraphCanvas = document.getElementById(
+      "uncontrolledPatientsTrend"
+    );
     if (uncontrolledGraphCanvas) {
-      new Chart(uncontrolledGraphCanvas.getContext("2d"), uncontrolledGraphConfig);
+      new Chart(
+        uncontrolledGraphCanvas.getContext("2d"),
+        uncontrolledGraphConfig
+      );
       populateUncontrolledGraphDefault();
     }
-  }
+  };
 
   this.setupMissedVisitsGraph = (data) => {
-    const adjustedPatients = withLtfu ? data.adjustedPatientCountsWithLtfu : data.adjustedPatientCounts;
-    const missedVisitsGraphNumerator = withLtfu ? data.missedVisitsWithLtfu : data.missedVisits;
-    const missedVisitsGraphRate = withLtfu ? data.missedVisitsWithLtfuRate : data.missedVisitsRate;
+    const adjustedPatients = withLtfu
+      ? data.adjustedPatientCountsWithLtfu
+      : data.adjustedPatientCounts;
+    const missedVisitsGraphNumerator = withLtfu
+      ? data.missedVisitsWithLtfu
+      : data.missedVisits;
+    const missedVisitsGraphRate = withLtfu
+      ? data.missedVisitsWithLtfuRate
+      : data.missedVisitsRate;
 
     const missedVisitsConfig = this.createBaseGraphConfig();
     missedVisitsConfig.data = {
       labels: Object.keys(missedVisitsGraphRate),
-      datasets: [{
-        label: "Missed visits",
-        backgroundColor: this.lightBlueColor,
-        borderColor: this.mediumBlueColor,
-        borderWidth: 2,
-        pointBackgroundColor: this.whiteColor,
-        hoverBackgroundColor: this.whiteColor,
-        hoverBorderWidth: 2,
-        data: Object.values(missedVisitsGraphRate),
-        type: "line",
-      }],
+      datasets: [
+        {
+          label: "Missed visits",
+          backgroundColor: this.lightBlueColor,
+          borderColor: this.mediumBlueColor,
+          borderWidth: 2,
+          pointBackgroundColor: this.whiteColor,
+          hoverBackgroundColor: this.whiteColor,
+          hoverBorderWidth: 2,
+          data: Object.values(missedVisitsGraphRate),
+          type: "line",
+        },
+      ],
     };
     missedVisitsConfig.options.scales = {
-      xAxes: [{
-        stacked: false,
-        display: true,
-        gridLines: {
-          display: false,
-          drawBorder: true,
-        },
-        ticks: {
-          autoSkip: false,
-          fontColor: this.darkGreyColor,
-          fontSize: 12,
-          fontFamily: "Roboto Condensed",
-          padding: 8,
-          min: 0,
-          beginAtZero: true,
-        },
-      }],
-      yAxes: [{
-        stacked: false,
-        display: true,
-        gridLines: {
+      xAxes: [
+        {
+          stacked: false,
           display: true,
-          drawBorder: false,
+          gridLines: {
+            display: false,
+            drawBorder: true,
+          },
+          ticks: {
+            autoSkip: false,
+            fontColor: this.darkGreyColor,
+            fontSize: 12,
+            fontFamily: "Roboto Condensed",
+            padding: 8,
+            min: 0,
+            beginAtZero: true,
+          },
         },
-        ticks: {
-          autoSkip: false,
-          fontColor: this.darkGreyColor,
-          fontSize: 12,
-          fontFamily: "Roboto Condensed",
-          padding: 8,
-          min: 0,
-          beginAtZero: true,
-          stepSize: 25,
-          max: 100,
+      ],
+      yAxes: [
+        {
+          stacked: false,
+          display: true,
+          gridLines: {
+            display: true,
+            drawBorder: false,
+          },
+          ticks: {
+            autoSkip: false,
+            fontColor: this.darkGreyColor,
+            fontSize: 12,
+            fontFamily: "Roboto Condensed",
+            padding: 8,
+            min: 0,
+            beginAtZero: true,
+            stepSize: 25,
+            max: 100,
+          },
         },
-      }],
-    }
+      ],
+    };
     missedVisitsConfig.options.tooltips = {
       enabled: false,
       custom: (tooltip) => {
-        let hoveredDatapoint = tooltip.dataPoints
-        if(hoveredDatapoint)
+        let hoveredDatapoint = tooltip.dataPoints;
+        if (hoveredDatapoint)
           populateMissedVisitsGraph(hoveredDatapoint[0].label);
-        else
-          populateMissedVisitsGraphDefault();
-      }
+        else populateMissedVisitsGraphDefault();
+      },
     };
 
     const populateMissedVisitsGraph = (period) => {
@@ -320,7 +366,9 @@ Reports = function (withLtfu) {
       const periodStartNode = cardNode.querySelector("[data-period-start]");
       const periodEndNode = cardNode.querySelector("[data-period-end]");
       const registrationsNode = cardNode.querySelector("[data-registrations]");
-      const registrationsPeriodEndNode = cardNode.querySelector("[data-registrations-period-end]")
+      const registrationsPeriodEndNode = cardNode.querySelector(
+        "[data-registrations-period-end]"
+      );
 
       const rate = this.formatPercentage(missedVisitsGraphRate[period]);
       const periodInfo = data.periodInfo[period];
@@ -331,27 +379,35 @@ Reports = function (withLtfu) {
       totalPatientsNode.innerHTML = this.formatNumberWithCommas(totalPatients);
       periodStartNode.innerHTML = periodInfo.bp_control_start_date;
       periodEndNode.innerHTML = periodInfo.bp_control_end_date;
-      registrationsNode.innerHTML = this.formatNumberWithCommas(adjustedPatientCounts);
-      registrationsPeriodEndNode.innerHTML = periodInfo.bp_control_registration_date;
-    }
+      registrationsNode.innerHTML = this.formatNumberWithCommas(
+        adjustedPatientCounts
+      );
+      registrationsPeriodEndNode.innerHTML =
+        periodInfo.bp_control_registration_date;
+    };
 
     const populateMissedVisitsGraphDefault = () => {
       const cardNode = document.getElementById("missed-visits");
       const mostRecentPeriod = cardNode.getAttribute("data-period");
 
       populateMissedVisitsGraph(mostRecentPeriod);
-    }
+    };
 
-    const missedVisitsGraphCanvas = document.getElementById("missedVisitsTrend");
+    const missedVisitsGraphCanvas =
+      document.getElementById("missedVisitsTrend");
     if (missedVisitsGraphCanvas) {
       new Chart(missedVisitsGraphCanvas.getContext("2d"), missedVisitsConfig);
       populateMissedVisitsGraphDefault();
     }
-  }
+  };
 
   this.setupCumulativeRegistrationsGraph = (data) => {
-    const cumulativeRegistrationsYAxis = this.createAxisMaxAndStepSize(data.cumulativeRegistrations);
-    const monthlyRegistrationsYAxis = this.createAxisMaxAndStepSize(data.monthlyRegistrations);
+    const cumulativeRegistrationsYAxis = this.createAxisMaxAndStepSize(
+      data.cumulativeRegistrations
+    );
+    const monthlyRegistrationsYAxis = this.createAxisMaxAndStepSize(
+      data.monthlyRegistrations
+    );
 
     const cumulativeRegistrationsGraphConfig = this.createBaseGraphConfig();
     cumulativeRegistrationsGraphConfig.type = "bar";
@@ -381,23 +437,25 @@ Reports = function (withLtfu) {
       ],
     };
     cumulativeRegistrationsGraphConfig.options.scales = {
-      xAxes: [{
-        stacked: true,
-        display: true,
-        gridLines: {
-          display: false,
-          drawBorder: false,
+      xAxes: [
+        {
+          stacked: true,
+          display: true,
+          gridLines: {
+            display: false,
+            drawBorder: false,
+          },
+          ticks: {
+            autoSkip: false,
+            fontColor: this.darkGreyColor,
+            fontSize: 12,
+            fontFamily: "Roboto Condensed",
+            padding: 8,
+            min: 0,
+            beginAtZero: true,
+          },
         },
-        ticks: {
-          autoSkip: false,
-          fontColor: this.darkGreyColor,
-          fontSize: 12,
-          fontFamily: "Roboto Condensed",
-          padding: 8,
-          min: 0,
-          beginAtZero: true,
-        },
-      }],
+      ],
       yAxes: [
         {
           id: "cumulativeRegistrations",
@@ -409,6 +467,7 @@ Reports = function (withLtfu) {
             drawBorder: false,
           },
           ticks: {
+            display: false,
             autoSkip: false,
             fontColor: this.darkGreyColor,
             fontSize: 12,
@@ -433,6 +492,7 @@ Reports = function (withLtfu) {
             drawBorder: false,
           },
           ticks: {
+            display: false,
             autoSkip: false,
             fontColor: this.darkGreyColor,
             fontSize: 12,
@@ -452,51 +512,67 @@ Reports = function (withLtfu) {
     cumulativeRegistrationsGraphConfig.options.tooltips = {
       enabled: false,
       custom: (tooltip) => {
-        let hoveredDatapoint = tooltip.dataPoints
-        if(hoveredDatapoint)
+        let hoveredDatapoint = tooltip.dataPoints;
+        if (hoveredDatapoint)
           populateCumulativeRegistrationsGraph(hoveredDatapoint[0].label);
-        else
-          populateCumulativeRegistrationsGraphDefault();
-      }
+        else populateCumulativeRegistrationsGraphDefault();
+      },
     };
 
     const populateCumulativeRegistrationsGraph = (period) => {
       const cardNode = document.getElementById("cumulative-registrations");
       const totalPatientsNode = cardNode.querySelector("[data-total-patients]");
-      const registrationsPeriodEndNode = cardNode.querySelector("[data-registrations-period-end]");
-      const monthlyRegistrationsNode = cardNode.querySelector("[data-monthly-registrations]");
-      const registrationsMonthEndNode = cardNode.querySelector("[data-registrations-month-end]");
+      const registrationsPeriodEndNode = cardNode.querySelector(
+        "[data-registrations-period-end]"
+      );
+      const monthlyRegistrationsNode = cardNode.querySelector(
+        "[data-monthly-registrations]"
+      );
+      const registrationsMonthEndNode = cardNode.querySelector(
+        "[data-registrations-month-end]"
+      );
 
       const periodInfo = data.periodInfo[period];
       const cumulativeRegistrations = data.cumulativeRegistrations[period];
       const monthlyRegistrations = data.monthlyRegistrations[period];
 
-      monthlyRegistrationsNode.innerHTML = this.formatNumberWithCommas(monthlyRegistrations);
-      totalPatientsNode.innerHTML = this.formatNumberWithCommas(cumulativeRegistrations);
+      monthlyRegistrationsNode.innerHTML =
+        this.formatNumberWithCommas(monthlyRegistrations);
+      totalPatientsNode.innerHTML = this.formatNumberWithCommas(
+        cumulativeRegistrations
+      );
       registrationsPeriodEndNode.innerHTML = periodInfo.bp_control_end_date;
       registrationsMonthEndNode.innerHTML = period;
-    }
+    };
 
     const populateCumulativeRegistrationsGraphDefault = () => {
       const cardNode = document.getElementById("cumulative-registrations");
       const mostRecentPeriod = cardNode.getAttribute("data-period");
 
       populateCumulativeRegistrationsGraph(mostRecentPeriod);
-    }
+    };
 
-    const cumulativeRegistrationsGraphCanvas = document.getElementById("cumulativeRegistrationsTrend");
+    const cumulativeRegistrationsGraphCanvas = document.getElementById(
+      "cumulativeRegistrationsTrend"
+    );
     if (cumulativeRegistrationsGraphCanvas) {
-      new Chart(cumulativeRegistrationsGraphCanvas.getContext("2d"), cumulativeRegistrationsGraphConfig);
+      new Chart(
+        cumulativeRegistrationsGraphCanvas.getContext("2d"),
+        cumulativeRegistrationsGraphConfig
+      );
       populateCumulativeRegistrationsGraphDefault();
     }
-  }
+  };
 
   this.setupVisitDetailsGraph = (data) => {
     const visitDetailsGraphConfig = this.createBaseGraphConfig();
     visitDetailsGraphConfig.type = "bar";
 
     const maxBarsToDisplay = 6;
-    const barsToDisplay = Math.min(Object.keys(data.controlRate).length, maxBarsToDisplay);
+    const barsToDisplay = Math.min(
+      Object.keys(data.controlRate).length,
+      maxBarsToDisplay
+    );
 
     visitDetailsGraphConfig.data = {
       labels: Object.keys(data.controlRate).slice(-barsToDisplay),
@@ -519,7 +595,9 @@ Reports = function (withLtfu) {
           label: "Visit but no BP measure",
           backgroundColor: this.mediumGreyColor,
           hoverBackgroundColor: this.darkGreyColor,
-          data: Object.values(data.visitButNoBPMeasureRate).slice(-barsToDisplay),
+          data: Object.values(data.visitButNoBPMeasureRate).slice(
+            -barsToDisplay
+          ),
           type: "bar",
         },
         {
@@ -532,71 +610,100 @@ Reports = function (withLtfu) {
       ],
     };
     visitDetailsGraphConfig.options.scales = {
-      xAxes: [{
-        stacked: true,
-        display: true,
-        gridLines: {
+      xAxes: [
+        {
+          stacked: true,
+          display: true,
+          gridLines: {
+            display: false,
+            drawBorder: false,
+          },
+          ticks: {
+            autoSkip: false,
+            fontColor: this.darkGreyColor,
+            fontSize: 12,
+            fontFamily: "Roboto Condensed",
+            padding: 8,
+            min: 0,
+            beginAtZero: true,
+          },
+        },
+      ],
+      yAxes: [
+        {
+          stacked: true,
           display: false,
-          drawBorder: false,
+          gridLines: {
+            display: false,
+            drawBorder: false,
+          },
+          ticks: {
+            autoSkip: false,
+            fontColor: this.darkGreyColor,
+            fontSize: 12,
+            fontFamily: "Roboto Condensed",
+            padding: 8,
+            min: 0,
+            beginAtZero: true,
+          },
         },
-        ticks: {
-          autoSkip: false,
-          fontColor: this.darkGreyColor,
-          fontSize: 12,
-          fontFamily: "Roboto Condensed",
-          padding: 8,
-          min: 0,
-          beginAtZero: true,
-        },
-      }],
-      yAxes: [{
-        stacked: true,
-        display: false,
-        gridLines: {
-          display: false,
-          drawBorder: false,
-        },
-        ticks: {
-          autoSkip: false,
-          fontColor: this.darkGreyColor,
-          fontSize: 12,
-          fontFamily: "Roboto Condensed",
-          padding: 8,
-          min: 0,
-          beginAtZero: true,
-        },
-      }],
+      ],
     };
     visitDetailsGraphConfig.options.tooltips = {
       mode: "x",
       enabled: false,
       custom: (tooltip) => {
-        let hoveredDatapoint = tooltip.dataPoints
-        if(hoveredDatapoint)
+        let hoveredDatapoint = tooltip.dataPoints;
+        if (hoveredDatapoint)
           populateVisitDetailsGraph(hoveredDatapoint[0].label);
-        else
-          populateVisitDetailsGraphDefault();
-      }
+        else populateVisitDetailsGraphDefault();
+      },
     };
 
     const populateVisitDetailsGraph = (period) => {
       const cardNode = document.getElementById("visit-details");
-      const missedVisitsRateNode = cardNode.querySelector("[data-missed-visits-rate]");
-      const visitButNoBPMeasureRateNode = cardNode.querySelector("[data-visit-but-no-bp-measure-rate]");
-      const uncontrolledRateNode = cardNode.querySelector("[data-uncontrolled-rate]");
-      const controlledRateNode = cardNode.querySelector("[data-controlled-rate]");
-      const missedVisitsPatientsNode = cardNode.querySelector("[data-missed-visits-patients]");
-      const visitButNoBPMeasurePatientsNode = cardNode.querySelector("[data-visit-but-no-bp-measure-patients]");
-      const uncontrolledPatientsNode = cardNode.querySelector("[data-uncontrolled-patients]");
-      const controlledPatientsNode = cardNode.querySelector("[data-controlled-patients]");
+      const missedVisitsRateNode = cardNode.querySelector(
+        "[data-missed-visits-rate]"
+      );
+      const visitButNoBPMeasureRateNode = cardNode.querySelector(
+        "[data-visit-but-no-bp-measure-rate]"
+      );
+      const uncontrolledRateNode = cardNode.querySelector(
+        "[data-uncontrolled-rate]"
+      );
+      const controlledRateNode = cardNode.querySelector(
+        "[data-controlled-rate]"
+      );
+      const missedVisitsPatientsNode = cardNode.querySelector(
+        "[data-missed-visits-patients]"
+      );
+      const visitButNoBPMeasurePatientsNode = cardNode.querySelector(
+        "[data-visit-but-no-bp-measure-patients]"
+      );
+      const uncontrolledPatientsNode = cardNode.querySelector(
+        "[data-uncontrolled-patients]"
+      );
+      const controlledPatientsNode = cardNode.querySelector(
+        "[data-controlled-patients]"
+      );
       const periodStartNodes = cardNode.querySelectorAll("[data-period-start]");
       const periodEndNodes = cardNode.querySelectorAll("[data-period-end]");
-      const registrationPeriodEndNodes = cardNode.querySelectorAll("[data-registrations-period-end]");
-      const adjustedPatientCountsNodes = cardNode.querySelectorAll("[data-adjusted-registrations]");
+      const registrationPeriodEndNodes = cardNode.querySelectorAll(
+        "[data-registrations-period-end]"
+      );
+      const adjustedPatientCountsNodes = cardNode.querySelectorAll(
+        "[data-adjusted-registrations]"
+      );
 
-      const missedVisitsRate = this.formatPercentage(data.missedVisitsRate[period]);
-      const visitButNoBPMeasureRate = this.formatPercentage(data.visitButNoBPMeasureRate[period]);
-      const uncontrolledRate = this.formatPercentage(data.uncontrolledRate[period]);
+      const missedVisitsRate = this.formatPercentage(
+        data.missedVisitsRate[period]
+      );
+      const visitButNoBPMeasureRate = this.formatPercentage(
+        data.visitButNoBPMeasureRate[period]
+      );
+      const uncontrolledRate = this.formatPercentage(
+        data.uncontrolledRate[period]
+      );
       const controlledRate = this.formatPercentage(data.controlRate[period]);
 
       const periodInfo = data.periodInfo[period];
@@ -610,33 +717,55 @@ Reports = function (withLtfu) {
       visitButNoBPMeasureRateNode.innerHTML = visitButNoBPMeasureRate;
       uncontrolledRateNode.innerHTML = uncontrolledRate;
       controlledRateNode.innerHTML = controlledRate;
-      missedVisitsPatientsNode.innerHTML = this.formatNumberWithCommas(totalMissedVisits);
-      visitButNoBPMeasurePatientsNode.innerHTML = this.formatNumberWithCommas(totalVisitButNoBPMeasure);
-      uncontrolledPatientsNode.innerHTML = this.formatNumberWithCommas(totalUncontrolledPatients);
-      controlledPatientsNode.innerHTML = this.formatNumberWithCommas(totalControlledPatients);
-      periodStartNodes.forEach(node => node.innerHTML = periodInfo.bp_control_start_date);
-      periodEndNodes.forEach(node => node.innerHTML = periodInfo.bp_control_end_date);
-      registrationPeriodEndNodes.forEach(node => node.innerHTML = periodInfo.bp_control_registration_date);
-      adjustedPatientCountsNodes.forEach(node => node.innerHTML = this.formatNumberWithCommas(adjustedPatientCounts));
-    }
+      missedVisitsPatientsNode.innerHTML =
+        this.formatNumberWithCommas(totalMissedVisits);
+      visitButNoBPMeasurePatientsNode.innerHTML = this.formatNumberWithCommas(
+        totalVisitButNoBPMeasure
+      );
+      uncontrolledPatientsNode.innerHTML = this.formatNumberWithCommas(
+        totalUncontrolledPatients
+      );
+      controlledPatientsNode.innerHTML = this.formatNumberWithCommas(
+        totalControlledPatients
+      );
+      periodStartNodes.forEach(
+        (node) => (node.innerHTML = periodInfo.bp_control_start_date)
+      );
+      periodEndNodes.forEach(
+        (node) => (node.innerHTML = periodInfo.bp_control_end_date)
+      );
+      registrationPeriodEndNodes.forEach(
+        (node) => (node.innerHTML = periodInfo.bp_control_registration_date)
+      );
+      adjustedPatientCountsNodes.forEach(
+        (node) =>
+          (node.innerHTML = this.formatNumberWithCommas(adjustedPatientCounts))
+      );
+    };
 
     const populateVisitDetailsGraphDefault = () => {
       const cardNode = document.getElementById("visit-details");
       const mostRecentPeriod = cardNode.getAttribute("data-period");
 
       populateVisitDetailsGraph(mostRecentPeriod);
-    }
+    };
 
-    const visitDetailsGraphCanvas = document.getElementById("missedVisitDetails");
+    const visitDetailsGraphCanvas =
+      document.getElementById("missedVisitDetails");
     if (visitDetailsGraphCanvas) {
-      new Chart(visitDetailsGraphCanvas.getContext("2d"), visitDetailsGraphConfig);
+      new Chart(
+        visitDetailsGraphCanvas.getContext("2d"),
+        visitDetailsGraphConfig
+      );
       populateVisitDetailsGraphDefault();
     }
-  }
+  };
 
   this.initializeTables = () => {
-    const tableSortAscending = {descending: false};
-    const regionComparisonTable = document.getElementById("region-comparison-table");
+    const tableSortAscending = { descending: false };
+    const regionComparisonTable = document.getElementById(
+      "region-comparison-table"
+    );
 
     if (regionComparisonTable) {
       new Tablesort(regionComparisonTable, tableSortAscending);
@@ -663,7 +792,7 @@ Reports = function (withLtfu) {
       uncontrolledWithLtfuRate: jsonData.uncontrolled_patients_with_ltfu_rate,
       visitButNoBPMeasure: jsonData.visited_without_bp_taken,
       visitButNoBPMeasureRate: jsonData.visited_without_bp_taken_rates,
-      periodInfo: jsonData.period_info
+      periodInfo: jsonData.period_info,
     };
   };
 
@@ -693,7 +822,7 @@ Reports = function (withLtfu) {
         },
       },
     };
-  }
+  };
 
   this.createAxisMaxAndStepSize = (data) => {
     const maxDataValue = Math.max(...Object.values(data));
@@ -712,13 +841,13 @@ Reports = function (withLtfu) {
     }
 
     if (numeral(value) !== undefined) {
-      return numeral(value).format('0,0');
+      return numeral(value).format("0,0");
     }
 
     return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-  }
+  };
 
   this.formatPercentage = (number) => {
     return (number || 0) + "%";
-  }
-}
+  };
+};

--- a/app/models/reports.rb
+++ b/app/models/reports.rb
@@ -1,6 +1,6 @@
 module Reports
   REGISTRATION_BUFFER_IN_MONTHS = 3
-  MAX_MONTHS_OF_DATA = 24
+  MAX_MONTHS_OF_DATA = 18
   PERCENTAGE_PRECISION = 0
 
   # The default period we report on is the current month.

--- a/app/views/admin/facilities/show.html.erb
+++ b/app/views/admin/facilities/show.html.erb
@@ -1,10 +1,10 @@
-<nav class="breadcrumb">
+<nav class="breadcrumb mt-n3 mt-md-0">
   <%= link_to 'All facilities', admin_facilities_path %>
   <i class="fas fa-angle-right light"></i> <%= @facility.facility_group.name %>
   <i class="fas fa-angle-right light"></i> <%= @facility.name %>
 </nav>
 <div class="page-header">
-  <h1 class="page-title">
+  <h1 class="page-title mt-32px">
     <%= @facility.name %>
   </h1>
   <nav class="page-nav">

--- a/app/views/admin/protocol_drugs/edit.html.erb
+++ b/app/views/admin/protocol_drugs/edit.html.erb
@@ -1,5 +1,5 @@
-<nav class="breadcrumb">
+<nav class="breadcrumb mt-n3 mt-md-0">
 	<%= link_to "Medication lists", admin_protocols_path, class: "#{active_controller?("admin/protocols")}" %> <i class="fas fa-chevron-right"></i> <%= link_to @protocol.name, [:admin, @protocol] %> <i class="fas fa-chevron-right"></i> Edit medication
 </nav>
-<h1>Edit medication</h1>
+<h1 class="mt-32px">Edit medication</h1>
 <%= render 'form', protocol_drug: @protocol_drug %>

--- a/app/views/admin/protocol_drugs/new.html.erb
+++ b/app/views/admin/protocol_drugs/new.html.erb
@@ -1,5 +1,5 @@
-<nav class="breadcrumb">
+<nav class="breadcrumb mt-n3 mt-md-0">
   <%= link_to "Medication lists", admin_protocols_path, class: "#{active_controller?("admin/protocols")}" %> <i class="fas fa-chevron-right"></i> <%= link_to @protocol.name, [:admin, @protocol] %> <i class="fas fa-chevron-right"></i> New medication
 </nav>
-<h1>New medication</h1>
+<h1 class="mt-32px">New medication</h1>
 <%= render 'form', protocol_drug: @protocol_drug %>

--- a/app/views/admin/protocols/show.html.erb
+++ b/app/views/admin/protocols/show.html.erb
@@ -1,10 +1,10 @@
 <div class="page-header">
   <div class="page-title">
-    <nav class="breadcrumb">
+    <nav class="breadcrumb mt-n3 mt-md-0">
       <%= link_to "Medication lists", admin_protocols_path, class: "#{active_controller?("admin/protocols")}" %>
       <i class="fas fa-chevron-right"></i> <%= @protocol.name %>
     </nav>
-    <h1 class="page-title">
+    <h1 class="page-title mt-32px">
       <%= @protocol.name %>
     </h1>
   </div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,9 +1,9 @@
-<nav class="breadcrumb">
+<nav class="breadcrumb mt-n3 mt-md-0">
   <%= link_to 'All users', admin_users_path %> <i class="fas fa-chevron-right"></i> <%= @user.full_name %>
 </nav>
 
 <div class="page-header">
-  <h1 class="page-title"><%= @user.full_name %></h1>
+  <h1 class="page-title mt-36px"><%= @user.full_name %></h1>
   <nav class="page-nav">
     <%= link_to 'Edit user', edit_admin_user_path(@user), class: 'btn btn-primary btn-sm' %>
 

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -1,7 +1,7 @@
 <% admin = AdminAccessPresenter.new(@admin) %>
 
 <div class="page-header">
-  <nav class="breadcrumb">
+  <nav class="breadcrumb mt-n3 mt-md-0">
     <%= link_to "Admins", admins_path, class: "#{active_controller?("email_authentications")}" %>
     <i class="fas fa-chevron-right"></i> <%= admin.full_name %>
   </nav>
@@ -9,9 +9,11 @@
 
 <div class="row mt-2">
   <div class="col-md-5">
-    <h2><%= admin.full_name %></h2>
-    <span class="user-role"><%= admin.role %> • </span>
-    <a class="user-email" href="mailto:<%= admin.email %>"><%= admin.email %></a>
+    <h1 class="page-title"><%= admin.full_name %></h1>
+    <p class="mb-16px">
+      <span class="user-role"><%= admin.role %> • </span>
+      <a class="user-email" href="mailto:<%= admin.email %>"><%= admin.email %></a>
+    </p>
   </div>
   <div class="col-md-7" style="text-align:right;">
     <%= link_to 'Edit admin', edit_admin_path(admin), class: "btn btn-sm btn-primary" %>

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -1,6 +1,6 @@
 <% period_selector = local_assigns.fetch(:period_selector, true) %>
 
-<div class="dashboard">
+<div class="dashboard mt-n3 mt-md-0">
 
   <nav class="breadcrumb mb-0px pb-16px">
     <%= link_to "All reports", dashboard_districts_path %>
@@ -14,7 +14,7 @@
     <%= @region.name %>
   </nav>
 
-  <h1 class="mb-3 page-header">
+  <h1 class="mb-3 mt-32px page-header">
     <%= @region.name %>
   </h1>
 

--- a/app/views/reports/regions/_treatment_outcomes_card.html.erb
+++ b/app/views/reports/regions/_treatment_outcomes_card.html.erb
@@ -12,15 +12,15 @@
       </div>
       <div class="flex-lg-1 mt-24px ml-lg-24px mt-print-2cm">
         <div>
-          <%= render "visit_details_heading",
-                     title: "Missed visits",
-                     numerator: t("missed_visits_copy.numerator"),
-                     denominator: t("denominator_copy", region_name: @region.name) %>
-          <div class="mb-12px d-lg-flex align-lg-center">
-            <p class="rate mb-0px fs-32px fw-bold mr-lg-12px c-blue"
+          <div class="mb-16px d-lg-flex align-lg-center">
+            <p class="rate mb-0px fs-32px fw-bold mr-lg-24px c-blue"
                data-missed-visits-rate="">
             </p>
             <div>
+              <%= render "visit_details_heading",
+                    title: "Missed visits",
+                    numerator: t("missed_visits_copy.numerator"),
+                    denominator: t("denominator_copy", region_name: @region.name) %>
               <p class="m-0px c-black">
                 <span data-missed-visits-patients=""></span>
                 patients with no visit from
@@ -38,13 +38,13 @@
           </div>
         </div>
         <div>
-          <%= render "visit_details_heading",
-                     title: "Visit but no BP taken",
-                     numerator: t("visit_but_no_bp_taken_copy.numerator"),
-                     denominator: t("denominator_copy", region_name: @region.name) %>
-          <div class="mb-12px d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold c-grey-medium mr-lg-12px" data-visit-but-no-bp-measure-rate=""></p>
+          <div class="mb-16px d-lg-flex align-lg-center">
+            <p class="mb-0px fs-32px fw-bold c-grey-dark mr-lg-24px" data-visit-but-no-bp-measure-rate=""></p>
             <div>
+              <%= render "visit_details_heading",
+                   title: "Visit but no BP taken",
+                   numerator: t("visit_but_no_bp_taken_copy.numerator"),
+                   denominator: t("denominator_copy", region_name: @region.name) %>
               <p class="m-0px c-black">
                 <span data-visit-but-no-bp-measure-patients=""></span>
                 patients with a visit but no BP taken from
@@ -62,15 +62,15 @@
           </div>
         </div>
         <div>
-          <%= render "visit_details_heading",
-                     title: "BP not controlled",
-                     numerator: t("bp_not_controlled_copy.numerator"),
-                     denominator: t("denominator_copy", region_name: @region.name) %>
-          <div class="mb-12px d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold mr-lg-12px c-print-black c-red"
+          <div class="mb-16px d-lg-flex align-lg-center">
+            <p class="mb-0px fs-32px fw-bold mr-lg-24px c-print-black c-red"
                data-uncontrolled-rate="">
             </p>
             <div>
+              <%= render "visit_details_heading",
+                   title: "BP not controlled",
+                   numerator: t("bp_not_controlled_copy.numerator"),
+                   denominator: t("denominator_copy", region_name: @region.name) %>
               <p class="m-0px c-black">
                 <span data-uncontrolled-patients=""></span>
                 patients with not controlled BP from
@@ -88,15 +88,15 @@
           </div>
         </div>
         <div>
-          <%= render "visit_details_heading",
-                     title: "BP controlled",
-                     numerator: t("bp_controlled_copy.numerator"),
-                     denominator: t("denominator_copy", region_name: @region.name) %>
-          <div class="mb-12px d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold mr-lg-12px c-print-black c-green-dark"
+          <div class="mb-16px d-lg-flex align-lg-center">
+            <p class="mb-0px fs-32px fw-bold mr-lg-24px c-print-black c-green-dark"
                data-controlled-rate="">
             </p>
             <div>
+              <%= render "visit_details_heading",
+                   title: "BP controlled",
+                   numerator: t("bp_controlled_copy.numerator"),
+                   denominator: t("denominator_copy", region_name: @region.name) %>
               <p class="m-0px c-black">
                 <span data-controlled-patients=""></span>
                 patients with controlled BP from

--- a/app/views/reports/regions/_visit_details_heading.html.erb
+++ b/app/views/reports/regions/_visit_details_heading.html.erb
@@ -1,4 +1,4 @@
-<div class="d-flex flex-1 mb-8px">
+<div class="d-flex flex-1">
   <p class="mb-0px mr-6px fw-bold">
     <%= title %>
   </p>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -76,7 +76,7 @@
         <p class="c-grey-dark">
           <%= t("registered_patients_copy.reports_card_subtitle", region_name: @region.name) %>
         </p>
-        <div class="d-flex align-center mb-12px">
+        <div class="d-flex align-center mb-24px">
           <div class="flex-1 d-lg-flex align-lg-center">
             <p class="mb-0px fs-32px fw-bold mr-lg-12px c-purple"
               data-total-patients="">
@@ -101,7 +101,7 @@
           </div>
         </div>
       </div>
-      <div class="h-320px mr-13px mb-16px ml-13px pb-4px">
+      <div class="h-320px mr-13px ml-13px pb-4px">
         <canvas id="cumulativeRegistrationsTrend"></canvas>
       </div>
     </div>


### PR DESCRIPTION
**Story card:** NONE

## Because

The mobile formatting of reports drives me bananas. Especially that dates in the charts overlap.

## This addresses

- Shows 18 months of data instead of 24 (there isn't room to show 24 on mobile).
- Removes ticks from Registrations card in report (they're arbitrary values on left and right side of the chart).
- Lines up the text and numbers in the Treatment Outcomes chart so it's easier to scan and more compact, with larger margins between the 4 sections.
- Fixes the top margin of the breadcrumb all over the admin

## Test instructions

Look at any reports page and especially look at it on mobile.