### PR TITLE
Allow enabling diabetes management reports at an actor level

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -125,7 +125,7 @@ class Reports::RegionsController < AdminController
   end
 
   def diabetes
-    unless @region.diabetes_management_enabled?
+    unless current_admin.feature_enabled?(:diabetes_management_reports) && @region.diabetes_management_enabled?
       raise ActionController::RoutingError.new("Not Found")
     end
 

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -169,8 +169,7 @@ class Region < ApplicationRecord
   end
 
   def diabetes_management_enabled?
-    Flipper.enabled?(:diabetes_management_reports) &&
-      facilities.where(enable_diabetes_management: true).exists?
+    facilities.where(enable_diabetes_management: true).exists?
   end
 
   REGION_TYPES.reject { |t| t == "root" }.map do |region_type|

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -32,7 +32,7 @@
         <%= link_to "Overview", url_params.merge(action: "show"), class: "nav-link #{active_action?("show")}" %>
         <%= link_to "Details", url_params.merge(action: "details"), class: "nav-link #{active_action?("details")}" %>
         <%= link_to "Cohort reports", reports_region_cohort_path(@region, report_scope: params[:report_scope]), class: "nav-link #{active_action?("cohort")}" %>
-        <% if @region.diabetes_management_enabled? %>
+        <% if current_admin.feature_enabled?(:diabetes_management_reports) && @region.diabetes_management_enabled? %>
           <%= link_to "Diabetes", reports_region_diabetes_path(@region, report_scope: params[:report_scope]), class: "nav-link #{active_action?("diabetes")}" %>
         <% end %>
         <% if @region.facility_region? && current_admin.feature_enabled?(:dashboard_progress_reports) %>

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
     end
 
     context "when region has diabetes management enabled" do
-      before :each do
+      before do
         Flipper.disable(:diabetes_management_reports)
       end
 
@@ -227,7 +227,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
       end
 
       it "contains a link to the diabetes management reports if the feature flag is enabled for an individual user" do
-        enabled_user = create(:admin, full_name: "FOO")
+        enabled_user = create(:admin)
         @facility.update(enable_diabetes_management: true)
         Flipper.enable_actor(:diabetes_management_reports, enabled_user)
 
@@ -245,7 +245,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
       end
 
       it "does not contain a link to the diabetes management reports if the feature flag is disabled for an other individual user" do
-        enabled_user = create(:admin, full_name: "FOO")
+        enabled_user = create(:admin)
         @facility.update(enable_diabetes_management: true)
         Flipper.enable_actor(:diabetes_management_reports, enabled_user)
 

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -214,6 +214,10 @@ RSpec.describe Reports::RegionsController, type: :controller do
     end
 
     context "when region has diabetes management enabled" do
+      before :each do
+        Flipper.disable(:diabetes_management_reports)
+      end
+
       it "contains a link to the diabetes management reports if the feature flag is enabled" do
         @facility.update(enable_diabetes_management: true)
         Flipper.enable(:diabetes_management_reports)
@@ -222,9 +226,29 @@ RSpec.describe Reports::RegionsController, type: :controller do
         assert_select "a[href*='diabetes']", count: 1
       end
 
+      it "contains a link to the diabetes management reports if the feature flag is enabled for an individual user" do
+        enabled_user = create(:admin, full_name: "FOO")
+        @facility.update(enable_diabetes_management: true)
+        Flipper.enable_actor(:diabetes_management_reports, enabled_user)
+
+        sign_in(enabled_user.email_authentication)
+        get :show, params: {id: @facility_region.slug, report_scope: "facility"}
+        assert_select "a[href*='diabetes']", count: 1
+      end
+
       it "does not contain a link to the diabetes management reports if the feature flag is disabled" do
         @facility.update(enable_diabetes_management: true)
         Flipper.disable(:diabetes_management_reports)
+        sign_in(cvho.email_authentication)
+        get :show, params: {id: @facility_region.slug, report_scope: "facility"}
+        assert_select "a[href*='diabetes']", count: 0
+      end
+
+      it "does not contain a link to the diabetes management reports if the feature flag is disabled for an other individual user" do
+        enabled_user = create(:admin, full_name: "FOO")
+        @facility.update(enable_diabetes_management: true)
+        Flipper.enable_actor(:diabetes_management_reports, enabled_user)
+
         sign_in(cvho.email_authentication)
         get :show, params: {id: @facility_region.slug, report_scope: "facility"}
         assert_select "a[href*='diabetes']", count: 0


### PR DESCRIPTION
**Story card:** [sc-8057](https://app.shortcut.com/simpledotorg/story/8057/unable-to-turn-on-flipper-for-individual-users)

## Because

We want to be able to enable the DM reports for individual users in order to test and audit the reports in production. There is a bug currently that prevents this. 

## This addresses

Fixes the bug so flipper checks the flag for individual actors

## Test instructions

Enable the flipper flag for a specific user and login as that user. You should be able to see the Diabetes link on the reports page. This link should not be visible for any other user. 