### PR TITLE
Remove user breakdown tables from diabetes reports

### DIFF
--- a/app/views/reports/regions/diabetes.html.erb
+++ b/app/views/reports/regions/diabetes.html.erb
@@ -270,9 +270,7 @@
   <%= render "bs_measurement_child_tables", children_data: @children_data, localized_region_type: @child_regions.first.localized_region_type %>
 <% end %>
 
-<% if @region.facility_region? %>
-  <%= render "facility_details" %>
-<% else %>
+<% if !@region.facility_region? %>
   <%= render(DiabetesRegistrationsAndFollowUpsComponent.new(@region,
     current_admin: current_admin,
     repository: @details_repository,


### PR DESCRIPTION
These tables were incorrectly added, probably due to a bad merge. They are currently displaying hypertension data. 