### PR TITLE
Fix typos in the diabetes graphs

### DIFF
--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -39,7 +39,7 @@ Reports = function (withLtfu) {
     this.setupBSBelow200Graph(data);
     this.setupCumulativeDiabetesRegistrationsGraph(data);
     this.setupBSOver200Graph(data);
-      this.setupDiabetesMissedVisitsGraph(data);
+    this.setupDiabetesMissedVisitsGraph(data);
   };
 
   this.setupControlledGraph = (data) => {
@@ -1248,9 +1248,9 @@ Reports = function (withLtfu) {
   };
 
   this.setupDiabetesMissedVisitsGraph = (data) => {
-        const adjustedPatients = withLtfu
-            ? data.adjustedPatientCountsWithLtfu
-            : data.adjustedPatientCounts;
+        const adjustedDiabetesPatients = withLtfu
+            ? data.adjustedDiabetesPatientCountsWithLtfu
+            : data.adjustedDiabetesPatientCounts;
         const diabetesMissedVisitsGraphNumerator = withLtfu
             ? data.diabetesMissedVisitsWithLtfu
             : data.diabetesMissedVisits;
@@ -1339,7 +1339,7 @@ Reports = function (withLtfu) {
             );
 
             const periodInfo = data.periodInfo[period];
-            const adjustedPatientCounts = adjustedPatients[period];
+            const adjustedPatientCounts = adjustedDiabetesPatients[period];
             const totalPatients = diabetesMissedVisitsGraphNumerator[period];
 
             rateNode.innerHTML = this.formatPercentage(diabetesMissedVisitsGraphRate[period]);

--- a/app/presenters/reports/repository_presenter.rb
+++ b/app/presenters/reports/repository_presenter.rb
@@ -21,7 +21,7 @@ module Reports
         controlled_patients: controlled[slug],
         cumulative_assigned_patients: cumulative_assigned_patients[slug],
         cumulative_registrations: cumulative_registrations[slug],
-        cumulative_diabetes_registrations: cumulative_registrations[slug],
+        cumulative_diabetes_registrations: cumulative_diabetes_registrations[slug],
         earliest_registration_period: earliest_patient_recorded_at_period[slug],
         ltfu_patients_rate: ltfu_rates[slug],
         ltfu_patients: ltfu[slug],


### PR DESCRIPTION
We inadvertently made typos in a couple of places, resulting in using HTN numbers for Diabetes reports.  