### PR TITLE
Added more months, formatted better on mobile, removed ticks

### DIFF
--- a/app/assets/javascripts/common/medications_dispensation.js
+++ b/app/assets/javascripts/common/medications_dispensation.js
@@ -3,117 +3,133 @@ MedicationsDispensationGraph = function () {
 
   this.listen = () => {
     this.initializeGraph();
-  }
+  };
 
   this.getGraphData = () => {
-    return JSON.parse(reports.getChartDataNode().textContent)["medications_dispensation"];
-  }
+    return JSON.parse(reports.getChartDataNode().textContent)[
+      "medications_dispensation"
+    ];
+  };
 
   this.getGraphPeriods = () => {
     let firstBucketData = Object.values(this.getGraphData())[0];
     return Object.keys(firstBucketData["counts"]);
-  }
+  };
 
   this.initializeGraph = () => {
     const graphData = this.getGraphData();
     const graphConfig = reports.createBaseGraphConfig();
-    let datasets = Object.keys(graphData).map(function(bucket, index){
+    let datasets = Object.keys(graphData).map(function (bucket, index) {
       return {
         label: bucket,
         data: Object.values(graphData[bucket]["percentages"]),
         numerators: graphData[bucket]["counts"],
         denominators: graphData[bucket]["totals"],
         borderColor: graphData[bucket]["color"],
-        backgroundColor: graphData[bucket]["color"]
-      }
-    })
+        backgroundColor: graphData[bucket]["color"],
+      };
+    });
 
     graphConfig.plugins = [ChartDataLabels];
-    graphConfig.type = 'bar';
+    graphConfig.type = "bar";
     graphConfig.data = {
       labels: this.getGraphPeriods(),
-      datasets: datasets
+      datasets: datasets,
     };
 
     graphConfig.options.scales = {
-      xAxes: [{
-        stacked: false,
-        display: true,
-        gridLines: {
-          display: false,
-          drawBorder: true,
-        },
-        ticks: {
-          autoSkip: false,
-          fontColor: reports.darkGreyColor,
-          fontSize: 12,
-          fontFamily: "Roboto Condensed",
-          padding: 0,
-          min: 0,
-          beginAtZero: true,
-        },
-      }],
-      yAxes: [{
-        stacked: false,
-        display: true,
-        minBarLength: 4,
-        gridLines: {
+      xAxes: [
+        {
+          stacked: false,
           display: true,
-          drawBorder: false,
+          gridLines: {
+            display: false,
+            drawBorder: true,
+          },
+          ticks: {
+            autoSkip: false,
+            fontColor: reports.darkGreyColor,
+            fontSize: 12,
+            fontFamily: "Roboto Condensed",
+            padding: 0,
+            min: 0,
+            beginAtZero: true,
+          },
         },
-        ticks: {
-          autoSkip: false,
-          fontColor: reports.darkGreyColor,
-          fontSize: 12,
-          fontFamily: "Roboto Condensed",
-          padding: 8,
-          min: 0,
-          beginAtZero: true,
-          stepSize: 25,
-          max: 100,
+      ],
+      yAxes: [
+        {
+          stacked: false,
+          display: true,
+          minBarLength: 4,
+          gridLines: {
+            display: true,
+            drawBorder: false,
+          },
+          ticks: {
+            display: false,
+            autoSkip: false,
+            fontColor: reports.darkGreyColor,
+            fontSize: 12,
+            fontFamily: "Roboto Condensed",
+            padding: 8,
+            min: 0,
+            beginAtZero: true,
+            stepSize: 25,
+            max: 100,
+          },
         },
-      }]
+      ],
     };
 
     graphConfig.options.plugins = {
       datalabels: {
-        align: 'end',
-        color: 'black',
-        anchor: 'end',
+        align: "end",
+        color: "black",
+        anchor: "end",
         offset: 1,
         font: {
-          family:'Roboto Condensed',
+          family: "Roboto Condensed",
           size: 12,
         },
-        formatter: function(value) {
-            return value + '%';
-        }
-      }
-    }
+        formatter: function (value) {
+          return value + "%";
+        },
+      },
+    };
 
     graphConfig.options.tooltips = {
       displayColors: false,
-      xAlign: 'center',
-      yAlign: 'top',
+      xAlign: "center",
+      yAlign: "top",
       xPadding: 6,
       yPadding: 6,
       caretSize: 3,
       caretPadding: 1,
       callbacks: {
-        title: function() {
-          return ""
+        title: function () {
+          return "";
         },
-        label: function(tooltipItem, data) {
-            let numerators = Object.values(data.datasets[tooltipItem.datasetIndex].numerators);
-            let denominators = Object.values(data.datasets[tooltipItem.datasetIndex].denominators);
-          return reports.formatNumberWithCommas(numerators[tooltipItem.index]) + " of " + reports.formatNumberWithCommas(denominators[tooltipItem.index]) + " follow-up patients";
+        label: function (tooltipItem, data) {
+          let numerators = Object.values(
+            data.datasets[tooltipItem.datasetIndex].numerators
+          );
+          let denominators = Object.values(
+            data.datasets[tooltipItem.datasetIndex].denominators
+          );
+          return (
+            reports.formatNumberWithCommas(numerators[tooltipItem.index]) +
+            " of " +
+            reports.formatNumberWithCommas(denominators[tooltipItem.index]) +
+            " follow-up patients"
+          );
         },
-      }
-    }
+      },
+    };
 
     const graphCanvas = document.getElementById("MedicationsDispensation");
     if (graphCanvas) {
       new Chart(graphCanvas.getContext("2d"), graphConfig);
     }
-  }
-}
+  };
+};

--- a/app/services/medication_dispensation_service.rb
+++ b/app/services/medication_dispensation_service.rb
@@ -1,5 +1,5 @@
 class MedicationDispensationService
-  MONTHS = -6
+  MONTHS = -5
 
   def self.call(*args)
     new(*args).call

--- a/app/services/medication_dispensation_service.rb
+++ b/app/services/medication_dispensation_service.rb
@@ -1,5 +1,5 @@
 class MedicationDispensationService
-  MONTHS = -2
+  MONTHS = -6
 
   def self.call(*args)
     new(*args).call

--- a/app/views/reports/regions/_medications_dispensation.html.erb
+++ b/app/views/reports/regions/_medications_dispensation.html.erb
@@ -18,9 +18,9 @@
       </div>
       <div class="p-absolute t-0 l-0 pe-none d-flex align-center justify-center w-100pt h-100pt">
       </div>
-      <div class="mr-16px d-lg-flex align-lg-center justify-lg-end mt-lg-0px pt-lg-16px">
+      <div class="ml-3 accessmr-16px d-lg-flex align-lg-center justify-lg-end mt-lg-0px pt-lg-16px">
         <% @details_chart_data[:medications_dispensation].each do |bucket, data| %>
-          <span class="mr-2 text-nowrap">
+          <span class="mr-3 text-nowrap">
             <span class="legend-label" style="background-color: <%= data[:color] %>"></span><%= bucket %>
           </span>
         <% end %>


### PR DESCRIPTION
Showing 6 months is tight on mobile, but works. This is much more useful for seeing the trend.
<img width="1449" alt="image" src="https://user-images.githubusercontent.com/711809/169252851-c38a44e1-cbdb-44a7-86ca-fbce20eda35b.png">
<img width="571" alt="image" src="https://user-images.githubusercontent.com/711809/169252954-1f7e5f94-4945-4cf9-abad-351a1fc1c004.png">
