### PR TITLE
Move tracer jobs to a different high priority queue

### DIFF
--- a/app/jobs/tracer_job.rb
+++ b/app/jobs/tracer_job.rb
@@ -1,7 +1,7 @@
 class TracerJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :high
+  sidekiq_options queue: :tracer
   sidekiq_options retry: false # job will be discarded if it fails
 
   def perform(submitted_at, raise_error)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,6 +3,7 @@
 :logfile: ./log/sidekiq.log
 
 :queues:
+  - [tracer, 4]
   - [high, 3]
   - [default, 2]
   - [low, 1]


### PR DESCRIPTION
**Story card:** [sc-7903](https://app.shortcut.com/simpledotorg/story/7903/throttle-send-sms-api-calls?vc_group_by=day&ct_workflow=all&cf_workflow=500000031)

## Because

Tracer jobs get clogged up if they are in a queue where other jobs are throttled. This should never happen since tracer jobs are priority numero uno.

## This addresses

Moves tracer jobs to a separate queue with the highest priority.
