### PR TITLE
Don't exclude multiple schedule appointments in experiment selection

### DIFF
--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -207,18 +207,17 @@ module Experimentation
     private
 
     # This exception handling has been added to temporarily handle patients with multiple
-    # scheduled appointments. This patients were earlier excluded from the eligible patients list
+    # scheduled appointments. These patients were earlier excluded from the eligible patients list
     # but we had to remove the exclusion for performance.
     def handle_multiple_enrollments
       begin
         yield
       rescue ActiveRecord::RecordNotUnique => error
         if error.message.include?('duplicate key value violates unique constraint "index_tgm_patient_id_and_experiment_id"')
-          Rails.logger.info("#{self.class.name} error while enrolling patient: #{e.message}")
+          Rails.logger.info("#{self.class.name} error while enrolling patient: #{error.message}")
         else
           raise error
         end
-
       end
     end
 

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -210,14 +210,12 @@ module Experimentation
     # scheduled appointments. These patients were earlier excluded from the eligible patients list
     # but we had to remove the exclusion for performance.
     def handle_multiple_enrollments
-      begin
-        yield
-      rescue ActiveRecord::RecordNotUnique => error
-        if error.message.include?('duplicate key value violates unique constraint "index_tgm_patient_id_and_experiment_id"')
-          Rails.logger.info("#{self.class.name} error while enrolling patient: #{error.message}")
-        else
-          raise error
-        end
+      yield
+    rescue ActiveRecord::RecordNotUnique => error
+      if error.message.include?('duplicate key value violates unique constraint "index_tgm_patient_id_and_experiment_id"')
+        Rails.logger.info("#{self.class.name} error while enrolling patient: #{error.message}")
+      else
+        raise error
       end
     end
 

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -40,13 +40,6 @@ module Experimentation
                                            .where("treatment_group_memberships.patient_id = patients.id")
                                            .where("end_time > ?", RECENT_EXPERIMENT_MEMBERSHIP_BUFFER.ago)
                                            .select(:patient_id))
-        .where("NOT EXISTS (:multiple_scheduled_appointments)",
-          multiple_scheduled_appointments: Appointment
-                                             .select(1)
-                                             .where("appointments.patient_id = patients.id")
-                                             .where(status: :scheduled)
-                                             .group(:patient_id)
-                                             .having("count(patient_id) > 1"))
         .then { |patients| exclude_nagaland_patients(patients) }
         .then { |patients| exclude_bangladesh_blocks(patients) }
     end
@@ -77,7 +70,11 @@ module Experimentation
           .includes(:assigned_facility, :registration_facility, :medical_history)
           .includes(latest_scheduled_appointments: [:facility, :creation_facility])
           .in_batches(of: BATCH_SIZE)
-          .each_record { |patient| random_treatment_group.enroll(patient, reporting_data(patient, date)) }
+          .each_record do |patient|
+          handle_multiple_enrollments do
+            random_treatment_group.enroll(patient, reporting_data(patient, date))
+          end
+        end
       end
     end
 
@@ -208,6 +205,22 @@ module Experimentation
     end
 
     private
+
+    # This exception handling has been added to temporarily handle patients with multiple
+    # scheduled appointments. This patients were earlier excluded from the eligible patients list
+    # but we had to remove the exclusion for performance.
+    def handle_multiple_enrollments
+      begin
+        yield
+      rescue ActiveRecord::RecordNotUnique => error
+        if error.message.include?('duplicate key value violates unique constraint "index_tgm_patient_id_and_experiment_id"')
+          Rails.logger.info("#{self.class.name} error while enrolling patient: #{e.message}")
+        else
+          raise error
+        end
+
+      end
+    end
 
     def remaining_enrollments_allowed(date)
       max_patients_per_day - treatment_group_memberships.where(experiment_inclusion_date: date).count

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -155,17 +155,6 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
       expect(described_class.eligible_patients).not_to include(patient)
     end
 
-    it "excludes any patients who have multiple scheduled appointments" do
-      excluded_patient = create(:patient, age: 18)
-      create_list(:appointment, 2, patient: excluded_patient, status: :scheduled)
-
-      included_patient = create(:patient, age: 18)
-      create(:appointment, patient: included_patient, status: :scheduled)
-
-      expect(described_class.eligible_patients).not_to include(excluded_patient)
-      expect(described_class.eligible_patients).to include(included_patient)
-    end
-
     it "doesn't include any patients whose assigned facility has been deleted" do
       excluded_patient = create(:patient, age: 18)
       excluded_patient.assigned_facility.discard
@@ -265,6 +254,10 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
         :registration_facility_district,
         :registration_facility_state
       ).values).to all be_present
+    end
+
+    it "does not raise an exception and continues with other patients if a patient is tried to enrolled more than once" do
+
     end
 
     it "enrolls a patient even if assigned/registration facility was discarded, no scheduled appointments are present" do


### PR DESCRIPTION
**Story card:** [sc-7945](https://app.shortcut.com/simpledotorg/story/7945/data-migration-to-cleanup-multiple-scheduled-appointments)

## Because

Excluding patients who have multiple `scheduled` appointments makes the `eligible_patients` query very expensive. For the running stale patient experiment, it takes ~3h to finish, whereas it finishes in ~2m when that clause is removed.

## This addresses

Since these patients result in inconsistent data [elsewhere as well](https://simpledotorg.slack.com/archives/CFHKJ5WJY/p1646895602911209), we are running a one time data migration to clean up these appointments. Instead of trying to optimise the query, this will allow us to drop the clause and handle this situation specifically for the small number of new appointments that get created everyday.

When we have a long term fix for multiple scheduled appointments, we should remove this exception handling.
