### PR TITLE
Inactive facilities cleanup

### DIFF
--- a/app/controllers/my_facilities_controller.rb
+++ b/app/controllers/my_facilities_controller.rb
@@ -31,10 +31,6 @@ class MyFacilitiesController < AdminController
 
     @facility_counts_by_size = {total: @facilities.group(:facility_size).count,
                                 inactive: @inactive_facilities.group(:facility_size).count}
-
-    @inactive_facilities_bp_counts =
-      {last_week: overview_query.total_bps_in_last_n_days(n: 7),
-       last_month: overview_query.total_bps_in_last_n_days(n: 30)}
   end
 
   def bp_controlled


### PR DESCRIPTION
**Story card:** [sc-8061](https://app.shortcut.com/simpledotorg/story/8061/update-inactive-facilities-definition-on-dashboard-to-match-metabase-s-active-facilities-definition)

## Because

Missed a cleanup in https://github.com/simpledotorg/simple-server/pull/3695

## This addresses

Removes dead code.