### PR TITLE
Minor changes to improve mobile formatting

### DIFF
--- a/app/components/registrations_and_follow_ups_component.html.erb
+++ b/app/components/registrations_and_follow_ups_component.html.erb
@@ -1,6 +1,6 @@
 <div class="card mt-0 pr-0 pr-md-3 pb-inside-avoid">
   <div class="d-flex flex-1 mb-8px">
-    <h3 class="mb-0px mr-8px">
+    <h3 class="mb-16px mr-8px">
       Patient registrations and follow-ups
     </h3>
     <%= render "definition_tooltip",

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -18,7 +18,7 @@
       <thead>
       <tr>
         <th class="sticky"></th>
-        <th colspan="2" class="sticky">
+        <th colspan="2" class="sticky nowrap">
           BP controlled
           <%= render "definition_tooltip",
                      definitions: {
@@ -27,7 +27,7 @@
                      }
           %>
         </th>
-        <th colspan="2" class="sticky">
+        <th colspan="2" class="sticky nowrap">
           BP not controlled
           <%= render "definition_tooltip",
                      definitions: {
@@ -36,7 +36,7 @@
                      }
           %>
         </th>
-        <th colspan="2" class="sticky">
+        <th colspan="2" class="sticky nowrap">
           Missed visits
           <%= render "definition_tooltip",
                      definitions: {
@@ -45,7 +45,7 @@
                      }
           %>
         </th>
-        <th colspan="2" class="sticky">
+        <th colspan="2" class="sticky nowrap">
           Registrations
           <%= render "definition_tooltip",
                      definitions: {


### PR DESCRIPTION
Story: https://app.shortcut.com/simpledotorg/story/7865/better-table-headers-wrapping-on-mobile

The TH headers just wrapped stupidly on mobile. I also added a little bottom margin to a header.