### PR TITLE
Add missing cached metrics in repository to cache warmer

### DIFF
--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -83,6 +83,9 @@ module Reports
         hypertension_follow_ups(group_by: "blood_pressures.user_id")
         bp_measures_by_user
         monthly_registrations_by_user
+        monthly_registrations_by_gender
+        controlled_by_gender
+        overdue_calls_by_user
       end
     end
 


### PR DESCRIPTION
**Story card:** [sc-7456](https://app.shortcut.com/simpledotorg/story/7456/overdue-call-results-caches-are-not-being-refreshed)

## Because

Redis cache for user-wise overdue call reports in facility details isn't being refreshed.

## This addresses

The `overdue_calls_by_user` metric was missing in the cache warmer job. This adds that and other missing metrics to the cache warming code path.
