### PR TITLE
Fix docker compose up command typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Beyond that, the setup instructions are now the same for Intel or M1 macs, as yo
 For quick development and testing, the server can be run locally using Docker Compose and the command:
 
 ```
-docker compose up
+docker-compose up
 ```
 
 The Dockerfile and docker-compose.yml files replicate the steps detailed below for manual installation, including the running of ngrok for local android development.


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

## Because

Typo in docker section of the readme

## This addresses

Fix docker compose up command typo in readme

## Test instructions

NA