### PR TITLE
Do db:schema:load in cap deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,11 +416,13 @@ bundle exec cap <environment> sidekiq:install
 You can now run a regular Capistrano deployment:
 
 ```bash
-bundle exec cap <environment> deploy
+FIRST_DEPLOY=true bundle exec cap <environment> deploy
 ```
 
 This may take a long time for the first deployment, since several dependencies (like Ruby) need to be installed.
 Subsequent deployments will be much faster.
+
+Note that `FIRST_DEPLOY=true` only needs to be specified on the first run. Any deployments afterwards don't need the flag.
 
 ### Deployment Resources
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -48,3 +48,15 @@ Capistrano::DSL.stages.each do |stage|
   next unless fetch(:enable_confirmation) == "true"
   after stage, "deploy:confirmation" if fetch(:envs_for_confirmation_step).any? { |env| stage == env }
 end
+
+task "deploy:schema_load" do
+  on primary :db do
+    within release_path do
+      with rails_env: fetch(:rails_env) do
+        execute :rake, "db:schema:load"
+      end
+    end
+  end
+end
+
+before "deploy:migrate", "deploy:schema_load" if ENV["FIRST_DEPLOY"]

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -11,7 +11,9 @@ namespace :deploy do
   task :fix_bundler_plugin_path do
     on release_roles([:all]) do
       within shared_path do
-        execute "sed", "-i", '"s#/home/deploy/apps/simple-server/releases/[0-9]\+/#/home/deploy/apps/simple-server/shared/#g"', ".bundle/plugin/index"
+        if test("[ -d .bundle/plugin/index ]")
+          execute "sed", "-i", '"s#/home/deploy/apps/simple-server/releases/[0-9]\+/#/home/deploy/apps/simple-server/shared/#g"', ".bundle/plugin/index"
+        end
       end
     end
   end


### PR DESCRIPTION
**Story card:** -

## Because
When a deploy is made to a fresh environment via capistrano, migrations fail because the env doesn't have the schema loaded.

## This addresses

Allows user to specify a `FIRST_DEPLOY` env var that runs a `db:schema:load` while deploying. Borrows from https://github.com/coopdevs/timeoverflow/commit/1511c41b37941fe06d64c3d3997c4663a6130bf2