### PR TITLE
Add data migration to mark old scheduled appointments as visited

### DIFF
--- a/db/data/20220419114625_mark_old_scheduled_appointments_visited.rb
+++ b/db/data/20220419114625_mark_old_scheduled_appointments_visited.rb
@@ -1,0 +1,19 @@
+class MarkOldScheduledAppointmentsVisited < ActiveRecord::Migration[5.2]
+  def up
+    patients_ids_with_multiple_appointments = Patient
+      .joins(:latest_scheduled_appointments)
+      .group("patients.id")
+      .having("count(patients.id) > 1")
+      .count
+      .keys
+
+    patients_ids_with_multiple_appointments.each do |patient_id|
+      old_scheduled_appointments = Patient.find(patient_id).latest_scheduled_appointments.offset(1)
+      old_scheduled_appointments.update_all(status: :visited, updated_at: Time.current)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/data/mark_old_scheduled_appointments_visited_spec.rb
+++ b/spec/data/mark_old_scheduled_appointments_visited_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+require Rails.root.join("db", "data", "20220419114625_mark_old_scheduled_appointments_visited")
+
+RSpec.describe MarkOldScheduledAppointmentsVisited do
+  it "marks older scheduled appointments visited for patients who have multiple scheduled appointments" do
+    # patient with no appointments
+    patient_1 = create(:patient)
+    # patient with one scheduled appointment
+    patient_2 = create(:patient)
+    # patient with multiple appointments
+    patient_3 = create(:patient)
+
+    patient_2_appointment_1 = create(:appointment, status: :scheduled, patient: patient_2)
+    patient_3_appointment_1 = create(:appointment, status: :scheduled, patient: patient_3, scheduled_date: 1.year.ago)
+    patient_3_appointment_2 = create(:appointment, status: :scheduled, patient: patient_3, scheduled_date: 6.months.ago)
+    patient_3_appointment_3 = create(:appointment, status: :scheduled, patient: patient_3, scheduled_date: 1.month.ago)
+
+    described_class.new.up
+
+    expect(patient_1.latest_scheduled_appointments.count).to eq(0)
+    expect(patient_2.latest_scheduled_appointments).to match_array([patient_2_appointment_1])
+    expect(patient_3.latest_scheduled_appointments).to match_array([patient_3_appointment_3])
+    expect(patient_3_appointment_1.reload.status).to eq("visited")
+    expect(patient_3_appointment_2.reload.status).to eq("visited")
+  end
+
+  it "sets updated_at correctly" do
+    Timecop.freeze(Time.current) do
+      # patient with multiple appointments
+      patient = create(:patient)
+      last_month = Time.current - 1.month
+
+      appointment_1 = create(:appointment, status: :scheduled, patient: patient, scheduled_date: 1.year.ago, updated_at: last_month)
+      appointment_2 = create(:appointment, status: :scheduled, patient: patient, scheduled_date: 6.months.ago, updated_at: last_month)
+      appointment_3 = create(:appointment, status: :scheduled, patient: patient, scheduled_date: 1.month.ago, updated_at: last_month)
+
+      described_class.new.up
+
+      expect(appointment_1.reload.updated_at).to eq(Time.current)
+      expect(appointment_2.reload.updated_at).to eq(Time.current)
+      expect(appointment_3.reload.updated_at).to eq(last_month)
+    end
+  end
+end

--- a/spec/data/mark_old_scheduled_appointments_visited_spec.rb
+++ b/spec/data/mark_old_scheduled_appointments_visited_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe MarkOldScheduledAppointmentsVisited do
 
       described_class.new.up
 
-      expect(appointment_1.reload.updated_at).to eq(Time.current)
-      expect(appointment_2.reload.updated_at).to eq(Time.current)
-      expect(appointment_3.reload.updated_at).to eq(last_month)
+      expect(appointment_1.reload.updated_at.strftime("%Y-%m-%d")).to eq(Time.current.strftime("%Y-%m-%d"))
+      expect(appointment_2.reload.updated_at.strftime("%Y-%m-%d")).to eq(Time.current.strftime("%Y-%m-%d"))
+      expect(appointment_3.reload.updated_at.strftime("%Y-%m-%d")).to eq(last_month.strftime("%Y-%m-%d"))
     end
   end
 end


### PR DESCRIPTION
**Story card:** [sc-7952](https://app.shortcut.com/simpledotorg/story/7952/mark-old-scheduled-appointments-as-visited-for-patients-with-multiple-scheduled-appointments)

## Because

We observed that ~30k patients have more than one scheduled appointment, this data migration will ensure that they only have one outstanding scheduled appointment.

## This addresses

For all patients that have multiple scheduled appointments, this data migration will mark all but their latest scheduled appointment as visited.