### PR TITLE
Add drug stock config for Haryana

### DIFF
--- a/config/data/drug_stock_config.yml
+++ b/config/data/drug_stock_config.yml
@@ -58,6 +58,23 @@ Gujarat:
     hypertension_diuretic:
       new_patient_coefficient: 0.05
       '331132': 1
+Haryana:
+  load_coefficient: 1
+  drug_categories:
+    hypertension_ccb:
+      new_patient_coefficient: 1.4
+      '329528': 1
+      '329526': 2
+    hypertension_arb:
+      new_patient_coefficient: 0.37
+      '316764': 1
+      '316765': 2
+      '979467': 1
+    hypertension_diuretic:
+      new_patient_coefficient: 0.05
+      '429503': 0.5
+      '316049': 1
+      '331132': 1
 Jharkhand:
   load_coefficient: 1
   drug_categories:


### PR DESCRIPTION
**Story card:** [sc-7730](https://app.shortcut.com/simpledotorg/story/7730/add-drug-stock-configuration-for-haryana)

## Because

We want to start tracking drug stock in Haryana

## This addresses

Adds the relevant drug and category coefficients