### PR TITLE
Fix patient_states current age spec

### DIFF
--- a/spec/models/reports/patient_state_spec.rb
+++ b/spec/models/reports/patient_state_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
   context "indicators" do
     describe "current_age" do
       it "determines the current age of the patient given their age, age_updated_at" do
-        patient = create(:patient, age: 58, recorded_at: 2.years.ago, age_updated_at: 2.years.ago)
+        current_date = Timecop.unfreeze { Date.today }
+        patient = create(:patient, age: 58, recorded_at: 2.years.ago, age_updated_at: current_date - 2.years)
         described_class.refresh
         with_reporting_time_zone do
           expect(described_class.where(patient_id: patient.id).pluck(:current_age)).to all eq(60)
@@ -30,7 +31,8 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
       end
 
       it "determines the current age of the patient given their dob, and prefers it even when age is present" do
-        patient = create(:patient, date_of_birth: 80.years.ago, age: 58, recorded_at: 2.years.ago, age_updated_at: 2.years.ago)
+        current_date = Timecop.unfreeze { Date.today }
+        patient = create(:patient, date_of_birth: current_date - 80.years, age: 58, recorded_at: 2.years.ago, age_updated_at: 2.years.ago)
         described_class.refresh
         with_reporting_time_zone do
           expect(described_class.where(patient_id: patient.id).pluck(:current_age)).to all eq(80)


### PR DESCRIPTION
**Story card:** -

## Because

A spec in `reporting_patient_states` is failing because it calculates age as of `Jun 30th 2021` using Timecop. Postgres is not affected by timecop though so the spec started breaking as of `July 1st 2022`.

## This addresses

Fixes the spec