### PR TITLE
Throttle appointment notifications

### DIFF
--- a/app/jobs/appointment_notification/worker.rb
+++ b/app/jobs/appointment_notification/worker.rb
@@ -3,6 +3,9 @@ class AppointmentNotification::Worker
   include Memery
 
   sidekiq_options queue: :high
+  sidekiq_throttle(
+    threshold: {limit: 600, period: 1.minute}
+  )
 
   def perform(notification_id)
     return unless flipper_enabled?

--- a/app/jobs/appointment_notification/worker.rb
+++ b/app/jobs/appointment_notification/worker.rb
@@ -1,6 +1,6 @@
 class AppointmentNotification::Worker
   include Sidekiq::Worker
-  include Memery
+  include Sidekiq::Throttled::Worker
 
   sidekiq_options queue: :high
   sidekiq_throttle(

--- a/app/services/messaging/bsnl/error.rb
+++ b/app/services/messaging/bsnl/error.rb
@@ -2,7 +2,7 @@ class Messaging::Bsnl::Error < Messaging::Error
   ERROR_CODE_REASONS = {/Invalid Mobile Number/ => :invalid_phone_number}
 
   def initialize(message)
-    @message = "Error while calling BSNL API: #{message}"
+    @message = message
     @reason = error_reason(message)
   end
 


### PR DESCRIPTION
**Story card:** [sc-7903](https://app.shortcut.com/simpledotorg/story/7903/throttle-send-sms-api-calls)

## Because

We want to rate limit the number of calls we make to the BSNL Send SMS API in order to prevent DOSing their servers.

## This addresses

BSNL hasn't showed signs of major troubles yet with some test traffic. We saw 7 timeouts in 10k messages. 

This adds a throttle to the appointment notification worker. The limit is a bit generous and we can bring it down if we continue to see any request timeouts.