### PR TITLE
Store BSNL message string in detailable

### DIFF
--- a/app/jobs/bsnl_sms_status_job.rb
+++ b/app/jobs/bsnl_sms_status_job.rb
@@ -16,6 +16,7 @@ class BsnlSmsStatusJob
 
     detailable = BsnlDeliveryDetail.find_by!(message_id: message_id)
     detailable.message_status = response["Message_Status"] if response["Message_Status"]
+    detailable.message = response["Message"] if response["Message"]
     detailable.result = response["Message_Status_Description"] if response["Message_Status_Description"]
     detailable.delivered_on = parse_timestamp(response["Delivery_Success_Time"]) if response["Delivery_Success_Time"]
     detailable.save!

--- a/db/migrate/20220412112538_add_bsnl_delivery_detail_message_string.rb
+++ b/db/migrate/20220412112538_add_bsnl_delivery_detail_message_string.rb
@@ -1,0 +1,5 @@
+class AddBsnlDeliveryDetailMessageString < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bsnl_delivery_details, :message, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -282,7 +282,8 @@ CREATE TABLE public.bsnl_delivery_details (
     delivered_on timestamp without time zone,
     deleted_at timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    message character varying
 );
 
 
@@ -5576,6 +5577,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220322115123'),
 ('20220403123845'),
 ('20220408132514'),
-('20220408135115');
+('20220408135115'),
+('20220412112538');
 
 

--- a/spec/jobs/bsnl_sms_status_job_spec.rb
+++ b/spec/jobs/bsnl_sms_status_job_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe BsnlSmsStatusJob, type: :job do
       detailable = create(:bsnl_delivery_detail, message_id: message_id)
       allow_any_instance_of(Messaging::Bsnl::Api).to receive(:get_message_status_report).and_return(
         {"Message_Status" => "7",
+         "Message" => "A test message",
          "Message_Status_Description" => "Message Delivered",
          "Delivery_Success_Time" => "03-04-2022 06:00:00 PM"}
       )
@@ -31,6 +32,7 @@ RSpec.describe BsnlSmsStatusJob, type: :job do
       detailable.reload
 
       expect(detailable.message_status).to eq("delivered")
+      expect(detailable.message).to eq("A test message")
       expect(detailable.result).to eq("Message Delivered")
       expect(detailable.delivered_on).to eq("Sun, 03 Apr 2022 12:30:00")
     end


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

## Because

Since BSNL prepares the final SMS body and sends it out to patients, we want to fetch what was sent out and store a copy of it for our records.

## This addresses

- Adds a message column to the deliver detail
- Starts storing the message body from the status call in the detailable
