### PR TITLE
Move india staging to dev AWS

### DIFF
--- a/app/views/my_facilities/index.html.erb
+++ b/app/views/my_facilities/index.html.erb
@@ -7,9 +7,18 @@
       <li>The Simple Dashboard will be inaccessible.</li>
     </ul>
   </div>
-<% elsif CountryConfig.current[:name] == "India" && SimpleServer.env.demo? %>
+<% elsif CountryConfig.current[:name] == "Bangladesh" && SimpleServer.env.production? %>
   <div class="alert alert-danger mb-48px" role="alert">
-    <h3 class="c-red-dark mt-8px">Maintenance: May 25</h3>
+    <h3 class="c-red-dark mt-8px">Maintenance: May 31</h3>
+    <p class="c-red-dark">The Simple Dashboard will be down for maintenance from noon to midnight on Wed May 25.</p>
+    <ul class="c-red-dark">
+      <li>Healthcare workers can still record patients, but sync to the Simple Dashboard will be down.</li>
+      <li>The Simple Dashboard will be inaccessible.</li>
+    </ul>
+  </div>
+<% elsif CountryConfig.current[:name] == "Sri Lanka" && SimpleServer.env.production? %>
+  <div class="alert alert-danger mb-48px" role="alert">
+    <h3 class="c-red-dark mt-8px">Maintenance: May 30</h3>
     <p class="c-red-dark">The Simple Dashboard will be down for maintenance from noon to midnight on Wed May 25.</p>
     <ul class="c-red-dark">
       <li>Healthcare workers can still record patients, but sync to the Simple Dashboard will be down.</li>

--- a/config/deploy/india/staging.rb
+++ b/config/deploy/india/staging.rb
@@ -1,1 +1,1 @@
-server "ec2-3-110-48-223.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db sidekiq cron seed_data]
+server "ec2-3-6-210-241.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db sidekiq cron seed_data]


### PR DESCRIPTION
**Story card:** [ch8213](https://app.shortcut.com/simpledotorg/story/8213/end-to-end-trial-of-the-migration-using-the-demo-env)

## Because

We moved india staging to the `simple-dev` AWS account.

## This addresses

Updates host IPs. Updates the downtime notice