### PR TITLE
Fix bugs on diabetes page

### DIFF
--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -1288,8 +1288,8 @@ Reports = function (withLtfu) {
 
   this.setupDiabetesMissedVisitsGraph = (data) => {
     const adjustedPatients = withLtfu
-      ? data.adjustedPatientCountsWithLtfu
-      : data.adjustedPatientCounts;
+      ? data.adjustedDiabetesPatientCountsWithLtfu
+      : data.adjustedDiabetesPatientCounts;
     const diabetesMissedVisitsGraphNumerator = withLtfu
       ? data.diabetesMissedVisitsWithLtfu
       : data.diabetesMissedVisits;

--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -974,7 +974,7 @@ Reports = function (withLtfu) {
             padding: 8,
             min: 0,
             beginAtZero: true,
-            stepSize: 50,
+            stepSize: 25,
             max: 100,
           },
         },
@@ -1180,7 +1180,7 @@ Reports = function (withLtfu) {
             drawBorder: false,
           },
           ticks: {
-            display: false,
+            display: true,
             autoSkip: false,
             fontColor: this.darkGreyColor,
             fontSize: 10,
@@ -1205,7 +1205,7 @@ Reports = function (withLtfu) {
             drawBorder: false,
           },
           ticks: {
-            display: true,
+            display: false,
             autoSkip: false,
             fontColor: this.darkGreyColor,
             fontSize: 10,
@@ -1213,8 +1213,8 @@ Reports = function (withLtfu) {
             padding: 8,
             min: 0,
             beginAtZero: true,
-            stepSize: monthlyDiabetesFollowupsYAxis.stepSize,
-            max: monthlyDiabetesFollowupsYAxis.max,
+            stepSize: cumulativeDiabetesRegistrationsYAxis.stepSize,
+            max: cumulativeDiabetesRegistrationsYAxis.max,
             callback: (label) => {
               return this.formatNumberWithCommas(label);
             },

--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -93,7 +93,7 @@ module Reports
     def warm_cache
       DELEGATED_RATES.each do |method|
         public_send(method)
-        public_send(method, with_ltfu: true) unless method.in?([:ltfu_rates, :missed_visits_with_ltfu_rates, :bs_below_200_rates, :bs_200_to_300_rates, :bs_over_300_rates])
+        public_send(method, with_ltfu: true) unless method.in?([:ltfu_rates, :missed_visits_with_ltfu_rates])
       end
       hypertension_follow_ups
       if regions.all? { |region| region.facility_region? }

--- a/app/presenters/reports/repository_presenter.rb
+++ b/app/presenters/reports/repository_presenter.rb
@@ -21,7 +21,7 @@ module Reports
         controlled_patients: controlled[slug],
         cumulative_assigned_patients: cumulative_assigned_patients[slug],
         cumulative_registrations: cumulative_registrations[slug],
-        cumulative_diabetes_registrations: cumulative_registrations[slug],
+        cumulative_diabetes_registrations: cumulative_diabetes_registrations[slug],
         earliest_registration_period: earliest_patient_recorded_at_period[slug],
         ltfu_patients_rate: ltfu_rates[slug],
         ltfu_patients: ltfu[slug],

--- a/app/views/reports/regions/diabetes.html.erb
+++ b/app/views/reports/regions/diabetes.html.erb
@@ -67,7 +67,7 @@
               <span data-fasting=""></span>
             </strong> Fasting, &nbsp;
             <strong>
-              <span style="font-weight:bold;" data-hba1c=""></span>
+              <span data-hba1c=""></span>
             </strong> HbA1c
           </p>
         </div>

--- a/app/views/reports/regions/diabetes.html.erb
+++ b/app/views/reports/regions/diabetes.html.erb
@@ -60,9 +60,15 @@
       <div>
         <div class="p-relative px-20px mb-12px">
           <p class="m-0px c-grey-dark c-print-black">
-            <span data-rbs-ppbs=""></span> RBS/PPBS
-            <span data-fasting=""></span> Fasting
-            <span data-hba1c=""></span> HbA1c
+            <strong>
+              <span data-rbs-ppbs=""></span>
+            </strong> RBS/PPBS, &nbsp;
+            <strong>
+              <span data-fasting=""></span>
+            </strong> Fasting, &nbsp;
+            <strong>
+              <span style="font-weight:bold;" data-hba1c=""></span>
+            </strong> HbA1c
           </p>
         </div>
       </div>

--- a/app/views/reports/regions/diabetes.html.erb
+++ b/app/views/reports/regions/diabetes.html.erb
@@ -162,13 +162,13 @@
           <%= t("bs_over_200_copy.reports_card_subtitle", region_name: @region.name) %>
         </p>
         <div class="mb-12px d-lg-flex align-lg-center">
-          <p class="mb-0px fs-32px fw-bold mr-lg-12px c-red minw-32px"
-             data-bs-200-to-300-rate="">
+          <p class="mb-0px fs-32px fw-bold mr-lg-12px c-maroon minw-32px"
+             data-bs-over-300-rate="">
           </p>
           <div>
             <p class="m-0px c-black">
-              <span data-total-bs-200-to-300-patients=""></span>
-              patients with a BS 200-299 from
+              <span data-total-bs-over-300-patients=""></span>
+              patients with a BS ≥300 from
               <span data-period-start=""></span>
               to
               <span data-period-end=""></span>
@@ -181,13 +181,13 @@
           </div>
         </div>
         <div class="mb-12px d-lg-flex align-lg-center">
-          <p class="mb-0px fs-32px fw-bold mr-lg-12px c-maroon minw-32px"
-             data-bs-over-300-rate="">
+          <p class="mb-0px fs-32px fw-bold mr-lg-12px c-red minw-32px"
+             data-bs-200-to-300-rate="">
           </p>
           <div>
             <p class="m-0px c-black">
-              <span data-total-bs-over-300-patients=""></span>
-              patients with a BS ≥300 from
+              <span data-total-bs-200-to-300-patients=""></span>
+              patients with a BS 200-299 from
               <span data-period-start=""></span>
               to
               <span data-period-end=""></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,8 +65,8 @@ en:
     reports_card_subtitle: "Hypertension patients with no visit in the last 3 months"
     numerator: "Patients with no visit in the last 3 months."
   diabetes_missed_visits_copy:
-    reports_card_subtitle: "Diabetic patients in %{region_name} with no visit in the last 3 months"
-    numerator: "Diabetic patients with no visit in the last 3 months."
+    reports_card_subtitle: "Diabetes patients in %{region_name} with no visit in the last 3 months"
+    numerator: "Diabetes patients with no visit in the last 3 months."
     denominator: "Diabetes patients assigned to %{region_name}, registered before the last 3 months. Dead and lost to follow-up patients are excluded."
   visit_but_no_bp_taken_copy:
     numerator: "Patients with no BP taken at their last visit in the last 3 months."


### PR DESCRIPTION
**Story card:** [sc-8218](https://app.shortcut.com/simpledotorg/story/8218/bugs-on-diabetes-page)

## Because

 There are a lot of bugs on the diabetes page

## This addresses

- Fix missed visit denominator
- Fix the total registrations count
- Fix the percentage in the red graph( BS 200-299 or BS >= 300 )
- Fix the typo in missed visit graphs tooltip. Change diabetic to diabetes
- Add commas, spaces, bold in the breakdown - footnote in the green graph( BS <200 )
- Use the same stack size for all graphs
  -  Use `0, 25, 50,75,100` for BS <200, BS 200-299 or BS >= 300 and Missed visits graph
  -  Use the step size based on the highest value of `cumulative diabetes registration`  for both `cumulative registrations and follow up` trend
  - Use the step size based on the highest value of `monthly registrations` for the `monthly registrations` trend
- Change the order of `%` s in the red graph( BS 200-299 or BS >= 300 )

## Test instructions

- Turn on diabetes_management_reports on the Flipper
- Visit the reports page of a facility which has enable_diabetes_management set to true
- Click on Diabetes link
- You should see all the above changes

<img width="1344" alt="Screenshot 2022-05-10 at 8 17 48 PM" src="https://user-images.githubusercontent.com/32141642/167657071-9d7c97e7-6bed-4b28-83d0-fb5ea86bdf64.png">

<img width="1344" alt="Screenshot 2022-05-10 at 8 17 57 PM" src="https://user-images.githubusercontent.com/32141642/167657017-146f1459-6481-4fad-82a8-4fda1f94c981.png">
