### PR TITLE
Fixed print formatting for Praveen's bug.

### DIFF
--- a/app/views/reports/regions/_medications_dispensation.html.erb
+++ b/app/views/reports/regions/_medications_dispensation.html.erb
@@ -1,6 +1,6 @@
 <div class="d-lg-flex flex-lg-wrap">
   <div class="d-lg-flex w-lg-50 pr-lg-2">
-    <div id="medications-dispensation" class="mt-8px mx-0px mb-16px bg-white br-4px bs-small d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black w-print-16cm pb-1">
+    <div id="medications-dispensation" class="mt-8px mx-0px mb-16px bg-white br-4px bs-small d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black pb-1">
       <div class="pt-20px px-20px">
         <div class="mb-8px">
           <h3 class="mb-0px mr-8px d-inline">

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -1,6 +1,6 @@
 <div class="d-lg-flex flex-lg-wrap">
   <div class="d-lg-flex w-lg-50 pr-lg-2">
-    <div id="patient-breakdown" data-period="<%= @period.to_s %>" class="mt-8px mx-0px mb-16px p-20px bg-white br-4px bs-small w-lg-full mt-lg-0 pb-inside-avoid b-print-black w-print-16cm">
+    <div id="patient-breakdown" data-period="<%= @period.to_s %>" class="mt-8px mx-0px mb-16px p-20px bg-white br-4px bs-small w-lg-full mt-lg-0 pb-inside-avoid b-print-black">
       <% if @region.supports_htn_population_coverage %>
         <div class="d-flex flex-1 mb-8px">
           <h3 class="mb-0px mr-8px">
@@ -89,7 +89,7 @@
     </div>
   </div>
   <div class="d-lg-flex w-lg-50 pl-lg-2">
-    <div id="ltfu-trend" data-period="<%= @period.to_s %>" class="mt-8px mx-0px mb-16px bg-white br-4px bs-small d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black w-print-16cm">
+    <div id="ltfu-trend" data-period="<%= @period.to_s %>" class="mt-8px mx-0px mb-16px bg-white br-4px bs-small d-lg-flex fd-lg-column justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black">
       <div class="pt-20px px-20px">
         <div class="d-flex flex-1 mb-8px">
           <h3 class="mb-0px mr-8px">

--- a/app/views/reports/regions/_treatment_outcomes_card.html.erb
+++ b/app/views/reports/regions/_treatment_outcomes_card.html.erb
@@ -1,13 +1,13 @@
 <div id="visit-details"
      data-period="<%= @period.to_s %>"
      class="mt-8px mx-0px mb-16px p-20px py-lg-20px pr-lg-20px pl-lg-0px bg-white br-4px bs-small d-lg-flex fd-lg-column
-            justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid pb-after-always b-print-black w-print-16cm">
+            justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid pb-after-always b-print-black">
   <h3 class="mb-0px pl-lg-20px">
     Treatment outcomes of patients under care
   </h3>
 
   <div class="d-flex fd-column fd-lg-row">
-      <div class="pl-lg-12px w-lg-50 h-lg-auto h-print-12cm minh-300px">
+      <div class="pl-lg-12px w-lg-50 h-lg-auto minh-300px">
         <canvas id="missedVisitDetails"></canvas>
       </div>
       <div class="flex-lg-1 mt-24px ml-lg-24px mt-print-2cm">

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -11,7 +11,7 @@
     <div id="bp-controlled"
          data-period="<%= @period.to_s %>"
          class="mt-8px mx-0px mb-16px bg-white br-4px bs-small d-lg-flex fd-lg-column
-                justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black w-print-16cm">
+                justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black">
 
       <div class="pt-20px px-20px">
         <div class="d-flex mb-8px">
@@ -61,7 +61,7 @@
     <div id="cumulative-registrations"
          data-period="<%= @period.to_s %>"
          class="mt-8px mx-0px mb-16px pb-4px bg-white br-4px bs-small d-lg-flex fd-lg-column
-                justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black w-print-16cm">
+                justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black">
       <div class="pt-20px px-20px">
         <div class="d-flex mb-8px">
           <div class="d-flex flex-1">
@@ -110,7 +110,7 @@
     <div id="bp-uncontrolled"
          data-period="<%= @period.to_s %>"
          class="mt-8px mx-0px mb-16px bg-white br-4px bs-small d-lg-flex fd-lg-column
-          justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black w-print-16cm">
+          justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black">
       <div class="pt-20px px-20px">
         <div class="d-flex mb-8px">
             <div class="d-flex flex-1">
@@ -160,7 +160,7 @@
     <div id="missed-visits"
          data-period="<%= @period.to_s %>"
          class="mt-8px mx-0px mb-16px bg-white br-4px bs-small d-lg-flex fd-lg-column
-          justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black w-print-16cm">
+          justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black">
       <div class="pt-20px px-20px">
         <div class="d-flex mb-8px">
           <div class="d-flex flex-1">

--- a/app/views/shared/_nav_bar.html.erb
+++ b/app/views/shared/_nav_bar.html.erb
@@ -164,7 +164,7 @@
 
 </nav>
 
-<div class="mobile-header">
+<div class="mobile-header d-print-none">
     <a href="#" onclick="openMenu()" class="navigation-icon"><i class="fa-regular fa-bars pr-1"></i> MENU</a>
     <%= link_to root_path, class: "navigation-brand" do %>
       <%= logo_for_environment %>

--- a/app/views/shared/_region_search.html.erb
+++ b/app/views/shared/_region_search.html.erb
@@ -1,4 +1,4 @@
-<div class="typeahead">
+<div class="typeahead d-print-none">
   <div class="input-group">
     <div class="input-group-prepend">
       <span class="input-group-text">


### PR DESCRIPTION
**Story card:** [sc-7799](https://app.shortcut.com/simpledotorg/story/7799/graph-alignment-is-broken-in-pdf-download)

## Because

Praveen pointed out that Reports graphs were overflowing the cards.

## This addresses

Someone coded these to be very fragile with specific "cm" widths for the cards. This is not a good approach. I took out the specific widths and will later come back and make them relative %s. I confirmed with Praveen that a single row of stacked cards is acceptable for now.

## Test instructions

Load any report. Try PRINT and look at print preview or PDF.