### PR TITLE
Add missed visits to user analytics

### DIFF
--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -48,7 +48,7 @@ body#progress {
     .cohort-controlled {
         background: $green;
         color: $white;
-        border-radius: 0 3px 3px 0;
+        border-radius: none;
     }
 
     .cohort-uncontrolled {
@@ -61,6 +61,12 @@ body#progress {
         background: $grey-light;
         color: $grey-darkest;
         border-radius: 3px 0 0 3px;
+    }
+
+    .cohort-missed-visits {
+        background: $blue;
+        color: $white;
+        border-radius: 0 3px 3px 0;
     }
 
     .cohort-none {
@@ -89,6 +95,10 @@ body#progress {
 
         &.red {
             background: $red;
+        }
+
+        &.blue {
+            background: $blue;
         }
     }
 

--- a/app/presenters/user_analytics_presenter.rb
+++ b/app/presenters/user_analytics_presenter.rb
@@ -25,6 +25,10 @@ class UserAnalyticsPresenter
     display_percentage(cohort[:no_bp], cohort[:registered])
   end
 
+  def cohort_missed_visits(cohort)
+    display_percentage(cohort[:missed_visits], cohort[:registered])
+  end
+
   def diabetes_enabled?
     current_facility.diabetes_enabled?
   end

--- a/app/presenters/user_analytics_presenter.rb
+++ b/app/presenters/user_analytics_presenter.rb
@@ -2,6 +2,7 @@ class UserAnalyticsPresenter
   include ApplicationHelper
   include DashboardHelper
   include ActionView::Helpers::NumberHelper
+  include Reports::Percentage
   include BustCache
 
   def initialize(current_facility)
@@ -14,30 +15,36 @@ class UserAnalyticsPresenter
   EXPIRE_STATISTICS_CACHE_IN = 15.minutes
 
   def cohort_controlled(cohort)
-    display_percentage(cohort[:controlled], cohort[:registered])
+    display_percentage(cohort_percentages(cohort)[:controlled])
   end
 
   def cohort_uncontrolled(cohort)
-    display_percentage(cohort[:uncontrolled], cohort[:registered])
+    display_percentage(cohort_percentages(cohort)[:uncontrolled])
   end
 
   def cohort_no_bp(cohort)
-    display_percentage(cohort[:no_bp], cohort[:registered])
+    display_percentage(cohort_percentages(cohort)[:no_bp])
   end
 
   def cohort_missed_visits(cohort)
-    display_percentage(cohort[:missed_visits], cohort[:registered])
+    display_percentage(cohort_percentages(cohort)[:missed_visits])
+  end
+
+  def cohort_percentages(cohort)
+    rounded_percentages({
+      controlled: cohort[:controlled],
+      uncontrolled: cohort[:uncontrolled],
+      no_bp: cohort[:no_bp],
+      missed_visits: cohort[:missed_visits]
+    })
   end
 
   def diabetes_enabled?
     current_facility.diabetes_enabled?
   end
 
-  def display_percentage(numerator, denominator)
-    return "0%" if denominator.nil? || denominator.zero? || numerator.nil?
-    percentage = (numerator * 100.0) / denominator
-
-    "#{percentage.round(0)}%"
+  def display_percentage(percentage)
+    "#{percentage}%"
   end
 
   def last_updated_at

--- a/app/views/api/v3/analytics/user_analytics/_progress_cohort_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_progress_cohort_report.html.erb
@@ -23,6 +23,9 @@
       <p class="left" style="color: #6C737A;">
         <span class="key-color grey"></span> <%= raw t("analytics.patients_with_no_bp_measure") %>
       </p>
+      <p class="left" style="color: #0075eb;">
+        <span class="key-color blue"></span> <%= raw t("analytics.patients_with_missed_visits") %>
+      </p>
     </div>
     <% @user_analytics.statistics.dig(:cohorts).each do |cohort| %>
       <div class="card cohort">
@@ -48,6 +51,9 @@
               </td>
               <td class="cohort-controlled" style="width: <%= @user_analytics.cohort_controlled(cohort) %>;">
                 <%= @user_analytics.cohort_controlled(cohort) %>
+              </td>
+              <td class="cohort-missed-visits" style="width: <%= @user_analytics.cohort_missed_visits(cohort) %>;">
+                <%= @user_analytics.cohort_missed_visits(cohort) %>
               </td>
             <% end %>
           </tr>

--- a/config/locales/api/en.yml
+++ b/config/locales/api/en.yml
@@ -57,6 +57,7 @@ en:
     patients_with_controlled_bp: "Patients visited with BP &lt;140/90"
     patients_with_uncontrolled_bp: "Patients visited with BP &ge;140/90"
     patients_with_no_bp_measure: "Patients with no BP measure"
+    patients_with_missed_visits: "Patients with a missed visit"
     registered_in: "registered in"
     result_from_last_visit_in: "Result from last visit in"
     no_patients: "No patients"

--- a/spec/presenters/user_analytics_presenter_spec.rb
+++ b/spec/presenters/user_analytics_presenter_spec.rb
@@ -164,28 +164,4 @@ RSpec.describe UserAnalyticsPresenter, type: :model do
       end
     end
   end
-
-  describe "#display_percentage" do
-    let(:current_facility) { create(:facility, facility_group: current_user.facility.facility_group) }
-
-    it "displays 0% if denominator is zero" do
-      expect(described_class.new(current_facility).display_percentage(2, 0)).to eq("0%")
-    end
-
-    it "displays 0% if denominator is nil" do
-      expect(described_class.new(current_facility).display_percentage(2, nil)).to eq("0%")
-    end
-
-    it "displays 0% if numerator is zero" do
-      expect(described_class.new(current_facility).display_percentage(0, 3)).to eq("0%")
-    end
-
-    it "displays 0% if numerator is nil" do
-      expect(described_class.new(current_facility).display_percentage(nil, 2)).to eq("0%")
-    end
-
-    it "displays the percentage rounded up" do
-      expect(described_class.new(current_facility).display_percentage(22, 7)).to eq("314%")
-    end
-  end
 end


### PR DESCRIPTION
**Story card:** [sc-8241](https://app.shortcut.com/simpledotorg/story/8241/include-missed-visits-in-progress-tab-cohort-reports)

## Because

Currently we don't show the percentage of missed visits in the progress reports, which causes confusion as the missed visits don't add up to 100.

## This addresses

Adds missed visits to cohort reports in the progress tab

## Test instructions

1. Generate user auth token using `bundle exec rails get_user_credentials`
2. Set the credentials in the request header
3. Navigate to `api/v3/analytics/user_analytics.html`
4. Click on `Cohort Reports` 
5. The cohort reports should have a missed visits bar, and all the percentages should add up to 100. 