### PR TITLE
Fetch BSNL sms statuses

### DIFF
--- a/app/jobs/bsnl_sms_status_job.rb
+++ b/app/jobs/bsnl_sms_status_job.rb
@@ -1,0 +1,50 @@
+class BsnlSmsStatusJob
+  include Sidekiq::Worker
+  include Sidekiq::Throttled::Worker
+  BSNL_TIME_ZONE = "Asia/Kolkata"
+
+  sidekiq_options queue: :default
+  sidekiq_options retry: 3
+
+  sidekiq_throttle(
+    threshold: { limit: 250, period: 1.minute }
+  )
+
+  def perform(message_id)
+    response = Messaging::Bsnl::Api.new.get_message_status_report(message_id)
+    handle_api_errors(message_id, response)
+
+    detailable = BsnlDeliveryDetail.find_by!(message_id: message_id)
+    detailable.message_status = response["Message_Status"] if response["Message_Status"]
+    detailable.result = response["Message_Status_Description"] if response["Message_Status_Description"]
+    detailable.delivered_on = parse_timestamp(response["Delivery_Success_Time"]) if response["Delivery_Success_Time"]
+    detailable.save!
+
+    log(response)
+  end
+
+  private
+
+  def log(response)
+    Rails.logger.info(
+      {
+        message_id: response["Message_Id"],
+        content_template_id: response["Content_Template_Id"],
+        error: response["Error"],
+        sms_count: response["SMS_Count"],
+        dlr_error_code: response["DLR_Error_Code"]
+      }
+    )
+  end
+
+  def handle_api_errors(message_id, response)
+    error = response["Error"]
+    if error.present?
+      raise Messaging::Bsnl::Error.new("Error fetching message status for #{message_id}: #{error}")
+    end
+  end
+
+  def parse_timestamp(timestamp)
+    ActiveSupport::TimeZone.new(BSNL_TIME_ZONE).strptime(timestamp, "%d-%m-%Y %H:%M:%S %p")
+  end
+end

--- a/app/models/bsnl_delivery_detail.rb
+++ b/app/models/bsnl_delivery_detail.rb
@@ -14,6 +14,9 @@ class BsnlDeliveryDetail < DeliveryDetail
   validates :recipient_number, presence: true
   validates :dlt_template_id, presence: true
 
+  IN_PROGRESS_STATUSES = %w[created inserted_in_queue submitted_to_smsc accepted_by_carrier]
+  scope :in_progress, -> { where(message_status: message_statuses.slice(*IN_PROGRESS_STATUSES).values).or(where(message_status: nil)) }
+
   def unsuccessful?
     input_error? || rejected_by_smsc? || delivery_failed?
   end
@@ -23,7 +26,7 @@ class BsnlDeliveryDetail < DeliveryDetail
   end
 
   def in_progress?
-    created? || inserted_in_queue? || submitted_to_smsc? || accepted_by_carrier?
+    IN_PROGRESS_STATUSES.includes?(message_status) || message_status.blank?
   end
 
   def self.create_with_communication!(message_id:, recipient_number:, dlt_template_id:)

--- a/app/services/messaging/bsnl/api.rb
+++ b/app/services/messaging/bsnl/api.rb
@@ -3,7 +3,8 @@ class Messaging::Bsnl::Api
   PORT = 5010
   URL_PATHS = {
     get_content_template_details: "/api/Get_Content_Template_Details",
-    send_sms: "/api/Send_Sms"
+    send_sms: "/api/Send_Sms",
+    message_status_report: "/api/Message_Status_Report"
   }
 
   def initialize
@@ -27,6 +28,12 @@ class Messaging::Bsnl::Api
 
   def get_template_details
     post(URL_PATHS[:get_content_template_details])["Content_Template_Ids"]
+  end
+
+  def get_message_status_report(message_id)
+    post(URL_PATHS[:message_status_report], {
+      "Message_id" => message_id
+    })
   end
 
   private

--- a/app/services/messaging/bsnl/sms.rb
+++ b/app/services/messaging/bsnl/sms.rb
@@ -3,6 +3,12 @@ class Messaging::Bsnl::Sms < Messaging::Channel
     Communication.communication_types[:sms]
   end
 
+  def self.get_message_statuses
+    BsnlDeliveryDetail.in_progress.in_batches(of: 1_000).each_record do |detailable|
+      BsnlSmsStatusJob.perform_async(detailable.id)
+    end
+  end
+
   # variable_content: A map that takes the values to be interpolated
   # in the templates. For example: { facility_name: "Facility A", patient_name: "Patient" }
   def send_message(recipient_number:, dlt_template_name:, variable_content:, &with_communication_do)

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -86,6 +86,10 @@ every :day, at: local("07:30 am"), roles: [:cron] do
   runner "Experimentation::Runner.call;AppointmentNotification::ScheduleExperimentReminders.call"
 end
 
+every :day, at: local("05:30 pm"), roles: [:cron] do
+  runner "Messaging::Bsnl::Sms.get_message_statuses"
+end
+
 every 2.minutes, roles: [:cron] do
   runner "TracerJob.perform_async(Time.current.iso8601, false)"
 end

--- a/spec/factories/bsnl_delivery_details.rb
+++ b/spec/factories/bsnl_delivery_details.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :bsnl_delivery_detail do
+    message_id { "1000000" }
+    message_status { "0" }
+    recipient_number { Faker::PhoneNumber.phone_number }
+    dlt_template_id { "14071640000000000000" }
+    result { "Message Created" }
+    delivered_on { nil }
+
+    association :communication
+  end
+end

--- a/spec/factories/bsnl_delivery_details.rb
+++ b/spec/factories/bsnl_delivery_details.rb
@@ -8,5 +8,7 @@ FactoryBot.define do
     delivered_on { nil }
 
     association :communication
+
+    trait(:created) { message_status { "0" } }
   end
 end

--- a/spec/jobs/bsnl_sms_status_job_spec.rb
+++ b/spec/jobs/bsnl_sms_status_job_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe BsnlSmsStatusJob, type: :job do
+  describe "#perform" do
+    it "raises an error if a detailable with the message ID doesn't exist" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("BSNL_IHCI_HEADER").and_return("ABCDEF")
+      allow(ENV).to receive(:[]).with("BSNL_IHCI_ENTITY_ID").and_return("123")
+      Configuration.create(name: "bsnl_sms_jwt", value: "a jwt token")
+
+      described_class.perform_async("non-existent-message-id")
+      expect { described_class.drain }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "calls the BSNL API and updates the status in the delivery detail" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("BSNL_IHCI_HEADER").and_return("ABCDEF")
+      allow(ENV).to receive(:[]).with("BSNL_IHCI_ENTITY_ID").and_return("123")
+      Configuration.create(name: "bsnl_sms_jwt", value: "a jwt token")
+
+      message_id = "12345"
+      detailable = create(:bsnl_delivery_detail, message_id: message_id)
+      allow_any_instance_of(Messaging::Bsnl::Api).to receive(:get_message_status_report).and_return(
+        { "Message_Status" => "7",
+          "Message_Status_Description" => "Message Delivered",
+          "Delivery_Success_Time" => "03-04-2022 06:00:00 PM" }
+      )
+
+      described_class.perform_async(message_id)
+      described_class.drain
+      detailable.reload
+
+      expect(detailable.message_status).to eq("delivered")
+      expect(detailable.result).to eq("Message Delivered")
+      expect(detailable.delivered_on).to eq("Sun, 03 Apr 2022 12:30:00")
+    end
+
+    it "raises exceptions if there's an error in fetching the status" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("BSNL_IHCI_HEADER").and_return("ABCDEF")
+      allow(ENV).to receive(:[]).with("BSNL_IHCI_ENTITY_ID").and_return("123")
+      Configuration.create(name: "bsnl_sms_jwt", value: "a jwt token")
+
+      message_id = "12345"
+      create(:bsnl_delivery_detail, message_id: message_id)
+      allow_any_instance_of(Messaging::Bsnl::Api).to receive(:get_message_status_report).and_return(
+        { "Error" => "Error description" }
+      )
+
+      described_class.perform_async(message_id)
+      expect { described_class.drain }.to raise_error(Messaging::Bsnl::Error)
+    end
+  end
+end

--- a/spec/models/bsnl_delivery_detail_spec.rb
+++ b/spec/models/bsnl_delivery_detail_spec.rb
@@ -5,6 +5,27 @@ RSpec.describe BsnlDeliveryDetail, type: :model do
     it { is_expected.to have_one(:communication) }
   end
 
+  describe ".in_progress" do
+    it "returns deliverables which are in progress" do
+      in_progress_status_codes = %w[0 2 3 5]
+      in_progress_details = in_progress_status_codes.map do |status_code|
+        create(:bsnl_delivery_detail, message_status: status_code)
+      end
+
+      delivered_detail = create(:bsnl_delivery_detail, message_status: "7")
+
+      expect(described_class.in_progress).to match_array(in_progress_details)
+      expect(described_class.in_progress).not_to include(delivered_detail)
+    end
+
+    it "returns deliverables if they don't have a message status set" do
+      detail = create(:bsnl_delivery_detail, message_status: nil)
+      delivered_detail = create(:bsnl_delivery_detail, message_status: "7")
+      expect(described_class.in_progress).to include(detail)
+      expect(described_class.in_progress).not_to include(delivered_detail)
+    end
+  end
+
   describe ".create_with_communication!" do
     it "creates a communication with a BsnlDeliveryDetail" do
       phone_number = "1111111111"

--- a/spec/services/messaging/bsnl/api_spec.rb
+++ b/spec/services/messaging/bsnl/api_spec.rb
@@ -42,4 +42,15 @@ RSpec.describe Messaging::Bsnl::Api do
       expect(described_class.new.get_template_details).to contain_exactly("A list of template details")
     end
   end
+
+  describe "#get_message_status_report" do
+    it "gets the message's status" do
+      allow(ENV).to receive(:[]).with("BSNL_IHCI_HEADER").and_return("ABCDEF")
+      allow(ENV).to receive(:[]).with("BSNL_IHCI_ENTITY_ID").and_return("123")
+      Configuration.create(name: "bsnl_sms_jwt", value: "a jwt token")
+
+      stub_request(:post, "https://bulksms.bsnl.in:5010/api/Message_Status_Report").to_return(body: {a: :hash}.to_json)
+      expect(described_class.new.get_message_status_report(123123)).to eq({"a" => "hash"})
+    end
+  end
 end

--- a/spec/services/messaging/bsnl/sms_spec.rb
+++ b/spec/services/messaging/bsnl/sms_spec.rb
@@ -1,4 +1,4 @@
-require "rspec"
+require "rails_helper"
 
 RSpec.describe Messaging::Bsnl::Sms do
   def mock_template
@@ -9,6 +9,14 @@ RSpec.describe Messaging::Bsnl::Sms do
     allow(mock_template).to receive(:sanitised_variable_content).and_return([{"Key" => "a", "Value" => "hash"}])
     allow(mock_template).to receive(:check_approved)
     mock_template
+  end
+
+  describe ".get_message_statuses" do
+    it "picks up any in progress BSNL delivery details and queues a BsnlSmsStatusJob" do
+      create_list(:bsnl_delivery_detail, 2, :created)
+
+      expect { described_class.get_message_statuses }.to change(Sidekiq::Queues["default"], :size).by(2)
+    end
   end
 
   describe "#send_message" do


### PR DESCRIPTION
**Story card:** [sc-7838](https://app.shortcut.com/simpledotorg/story/7838/add-job-to-fetch-bsnl-sms-delivery-statuses)

## Because

BSNL does not support callbacks for status updates and instead has an API to fetch message statuses from. We will need periodically fetch those statuses from the API.

## This addresses

- Adds a job that can fetch the result for a message
- Adds the orchestrator for these jobs to `schedule.rb`. We'll fetch the statuses for all pending messages once a day.
