### PR TITLE
Add downtime notice for all envs

### DIFF
--- a/app/views/my_facilities/index.html.erb
+++ b/app/views/my_facilities/index.html.erb
@@ -1,7 +1,34 @@
 <% if CountryConfig.current[:name] == "India" && SimpleServer.env.production? %>
   <div class="alert alert-danger mb-48px" role="alert">
-    <h3 class="c-red-dark mt-8px">Maintenance: May 21-22</h3>
+    <h3 class="c-red-dark mt-8px">Maintenance: May 28-29</h3>
     <p class="c-red-dark">The Simple Dashboard will be down for maintenance from the afternoon on Sat May 28 to the evening of Sun May 29.</p>
+    <ul class="c-red-dark">
+      <li>Healthcare workers can still record patients, but sync to the Simple Dashboard will be down.</li>
+      <li>The Simple Dashboard will be inaccessible.</li>
+    </ul>
+  </div>
+<% elsif SimpleServer.env.sandbox? || SimpleServer.env.qa? %>
+  <div class="alert alert-danger mb-48px" role="alert">
+    <h3 class="c-red-dark mt-8px">Maintenance: May 24</h3>
+    <p class="c-red-dark">The Simple Dashboard will be down for maintenance from noon to midnight on Tue May 24.</p>
+    <ul class="c-red-dark">
+      <li>Healthcare workers can still record patients, but sync to the Simple Dashboard will be down.</li>
+      <li>The Simple Dashboard will be inaccessible.</li>
+    </ul>
+  </div>
+<% elsif CountryConfig.current[:name] == "India" && SimpleServer.env.demo? %>
+  <div class="alert alert-danger mb-48px" role="alert">
+    <h3 class="c-red-dark mt-8px">Maintenance: May 25</h3>
+    <p class="c-red-dark">The Simple Dashboard will be down for maintenance from noon to midnight on Wed May 25.</p>
+    <ul class="c-red-dark">
+      <li>Healthcare workers can still record patients, but sync to the Simple Dashboard will be down.</li>
+      <li>The Simple Dashboard will be inaccessible.</li>
+    </ul>
+  </div>
+<% elsif (CountryConfig.current[:name] == "Bangladesh" || CountryConfig.current[:name] == "Sri Lanka") && SimpleServer.env.demo? %>
+  <div class="alert alert-danger mb-48px" role="alert">
+    <h3 class="c-red-dark mt-8px">Maintenance: May 26</h3>
+    <p class="c-red-dark">The Simple Dashboard will be down for maintenance from noon to midnight on Thu May 26.</p>
     <ul class="c-red-dark">
       <li>Healthcare workers can still record patients, but sync to the Simple Dashboard will be down.</li>
       <li>The Simple Dashboard will be inaccessible.</li>


### PR DESCRIPTION
**Story card:** [sc-8268](https://app.shortcut.com/simpledotorg/story/8268/migrate-production-infrastructure?vc_group_by=day&ct_workflow=all&cf_workflow=500000031&workflow_state_ids=500000007&workflow_state_ids=500000006&groupBy=workflowState)

## Because

We are going to be running postgres upgrades/account changes on all environments this week that will involve some downtime. The scheduled downtime for these envs will be
- Sandbox and QA - Tue 24 May noon to evening
- India demo - Wed 25 May noon to evening
- BD and SL demo - Thu 26 May noon to evening
- IHCI production - Sat 28 May noon to evening

## This addresses

Adds a notice to dashboard.
