### PR TITLE
Fix data queries for region whatsapp graphics download

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -216,7 +216,7 @@ class Reports::RegionsController < AdminController
     @year = params[:year].to_i if params[:year].present?
 
     @cohort_analytics = @region.cohort_analytics(period: :quarter, prev_periods: 3)
-    @dashboard_analytics = @region.dashboard_analytics(period: :quarter, prev_periods: 4)
+    @dashboard_analytics = @region.dashboard_analytics(period: :quarter, prev_periods: 4, include_current_period: false)
 
     whatsapp_graphics_handler(
       @region.organization.name,

--- a/app/queries/district_analytics_query.rb
+++ b/app/queries/district_analytics_query.rb
@@ -71,16 +71,13 @@ class DistrictAnalyticsQuery
   end
 
   def registered_patients_by_period
-    @facilities.each_with_object({}) { |facility, result|
-      counts = period_to_dates(repository.monthly_registrations[facility.region.slug])
-      next unless counts&.any?
+    result = ActivityService.new(region, period: @period, group: Patient.arel_table[:registration_facility_id]).registrations
 
-      result[facility.id] = {registered_patients_by_period: counts}
-    }
+    group_by_date_and_facility(result, :registered_patients_by_period)
   end
 
   def follow_up_patients_by_period
-    result = ActivityService.new(region, group: BloodPressure.arel_table[:facility_id]).follow_ups
+    result = ActivityService.new(region, period: @period, group: BloodPressure.arel_table[:facility_id]).follow_ups
 
     group_by_date_and_facility(result, :follow_up_patients_by_period)
   end

--- a/app/queries/facility_analytics_query.rb
+++ b/app/queries/facility_analytics_query.rb
@@ -46,13 +46,13 @@ class FacilityAnalyticsQuery
   end
 
   def registered_patients_by_period
-    result = ActivityService.new(@facility, group: [:registration_user_id]).registrations
+    result = ActivityService.new(@facility, period: @period, group: [:registration_user_id]).registrations
 
     group_by_date_and_user(result, :registered_patients_by_period)
   end
 
   def follow_up_patients_by_period
-    result = ActivityService.new(@facility, group: [BloodPressure.arel_table[:user_id]]).follow_ups
+    result = ActivityService.new(@facility, period: @period, group: [BloodPressure.arel_table[:user_id]]).follow_ups
 
     group_by_date_and_user(result, :follow_up_patients_by_period)
   end

--- a/app/services/activity_service.rb
+++ b/app/services/activity_service.rb
@@ -42,11 +42,11 @@ class ActivityService
   def registrations_relation
     case diagnosis
     when :hypertension
-      region.registered_hypertension_patients
+      region.registered_hypertension_patients.for_reports
     when :diabetes
-      region.registered_diabetes_patients
+      region.registered_diabetes_patients.excluding_dead
     when :all
-      region.registered_patients
+      region.registered_patients.excluding_dead
     else
       raise ArgumentError, "Unsupported diagnosis"
     end


### PR DESCRIPTION
**Story card:** [sc-8035](https://app.shortcut.com/simpledotorg/story/8035/registration-number-for-all-quarters-and-follow-numbers-for-one-quarter-is-missing)

## Because

The downloadable summary (aka "whatsapp graphics") is broken

## This addresses
- Use the correct period (`quarter` instead of `month`)
- Exclude current quarter for the `DashboardAnalytics` query) 