### PR TITLE
Added font-sizes to media queries and fixed tabbed nav on mobile

### DIFF
--- a/app/assets/stylesheets/partials/_reports.scss
+++ b/app/assets/stylesheets/partials/_reports.scss
@@ -272,7 +272,8 @@
 .fs-32px {
   font-size: 32px;
 }
-.fs-xxlarge {
+.fs-xxlarge,
+.fs-48px {
   font-size: 48px;
 }
 .fs-italic {
@@ -637,6 +638,32 @@
     padding-bottom: 20px;
   }
   // Typography
+  .fs-lg-12px {
+    font-size: 12px;
+  }
+  .fs-lg-14px {
+    font-size: 14px;
+  }
+  .fs-lg-16px {
+    font-size: 16px;
+  }
+  .fs-lg-20px {
+    font-size: 20px;
+  }
+  .fs-lg-24px {
+    font-size: 24px;
+  }
+  .fs-lg-28px {
+    font-size: 28px;
+  }
+  .fs-lg-32px {
+    font-size: 32px;
+  }
+  .fs-lg-xxlarge,
+  .fs-lg-48px {
+    font-size: 48px;
+  }
+
   .fw-lg-bold {
     font-weight: 700;
   }

--- a/app/views/my_facilities/_facilities_tables_nav.html.erb
+++ b/app/views/my_facilities/_facilities_tables_nav.html.erb
@@ -4,23 +4,23 @@
 
 <div class="d-flex fd-column fd-lg-row justify-lg-between mb-24px d-print-none sub-menu">
   <div class="d-flex order-2 order-lg-1">
-    <p class="mr-24px mb-0px pb-8px fs-20px fw-bold td-none <%= params[:action] == "bp_controlled" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
+    <p class="mr-12px mr-lg-24px mb-0px pb-8px fs-16px fs-lg-20px fw-bold td-none <%= params[:action] == "bp_controlled" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
       <%= link_to(my_facilities_bp_controlled_path(preserve_query_params(request.query_parameters, ["zone", "size", "facility_group"])), class: "#{active_action?("bp_controlled")}") do %>
         BP controlled
       <% end %>
     </p>
-    <p class="mr-24px mb-0px pb-8px fs-20px fw-bold <%= params[:action] == "bp_not_controlled" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
+    <p class="mr-12px mr-lg-24px mb-0px pb-8px fs-16px fs-lg-20px fw-bold <%= params[:action] == "bp_not_controlled" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
       <%= link_to(my_facilities_bp_not_controlled_path(preserve_query_params(request.query_parameters, ["zone", "size", "facility_group"])), class: "#{active_action?("bp_not_controlled")}") do %>
         BP not controlled
       <% end %>
     </p>
-    <p class="mr-24px mb-0px pb-8px fs-20px fw-bold <%= params[:action] == "missed_visits" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
+    <p class="mr-12px mr-lg-24px mb-0px pb-8px fs-16px fs-lg-20px fw-bold <%= params[:action] == "missed_visits" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
       <%= link_to(my_facilities_missed_visits_path(preserve_query_params(request.query_parameters, ["zone", "size", "period", "facility_group"])), class: "#{active_action?("missed_visits")}") do %>
         Missed visits
       <% end %>
     </p>
   </div>
-  <div class="d-flex actions order-1 mb-24px order-lg-2 mb-lg-0 text-grey">
+  <div class="d-flex actions order-1 mb-48px order-lg-2 mb-lg-0 text-grey">
     Last updated on <%= @last_updated_at %>
   </div>
 </div>

--- a/app/views/my_facilities/drug_stocks/_drug_stock_nav.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_stock_nav.html.erb
@@ -4,18 +4,18 @@
 
 <div class="d-flex fd-column fd-lg-row justify-lg-between mb-24px d-print-none sub-menu">
   <div class="d-flex order-2 order-lg-1">
-    <p class="mr-24px mb-0px pb-8px fs-20px fw-bold td-none <%= params[:action] == "drug_stocks" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
+    <p class="mr-12px mr-lg-24px mb-0px pb-8px fs-16px fs-lg-20px fw-bold td-none <%= params[:action] == "drug_stocks" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
       <%= link_to(my_facilities_drug_stocks_path(preserve_query_params(request.query_parameters, ["facility_group", "zone", "size", "for_end_of_month"])), class: "#{active_action?("drug_stocks")}") do %>
         Stock on hand
       <% end %>
     </p>
-    <p class="mr-24px mb-0px pb-8px fs-20px fw-bold <%= params[:action] == "drug_consumption" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
+    <p class="mr-12px mr-lg-24px mb-0px pb-8px fs-16px fs-lg-20px fw-bold <%= params[:action] == "drug_consumption" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
       <%= link_to(my_facilities_drug_consumption_path(preserve_query_params(request.query_parameters, ["facility_group", "zone", "size", "for_end_of_month"])), class: "#{active_action?("drug_consumption")}") do %>
         Drug consumption
       <% end %>
     </p>
   </div>
-  <div class="d-flex actions order-1 mb-24px order-lg-2 mb-lg-0 text-grey">
+  <div class="d-flex actions order-1 mb-48px order-lg-2 mb-lg-0 text-grey">
     <% if @facilities.present? %>
       Last updated on <%= @report&.fetch(:last_updated_at)&.to_s(:day_mon_year_time) %>
     <% end %>

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -28,17 +28,17 @@
   %>
   <div class="d-flex fd-column fd-lg-row justify-lg-between mb-24px d-print-none">
     <div class="d-flex order-2 order-lg-1">
-      <p class="mr-24px mb-0px pb-8px fs-20px fw-bold td-none <%= params[:action] == "show" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
+      <p class="mr-12px mr-lg-24px mb-0px pb-8px fs-16px fs-lg-20px fw-bold td-none <%= params[:action] == "show" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
         <%= link_to_unless_current "Overview", url_params.merge(action: "show"), :class => "c-grey-dark td-none" %>
       </p>
-      <p class="mr-24px mb-0px pb-8px fs-20px fw-bold <%= params[:action] == "details" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
+      <p class="mr-12px mr-lg-24px mb-0px pb-8px fs-16px fs-lg-20px fw-bold <%= params[:action] == "details" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
         <%= link_to_unless_current "Details", url_params.merge(action: "details"), :class => "c-grey-dark td-none" %>
       </p>
-      <p class="mr-24px mb-0px pb-8px fs-20px fw-bold <%= params[:action] == "cohort" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
+      <p class="mr-12px mr-lg-24px mb-0px pb-8px fs-16px fs-lg-20px fw-bold <%= params[:action] == "cohort" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
         <%= link_to_unless_current "Cohort reports", reports_region_cohort_path(@region, report_scope: params[:report_scope]), :class => "c-grey-dark td-none" %>
       </p>
       <% if @region.facility_region? && current_admin.feature_enabled?(:dashboard_progress_reports) %>
-        <p class="mr-lg-24px mb-0px pb-8px fs-20px fw-bold <%= params[:action] == "cohort" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
+        <p class="mr-12px mr-lg-24px mb-0px pb-8px fs-16px fs-lg-20px fw-bold <%= params[:action] == "cohort" ? "c-red bb-2px bb-red" : "c-grey-dark" %>">
           <%= link_to "Progress", reports_progress_path(@region), :class => "c-grey-dark td-none" %>
         </p>
       <% end %>


### PR DESCRIPTION
Added font-sizes to media queries so you can choose different sizes for mobile. Edited all tabbed navigations to size down to 16px for mobile.

**Story card:** NONE

## Because

Tabbed nav in My Facilities, Drug Stock, and Reports wraps terribly on mobile. Also, it was not possible to select smaller font sizes for mobile, so I added this to the css.

## Test instructions

Check the tabbed navigations look good. They do!