### PR TITLE
Changed how large percentage numbers are displayed

### DIFF
--- a/app/assets/stylesheets/partials/_reports.scss
+++ b/app/assets/stylesheets/partials/_reports.scss
@@ -729,3 +729,10 @@
   top: 2px;
   margin-right: 4px;
 }
+.graph-percent {
+  margin: 0 18px 0 0;
+  font-weight: bold;
+  min-width: 2em;
+  text-align: center;
+  display: inline-block;
+}

--- a/app/views/reports/regions/_diabetes_treatment_outcomes_card.html.erb
+++ b/app/views/reports/regions/_diabetes_treatment_outcomes_card.html.erb
@@ -13,7 +13,7 @@
       <div class="flex-lg-1 mt-24px ml-lg-24px mt-print-2cm">
         <div>
           <div class="mb-16px d-lg-flex align-lg-center">
-            <p class="rate mb-0px fs-32px fw-bold mr-lg-24px c-blue"
+            <p class="c-print-black c-blue graph-percent fs-28px"
                data-missed-visits-rate="">
             </p>
             <div>
@@ -39,7 +39,7 @@
         </div>
         <div>
           <div class="mb-16px d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold mr-lg-24px c-grey-dark " data-visit-but-no-bs-measure-rate=""></p>
+            <p class="c-print-black c-grey-dark graph-percent fs-28px" data-visit-but-no-bs-measure-rate=""></p>
             <div>
               <%= render "visit_details_heading",
                    title: "Visit but no BS taken",
@@ -63,7 +63,7 @@
         </div>
         <div>
           <div class="mb-16px d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold mr-lg-24px c-print-black c-maroon"
+            <p class="c-print-black c-maroon graph-percent fs-28px"
                data-bs-over-300-rate="">
             </p>
             <div>
@@ -89,7 +89,7 @@
         </div>
         <div>
           <div class="mb-16px d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold mr-lg-24px c-print-black c-red"
+            <p class="c-print-black c-red graph-percent fs-28px"
                data-bs-200-to-300-rate="">
             </p>
             <div>
@@ -115,7 +115,7 @@
         </div>
         <div>
           <div class="mb-16px d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold mr-lg-24px c-print-black c-green-dark"
+            <p class="c-print-black c-green-dark graph-percent fs-28px"
                data-bs-below-200-rate="">
             </p>
             <div>

--- a/app/views/reports/regions/_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_patient_breakdown_charts.html.erb
@@ -103,13 +103,13 @@
           <%= t("lost_to_follow_up_copy.reports_card_subtitle") %>
         </p>
         <div class="mb-12px d-lg-flex align-lg-center">
-          <p class="mb-0px fs-32px fw-bold
+          <p class="c-print-black graph-percent fs-28px
             <% current_ltfu_rate = @chart_data[:ltfu_trend][:ltfu_patients_rate][@period] %>
             <% if current_ltfu_rate %>
               c-blue-dark
             <% else %>
               c-grey-medium
-            <% end %> mr-lg-12px" data-rate="<%= number_to_percentage(current_ltfu_rate, precision: 0) %>">
+            <% end %>" data-rate="<%= number_to_percentage(current_ltfu_rate, precision: 0) %>">
             <% if current_ltfu_rate %>
               <%= number_to_percentage(current_ltfu_rate, precision: 0) %>
             <% else %>

--- a/app/views/reports/regions/_treatment_outcomes_card.html.erb
+++ b/app/views/reports/regions/_treatment_outcomes_card.html.erb
@@ -13,7 +13,7 @@
       <div class="flex-lg-1 mt-24px ml-lg-24px mt-print-2cm">
         <div>
           <div class="mb-16px d-lg-flex align-lg-center">
-            <p class="rate mb-0px fs-32px fw-bold mr-lg-24px c-blue"
+            <p class="c-print-black c-blue graph-percent fs-28px"
                data-missed-visits-rate="">
             </p>
             <div>
@@ -39,7 +39,7 @@
         </div>
         <div>
           <div class="mb-16px d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold c-grey-dark mr-lg-24px" data-visit-but-no-bp-measure-rate=""></p>
+            <p class="c-print-black c-grey-dark graph-percent fs-28px" data-visit-but-no-bp-measure-rate=""></p>
             <div>
               <%= render "visit_details_heading",
                    title: "Visit but no BP taken",
@@ -63,7 +63,7 @@
         </div>
         <div>
           <div class="mb-16px d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold mr-lg-24px c-print-black c-red"
+            <p class="c-print-black c-red graph-percent fs-28px"
                data-uncontrolled-rate="">
             </p>
             <div>
@@ -89,7 +89,7 @@
         </div>
         <div>
           <div class="mb-16px d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold mr-lg-24px c-print-black c-green-dark"
+            <p class="c-print-black c-green-dark graph-percent fs-28px"
                data-controlled-rate="">
             </p>
             <div>

--- a/app/views/reports/regions/diabetes.html.erb
+++ b/app/views/reports/regions/diabetes.html.erb
@@ -30,7 +30,7 @@
           <%= t("bs_below_200_copy.reports_card_subtitle", region_name: @region.name) %>
         </p>
         <div class="mb-12px d-lg-flex align-lg-center">
-          <p class="mb-0px fs-32px fw-bold mr-lg-12px c-green-dark minw-32px"
+          <p class="c-print-black c-green-dark graph-percent fs-28px"
              data-rate="">
           </p>
           <div>
@@ -98,33 +98,33 @@
         </p>
         <div class="d-flex align-center mb-24px">
           <div class="flex-1 d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold mr-lg-12px c-purple"
+            <p class="c-print-black c-purple graph-percent fs-24px"
                data-total-patients="">
             </p>
             <div>
-              <p class="m-0px c-black c-print-black">
+              <p class="m-0px c-black c-print-black fs-14px">
                 total <%= "registration".pluralize(@data.dig(:cumulative_diabetes_registrations, @period)) %><br>till
                 <span data-registrations-period-end=""></span>
               </p>
             </div>
           </div>
           <div class="flex-1 d-lg-flex align-lg-center flex-lg-1">
-            <p class="mb-0px fs-32px fw-bold mr-lg-12px c-purple-medium"
+            <p class="c-print-black c-purple-medium graph-percent fs-24px"
                data-monthly-registrations="">
             </p>
             <div>
-              <p class="m-0px c-black c-print-black">
+              <p class="m-0px c-black c-print-black fs-14px">
                 new <%= "registration".pluralize(@data.dig(:diabetes_registrations, @period)) %><br>in
                 <span data-registrations-month-end=""></span>
               </p>
             </div>
           </div>
           <div class="flex-1 d-lg-flex align-lg-center flex-lg-1">
-            <p class="mb-0px fs-32px fw-bold mr-lg-12px c-orange"
+            <p class="c-print-black c-orange graph-percent fs-24px"
                data-monthly-follow-ups="">
             </p>
             <div>
-              <p class="m-0px c-black c-print-black">
+              <p class="m-0px c-black c-print-black fs-14px">
                 follow-up <%= "patient".pluralize(@data.dig(:monthly_diabetes_followups, @period)) %><br>in
                 <span data-follow-ups-month-end=""></span>
               </p>
@@ -162,7 +162,7 @@
           <%= t("bs_over_200_copy.reports_card_subtitle", region_name: @region.name) %>
         </p>
         <div class="mb-12px d-lg-flex align-lg-center">
-          <p class="mb-0px fs-32px fw-bold mr-lg-12px c-maroon minw-32px"
+          <p class="c-print-black c-maroon graph-percent fs-28px"
              data-bs-over-300-rate="">
           </p>
           <div>
@@ -181,7 +181,7 @@
           </div>
         </div>
         <div class="mb-12px d-lg-flex align-lg-center">
-          <p class="mb-0px fs-32px fw-bold mr-lg-12px c-red minw-32px"
+          <p class="c-print-black c-red graph-percent fs-28px"
              data-bs-200-to-300-rate="">
           </p>
           <div>
@@ -234,7 +234,7 @@
           <%= t("diabetes_missed_visits_copy.reports_card_subtitle", region_name: @region.name) %>
         </p>
         <div class="mb-12px d-lg-flex align-lg-center">
-          <p class="mb-0px fs-32px fw-bold mr-lg-12px c-blue minw-32px"
+          <p class="c-print-black c-blue graph-percent fs-28px"
              data-rate="">
           </p>
           <div>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -29,7 +29,7 @@
           <%= t("bp_controlled_copy.reports_card_subtitle") %>
         </p>
         <div class="mb-12px d-lg-flex align-lg-center">
-          <p class="mb-0px fs-32px fw-bold mr-lg-12px c-green-dark minw-32px"
+          <p class="c-print-black c-green-dark graph-percent fs-28px"
              data-rate="">
           </p>
           <div>
@@ -78,7 +78,7 @@
         </p>
         <div class="d-flex align-center mb-24px">
           <div class="flex-1 d-lg-flex align-lg-center">
-            <p class="mb-0px fs-32px fw-bold mr-lg-12px c-purple"
+            <p class="c-print-black c-purple graph-percent fs-28px"
               data-total-patients="">
             </p>
             <div>
@@ -89,7 +89,7 @@
             </div>
           </div>
           <div class="flex-1 d-lg-flex align-lg-center flex-lg-1">
-            <p class="mb-0px fs-32px fw-bold mr-lg-12px c-purple-medium"
+            <p class="c-print-black c-purple-medium graph-percent fs-28px"
               data-monthly-registrations="">
             </p>
             <div>
@@ -127,7 +127,7 @@
           <%= t("bp_not_controlled_copy.reports_card_subtitle") %>
         </p>
         <div class="mb-12px d-lg-flex align-lg-center">
-          <p class="mb-0px fs-32px fw-bold mr-lg-12px c-red minw-32px"
+          <p class="c-print-black c-red graph-percent fs-28px"
              data-rate="">
           </p>
           <div>
@@ -177,7 +177,7 @@
           <%= t("missed_visits_copy.reports_card_subtitle") %>
         </p>
         <div class="mb-12px d-lg-flex align-lg-center">
-          <p class="mb-0px fs-32px fw-bold mr-lg-12px c-blue minw-32px"
+          <p class="c-print-black c-blue graph-percent fs-28px"
              data-rate="">
           </p>
           <div>


### PR DESCRIPTION
No card.

Numbers used to align terribly between 2-digit and 3-digit numbers. I made them all inline-block with a min-width. I also reduced the font-size of the registration numbers in DM Reports because when 100,000 patients are displayed in 3 columns, things get funky.

See alignment of the big colorful numbers in the screenshot below.
 
<img width="1488" alt="image" src="https://user-images.githubusercontent.com/711809/168035975-b2535c63-002a-45e2-8fc2-611c8908ebd8.png">
