### PR TITLE
Fix totals on details dashboard

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -3,7 +3,7 @@ class Reports::RegionsController < AdminController
   include GraphicsDownload
   include RegionSearch
 
-  before_action :set_period, only: [:show, :cohort, :diabetes]
+  before_action :set_period, only: [:show, :cohort, :diabetes, :details]
   before_action :set_page, only: [:show, :details]
   before_action :set_per_page, only: [:show, :details]
   before_action :find_region, except: [:index, :fastindex, :monthly_district_data_report]


### PR DESCRIPTION
**Story card:** [sc-8359](https://app.shortcut.com/simpledotorg/story/8359)

## Because

Totals on details page broke during a recent reporting refactor.

## This addresses

Fixes the bug. This was broken since `current_period` was not being set on the details page.

Before
![image](https://user-images.githubusercontent.com/16774200/170506499-2e4fddde-a132-4681-a763-9722a98c05f5.png)

After 
![image](https://user-images.githubusercontent.com/16774200/170506423-160ba31f-1c12-47c4-adb6-b3ebbf714674.png)
