### PR TITLE
Fix incorrect count missed visits with ltfu patients

### DIFF
--- a/app/models/reports/region_summary.rb
+++ b/app/models/reports/region_summary.rb
@@ -46,6 +46,7 @@ module Reports
     UNDER_CARE_WITH_LTFU = %i[
       adjusted_missed_visit
       adjusted_visited_no_bp
+      adjusted_bs_missed_visit
     ].freeze
 
     attr_reader :id_field

--- a/app/models/reports/region_summary_schema.rb
+++ b/app/models/reports/region_summary_schema.rb
@@ -158,7 +158,7 @@ module Reports
     end
 
     memoize def diabetes_missed_visits(with_ltfu: false)
-      field = with_ltfu ? :adjusted_bs_missed_visit_lost_to_follow_up : :adjusted_bs_missed_visit_under_care
+      field = with_ltfu ? :adjusted_bs_missed_visit_under_care_with_lost_to_follow_up : :adjusted_bs_missed_visit_under_care
       values_at(field)
     end
 

--- a/spec/models/reports/region_summary_schema_spec.rb
+++ b/spec/models/reports/region_summary_schema_spec.rb
@@ -284,10 +284,10 @@ describe Reports::RegionSummarySchema, type: :model do
 
         (("Apr 2019".to_period)..("Dec 2019".to_period)).each do |period|
           expect(schema.diabetes_missed_visits_rates[facility_1.region.slug][period]).to eq(100)
-          expect(schema.diabetes_missed_visits_rates(with_ltfu: true)[facility_1.region.slug][period]).to eq(0)
+          expect(schema.diabetes_missed_visits_rates(with_ltfu: true)[facility_1.region.slug][period]).to eq(100)
 
           expect(schema.diabetes_missed_visits_rates[facility_2.region.slug][period]).to eq(100)
-          expect(schema.diabetes_missed_visits_rates(with_ltfu: true)[facility_2.region.slug][period]).to eq(0)
+          expect(schema.diabetes_missed_visits_rates(with_ltfu: true)[facility_2.region.slug][period]).to eq(100)
         end
 
         (("Jan 2020".to_period)..("Feb 2020".to_period)).each do |period|
@@ -316,9 +316,9 @@ describe Reports::RegionSummarySchema, type: :model do
         expect(schema.diabetes_missed_visits_rates(with_ltfu: true)[facility_2.region.slug]["May 2020".to_period]).to eq(0)
 
         expect(schema.diabetes_missed_visits_rates[facility_1.region.slug]["Jun 2020".to_period]).to eq 50
-        expect(schema.diabetes_missed_visits_rates(with_ltfu: true)[facility_1.region.slug]["Jun 2020".to_period]).to eq 0
+        expect(schema.diabetes_missed_visits_rates(with_ltfu: true)[facility_1.region.slug]["Jun 2020".to_period]).to eq 50
         expect(schema.diabetes_missed_visits_rates[facility_2.region.slug]["Jun 2020".to_period]).to eq 67
-        expect(schema.diabetes_missed_visits_rates(with_ltfu: true)[facility_2.region.slug]["Jun 2020".to_period]).to eq 0
+        expect(schema.diabetes_missed_visits_rates(with_ltfu: true)[facility_2.region.slug]["Jun 2020".to_period]).to eq 67
       end
     end
 

--- a/spec/models/reports/region_summary_spec.rb
+++ b/spec/models/reports/region_summary_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
         adjusted_bs_missed_visit_lost_to_follow_up
         adjusted_bs_200_to_300_under_care
         adjusted_bs_over_300_under_care
+        adjusted_bs_missed_visit_under_care_with_lost_to_follow_up
       ].map(&:to_s)
       (3.months.ago.to_period..now.to_period).each do |period|
         expect(results["facility-1"][period].keys).to match_array(expected_keys)


### PR DESCRIPTION
We were not counting patients who are undercare but have missed their visit in last 3 months while reporting for diabetes patients including the lost to follow up patients. 