### PR TITLE
Change Hydrochlorothizide 12.5mg drug factor

### DIFF
--- a/config/data/drug_stock_config.yml
+++ b/config/data/drug_stock_config.yml
@@ -72,7 +72,7 @@ Haryana:
       '979467': 1
     hypertension_diuretic:
       new_patient_coefficient: 0.05
-      '429503': 0.5
+      '429503': 1
       '316049': 1
       '331132': 1
       'Chlor6.25': 1


### PR DESCRIPTION
**Story card:** [sc-7958](https://app.shortcut.com/simpledotorg/story/7958/hi-uk98l8at0)

## Because

Our drug stock configuration for Haryana had an error

## This addresses

Fixes the factor for Hydrochlorothiazide 12.5mg