### PR TITLE
Restart sidekiq every night

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -54,6 +54,10 @@ every :day, at: local("11:00 pm"), roles: [:cron] do
   runner "Messaging::Bsnl::Sms.get_message_statuses"
 end
 
+every :day, at: local("11:45 pm"), roles: [:sidekiq] do
+  command "systemctl restart sidekiq --user"
+end
+
 every :day, at: local("12:00 am"), roles: [:whitelist_phone_numbers] do
   rake "exotel_tasks:whitelist_patient_phone_numbers"
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -15,6 +15,10 @@ every :day, at: local("11:00 pm").utc, roles: [:cron] do
   rake "appointment_notification:three_days_after_missed_visit"
 end
 
+every :day, at: local("11:45 pm"), roles: [:sidekiq] do
+  command "systemctl restart sidekiq --user"
+end
+
 every :day, at: local("12:00 am"), roles: [:whitelist_phone_numbers] do
   rake "exotel_tasks:whitelist_patient_phone_numbers"
 end


### PR DESCRIPTION
**Story card:** [sc-8182](https://app.shortcut.com/simpledotorg/story/8182/sidekiq-downtime-issues)

## Because

We've been seeing memory bloat (and a potential memory leak) on our sidekiq servers. We've tried https://github.com/simpledotorg/deployment/pull/423 and are exploring turning on `jemalloc`. Those fixes withstanding, we should consider restarting sidekiq periodically since ~~we do have a memory leak and it's hard to pin down~~ long running sidekiq processes tend to bloat due to memory fragmentation.

~~This seems to be a common enough solution when people can't get ahold of what's leaking memory https://blog.ty-porter.dev/development/2021/05/30/heroku-memory-bloat.html.~~

## This addresses

Adds a cron task to restart sidekiq every night. Also rearranges `schedule.rb` to be chronological.