### PR TITLE
Move sidekiq tracer jobs to the high priority queue

### DIFF
--- a/app/jobs/tracer_job.rb
+++ b/app/jobs/tracer_job.rb
@@ -1,5 +1,7 @@
 class TracerJob
   include Sidekiq::Worker
+
+  sidekiq_options queue: :high
   sidekiq_options retry: false # job will be discarded if it fails
 
   def perform(submitted_at, raise_error)


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

## Because

Sidekiq tracer jobs are currently processed on the `default` queue. This is problematic when there is a large number of enqueued jobs that hold up the tracer job and triggers alerts

## This addresses

Moves tracer jobs to the `high` queue, so these jobs are not blocked