### PR TITLE
No-op a data migration (Jan 22 IHCI experiments)

### DIFF
--- a/db/data/20211227141152_create_january2022_ihci_experiment.rb
+++ b/db/data/20211227141152_create_january2022_ihci_experiment.rb
@@ -1,19 +1,21 @@
 class CreateJanuary2022IhciExperiment < ActiveRecord::Migration[5.2]
   def up
-    return unless CountryConfig.current_country?("India") && SimpleServer.env.production?
-
-    Seed::Experiment2Seeder.create_current_experiment(
-      experiment_name: "Current Patient January 2022",
-      start_time: Date.parse("Jan 3, 2022").beginning_of_day,
-      end_time: Date.parse("Feb 2, 2022").end_of_day,
-      max_patients_per_day: 9000
-    )
-    Seed::Experiment2Seeder.create_stale_experiment(
-      experiment_name: "Stale Patient January 2022",
-      start_time: Date.parse("Jan 3, 2021").beginning_of_day,
-      end_time: Date.parse("Feb 2, 2021").end_of_day,
-      max_patients_per_day: 6000
-    )
+    # return unless CountryConfig.current_country?("India") && SimpleServer.env.production?
+    #
+    # Seed::Experiment2Seeder.create_current_experiment(
+    #   experiment_name: "Current Patient January 2022",
+    #   start_time: Date.parse("Jan 3, 2022").beginning_of_day,
+    #   end_time: Date.parse("Feb 2, 2022").end_of_day,
+    #   max_patients_per_day: 9000
+    # )
+    # Seed::Experiment2Seeder.create_stale_experiment(
+    #   experiment_name: "Stale Patient January 2022",
+    #   start_time: Date.parse("Jan 3, 2021").beginning_of_day,
+    #   end_time: Date.parse("Feb 2, 2021").end_of_day,
+    #   max_patients_per_day: 6000
+    # )
+    #
+    # don't do anything, this migration causes problems since it overlaps with 20211227141152_create_january2022_ihci_experiment.rb
   end
 
   def down


### PR DESCRIPTION
**Story card:** n/a

## Because

No-op the first Jan 22 IHCI experiments, they're re-created by the next migration. Having both actively causes issues since they overlap
