### PR TITLE
Show adjusted patient numbers in monthly data

### DIFF
--- a/app/exporters/monthly_district_report/block_data.rb
+++ b/app/exporters/monthly_district_report/block_data.rb
@@ -58,7 +58,7 @@ module MonthlyDistrictReport
         "Blocks" => block.name,
         "Total registrations" => repo.cumulative_registrations[block.slug][report_month],
         "Total assigned patients" => repo.cumulative_assigned_patients[block.slug][report_month],
-        "Total patients under care" => repo.under_care[block.slug][report_month],
+        "Total patients under care" => repo.adjusted_patients[block.slug][report_month],
         "Total patients lost to followup" => repo.ltfu[block.slug][report_month],
         "% BP controlled" => percentage_string(repo.controlled_rates[block.slug][report_month]),
         "% BP uncontrolled" => percentage_string(repo.uncontrolled_rates[block.slug][report_month]),

--- a/app/exporters/monthly_district_report/facility_data.rb
+++ b/app/exporters/monthly_district_report/facility_data.rb
@@ -46,7 +46,7 @@ module MonthlyDistrictReport
         "Name of facility" => facility.name,
         "Name of block" => facility_region.block_name,
         "Total registrations" => repo.cumulative_registrations[facility_region.slug][month],
-        "Patients under care" => repo.under_care[facility_region.slug][month],
+        "Patients under care" => repo.adjusted_patients[facility_region.slug][month],
         "Registrations this month" => repo.monthly_registrations[facility_region.slug][month],
         "BP control % of all patients registered before 3 months" => percentage_string(repo.controlled_rates[facility_region.slug][month])
       }

--- a/spec/exporters/monthly_district_report/block_data_spec.rb
+++ b/spec/exporters/monthly_district_report/block_data_spec.rb
@@ -18,6 +18,11 @@ def mock_block_repo(repo, district, month)
     district[:block_2].slug => periods.zip([4, 12, 11, 23, 14, 24]).to_h
   })
 
+  allow(repo).to receive(:adjusted_patients).and_return({
+    district[:block_1].slug => periods.zip([2, 11, 15, 22, 25, 12]).to_h,
+    district[:block_2].slug => periods.zip([4, 12, 11, 23, 14, 24]).to_h
+  })
+
   allow(repo).to receive(:ltfu).and_return({
     district[:block_1].slug => {month => 3},
     district[:block_2].slug => {month => 4}

--- a/spec/exporters/monthly_district_report/facility_data_spec.rb
+++ b/spec/exporters/monthly_district_report/facility_data_spec.rb
@@ -6,7 +6,7 @@ def mock_facility_repo(repo, district, month)
     district[:facility_2].slug => {month => 23}
   })
 
-  allow(repo).to receive(:under_care).and_return({
+  allow(repo).to receive(:adjusted_patients).and_return({
     district[:facility_1].slug => {month => 12},
     district[:facility_2].slug => {month => 24}
   })


### PR DESCRIPTION
**Story card:** [sc-7833](https://app.shortcut.com/simpledotorg/story/7833)

## Because

In the monthly district data, we currently show the "Total patients under care" as of the current month. The trends however use the "Adjusted patients under care number" (under care as of 3 months ago) to calculate the control/uncontrolled rates. This can be potentially misleading to CVHOs.

## This addresses

Changes the "Total patients under care" to show `adjusted_patients` instead of `under_care`.

