### PR TITLE
Switch to simple-standalone

### DIFF
--- a/.semaphore/ethiopia_demo_deployment.yml
+++ b/.semaphore/ethiopia_demo_deployment.yml
@@ -6,8 +6,8 @@ blocks:
       jobs:
         - name: Deploy to Ethiopia Demo
           commands:
-            - git clone https://github.com/simpledotorg/deployment
-            - cd deployment/standalone
+            - git clone https://github.com/simpledotorg/simple-standalone
+            - cd simple-standalone
             - make init
             - "make deploy hosts=ethiopia/demo password_file=~/.ansible/vault_password_et branch=$SEMAPHORE_GIT_SHA"
       secrets:

--- a/.semaphore/ethiopia_production_deployment.yml
+++ b/.semaphore/ethiopia_production_deployment.yml
@@ -6,8 +6,8 @@ blocks:
       jobs:
         - name: Deploy to Ethiopia Production
           commands:
-            - git clone https://github.com/simpledotorg/deployment
-            - cd deployment/standalone
+            - git clone https://github.com/simpledotorg/simple-standalone
+            - cd simple-standalone
             - make init
             - "make deploy hosts=ethiopia/production password_file=~/.ansible/vault_password_et branch=$SEMAPHORE_GIT_SHA"
       secrets:


### PR DESCRIPTION
**Story card:** [sc-8429](https://app.shortcut.com/simpledotorg/story/8429/fix-semaphore-deployments-to-standalone-envs)

## Because

We've switched to using `https://github.com/simpledotorg/simple-standalone` to manage standalone envs

## This addresses

Updates the semaphore deployment scripts to use the new repo