### PR TITLE
Add graph to show the diabetes visits breakdown

### DIFF
--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -1156,7 +1156,7 @@ Reports = function (withLtfu) {
             drawBorder: false,
           },
           ticks: {
-            display: true,
+            display: false,
             autoSkip: false,
             fontColor: this.darkGreyColor,
             fontSize: 10,
@@ -1181,7 +1181,7 @@ Reports = function (withLtfu) {
             drawBorder: false,
           },
           ticks: {
-            display: true,
+            display: false,
             autoSkip: false,
             fontColor: this.darkGreyColor,
             fontSize: 10,
@@ -1420,40 +1420,40 @@ Reports = function (withLtfu) {
 
     const maxBarsToDisplay = 6;
     const barsToDisplay = Math.min(
-        Object.keys(data.bsBelow200Rate).length,
-        maxBarsToDisplay
+      Object.keys(data.bsBelow200Rate).length,
+      maxBarsToDisplay
     );
 
     diabetesVisitDetailsGraphConfig.data = {
       labels: Object.keys(data.bsBelow200Rate).slice(-barsToDisplay),
       datasets: [
         {
-          label: "BP <200",
+          label: "BS <200",
           backgroundColor: this.mediumGreenColor,
           hoverBackgroundColor: this.darkGreenColor,
           data: Object.values(data.bsBelow200Rate).slice(-barsToDisplay),
           type: "bar",
         },
         {
-          label: "BP 200-299",
+          label: "BS 200-299",
           backgroundColor: this.mediumRedColor,
           hoverBackgroundColor: this.darkRedColor,
           data: Object.values(data.bs200to300Rate).slice(-barsToDisplay),
           type: "bar",
         },
         {
-          label: "BP ≥300",
+          label: "BS ≥300",
           backgroundColor: this.maroonColor,
           hoverBackgroundColor: this.darkMaroonColor,
           data: Object.values(data.bsOver300Rate).slice(-barsToDisplay),
           type: "bar",
         },
         {
-          label: "Visit but no BP measure",
+          label: "Visit but no BS measure",
           backgroundColor: this.mediumGreyColor,
           hoverBackgroundColor: this.darkGreyColor,
           data: Object.values(data.visitButNoBSMeasureRate).slice(
-              -barsToDisplay
+            -barsToDisplay
           ),
           type: "bar",
         },
@@ -1461,7 +1461,9 @@ Reports = function (withLtfu) {
           label: "Missed visits",
           backgroundColor: this.mediumBlueColor,
           hoverBackgroundColor: this.darkBlueColor,
-          data: Object.values(data.diabetesMissedVisitsRate).slice(-barsToDisplay),
+          data: Object.values(data.diabetesMissedVisitsRate).slice(
+            -barsToDisplay
+          ),
           type: "bar",
         },
       ],
@@ -1520,46 +1522,50 @@ Reports = function (withLtfu) {
     const populateDiabetesVisitDetailsGraph = (period) => {
       const cardNode = document.getElementById("diabetes-visit-details");
       const missedVisitsRateNode = cardNode.querySelector(
-          "[data-missed-visits-rate]"
+        "[data-missed-visits-rate]"
       );
       const visitButNoBSMeasureRateNode = cardNode.querySelector(
-          "[data-visit-but-no-bs-measure-rate]"
+        "[data-visit-but-no-bs-measure-rate]"
       );
       const bsBelow200RateNode = cardNode.querySelector(
-          "[data-bs-below-200-rate]"
+        "[data-bs-below-200-rate]"
       );
       const bs200To300RateNode = cardNode.querySelector(
-          "[data-bs-200-to-300-rate]"
+        "[data-bs-200-to-300-rate]"
       );
       const bsOver300RateNode = cardNode.querySelector(
-          "[data-bs-over-300-rate]"
+        "[data-bs-over-300-rate]"
       );
       const missedVisitsPatientsNode = cardNode.querySelector(
-          "[data-missed-visits-patients]"
+        "[data-missed-visits-patients]"
       );
       const visitButNoBSMeasurePatientsNode = cardNode.querySelector(
-          "[data-visit-but-no-bs-measure-patients]"
+        "[data-visit-but-no-bs-measure-patients]"
       );
       const bsOver300PatientsNode = cardNode.querySelector(
-          "[data-bs-over-300-patients]"
+        "[data-bs-over-300-patients]"
       );
       const bs200To300PatientsNode = cardNode.querySelector(
-          "[data-bs-200-to-300-patients]"
+        "[data-bs-200-to-300-patients]"
       );
       const bsBelow200PatientsNode = cardNode.querySelector(
-          "[data-bs-below-200-patients]"
+        "[data-bs-below-200-patients]"
       );
       const periodStartNodes = cardNode.querySelectorAll("[data-period-start]");
       const periodEndNodes = cardNode.querySelectorAll("[data-period-end]");
       const registrationPeriodEndNodes = cardNode.querySelectorAll(
-          "[data-registrations-period-end]"
+        "[data-registrations-period-end]"
       );
       const adjustedPatientCountsNodes = cardNode.querySelectorAll(
-          "[data-adjusted-registrations]"
+        "[data-adjusted-registrations]"
       );
 
-      const missedVisitsRate = this.formatPercentage(data.diabetesMissedVisitsRate[period]);
-      const visitButNoBSMeasureRate = this.formatPercentage(data.visitButNoBSMeasureRate[period]);
+      const missedVisitsRate = this.formatPercentage(
+        data.diabetesMissedVisitsRate[period]
+      );
+      const visitButNoBSMeasureRate = this.formatPercentage(
+        data.visitButNoBSMeasureRate[period]
+      );
       const bsOver300Rate = this.formatPercentage(data.bsOver300Rate[period]);
       const bs200To300Rate = this.formatPercentage(data.bs200to300Rate[period]);
       const bsBelow200Rate = this.formatPercentage(data.bsBelow200Rate[period]);
@@ -1577,24 +1583,33 @@ Reports = function (withLtfu) {
       bsOver300RateNode.innerHTML = bsOver300Rate;
       bs200To300RateNode.innerHTML = bs200To300Rate;
       bsBelow200RateNode.innerHTML = bsBelow200Rate;
-      missedVisitsPatientsNode.innerHTML = this.formatNumberWithCommas( totalMissedVisits );
-      visitButNoBSMeasurePatientsNode.innerHTML = this.formatNumberWithCommas( totalVisitButNoBSMeasure );
-      bsOver300PatientsNode.innerHTML = this.formatNumberWithCommas( totalBSOver300Patients );
-      bs200To300PatientsNode.innerHTML = this.formatNumberWithCommas( totalBS200To300Patients );
-      bsBelow200PatientsNode.innerHTML = this.formatNumberWithCommas( totalBSBelow200Patients );
+      missedVisitsPatientsNode.innerHTML =
+        this.formatNumberWithCommas(totalMissedVisits);
+      visitButNoBSMeasurePatientsNode.innerHTML = this.formatNumberWithCommas(
+        totalVisitButNoBSMeasure
+      );
+      bsOver300PatientsNode.innerHTML = this.formatNumberWithCommas(
+        totalBSOver300Patients
+      );
+      bs200To300PatientsNode.innerHTML = this.formatNumberWithCommas(
+        totalBS200To300Patients
+      );
+      bsBelow200PatientsNode.innerHTML = this.formatNumberWithCommas(
+        totalBSBelow200Patients
+      );
 
       periodStartNodes.forEach(
-          (node) => (node.innerHTML = periodInfo.bp_control_start_date)
+        (node) => (node.innerHTML = periodInfo.bp_control_start_date)
       );
       periodEndNodes.forEach(
-          (node) => (node.innerHTML = periodInfo.bp_control_end_date)
+        (node) => (node.innerHTML = periodInfo.bp_control_end_date)
       );
       registrationPeriodEndNodes.forEach(
-          (node) => (node.innerHTML = periodInfo.bp_control_registration_date)
+        (node) => (node.innerHTML = periodInfo.bp_control_registration_date)
       );
       adjustedPatientCountsNodes.forEach(
-          (node) =>
-              (node.innerHTML = this.formatNumberWithCommas(adjustedPatientCounts))
+        (node) =>
+          (node.innerHTML = this.formatNumberWithCommas(adjustedPatientCounts))
       );
     };
 
@@ -1605,12 +1620,13 @@ Reports = function (withLtfu) {
       populateDiabetesVisitDetailsGraph(mostRecentPeriod);
     };
 
-    const diabetesVisitDetailsGraphCanvas =
-        document.getElementById("diabetesVisitDetails");
+    const diabetesVisitDetailsGraphCanvas = document.getElementById(
+      "diabetesVisitDetails"
+    );
     if (diabetesVisitDetailsGraphCanvas) {
       new Chart(
-          diabetesVisitDetailsGraphCanvas.getContext("2d"),
-          diabetesVisitDetailsGraphConfig
+        diabetesVisitDetailsGraphCanvas.getContext("2d"),
+        diabetesVisitDetailsGraphConfig
       );
       populateDiabetesVisitDetailsGraphDefault();
     }

--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -1370,8 +1370,8 @@ Reports = function (withLtfu) {
     };
 
   this.setupDiabetesVisitDetailsGraph = (data) => {
-    const visitDetailsGraphConfig = this.createBaseGraphConfig();
-    visitDetailsGraphConfig.type = "bar";
+    const diabetesVisitDetailsGraphConfig = this.createBaseGraphConfig();
+    diabetesVisitDetailsGraphConfig.type = "bar";
 
     const maxBarsToDisplay = 6;
     const barsToDisplay = Math.min(
@@ -1379,7 +1379,7 @@ Reports = function (withLtfu) {
         maxBarsToDisplay
     );
 
-    visitDetailsGraphConfig.data = {
+    diabetesVisitDetailsGraphConfig.data = {
       labels: Object.keys(data.bsBelow200Rate).slice(-barsToDisplay),
       datasets: [
         {
@@ -1421,7 +1421,7 @@ Reports = function (withLtfu) {
         },
       ],
     };
-    visitDetailsGraphConfig.options.scales = {
+    diabetesVisitDetailsGraphConfig.options.scales = {
       xAxes: [
         {
           stacked: true,
@@ -1461,7 +1461,7 @@ Reports = function (withLtfu) {
         },
       ],
     };
-    visitDetailsGraphConfig.options.tooltips = {
+    diabetesVisitDetailsGraphConfig.options.tooltips = {
       mode: "x",
       enabled: false,
       custom: (tooltip) => {
@@ -1513,12 +1513,8 @@ Reports = function (withLtfu) {
           "[data-adjusted-registrations]"
       );
 
-      const missedVisitsRate = this.formatPercentage(
-          data.missedVisitsRate[period]
-      );
-      const visitButNoBSMeasureRate = this.formatPercentage(
-          data.visitButNoBSMeasureRate[period]
-      );
+      const missedVisitsRate = this.formatPercentage(data.diabetesMissedVisitsRate[period]);
+      const visitButNoBSMeasureRate = this.formatPercentage(data.visitButNoBSMeasureRate[period]);
       const bsOver300Rate = this.formatPercentage(data.bsOver300Rate[period]);
       const bs200To300Rate = this.formatPercentage(data.bs200to300Rate[period]);
       const bsBelow200Rate = this.formatPercentage(data.bsBelow200Rate[period]);
@@ -1526,7 +1522,7 @@ Reports = function (withLtfu) {
       const periodInfo = data.periodInfo[period];
       const adjustedPatientCounts = data.adjustedDiabetesPatientCounts[period];
       const totalMissedVisits = data.diabetesMissedVisits[period];
-      const totalVisitButNoBPMeasure = data.visitButNoBSMeasure[period];
+      const totalVisitButNoBSMeasure = data.visitButNoBSMeasure[period];
       const totalBSOver300Patients = data.bsOver300Patients[period];
       const totalBS200To300Patients = data.bs200to300Patients[period];
       const totalBSBelow200Patients = data.bsBelow200Patients[period];
@@ -1536,20 +1532,12 @@ Reports = function (withLtfu) {
       bsOver300RateNode.innerHTML = bsOver300Rate;
       bs200To300RateNode.innerHTML = bs200To300Rate;
       bsBelow200RateNode.innerHTML = bsBelow200Rate;
-      missedVisitsPatientsNode.innerHTML =
-          this.formatNumberWithCommas(totalMissedVisits);
-      visitButNoBSMeasurePatientsNode.innerHTML = this.formatNumberWithCommas(
-          totalVisitButNoBPMeasure // FIXME
-      );
-      bsOver300PatientsNode.innerHTML = this.formatNumberWithCommas(
-          totalBSOver300Patients
-      );
-      bs200To300PatientsNode.innerHTML = this.formatNumberWithCommas(
-          totalBS200To300Patients
-      );
-      bsBelow200PatientsNode.innerHTML = this.formatNumberWithCommas(
-          totalBSBelow200Patients
-      );
+      missedVisitsPatientsNode.innerHTML = this.formatNumberWithCommas( totalMissedVisits );
+      visitButNoBSMeasurePatientsNode.innerHTML = this.formatNumberWithCommas( totalVisitButNoBSMeasure );
+      bsOver300PatientsNode.innerHTML = this.formatNumberWithCommas( totalBSOver300Patients );
+      bs200To300PatientsNode.innerHTML = this.formatNumberWithCommas( totalBS200To300Patients );
+      bsBelow200PatientsNode.innerHTML = this.formatNumberWithCommas( totalBSBelow200Patients );
+
       periodStartNodes.forEach(
           (node) => (node.innerHTML = periodInfo.bp_control_start_date)
       );
@@ -1572,12 +1560,12 @@ Reports = function (withLtfu) {
       populateDiabetesVisitDetailsGraph(mostRecentPeriod);
     };
 
-    const visitDetailsGraphCanvas =
-        document.getElementById("missedDiabetesVisitDetails");
-    if (visitDetailsGraphCanvas) {
+    const diabetesVisitDetailsGraphCanvas =
+        document.getElementById("diabetesVisitDetails");
+    if (diabetesVisitDetailsGraphCanvas) {
       new Chart(
-          visitDetailsGraphCanvas.getContext("2d"),
-          visitDetailsGraphConfig
+          diabetesVisitDetailsGraphCanvas.getContext("2d"),
+          diabetesVisitDetailsGraphConfig
       );
       populateDiabetesVisitDetailsGraphDefault();
     }

--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -39,7 +39,8 @@ Reports = function (withLtfu) {
     this.setupBSBelow200Graph(data);
     this.setupCumulativeDiabetesRegistrationsGraph(data);
     this.setupBSOver200Graph(data);
-      this.setupDiabetesMissedVisitsGraph(data);
+    this.setupDiabetesMissedVisitsGraph(data);
+    this.setupDiabetesVisitDetailsGraph(data);
   };
 
   this.setupControlledGraph = (data) => {
@@ -1368,6 +1369,220 @@ Reports = function (withLtfu) {
         }
     };
 
+  this.setupDiabetesVisitDetailsGraph = (data) => {
+    const visitDetailsGraphConfig = this.createBaseGraphConfig();
+    visitDetailsGraphConfig.type = "bar";
+
+    const maxBarsToDisplay = 6;
+    const barsToDisplay = Math.min(
+        Object.keys(data.bsBelow200Rate).length,
+        maxBarsToDisplay
+    );
+
+    visitDetailsGraphConfig.data = {
+      labels: Object.keys(data.bsBelow200Rate).slice(-barsToDisplay),
+      datasets: [
+        {
+          label: "BP <200",
+          backgroundColor: this.mediumGreenColor,
+          hoverBackgroundColor: this.darkGreenColor,
+          data: Object.values(data.bsBelow200Rate).slice(-barsToDisplay),
+          type: "bar",
+        },
+        {
+          label: "BP 200-299",
+          backgroundColor: this.mediumRedColor,
+          hoverBackgroundColor: this.darkRedColor,
+          data: Object.values(data.bs200to300Rate).slice(-barsToDisplay),
+          type: "bar",
+        },
+        {
+          label: "BP ≥300",
+          backgroundColor: this.maroonColor,
+          hoverBackgroundColor: this.darkMaroonColor,
+          data: Object.values(data.bsOver300Rate).slice(-barsToDisplay),
+          type: "bar",
+        },
+        {
+          label: "Visit but no BP measure",
+          backgroundColor: this.mediumGreyColor,
+          hoverBackgroundColor: this.darkGreyColor,
+          data: Object.values(data.visitButNoBSMeasureRate).slice(
+              -barsToDisplay
+          ),
+          type: "bar",
+        },
+        {
+          label: "Missed visits",
+          backgroundColor: this.mediumBlueColor,
+          hoverBackgroundColor: this.darkBlueColor,
+          data: Object.values(data.diabetesMissedVisitsRate).slice(-barsToDisplay),
+          type: "bar",
+        },
+      ],
+    };
+    visitDetailsGraphConfig.options.scales = {
+      xAxes: [
+        {
+          stacked: true,
+          display: true,
+          gridLines: {
+            display: false,
+            drawBorder: false,
+          },
+          ticks: {
+            autoSkip: false,
+            fontColor: this.darkGreyColor,
+            fontSize: 10,
+            fontFamily: "Roboto",
+            padding: 8,
+            min: 0,
+            beginAtZero: true,
+          },
+        },
+      ],
+      yAxes: [
+        {
+          stacked: true,
+          display: false,
+          gridLines: {
+            display: false,
+            drawBorder: false,
+          },
+          ticks: {
+            autoSkip: false,
+            fontColor: this.darkGreyColor,
+            fontSize: 10,
+            fontFamily: "Roboto",
+            padding: 8,
+            min: 0,
+            beginAtZero: true,
+          },
+        },
+      ],
+    };
+    visitDetailsGraphConfig.options.tooltips = {
+      mode: "x",
+      enabled: false,
+      custom: (tooltip) => {
+        let hoveredDatapoint = tooltip.dataPoints;
+        if (hoveredDatapoint)
+          populateDiabetesVisitDetailsGraph(hoveredDatapoint[0].label);
+        else populateDiabetesVisitDetailsGraphDefault();
+      },
+    };
+
+    const populateDiabetesVisitDetailsGraph = (period) => {
+      const cardNode = document.getElementById("diabetes-visit-details");
+      const missedVisitsRateNode = cardNode.querySelector(
+          "[data-missed-visits-rate]"
+      );
+      const visitButNoBSMeasureRateNode = cardNode.querySelector(
+          "[data-visit-but-no-bs-measure-rate]"
+      );
+      const bsBelow200RateNode = cardNode.querySelector(
+          "[data-bs-below-200-rate]"
+      );
+      const bs200To300RateNode = cardNode.querySelector(
+          "[data-bs-200-to-300-rate]"
+      );
+      const bsOver300RateNode = cardNode.querySelector(
+          "[data-bs-over-300-rate]"
+      );
+      const missedVisitsPatientsNode = cardNode.querySelector(
+          "[data-missed-visits-patients]"
+      );
+      const visitButNoBSMeasurePatientsNode = cardNode.querySelector(
+          "[data-visit-but-no-bs-measure-patients]"
+      );
+      const bsOver300PatientsNode = cardNode.querySelector(
+          "[data-bs-over-300-patients]"
+      );
+      const bs200To300PatientsNode = cardNode.querySelector(
+          "[data-bs-200-to-300-patients]"
+      );
+      const bsBelow200PatientsNode = cardNode.querySelector(
+          "[data-bs-below-200-patients]"
+      );
+      const periodStartNodes = cardNode.querySelectorAll("[data-period-start]");
+      const periodEndNodes = cardNode.querySelectorAll("[data-period-end]");
+      const registrationPeriodEndNodes = cardNode.querySelectorAll(
+          "[data-registrations-period-end]"
+      );
+      const adjustedPatientCountsNodes = cardNode.querySelectorAll(
+          "[data-adjusted-registrations]"
+      );
+
+      const missedVisitsRate = this.formatPercentage(
+          data.missedVisitsRate[period]
+      );
+      const visitButNoBSMeasureRate = this.formatPercentage(
+          data.visitButNoBSMeasureRate[period]
+      );
+      const bsOver300Rate = this.formatPercentage(data.bsOver300Rate[period]);
+      const bs200To300Rate = this.formatPercentage(data.bs200to300Rate[period]);
+      const bsBelow200Rate = this.formatPercentage(data.bsBelow200Rate[period]);
+
+      const periodInfo = data.periodInfo[period];
+      const adjustedPatientCounts = data.adjustedDiabetesPatientCounts[period];
+      const totalMissedVisits = data.diabetesMissedVisits[period];
+      const totalVisitButNoBPMeasure = data.visitButNoBSMeasure[period];
+      const totalBSOver300Patients = data.bsOver300Patients[period];
+      const totalBS200To300Patients = data.bs200to300Patients[period];
+      const totalBSBelow200Patients = data.bsBelow200Patients[period];
+
+      missedVisitsRateNode.innerHTML = missedVisitsRate;
+      visitButNoBSMeasureRateNode.innerHTML = visitButNoBSMeasureRate;
+      bsOver300RateNode.innerHTML = bsOver300Rate;
+      bs200To300RateNode.innerHTML = bs200To300Rate;
+      bsBelow200RateNode.innerHTML = bsBelow200Rate;
+      missedVisitsPatientsNode.innerHTML =
+          this.formatNumberWithCommas(totalMissedVisits);
+      visitButNoBSMeasurePatientsNode.innerHTML = this.formatNumberWithCommas(
+          totalVisitButNoBPMeasure // FIXME
+      );
+      bsOver300PatientsNode.innerHTML = this.formatNumberWithCommas(
+          totalBSOver300Patients
+      );
+      bs200To300PatientsNode.innerHTML = this.formatNumberWithCommas(
+          totalBS200To300Patients
+      );
+      bsBelow200PatientsNode.innerHTML = this.formatNumberWithCommas(
+          totalBSBelow200Patients
+      );
+      periodStartNodes.forEach(
+          (node) => (node.innerHTML = periodInfo.bp_control_start_date)
+      );
+      periodEndNodes.forEach(
+          (node) => (node.innerHTML = periodInfo.bp_control_end_date)
+      );
+      registrationPeriodEndNodes.forEach(
+          (node) => (node.innerHTML = periodInfo.bp_control_registration_date)
+      );
+      adjustedPatientCountsNodes.forEach(
+          (node) =>
+              (node.innerHTML = this.formatNumberWithCommas(adjustedPatientCounts))
+      );
+    };
+
+    const populateDiabetesVisitDetailsGraphDefault = () => {
+      const cardNode = document.getElementById("diabetes-visit-details");
+      const mostRecentPeriod = cardNode.getAttribute("data-period");
+
+      populateDiabetesVisitDetailsGraph(mostRecentPeriod);
+    };
+
+    const visitDetailsGraphCanvas =
+        document.getElementById("missedDiabetesVisitDetails");
+    if (visitDetailsGraphCanvas) {
+      new Chart(
+          visitDetailsGraphCanvas.getContext("2d"),
+          visitDetailsGraphConfig
+      );
+      populateDiabetesVisitDetailsGraphDefault();
+    }
+  };
+
   this.initializeTables = () => {
     const tableSortAscending = { descending: false };
     const regionComparisonTable = document.getElementById(
@@ -1418,7 +1633,9 @@ Reports = function (withLtfu) {
       bs200to300WithLtfuRate: jsonData.bs_200_to_300_with_ltfu_rates,
       bsOver300Patients: jsonData.bs_over_300_patients,
       bsOver300Rate: jsonData.bs_over_300_rates,
-      bsOver300WithLtfuRate: jsonData.bs_over_300_with_ltfu_rates
+      bsOver300WithLtfuRate: jsonData.bs_over_300_with_ltfu_rates,
+      visitButNoBSMeasure: jsonData.visited_without_bs_taken,
+      visitButNoBSMeasureRate: jsonData.visited_without_bs_taken_rates,
     };
   };
 

--- a/app/models/reports/region_summary_schema.rb
+++ b/app/models/reports/region_summary_schema.rb
@@ -226,8 +226,14 @@ module Reports
       values_at(field)
     end
 
-    def visited_without_bs_taken
+    memoize def visited_without_bs_taken
       values_at(:adjusted_visited_no_bs_under_care)
+    end
+
+    memoize def visited_without_bs_taken_rates(with_ltfu: false)
+      region_period_cached_query(__method__, with_ltfu: with_ltfu) do |entry|
+        diabetes_treatment_outcome_rates(entry, with_ltfu)[__method__]
+      end
     end
 
     memoize def visited_without_bp_taken_rates(with_ltfu: false)

--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -48,6 +48,7 @@ module Reports
       bs_200_to_300_rates
       bs_over_300_rates
       diabetes_missed_visits_rates
+      visited_without_bs_taken_rates
     ]
 
     DELEGATED_COUNTS = %i[
@@ -84,6 +85,7 @@ module Reports
       bs_200_to_300_patients
       bs_over_300_patients
       diabetes_missed_visits
+      visited_without_bs_taken
     ]
 
     DELEGATED_BREAKDOWNS = %i[

--- a/app/presenters/reports/repository_presenter.rb
+++ b/app/presenters/reports/repository_presenter.rb
@@ -54,7 +54,10 @@ module Reports
         diabetes_missed_visits: diabetes_missed_visits[slug],
         diabetes_missed_visits_with_ltfu: diabetes_missed_visits(with_ltfu: true)[slug],
         diabetes_missed_visits_rates: diabetes_missed_visits_rates[slug],
-        diabetes_missed_visits_with_ltfu_rates: diabetes_missed_visits_rates(with_ltfu: true)[slug]
+        diabetes_missed_visits_with_ltfu_rates: diabetes_missed_visits_rates(with_ltfu: true)[slug],
+        visited_without_bs_taken_rates: visited_without_bs_taken_rates[slug],
+        visited_without_bs_taken_with_ltfu_rates: visited_without_bs_taken_rates(with_ltfu: true)[slug],
+        visited_without_bs_taken: visited_without_bs_taken[slug]
       }
     end
 

--- a/app/services/monthly_district_data_service.rb
+++ b/app/services/monthly_district_data_service.rb
@@ -121,7 +121,7 @@ class MonthlyDistrictDataService
       Array.new(month_headers.size - 1, nil),
       "Follow-up patients",
       Array.new(month_headers.size - 1, nil),
-      "Treatment outcomes of patients under care",
+      "Treatment status of patients under care",
       Array.new(outcome_headers.size - 1, nil),
       medications_dispensation_section_header,
       "Drug availability",

--- a/app/services/monthly_state_data_service.rb
+++ b/app/services/monthly_state_data_service.rb
@@ -108,7 +108,7 @@ class MonthlyStateDataService
       Array.new(month_headers.size - 1, nil),
       "Follow-up patients",
       Array.new(month_headers.size - 1, nil),
-      "Treatment outcomes of patients under care",
+      "Treatment status of patients under care",
       Array.new(outcome_headers.size - 1, nil),
       medications_dispensation_section_header,
       "Drug availability",

--- a/app/views/reports/regions/_diabetes_treatment_outcomes_card.html.erb
+++ b/app/views/reports/regions/_diabetes_treatment_outcomes_card.html.erb
@@ -1,0 +1,144 @@
+<div id="diabetes-visit-details"
+     data-period="<%= @period.to_s %>"
+     class="mt-8px mx-0px mb-16px p-20px py-lg-20px pr-lg-20px pl-lg-0px bg-white br-4px bs-small d-lg-flex fd-lg-column
+            justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid pb-after-always b-print-black">
+  <h3 class="mb-0px pl-lg-20px">
+    Treatment outcomes of diabetes patients under care
+  </h3>
+
+  <div class="d-flex fd-column fd-lg-row">
+      <div class="pl-lg-12px w-lg-50 h-lg-auto minh-300px">
+        <canvas id="missedDiabetesVisitDetails"></canvas>
+      </div>
+      <div class="flex-lg-1 mt-24px ml-lg-24px mt-print-2cm">
+        <div>
+          <div class="mb-16px d-lg-flex align-lg-center">
+            <p class="rate mb-0px fs-32px fw-bold mr-lg-24px c-blue"
+               data-missed-visits-rate="">
+            </p>
+            <div>
+              <%= render "visit_details_heading",
+                    title: "Missed visits",
+                    numerator: t("missed_visits_copy.numerator"),
+                    denominator: t("denominator_copy", region_name: @region.name) %>
+              <p class="m-0px c-black">
+                <span data-missed-visits-patients=""></span>
+                patients with no visit from
+                <span data-period-start=""></span>
+                to
+                <span data-period-end=""></span>
+              </p>
+              <p class="m-0px c-grey-dark c-print-black">
+                of
+                <span data-adjusted-registrations=""></span>
+                patients registered till
+                <span data-registrations-period-end=""></span>
+              </p>
+            </div>
+          </div>
+        </div>
+        <div>
+          <div class="mb-16px d-lg-flex align-lg-center">
+            <p class="mb-0px fs-32px fw-bold c-grey-dark mr-lg-24px" data-visit-but-no-bs-measure-rate=""></p>
+            <div>
+              <%= render "visit_details_heading",
+                   title: "Visit but no BP taken",
+                   numerator: t("visit_but_no_bp_taken_copy.numerator"),
+                   denominator: t("denominator_copy", region_name: @region.name) %>
+              <p class="m-0px c-black">
+                <span data-visit-but-no-bs-measure-patients=""></span>
+                patients with a visit but no BP taken from
+                <span data-period-start=""></span>
+                to
+                <span data-period-end=""></span>
+              </p>
+              <p class="m-0px c-grey-dark c-print-black">
+                of
+                <span data-adjusted-registrations=""></span>
+                patients registered till
+                <span data-registrations-period-end=""></span>
+              </p>
+            </div>
+          </div>
+        </div>
+        <div>
+          <div class="mb-16px d-lg-flex align-lg-center">
+            <p class="mb-0px fs-32px fw-bold mr-lg-24px c-print-black c-red"
+               data-bs-over-300-rate="">
+            </p>
+            <div>
+              <%= render "visit_details_heading",
+                   title: "BP not controlled",
+                   numerator: t("bp_not_controlled_copy.numerator"),
+                   denominator: t("denominator_copy", region_name: @region.name) %>
+              <p class="m-0px c-black">
+                <span data-bs-over-300-patients=""></span>
+                patients with BS ≥300 taken between
+                <span data-period-start=""></span>
+                to
+                <span data-period-end=""></span>
+              </p>
+              <p class="m-0px c-grey-dark c-print-black">
+                of
+                <span data-adjusted-registrations=""></span>
+                patients registered till
+                <span data-registrations-period-end=""></span>
+              </p>
+            </div>
+          </div>
+        </div>
+        <div>
+          <div class="mb-16px d-lg-flex align-lg-center">
+            <p class="mb-0px fs-32px fw-bold mr-lg-24px c-print-black c-red"
+               data-bs-200-to-300-rate="">
+            </p>
+            <div>
+              <%= render "visit_details_heading",
+                         title: "BP not controlled",
+                         numerator: t("bp_not_controlled_copy.numerator"),
+                         denominator: t("denominator_copy", region_name: @region.name) %>
+              <p class="m-0px c-black">
+                <span data-bs-200-to-300-patients=""></span>
+                patients with BS 200-299 taken between
+                <span data-period-start=""></span>
+                to
+                <span data-period-end=""></span>
+              </p>
+              <p class="m-0px c-grey-dark c-print-black">
+                of
+                <span data-adjusted-registrations=""></span>
+                patients registered till
+                <span data-registrations-period-end=""></span>
+              </p>
+            </div>
+          </div>
+        </div>
+        <div>
+          <div class="mb-16px d-lg-flex align-lg-center">
+            <p class="mb-0px fs-32px fw-bold mr-lg-24px c-print-black c-green-dark"
+               data-bs-below-200-rate="">
+            </p>
+            <div>
+              <%= render "visit_details_heading",
+                   title: "BP controlled",
+                   numerator: t("bp_controlled_copy.numerator"),
+                   denominator: t("denominator_copy", region_name: @region.name) %>
+              <p class="m-0px c-black">
+                <span data-bs-below-200-patients=""></span>
+                patients with BS <200 taken between
+                <span data-period-start=""></span>
+                to
+                <span data-period-end=""></span>
+              </p>
+              <p class="m-0px c-grey-dark c-print-black">
+                of
+                <span data-adjusted-registrations=""></span>
+                patients registered till
+                <span data-registrations-period-end=""></span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+</div>

--- a/app/views/reports/regions/_diabetes_treatment_outcomes_card.html.erb
+++ b/app/views/reports/regions/_diabetes_treatment_outcomes_card.html.erb
@@ -3,7 +3,7 @@
      class="mt-8px mx-0px mb-16px p-20px py-lg-20px pr-lg-20px pl-lg-0px bg-white br-4px bs-small d-lg-flex fd-lg-column
             justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid pb-after-always b-print-black">
   <h3 class="mb-0px pl-lg-20px">
-    Treatment outcomes of diabetes patients under care
+    Treatment status of patients under care
   </h3>
 
   <div class="d-flex fd-column fd-lg-row">

--- a/app/views/reports/regions/_diabetes_treatment_outcomes_card.html.erb
+++ b/app/views/reports/regions/_diabetes_treatment_outcomes_card.html.erb
@@ -8,7 +8,7 @@
 
   <div class="d-flex fd-column fd-lg-row">
       <div class="pl-lg-12px w-lg-50 h-lg-auto minh-300px">
-        <canvas id="missedDiabetesVisitDetails"></canvas>
+        <canvas id="diabetesVisitDetails"></canvas>
       </div>
       <div class="flex-lg-1 mt-24px ml-lg-24px mt-print-2cm">
         <div>
@@ -19,8 +19,8 @@
             <div>
               <%= render "visit_details_heading",
                     title: "Missed visits",
-                    numerator: t("missed_visits_copy.numerator"),
-                    denominator: t("denominator_copy", region_name: @region.name) %>
+                    numerator: t("diabetes_missed_visits_copy.numerator"),
+                    denominator: t("diabetes_denominator_copy", region_name: @region.name) %>
               <p class="m-0px c-black">
                 <span data-missed-visits-patients=""></span>
                 patients with no visit from
@@ -39,15 +39,15 @@
         </div>
         <div>
           <div class="mb-16px d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold c-grey-dark mr-lg-24px" data-visit-but-no-bs-measure-rate=""></p>
+            <p class="mb-0px fs-32px fw-bold mr-lg-24px c-grey-dark " data-visit-but-no-bs-measure-rate=""></p>
             <div>
               <%= render "visit_details_heading",
-                   title: "Visit but no BP taken",
-                   numerator: t("visit_but_no_bp_taken_copy.numerator"),
-                   denominator: t("denominator_copy", region_name: @region.name) %>
+                   title: "Visit but no BS taken",
+                   numerator: t("visit_but_no_bs_taken_copy.numerator"),
+                   denominator: t("diabetes_denominator_copy", region_name: @region.name) %>
               <p class="m-0px c-black">
                 <span data-visit-but-no-bs-measure-patients=""></span>
-                patients with a visit but no BP taken from
+                patients with a visit but no BS taken from
                 <span data-period-start=""></span>
                 to
                 <span data-period-end=""></span>
@@ -63,14 +63,14 @@
         </div>
         <div>
           <div class="mb-16px d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold mr-lg-24px c-print-black c-red"
+            <p class="mb-0px fs-32px fw-bold mr-lg-24px c-print-black c-maroon"
                data-bs-over-300-rate="">
             </p>
             <div>
               <%= render "visit_details_heading",
-                   title: "BP not controlled",
-                   numerator: t("bp_not_controlled_copy.numerator"),
-                   denominator: t("denominator_copy", region_name: @region.name) %>
+                   title: "BS ≥300",
+                   numerator: t("bs_over_200_copy.bs_over_300_numerator"),
+                   denominator: t("diabetes_denominator_copy", region_name: @region.name) %>
               <p class="m-0px c-black">
                 <span data-bs-over-300-patients=""></span>
                 patients with BS ≥300 taken between
@@ -94,9 +94,9 @@
             </p>
             <div>
               <%= render "visit_details_heading",
-                         title: "BP not controlled",
-                         numerator: t("bp_not_controlled_copy.numerator"),
-                         denominator: t("denominator_copy", region_name: @region.name) %>
+                         title: "BS 200-299",
+                         numerator: t("bs_over_200_copy.bs_200_to_299_numerator"),
+                         denominator: t("diabetes_denominator_copy", region_name: @region.name) %>
               <p class="m-0px c-black">
                 <span data-bs-200-to-300-patients=""></span>
                 patients with BS 200-299 taken between
@@ -120,9 +120,9 @@
             </p>
             <div>
               <%= render "visit_details_heading",
-                   title: "BP controlled",
-                   numerator: t("bp_controlled_copy.numerator"),
-                   denominator: t("denominator_copy", region_name: @region.name) %>
+                   title: "BS <200",
+                   numerator: t("bs_below_200_copy.numerator"),
+                   denominator: t("diabetes_denominator_copy", region_name: @region.name) %>
               <p class="m-0px c-black">
                 <span data-bs-below-200-patients=""></span>
                 patients with BS <200 taken between

--- a/app/views/reports/regions/_treatment_outcomes_card.html.erb
+++ b/app/views/reports/regions/_treatment_outcomes_card.html.erb
@@ -3,7 +3,7 @@
      class="mt-8px mx-0px mb-16px p-20px py-lg-20px pr-lg-20px pl-lg-0px bg-white br-4px bs-small d-lg-flex fd-lg-column
             justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid pb-after-always b-print-black">
   <h3 class="mb-0px pl-lg-20px">
-    Treatment outcomes of patients under care
+    Treatment status of patients under care
   </h3>
 
   <div class="d-flex fd-column fd-lg-row">

--- a/app/views/reports/regions/diabetes.html.erb
+++ b/app/views/reports/regions/diabetes.html.erb
@@ -255,8 +255,9 @@
       </div>
     </div>
   </div>
-
 </div>
+
+<%= render "diabetes_treatment_outcomes_card" %>
 
 <div id="data-json" style="display: none;">
   <%= raw @data.to_json %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,30 +23,30 @@ en:
   name: "Name"
   phone_number: "Phone Number"
   registration_approval_email:
-    accessible_facilities: 'User will have access to data from'
-    organization: "Organization"
-    registration_facility: 'Registration Facility'
-    subject: 'New Registration: User %{full_name} is requesting access to %{org_name} facilities.'
-    allow_or_deny_access: "Allow or deny access"
-  reset_password_approval_email:
-    accessible_facilities: 'User will have access to data from'
+    accessible_facilities: "User will have access to data from"
     organization: "Organization"
     registration_facility: "Registration Facility"
-    subject: 'PIN Reset: User %{full_name} is requesting access.'
+    subject: "New Registration: User %{full_name} is requesting access to %{org_name} facilities."
+    allow_or_deny_access: "Allow or deny access"
+  reset_password_approval_email:
+    accessible_facilities: "User will have access to data from"
+    organization: "Organization"
+    registration_facility: "Registration Facility"
+    subject: "PIN Reset: User %{full_name} is requesting access."
     allow_or_deny_access: "Allow or deny access"
   anonymized_data_download_email:
-    accessible_facilities: 'Attached documents contain anonymized data from'
-    organization: 'Organization'
-    district_subject: 'Anonymized Data dump for District %{district_name}, requested by User %{recipient_name}'
-    facility_subject: 'Anonymized Data dump for Facility %{facility_name}, requested by User %{recipient_name}'
-    district_notice: 'You will soon be emailed a copy of the anonymized data for %{district_name}.'
-    facility_notice: 'You will soon be emailed a copy of the anonymized data for %{facility_name}.'
+    accessible_facilities: "Attached documents contain anonymized data from"
+    organization: "Organization"
+    district_subject: "Anonymized Data dump for District %{district_name}, requested by User %{recipient_name}"
+    facility_subject: "Anonymized Data dump for Facility %{facility_name}, requested by User %{recipient_name}"
+    district_notice: "You will soon be emailed a copy of the anonymized data for %{district_name}."
+    facility_notice: "You will soon be emailed a copy of the anonymized data for %{facility_name}."
   patient_list_email:
     subject: "Patient list for %{model_type} %{model_name} attached"
-    notice: 'You will soon be emailed a copy of the patient line list for %{model_type} %{model_name}.'
-    patient_list: 'Patient list'
-    requested: 'As you requested, please find the patient list for %{model_type} %{model_name} attached. It contains patient details for every patient registered in the %{model_type}.'
-    confidential: 'Please note that this information is confidential and should be kept private.'
+    notice: "You will soon be emailed a copy of the patient line list for %{model_type} %{model_name}."
+    patient_list: "Patient list"
+    requested: "As you requested, please find the patient list for %{model_type} %{model_name} attached. It contains patient details for every patient registered in the %{model_type}."
+    confidential: "Please note that this information is confidential and should be kept private."
     unrequested_html: 'If you did not request this or have questions, please immediately reply to <a href="mailto:help@simple.org">help@simple.org</a>'
   bp_controlled_copy:
     reports_card_subtitle: "Hypertension patients with BP <140/90 at their last visit in the last 3 months"
@@ -143,8 +143,8 @@ en:
         title: "Follow-up patients"
         subtitle: "Patients that had a BP taken, a blood sugar taken, an appointment scheduled, or their medications updated at %{facility_name}."
       patients_initiated_on_treatment_card:
-        title: "Where is the \"Patients initiated on treatment\" data?"
-        main_text: "Use \"Registered patients\", it will always equal \"Patients initiated on treatment\" for patients registered on Simple."
+        title: 'Where is the "Patients initiated on treatment" data?'
+        main_text: 'Use "Registered patients", it will always equal "Patients initiated on treatment" for patients registered on Simple.'
       more_patient_data_coming_soon_card:
         title: "More patient data coming soon"
         main_text: "Daily registration and follow-up data broken down by disease and gender will be added soon."
@@ -178,7 +178,7 @@ en:
         title: "Monthly follow-up patients"
         subtitle: "%{diagnosis} patients with a BP taken, a blood sugar taken, an appointment scheduled, or a medication updated at %{facility_name} during a month."
       patient_treatment_outcomes:
-        section_title: "Patient treatment outcomes"
+        section_title: "Patient treatment status"
         chart_tooltip: "%{number_of_patients} %{number_of_patient_or_patients} with %{threshold} between %{start_period} and %{end_period} of %{number_of_registered_patients} %{number_of_registered_patient_or_patients} registered till %{registration_period}."
         controlled_card:
           subtitle: "%{diagnosis} patients at %{facility_name} registered >3 months ago with %{controlled_threshold} at their last visit in the last 3 months."
@@ -212,11 +212,11 @@ en:
         cohort_bar_tooltip: "%{total_patients} %{patient_or_patients} with %{threshold}"
 
   admin:
-    reset_otp_alert: 'Are you sure you want to reset the OTP? This will invalidate the previous OTP and a SMS will be sent to the user with the new OTP'
-    disable_access_alert: 'Are you sure you want to disable the access for user?'
-    enable_access_alert: 'Are you sure you want to enable the access for user?'
-    allowed_access_to_user: '%{admin_name} allowed access'
-    denied_access_to_user: '%{admin_name} denied access'
+    reset_otp_alert: "Are you sure you want to reset the OTP? This will invalidate the previous OTP and a SMS will be sent to the user with the new OTP"
+    disable_access_alert: "Are you sure you want to disable the access for user?"
+    enable_access_alert: "Are you sure you want to enable the access for user?"
+    allowed_access_to_user: "%{admin_name} allowed access"
+    denied_access_to_user: "%{admin_name} denied access"
     dashboard_title: "Simple Dashboard"
     phi_download_alert: "You are about to download confidental patient data. Are you sure you want to proceed?"
     phi_anonymized_download_alert: "You are about to download confidential (anonymized) patient data. Are you sure you want to proceed?"
@@ -273,7 +273,7 @@ en:
       unlock_instructions:
         subject: "Unlock instructions"
     omniauth_callbacks:
-      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      failure: 'Could not authenticate you from %{kind} because "%{reason}".'
       success: "Successfully authenticated from %{kind} account."
     password_creation:
       needs_number: "Includes one number"
@@ -376,17 +376,60 @@ en:
 
         The comprehensive list of authentication mechanisms used is provided below. It lists the specific details of
         using access tokens and other request headers to authenticate with the API.
-      title: 'Simple Server'
+      title: "Simple Server"
       logo:
-        image: 'rtsl_logo.png'
-        background_color: '#FFFFFF'
+        image: "rtsl_logo.png"
+        background_color: "#FFFFFF"
       contact:
-        email: 'eng-backend@resolvetosavelives.org'
+        email: "eng-backend@resolvetosavelives.org"
       license:
-        name: 'MIT'
-        url: 'https://github.com/simpledotorg/simple-server/blob/master/LICENSE'
+        name: "MIT"
+        url: "https://github.com/simpledotorg/simple-server/blob/master/LICENSE"
 
   faker:
     name:
-      first_name: ['Ishita', 'Riya', 'Aditya', 'Shreya', 'Mahesh', 'Priya', 'Deepak', 'Rahul', 'Ankit', 'Tanvi', 'Amit', 'Yash', 'Abhishek', 'Tanya', 'Shyam', 'Vani', 'Divya', 'Rohit', 'Anjali', 'Priyanka']
-      last_name: ['Lamba', 'Bahl', 'Sodhi', 'Sardana', 'Puri', 'Chhabra', 'Khanna', 'Malhotra', 'Mehra', 'Garewal', 'Dhillon', 'Bharathi', 'Madhu', 'Bharathi', 'Manabi', 'Anjum', 'Vani', 'Riya', 'Shreya']
+      first_name:
+        [
+          "Ishita",
+          "Riya",
+          "Aditya",
+          "Shreya",
+          "Mahesh",
+          "Priya",
+          "Deepak",
+          "Rahul",
+          "Ankit",
+          "Tanvi",
+          "Amit",
+          "Yash",
+          "Abhishek",
+          "Tanya",
+          "Shyam",
+          "Vani",
+          "Divya",
+          "Rohit",
+          "Anjali",
+          "Priyanka",
+        ]
+      last_name:
+        [
+          "Lamba",
+          "Bahl",
+          "Sodhi",
+          "Sardana",
+          "Puri",
+          "Chhabra",
+          "Khanna",
+          "Malhotra",
+          "Mehra",
+          "Garewal",
+          "Dhillon",
+          "Bharathi",
+          "Madhu",
+          "Bharathi",
+          "Manabi",
+          "Anjum",
+          "Vani",
+          "Riya",
+          "Shreya",
+        ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,10 +66,12 @@ en:
     numerator: "Patients with no visit in the last 3 months."
   diabetes_missed_visits_copy:
     reports_card_subtitle: "Diabetic patients in %{region_name} with no visit in the last 3 months"
-    numerator: "Diabetic patients with no visit in the last 3 months."
+    numerator: "Patients with no visit in the last 3 months."
     denominator: "Diabetes patients assigned to %{region_name}, registered before the last 3 months. Dead and lost to follow-up patients are excluded."
   visit_but_no_bp_taken_copy:
     numerator: "Patients with no BP taken at their last visit in the last 3 months."
+  visit_but_no_bs_taken_copy:
+    numerator: "Patients with no BS taken at their last visit in the last 3 months."
   lost_to_follow_up_copy:
     reports_card_subtitle: "Hypertension patients with no visit in the last 12 months."
     numerator: "Patients with no visit in the last 12 months."

--- a/spec/models/reports/facility_state_spec.rb
+++ b/spec/models/reports/facility_state_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Reports::FacilityState, {type: :model, reporting_spec: true} do
     end
   end
 
-  context "treatment outcomes in the last 3 months" do
+  context "treatment status in the last 3 months" do
     it "computes totals for under care patients" do
       facility = create(:facility)
 
@@ -452,7 +452,7 @@ RSpec.describe Reports::FacilityState, {type: :model, reporting_spec: true} do
       end
     end
 
-    context "treatment outcomes in last 3 months" do
+    context "treatment status in last 3 months" do
       it "contains number of total under care patients at a facility, broken down by the blood sugar type and risk state" do
         facility = create(:facility)
         [:random, :post_prandial, :fasting, :hba1c].each do |blood_sugar_type|

--- a/spec/models/reports/percentage_spec.rb
+++ b/spec/models/reports/percentage_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe Reports::Percentage, type: :helper do
         expect(rounded_percentages({a: 0, b: 0, c: 0})).to eq({a: 0, b: 0, c: 0})
       end
 
+      it "returns zero when the percentage is less than 1" do
+        expect(rounded_percentages({a: 1, b: 137, c: 73})).to eq({a: 0, b: 65, c: 35})
+      end
+
       it "returns nils when the counts are all nil" do
         expect(rounded_percentages({a: nil, b: nil, c: nil})).to eq({a: nil, b: nil, c: nil})
       end

--- a/spec/models/reports/region_summary_schema_spec.rb
+++ b/spec/models/reports/region_summary_schema_spec.rb
@@ -261,7 +261,7 @@ describe Reports::RegionSummarySchema, type: :model do
     end
 
     describe "#diabetes_missed_visits_rates" do
-      it "returns the adjusted count of patients with missed visits in a region" do
+      it "returns the percentage of patients with missed visits in a region" do
         facility_1_patients = create_list(:patient, 4, :diabetes, assigned_facility: facility_1, recorded_at: jan_2019)
         create(:blood_sugar, :with_encounter, :random, :bs_below_200, patient: facility_1_patients.first, facility: facility_1, recorded_at: jan_2020 + 3.months)
         create(:blood_sugar, :with_encounter, :post_prandial, :bs_below_200, patient: facility_1_patients.second, facility: facility_1, recorded_at: jan_2020 + 2.months)
@@ -323,7 +323,7 @@ describe Reports::RegionSummarySchema, type: :model do
     end
 
     describe "#visited_without_bs_taken_rates" do
-      it "returns the adjusted count of patients with missed visits in a region" do
+      it "returns the percentage of patients who visited without bs taken in a region" do
         facility_1_patients = create_list(:patient, 4, :diabetes, assigned_facility: facility_1, recorded_at: jan_2019)
         create(:blood_sugar, :with_encounter, patient: facility_1_patients.first, facility: facility_1, recorded_at: jan_2020 + 3.months)
         create(:blood_pressure, :with_encounter, patient: facility_1_patients.second, facility: facility_1, recorded_at: jan_2020 + 2.months)

--- a/spec/models/reports/region_summary_schema_spec.rb
+++ b/spec/models/reports/region_summary_schema_spec.rb
@@ -322,6 +322,45 @@ describe Reports::RegionSummarySchema, type: :model do
       end
     end
 
+    describe "#visited_without_bs_taken_rates" do
+      it "returns the adjusted count of patients with missed visits in a region" do
+        facility_1_patients = create_list(:patient, 4, :diabetes, assigned_facility: facility_1, recorded_at: jan_2019)
+        create(:blood_sugar, :with_encounter, patient: facility_1_patients.first, facility: facility_1, recorded_at: jan_2020 + 3.months)
+        create(:blood_pressure, :with_encounter, patient: facility_1_patients.second, facility: facility_1, recorded_at: jan_2020 + 2.months)
+        create(:prescription_drug, patient: facility_1_patients.third, facility: facility_1, recorded_at: jan_2020 + 2.months)
+        create(:appointment, patient: facility_1_patients.fourth, facility: facility_1, recorded_at: jan_2020 + 3.months)
+
+        facility_2_patients = create_list(:patient, 3, :diabetes, assigned_facility: facility_2, recorded_at: jan_2019)
+        create(:blood_pressure, :with_encounter, patient: facility_2_patients.first, facility: facility_2, recorded_at: jan_2020 + 3.months)
+        create(:prescription_drug, patient: facility_2_patients.second, facility: facility_2, recorded_at: jan_2020 + 2.months)
+        create(:appointment, patient: facility_2_patients.third, facility: facility_2, recorded_at: jan_2020 + 2.months)
+
+        refresh_views
+        schema = described_class.new([facility_1.region, facility_2.region, region], periods: range)
+
+        expect(schema.visited_without_bs_taken_rates[facility_1.region.slug]["Mar 2020".to_period]).to eq(100)
+        expect(schema.visited_without_bs_taken_rates(with_ltfu: true)[facility_1.region.slug]["Mar 2020".to_period]).to eq(50)
+        expect(schema.visited_without_bs_taken_rates[facility_2.region.slug]["Mar 2020".to_period]).to eq(100)
+        expect(schema.visited_without_bs_taken_rates(with_ltfu: true)[facility_2.region.slug]["Mar 2020".to_period]).to eq(67)
+        expect(schema.visited_without_bs_taken_rates[region.slug]["Mar 2020".to_period]).to eq(100)
+        expect(schema.visited_without_bs_taken_rates(with_ltfu: true)[region.slug]["Mar 2020".to_period]).to eq(57)
+
+        expect(schema.visited_without_bs_taken_rates[facility_1.region.slug]["Apr 2020".to_period]).to eq(75)
+        expect(schema.visited_without_bs_taken_rates(with_ltfu: true)[facility_1.region.slug]["Apr 2020".to_period]).to eq(75)
+        expect(schema.visited_without_bs_taken_rates[facility_2.region.slug]["Apr 2020".to_period]).to eq(100)
+        expect(schema.visited_without_bs_taken_rates(with_ltfu: true)[facility_2.region.slug]["Apr 2020".to_period]).to eq(100)
+        expect(schema.visited_without_bs_taken_rates[region.slug]["Apr 2020".to_period]).to eq(86)
+        expect(schema.visited_without_bs_taken_rates(with_ltfu: true)[region.slug]["Apr 2020".to_period]).to eq(86)
+
+        expect(schema.visited_without_bs_taken_rates[facility_1.region.slug]["May 2020".to_period]).to eq(75)
+        expect(schema.visited_without_bs_taken_rates(with_ltfu: true)[facility_1.region.slug]["May 2020".to_period]).to eq(75)
+        expect(schema.visited_without_bs_taken_rates[facility_2.region.slug]["May 2020".to_period]).to eq(100)
+        expect(schema.visited_without_bs_taken_rates(with_ltfu: true)[facility_2.region.slug]["May 2020".to_period]).to eq(100)
+        expect(schema.visited_without_bs_taken_rates[region.slug]["May 2020".to_period]).to eq(86)
+        expect(schema.visited_without_bs_taken_rates(with_ltfu: true)[region.slug]["May 2020".to_period]).to eq(86)
+      end
+    end
+
     describe "diabetes_treatment_outcome_breakdown" do
       it "retuns the breakdown of differest blood sugar types for a diabetes outcome" do
         facility_1_patients = create_list(:patient, 4, :diabetes, assigned_facility: facility_1, recorded_at: jan_2019)

--- a/spec/services/monthly_district_data_service_spec.rb
+++ b/spec/services/monthly_district_data_service_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe MonthlyDistrictDataService, reporting_spec: true do
         [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
           "New Registrations", nil, nil, nil, nil, nil,
           "Follow-up patients", nil, nil, nil, nil, nil,
-          "Treatment outcomes of patients under care", nil, nil, nil, nil,
+          "Treatment status of patients under care", nil, nil, nil, nil,
           "Drug availability", nil, nil]
       }
 
@@ -230,7 +230,7 @@ RSpec.describe MonthlyDistrictDataService, reporting_spec: true do
         [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
           "New Registrations", nil, nil, nil, nil, nil,
           "Follow-up patients", nil, nil, nil, nil, nil,
-          "Treatment outcomes of patients under care", nil, nil, nil, nil,
+          "Treatment status of patients under care", nil, nil, nil, nil,
           "Days of patient medications", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
           "Drug availability", nil, nil]
       }

--- a/spec/services/monthly_state_data_service_spec.rb
+++ b/spec/services/monthly_state_data_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe MonthlyStateDataService, reporting_spec: true do
         [nil, nil, nil, nil, nil, nil, nil, nil, nil,
           "New Registrations", nil, nil, nil, nil, nil,
           "Follow-up patients", nil, nil, nil, nil, nil,
-          "Treatment outcomes of patients under care", nil, nil, nil, nil,
+          "Treatment status of patients under care", nil, nil, nil, nil,
           "Drug availability", nil, nil]
       }
       let(:headers) {
@@ -171,7 +171,7 @@ RSpec.describe MonthlyStateDataService, reporting_spec: true do
         [nil, nil, nil, nil, nil, nil, nil, nil, nil,
           "New Registrations", nil, nil, nil, nil, nil,
           "Follow-up patients", nil, nil, nil, nil, nil,
-          "Treatment outcomes of patients under care", nil, nil, nil, nil,
+          "Treatment status of patients under care", nil, nil, nil, nil,
           "Days of patient medications", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
           "Drug availability", nil, nil]
       }


### PR DESCRIPTION
**Story card:** [sc-7783](https://app.shortcut.com/simpledotorg/story/7783/add-diabetes-treatment-outcomes-graph)

## Because

We need to add a graph showing the breakdown of diabetic visits

## This addresses

Adds HTML and javascript changes necessary to show the breakdown graph

## Test instructions

1. Turn on diabetes_management_reports on the flipper
2. Visit the reports page of a facility which has enable_diabetes_management set to true
3. Click on the Diabetes link
4. You should see the Treatment outcomes of diabetes patients under care graph

<img width="1344" alt="Screenshot 2022-05-10 at 8 37 26 PM" src="https://user-images.githubusercontent.com/32141642/167661247-3b542dbb-aac4-4115-9b41-ef39cf68192f.png">
