### PR TITLE
Allow deploying cron jobs to sidekiq servers

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -36,7 +36,7 @@ append :linked_files, ".env.production"
 append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system", "public/packs", "node_modules"
 
 set :whenever_path, -> { release_path }
-set :whenever_roles, [:cron, :whitelist_phone_numbers]
+set :whenever_roles, [:cron, :whitelist_phone_numbers, :sidekiq]
 set :enable_confirmation, ENV["CONFIRM"] || "true"
 set :envs_for_confirmation_step, ["production", "staging"]
 


### PR DESCRIPTION
**Story card:** [sc-8182](https://app.shortcut.com/simpledotorg/story/8182/sidekiq-downtime-issues)

## Because
We added a nightly cron job to run on sidekiq servers via `schedule.rb` in https://github.com/simpledotorg/simple-server/pull/3716. It's not deployed to the boxes unless specified in `whenever`'s config.

## This addresses

Adds sidekiq server to whenever config.