### PR TITLE
Use `Date.today` as the mock time

### DIFF
--- a/spec/services/reports/facility_progress_service_spec.rb
+++ b/spec/services/reports/facility_progress_service_spec.rb
@@ -131,8 +131,8 @@ RSpec.describe Reports::FacilityProgressService, type: :model do
       end
     end
 
-    xit "returns includes data from current day for follow up numbers" do
-      Timecop.freeze("10-03-2022 11:35AM") do
+    it "includes data from current day for follow up numbers" do
+      Timecop.freeze(Date.today.at_noon) do
         facility = create(:facility, enable_diabetes_management: true)
         htn_patient1 = create(:patient, :hypertension, registration_facility: facility, registration_user: user, recorded_at: 2.months.ago)
         htn_patient2 = create(:patient, :hypertension, registration_facility: facility, registration_user: user, recorded_at: 2.months.ago)


### PR DESCRIPTION
**Story card:** [sc-7915](https://app.shortcut.com/simpledotorg/story/7915/fix-facility-progress-spec)

## Because

Mat views use the system time which is different from the initial mock time, resulting the test to fail after a specific date.

## This addresses

It fixes the mock time so that the test is independent of the current date