### PR TITLE
Run the experiment rake tasks earlier

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -82,7 +82,7 @@ every :monday, at: local("6:00 am"), roles: [:cron] do
   end
 end
 
-every :day, at: local("07:30 am"), roles: [:cron] do
+every :day, at: local("05:45 am"), roles: [:cron] do
   runner "Experimentation::Runner.call;AppointmentNotification::ScheduleExperimentReminders.call"
 end
 


### PR DESCRIPTION
**Story card:** N/A

## Because
Stale patient enrollment is taking a long time, starting it earlier so it can wrap up earlier.
This is intended as an immediate-term fix to buy us time while we make performance optimizations 
