### PR TITLE
Exclude English patients temporarily from current A/B experiment

### DIFF
--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -47,7 +47,14 @@ module Experimentation
                                              .where(status: :scheduled)
                                              .group(:patient_id)
                                              .having("count(patient_id) > 1"))
+        .then { |patients| exclude_nagaland_patients(patients) }
         .then { |patients| exclude_bangladesh_blocks(patients) }
+    end
+
+    def self.exclude_nagaland_patients(patients)
+      return patients unless CountryConfig.current_country?("India")
+
+      patients.where.not(facilities: {state: "Nagaland"})
     end
 
     def self.exclude_bangladesh_blocks(patients)

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -177,6 +177,19 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
       expect(described_class.eligible_patients).to include(included_patient)
     end
 
+    it "doesn't include patients in Nagaland since english templates are pending DLT approval" do
+      facility = create(:facility, state: "Nagaland")
+      excluded_patient = create(:patient, age: 18, assigned_facility: facility)
+      create(:appointment, patient: excluded_patient, status: :scheduled)
+
+      included_patient = create(:patient, age: 18)
+      create(:appointment, patient: included_patient, status: :scheduled)
+
+      puts described_class.eligible_patients.to_sql
+      expect(described_class.eligible_patients).not_to include(excluded_patient)
+      expect(described_class.eligible_patients).to include(included_patient)
+    end
+
     it "doesn't include patients who are assigned in the excluded blocks list" do
       facility = create(:facility)
       patient = create(:patient, age: 18, assigned_facility: facility)


### PR DESCRIPTION
**Story card:** -

## Because

We had to resubmit english SMS templates for DLT approval because they were originally submitted as "Non-regional". This prevented us from using unicode characters in the messages. Since the new templates have been submitted, we don't have any approved english DLT messages. Any english messages sent will be rejected.

## This addresses

This adds a temporary exclusion to the experiment's selection criteria for patients in english speaking regions (only Nagaland). This PR should be reverted once the english SMSes have been approved on DLT.