### PR TITLE
Adjust BSNL balance alert

### DIFF
--- a/lib/tasks/scripts/get_bsnl_account_balance.rb
+++ b/lib/tasks/scripts/get_bsnl_account_balance.rb
@@ -1,8 +1,8 @@
 class GetBsnlAccountBalance
-  # (20_000 * 3 patients from current experiments + 15_000 patients from stale experiments) * 3 segments per message
+  # (15_000 * 3 patients from current experiments + 15_000 patients from stale experiments) * 3 segments per message
   # We're unlikely to actually hit this number on any given day, but we'd like to alert early if we're close to the limit
-  MAX_DAILY_MESSAGE_SEGMENT_COUNT = 75_000 * 3
-  BALANCE_EXPIRY_ALERT_DAYS = 7
+  MAX_DAILY_MESSAGE_SEGMENT_COUNT = 50_000 * 3
+  BALANCE_EXPIRY_ALERT_DAYS = 5
 
   attr_reader :recharge_details, :expiry_date, :total_balance_remaining
 


### PR DESCRIPTION
**Story card:** -

## Because

The BSNL minimum balance alert is always firing currently which makes it useless. Since we haven't been able to buy a large package and are going to buy packages every week or two, we want the alert to notify us if we're actually cutting it too close.

## This addresses

Adjusts the alerts to more realistic numbers. This will notify us when we have 4-5 days of messages left.