### PR TITLE
Update QA and SBX server addresses

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,1 +1,1 @@
-server "ec2-3-108-62-212.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db sidekiq cron]
+server "ec2-3-111-217-201.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db sidekiq cron]

--- a/config/deploy/sandbox.rb
+++ b/config/deploy/sandbox.rb
@@ -1,2 +1,2 @@
-server "ec2-52-66-104-164.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db cron whitelist_phone_numbers seed_data]
+server "ec2-3-109-144-155.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db cron whitelist_phone_numbers seed_data]
 server "ec2-3-108-193-51.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web sidekiq]


### PR DESCRIPTION
**Story card:** [sc-8306](https://app.shortcut.com/simpledotorg/story/8306/upgrade-postgres-to-14-on-non-prod-envs)

## Because

We stopped the server instances while upgrading Postgresql to 14.2

## This addresses

Adds the new server addresses