### PR TITLE
Fix ltfu toggle bug

### DIFF
--- a/app/views/reports/regions/_ltfu_toggle.html.erb
+++ b/app/views/reports/regions/_ltfu_toggle.html.erb
@@ -1,8 +1,9 @@
 <div class="align-right custom-control custom-switch">
-  <form method="get">
+  <form method="get" name="ltfu_form">
     <input type="checkbox"
            onChange="this.form.submit()"
            name="with_ltfu"
+           for="ltfu_form"
            class="custom-control-input"
            id="<%= id %>"
            <% if enabled %>checked<% end %>>
@@ -12,8 +13,8 @@
     </label>
     <% if params[:period].present? %>
       <!-- Preserve period selection in reports header -->
-      <input type="hidden" form="ltfu_form" name="period[type]" value="<%= params[:period]["type"] %>">
-      <input type="hidden" form="ltfu_form" name="period[value]" value="<%= params[:period]["value"] %>">
+      <input type="hidden" for="ltfu_form" name="period[type]" value="<%= params[:period]["type"] %>">
+      <input type="hidden" for="ltfu_form" name="period[value]" value="<%= params[:period]["value"] %>">
     <% end %>
   </form>
 </div>


### PR DESCRIPTION
When the ltfu toggle is clicked, it resets the period for the report.
This change fixes this behavior.

**Story card:** [sc-8172](https://app.shortcut.com/simpledotorg/story/8172/fix-unexpected-ltfu-toggle-behaviour)

## Because

When the ltfu toggle is clicked, it resets the period for the report.

## This addresses

The form was not named, so the period params were being reset on submit. We have named the form in this PR. 

## Test instructions

- On the reports page, select a period from the drop down
- When the ltfu toggle is clicked, the forms should show the reports including LTFU data, and the period should remain the same as previously selected. 
- The period selection should also be seen in the url params