### PR TITLE
Remove dead patient count from assigned patient count in patient breakdown card

### DIFF
--- a/app/views/reports/regions/_diabetes_patient_breakdown_charts.html.erb
+++ b/app/views/reports/regions/_diabetes_patient_breakdown_charts.html.erb
@@ -36,7 +36,9 @@
           </span>
           </p>
           <p class="mb-8px fw-bold">
-            <%= number_with_delimiter(@details_chart_data[:patient_breakdown][:total_assigned_patients]) %>
+            <%= number_with_delimiter(
+                  @details_chart_data[:patient_breakdown][:total_assigned_patients] - @details_chart_data[:patient_breakdown][:dead_patients]
+                ) %>
           </p>
         </div>
       <% end %>

--- a/app/views/reports/regions/_hypertension_patient_coverage.html.erb
+++ b/app/views/reports/regions/_hypertension_patient_coverage.html.erb
@@ -102,6 +102,8 @@
     </span>
   </p>
   <p class="mb-8px fw-bold">
-    <%= number_with_delimiter(@details_chart_data[:patient_breakdown][:total_assigned_patients]) %>
+    <%= number_with_delimiter(
+          @details_chart_data[:patient_breakdown][:total_assigned_patients] - @details_chart_data[:patient_breakdown][:dead_patients]
+        ) %>
   </p>
 </div>


### PR DESCRIPTION
**Story card:** [sc-8478](https://app.shortcut.com/simpledotorg/story/8478/remove-dead-patient-count-from-assigned-patient-count-in-patient-breakdown-card)

## Because

As per the slack discussion [here](https://simpledotorg.slack.com/archives/CFHKJ5WJY/p1654754874885769?thread_ts=1654623265.477299&cid=CFHKJ5WJY),  we need to remove the dead patient counts from assigned patient counts in Patient breakdown card

## This addresses

Removes the dead patient counts from assigned patient counts in the Patient breakdown card

## Test instructions

- Go to Reports> Hypertension or Reports/Diabetes
- You should now see the assigned patients count as the sum of  `Patient under care` and `LTFU patient`
