### PR TITLE
Move OTPs to high queue

### DIFF
--- a/app/jobs/request_otp_sms_job.rb
+++ b/app/jobs/request_otp_sms_job.rb
@@ -1,4 +1,6 @@
 class RequestOtpSmsJob < ApplicationJob
+  queue_as :high
+
   def perform(user)
     handle_twilio_errors(user) do
       Messaging::Twilio::OtpSms.send_message(

--- a/app/jobs/send_patient_otp_sms_job.rb
+++ b/app/jobs/send_patient_otp_sms_job.rb
@@ -1,4 +1,6 @@
 class SendPatientOtpSmsJob < ApplicationJob
+  queue_as :high
+
   def perform(passport_authentication)
     phone_number = passport_authentication.patient&.latest_mobile_number
     return unless phone_number.present?


### PR DESCRIPTION
**Story card:** -

## Because

OTPs get delayed if the `default` queue is filled with other jobs.

## This addresses

Moves OTPs to the `high` queue. We only use the high queue for time sensitive operations such as sending SMSes.
