### PR TITLE
Remove dm flags

### DIFF
--- a/app/assets/stylesheets/partials/_navigation.scss
+++ b/app/assets/stylesheets/partials/_navigation.scss
@@ -245,12 +245,20 @@ TABBED NAVIGATION
     padding-right: 0;
     margin-right: 22px;
     color: $grey-dark;
-    
+
     &:hover {
       color: $grey-darkest;
     }
   }
-  
+
+  span.nav-link {
+    color: $grey-darkest;
+
+    &:hover {
+      color: $grey-darkest;
+    }
+  }
+
   .nav-link.active {
     color: $red;
     border-bottom: 2px solid $red;

--- a/app/components/diabetes_registrations_and_follow_ups_component.html.erb
+++ b/app/components/diabetes_registrations_and_follow_ups_component.html.erb
@@ -85,12 +85,7 @@
           <% slug = resource.region.slug %>
           <tr>
             <td class="row-title">
-              <% if current_admin.feature_enabled?(:diabetes_management_reports) %>
-                <%= link_to resource.name, reports_region_path(resource.region, report_scope: resource.region_type) %>
-              <% else %>
-                <%= link_to resource.name, reports_region_details_path(resource.region, report_scope: resource.region_type) %>
-              <% end %>
-
+              <%= link_to resource.name, reports_region_path(resource.region, report_scope: resource.region_type) %>
             </td>
             <td class="ta-right">
               <%= number_or_dash_with_delimiter(repository.cumulative_diabetes_registrations[slug][current_period]) %>

--- a/app/components/registrations_and_follow_ups_component.html.erb
+++ b/app/components/registrations_and_follow_ups_component.html.erb
@@ -87,12 +87,7 @@
           <% slug = resource.region.slug %>
           <tr>
             <td class="row-title">
-              <% if current_admin.feature_enabled?(:diabetes_management_reports) %>
-                <%= link_to resource.name, reports_region_path(resource.region, report_scope: resource.region_type) %>
-              <% else %>
-                <%= link_to resource.name, reports_region_details_path(resource.region, report_scope: resource.region_type) %>
-              <% end %>
-
+              <%= link_to resource.name, reports_region_path(resource.region, report_scope: resource.region_type) %>
             </td>
             <td class="ta-right">
               <%= number_or_dash_with_delimiter(repository.cumulative_registrations[slug][current_period]) %>
@@ -164,12 +159,7 @@
           <% next unless repository.earliest_patient_recorded_at[resource.slug] %>
           <tr>
             <td class="row-title">
-              <% if current_admin.feature_enabled?(:diabetes_management_reports) %>
-                <%= link_to resource.name, reports_region_path(resource.region, report_scope: resource.region_type) %>
-              <% else %>
-                <%= link_to resource.name, reports_region_details_path(resource.region, report_scope: resource.region_type) %>
-              <% end %>
-
+              <%= link_to resource.name, reports_region_path(resource.region, report_scope: resource.region_type) %>
             </td>
             <% range.each do |period| %>
               <td class="ta-right">

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -115,7 +115,6 @@ class Reports::RegionsController < AdminController
     # ======================
     @cohort_period = Period.quarter(Time.current)
     @cohort_data = CohortService.new(region: @region, periods: @cohort_period.downto(5)).call
-    
 
     @data = @overview_data
 

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -77,49 +77,47 @@ class Reports::RegionsController < AdminController
       }
     }
 
-    if current_admin.feature_enabled?(:diabetes_management_reports)
-      # ======================
-      # DETAILS
-      # ======================
-      @details_period = Period.month(Time.current)
-      @details_period_range = Range.new(@details_period.advance(months: -5), @details_period)
-      months = -(Reports::MAX_MONTHS_OF_DATA - 1)
+    # ======================
+    # DETAILS
+    # ======================
+    @details_period = Period.month(Time.current)
+    @details_period_range = Range.new(@details_period.advance(months: -5), @details_period)
+    months = -(Reports::MAX_MONTHS_OF_DATA - 1)
 
-      regions = if @region.facility_region?
-        [@region]
-      else
-        [@region, @region.reportable_children].flatten
-      end
-
-      if current_admin.feature_enabled?(:show_call_results) && @region.state_region?
-        regions.concat(@region.district_regions)
-      end
-
-      @details_repository = Reports::Repository.new(regions, periods: @details_period_range)
-
-      chart_range = (@details_period.advance(months: months)..@details_period)
-      chart_repo = Reports::Repository.new(@region, periods: chart_range)
-      @details_chart_data = {
-        patient_breakdown: PatientBreakdownService.call(region: @region, period: @details_period)[:hypertension],
-        ltfu_trend: ltfu_chart_data(chart_repo, chart_range),
-        **medications_dispensation_data(region: @region, period: @details_period, diagnosis: :hypertension)
-      }
-
-      if @region.facility_region?
-        @recent_blood_pressures = paginate(
-          @region.source.blood_pressures.for_recent_bp_log.includes(:patient, :facility)
-        )
-      end
-
-      # ======================
-      # COHORT REPORTS
-      # ======================
-      @cohort_period = Period.quarter(Time.current)
-      @cohort_data = CohortService.new(region: @region, periods: @cohort_period.downto(5)).call
+    regions = if @region.facility_region?
+      [@region]
+    else
+      [@region, @region.reportable_children].flatten
     end
 
+    if current_admin.feature_enabled?(:show_call_results) && @region.state_region?
+      regions.concat(@region.district_regions)
+    end
+
+    @details_repository = Reports::Repository.new(regions, periods: @details_period_range)
+
+    chart_range = (@details_period.advance(months: months)..@details_period)
+    chart_repo = Reports::Repository.new(@region, periods: chart_range)
+    @details_chart_data = {
+      patient_breakdown: PatientBreakdownService.call(region: @region, period: @details_period)[:hypertension],
+      ltfu_trend: ltfu_chart_data(chart_repo, chart_range),
+      **medications_dispensation_data(region: @region, period: @details_period, diagnosis: :hypertension)
+    }
+
+    if @region.facility_region?
+      @recent_blood_pressures = paginate(
+        @region.source.blood_pressures.for_recent_bp_log.includes(:patient, :facility)
+      )
+    end
+
+    # ======================
+    # COHORT REPORTS
+    # ======================
+    @cohort_period = Period.quarter(Time.current)
+    @cohort_data = CohortService.new(region: @region, periods: @cohort_period.downto(5)).call
+    
+
     @data = @overview_data
-    @data.merge!(@details_chart_data) if current_admin.feature_enabled?(:diabetes_management_reports)
 
     respond_to do |format|
       format.html
@@ -170,10 +168,6 @@ class Reports::RegionsController < AdminController
   end
 
   def diabetes
-    unless current_admin.feature_enabled?(:diabetes_management_reports) && @region.diabetes_management_enabled?
-      raise ActionController::RoutingError.new("Not Found")
-    end
-
     start_period = @period.advance(months: -(Reports::MAX_MONTHS_OF_DATA - 1))
     range = Range.new(start_period, @period)
     @repository = Reports::Repository.new(@region, periods: range)

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -52,7 +52,7 @@
              blood_pressures: @recent_blood_pressures,
              display_model: :user %>
 
-  <% if current_admin.feature_enabled?(:diabetes_management_reports) && @recent_blood_sugars.present? %>
+  <% if @recent_blood_sugars.present? %>
     <%= render Dashboard::Diabetes::RecentMeasurementsComponent.new(
       user: @user,
       recent_blood_sugars: @recent_blood_sugars,

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -32,7 +32,7 @@
         <% if @region.diabetes_management_enabled? %>
           <%= link_to "Hypertension", url_params.merge(action: "show"), class: "nav-link #{active_action?("show")}" %>
         <% else %>
-          <span class="nav-link">Hypertension report</span>
+          <h3>Hypertension report</h3>
         <% end %>
         <% if @region.diabetes_management_enabled? %>
           <%= link_to "Diabetes", reports_region_diabetes_path(@region, report_scope: params[:report_scope]), class: "nav-link #{active_action?("diabetes")}" %>

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -29,15 +29,13 @@
   <div class="d-flex fd-column fd-lg-row justify-lg-between mb-24px d-print-none">
     <div class="d-flex order-2 order-lg-1">
       <nav class="nav">
-        <% if current_admin.feature_enabled?(:diabetes_management_reports) %>
+        <% if @region.diabetes_management_enabled? %>
           <%= link_to "Hypertension", url_params.merge(action: "show"), class: "nav-link #{active_action?("show")}" %>
-          <% if @region.diabetes_management_enabled? %>
-            <%= link_to "Diabetes", reports_region_diabetes_path(@region, report_scope: params[:report_scope]), class: "nav-link #{active_action?("diabetes")}" %>
-          <% end %>
         <% else %>
-          <%= link_to "Overview", url_params.merge(action: "show"), class: "nav-link #{active_action?("show")}" %>
-          <%= link_to "Details", url_params.merge(action: "details"), class: "nav-link #{active_action?("details")}" %>
-          <%= link_to "Cohort reports", reports_region_cohort_path(@region, report_scope: params[:report_scope]), class: "nav-link #{active_action?("cohort")}" %>
+          <span class="nav-link">Hypertension report</span>
+        <% end %>
+        <% if @region.diabetes_management_enabled? %>
+          <%= link_to "Diabetes", reports_region_diabetes_path(@region, report_scope: params[:report_scope]), class: "nav-link #{active_action?("diabetes")}" %>
         <% end %>
         <% if @region.facility_region? && current_admin.feature_enabled?(:dashboard_progress_reports) %>
             <%= link_to "Progress", reports_progress_path(@region), :class => "nav-link" %>
@@ -105,7 +103,7 @@
       <% end %>
 
       <div class="ml-8px">
-        <% if current_admin.feature_enabled?(:diabetes_management_reports) && action_name == "diabetes"%>
+        <% if action_name == "diabetes"%>
           <div class="dropdown show mb-24px bs-small mb-lg-0">
             <a class="btn btn-sm dropdown-toggle c-grey-medium bg-white disabled" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <i class="fa fa-arrow-circle-down w-16px ta-center mr-4px c-grey-medium"></i>

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -32,7 +32,7 @@
         <% if @region.diabetes_management_enabled? %>
           <%= link_to "Hypertension", url_params.merge(action: "show"), class: "nav-link #{active_action?("show")}" %>
         <% else %>
-          <h3>Hypertension report</h3>
+          <span class="nav-link">Hypertension report</span>
         <% end %>
         <% if @region.diabetes_management_enabled? %>
           <%= link_to "Diabetes", reports_region_diabetes_path(@region, report_scope: params[:report_scope]), class: "nav-link #{active_action?("diabetes")}" %>

--- a/app/views/reports/regions/_hypertension_downloads.html.erb
+++ b/app/views/reports/regions/_hypertension_downloads.html.erb
@@ -1,8 +1,7 @@
 <div class="dropdown show mb-24px bs-small mb-lg-0">
   <a class="btn btn-sm dropdown-toggle c-black bg-white" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <i class="fa fa-arrow-circle-down w-16px ta-center mr-4px c-blue"></i>
-    Downloads
-    <% if current_admin.feature_enabled?(:diabetes_management_reports) %>(HTN)<% end %>
+    Downloads <% if @region.diabetes_management_enabled? %>(HTN)<% end %>
   </a>
   <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
 

--- a/app/views/reports/regions/_overview_footnotes.html.erb
+++ b/app/views/reports/regions/_overview_footnotes.html.erb
@@ -1,9 +1,9 @@
 <div class="row mt-5 mb-64px">
     <div class="col-lg-7">
-      <h4 class="mb-16px pb-8px">
-        Definitions
-      </h4>
-      <div class="mb-24px">
+    <h4 class="mb-16px pb-8px">
+      Definitions
+    </h4>
+    <div class="mb-24px">
         <p class="mb-8px fs-16px fw-bold c-grey-dark">
           Total assigned patients
         </p>
@@ -12,8 +12,8 @@
             <%= t("assigned_patients_copy.total_assigned_patients", region_name: @region.name) %>
           </p>
         </div>
-      </div>
-      <div class="mb-24px">
+    </div>
+    <div class="mb-24px">
         <p class="mb-8px fs-16px fw-bold c-grey-dark">
           Total registered patients
         </p>
@@ -22,8 +22,8 @@
             <%= t("registered_patients_copy.total_registered_patients", region_name: @region.name) %>
           </p>
         </div>
-      </div>
-      <div class="mb-24px">
+    </div>
+    <div class="mb-24px">
         <p class="mb-8px fs-16px fw-bold c-grey-dark">
           Monthly registered patients
         </p>
@@ -32,8 +32,8 @@
             <%= t("registered_patients_copy.monthly_registered_patients", region_name: @region.name) %>
           </p>
         </div>
-      </div>
-      <div class="mb-24px">
+    </div>
+    <div class="mb-24px">
         <p class="mb-8px fs-16px fw-bold c-grey-dark">
           BP controlled
         </p>
@@ -45,8 +45,8 @@
             <strong>Denominator:</strong> <%= t("denominator_copy", region_name: @region.name) %>
           </p>
         </div>
-      </div>
-      <div class="mb-24px">
+    </div>
+    <div class="mb-24px">
         <p class="mb-8px fs-16px fw-bold c-grey-dark">
           BP not controlled
         </p>
@@ -58,8 +58,8 @@
             <strong>Denominator</strong> <%= t("denominator_copy", region_name: @region.name) %>
           </p>
         </div>
-      </div>
-      <div class="mb-24px">
+    </div>
+    <div class="mb-24px">
         <p class="mb-8px fs-16px fw-bold c-grey-dark">
           Missed visits
         </p>
@@ -71,8 +71,8 @@
             <strong>Denominator</strong> <%= t("denominator_copy", region_name: @region.name) %>
           </p>
         </div>
-      </div>
-      <div class="mb-24px">
+    </div>
+    <div class="mb-24px">
         <p class="mb-8px fs-16px fw-bold c-grey-dark">
           Visit but no BP taken
         </p>
@@ -84,8 +84,8 @@
             <strong>Denominator</strong> <%= t("denominator_copy", region_name: @region.name) %>
           </p>
         </div>
-      </div>
-      <div class="mb-24px">
+    </div>
+    <div class="mb-24px">
         <p class="mb-8px fs-16px fw-bold c-grey-dark">
           Patients under care
         </p>
@@ -94,85 +94,84 @@
             <%= t("patients_under_care_copy") %>
           </p>
         </div>
+    </div>
+      
+    <div class="mb-24px">
+      <p class="mb-8px fs-16px fw-bold c-grey-dark">
+        Lost to follow-up
+      </p>
+      <div class="pl-16px">
+        <p class="mb-8px fs-14px c-grey-dark">
+          <strong>Numerator:</strong> <%= t("lost_to_follow_up_copy.numerator") %>
+        </p>
+        <p class="mb-0px fs-14px c-grey-dark">
+          <strong>Denominator</strong> <%= t("ltfu_denominator_copy", region_name: @region.name) %>
+        </p>
       </div>
-      <% if current_admin.feature_enabled?(:diabetes_management_reports) %>
-        <div class="mb-24px">
-          <p class="mb-8px fs-16px fw-bold c-grey-dark">
-            Lost to follow-up
-          </p>
-          <div class="pl-16px">
-            <p class="mb-8px fs-14px c-grey-dark">
-              <strong>Numerator:</strong> <%= t("lost_to_follow_up_copy.numerator") %>
-            </p>
-            <p class="mb-0px fs-14px c-grey-dark">
-              <strong>Denominator</strong> <%= t("ltfu_denominator_copy", region_name: @region.name) %>
-            </p>
-          </div>
-        </div>
-        <div class="mb-24px">
-          <p class="mb-8px fs-16px fw-bold c-grey-dark">
-            <% if @region.facility_region? %>
-              Follow-up patients per user
-            <% else %>
-              Follow-up patients
-            <% end %>
-          </p>
-          <div class="pl-16px">
-            <p class="mb-8px fs-14px c-grey-dark">
-              <%= t(:follow_up_patients_copy, region_name: @region.name) %>
-            </p>
-          </div>
-        </div>
+    </div>
+    <div class="mb-24px">
+      <p class="mb-8px fs-16px fw-bold c-grey-dark">
         <% if @region.facility_region? %>
-          <div class="mb-0px">
-            <p class="mb-8px fs-16px fw-bold c-grey-dark">
-              BP measures taken
-            </p>
-            <div class="pl-16px">
-              <p class="mb-8px fs-14px c-grey-dark">
-                <%= t("bp_measures_taken_copy", region_name: @region.name) %>
-              </p>
-            </div>
-          </div>
+          Follow-up patients per user
+        <% else %>
+          Follow-up patients
         <% end %>
-        <% if @region.supports_htn_population_coverage %>
-          <div class="mb-24px">
-            <p class="mb-8px fs-16px fw-bold c-grey-dark">
-              Hypertension patient coverage
-            </p>
-            <div class="pl-16px">
-              <p class="mb-8px fs-14px c-grey-dark">
-                <%= t("hypertension_patient_coverage_copy") %>
-              </p>
-            </div>
-          </div>
-          <div class="mb-24px">
-            <p class="mb-8px fs-16px fw-bold c-grey-dark">
-              Total estimated hypertensive population
-            </p>
-            <div class="pl-16px">
-              <p class="mb-8px fs-14px c-grey-dark">
-                <%= total_estimated_hypertensive_population_copy(@region) %>
-              </p>
-            </div>
-          </div>
-        <% end %>
-        <% if current_admin.feature_enabled?(:medications_dispensation) %>
-          <div class="mb-0px">
-          <p class="mb-8px fs-16px fw-bold c-grey-dark">
-            Days of medications handed to follow-up patients
+      </p>
+      <div class="pl-16px">
+        <p class="mb-8px fs-14px c-grey-dark">
+          <%= t(:follow_up_patients_copy, region_name: @region.name) %>
+        </p>
+      </div>
+    </div>
+    <% if @region.facility_region? %>
+      <div class="mb-0px">
+        <p class="mb-8px fs-16px fw-bold c-grey-dark">
+          BP measures taken
+        </p>
+        <div class="pl-16px">
+          <p class="mb-8px fs-14px c-grey-dark">
+            <%= t("bp_measures_taken_copy", region_name: @region.name) %>
           </p>
-          <div class="pl-16px">
-            <p class="mb-8px fs-14px c-grey-dark">
-              <strong>Numerator:</strong> <%= t("medications_dispensation_copy.numerator") %>
-            </p>
-            <p class="mb-0px fs-14px c-grey-dark">
-              <strong>Denominator</strong> <%= t("medications_dispensation_copy.denominator") %>
-            </p>
-          </div>
-          </div>
-        <% end %>
-      <% end %>
+        </div>
+      </div>
+    <% end %>
+    <% if @region.supports_htn_population_coverage %>
+      <div class="mb-24px">
+        <p class="mb-8px fs-16px fw-bold c-grey-dark">
+          Hypertension patient coverage
+        </p>
+        <div class="pl-16px">
+          <p class="mb-8px fs-14px c-grey-dark">
+            <%= t("hypertension_patient_coverage_copy") %>
+          </p>
+        </div>
+      </div>
+      <div class="mb-24px">
+        <p class="mb-8px fs-16px fw-bold c-grey-dark">
+          Total estimated hypertensive population
+        </p>
+        <div class="pl-16px">
+          <p class="mb-8px fs-14px c-grey-dark">
+            <%= total_estimated_hypertensive_population_copy(@region) %>
+          </p>
+        </div>
+      </div>
+    <% end %>
+    <% if current_admin.feature_enabled?(:medications_dispensation) %>
+      <div class="mb-0px">
+      <p class="mb-8px fs-16px fw-bold c-grey-dark">
+        Days of medications handed to follow-up patients
+      </p>
+      <div class="pl-16px">
+        <p class="mb-8px fs-14px c-grey-dark">
+          <strong>Numerator:</strong> <%= t("medications_dispensation_copy.numerator") %>
+        </p>
+        <p class="mb-0px fs-14px c-grey-dark">
+          <strong>Denominator</strong> <%= t("medications_dispensation_copy.denominator") %>
+        </p>
+      </div>
+      </div>
+    <% end %>
     </div>
     <% unless @region.region_type == "facility" %>
     <div class="col-lg-5">

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -106,8 +106,7 @@
       <div class="h-320px mr-13px ml-13px pb-4px">
         <canvas id="cumulativeRegistrationsTrend"></canvas>
       </div>
-      <% if current_admin.feature_enabled?(:diabetes_management_reports) %>
-        <% if @region.diabetes_management_enabled? %>
+      <% if @region.diabetes_management_enabled? %>
         <div>
           <div class="p-relative px-20px mb-12px">
             <p class="m-0px c-grey-dark c-print-black">
@@ -115,7 +114,6 @@
             </p>
           </div>
         </div>
-        <% end %>
       <% end %>
     </div>
   </div>
@@ -221,52 +219,41 @@
 
 <%= render "treatment_outcomes_card" %>
 
-<% if !current_admin.feature_enabled?(:diabetes_management_reports) %>
-  <% if @children_data.any? %>
-    <h4 class="mt-5 mb-32px">Compare performance</h4>
-    <%= render "child_data_tables", data: @children_data, localized_region_type: @child_regions.first.localized_region_type %>
-  <% end %>
+<h4 class="mt-5 mb-32px">Details</h4>
+<%= render "reports/regions/patient_breakdown_charts" %>
+
+<% if current_admin.feature_enabled?(:medications_dispensation) %>
+  <h4 class="mt-5 mb-32px">Medications</h4>
+  <%= render "reports/regions/medications_dispensation" %>
 <% end %>
 
-<% if current_admin.feature_enabled?(:diabetes_management_reports) %>
-
-  <h4 class="mt-5 mb-32px">Details</h4>
-  <%= render "reports/regions/patient_breakdown_charts" %>
-
-  <% if current_admin.feature_enabled?(:medications_dispensation) %>
-    <h4 class="mt-5 mb-32px">Medications</h4>
-    <%= render "reports/regions/medications_dispensation" %>
-  <% end %>
-
-  <% if @children_data.any? %>
-    <h4 class="mt-5 mb-32px">Compare performance</h4>
-    <%= render "child_data_tables", data: @children_data, localized_region_type: @child_regions.first.localized_region_type %>
-  <% end %>
-
-  <% if @region.facility_region? %>
-    <h4 class="mt-5 mb-32px">Facility activity</h4>
-    <%= render "facility_details" %>
-  <% else %>
-    <%= render(RegistrationsAndFollowUpsComponent.new(@region,
-      current_admin: current_admin,
-      repository: @details_repository,
-      current_period: @period)) %>
-  <% end %>
-
-  <h4 class="mt-5 mb-32px">Cohort reports</h4>
-
-  <div class="d-lg-flex">
-    <%= render Reports::CohortComponent.new(@cohort_period, @cohort_data) %>
-  </div>
-
-  <% if @region.facility_region? %>
-    <h4 class="mt-5 mb-32px">BP Recording Activity</h4>
-    <%= render "shared/recent_bp_log",
-                blood_pressures: @recent_blood_pressures,
-                display_model: :facility %>
-  <% end %>
+<% if @children_data.any? %>
+  <h4 class="mt-5 mb-32px">Compare performance</h4>
+  <%= render "child_data_tables", data: @children_data, localized_region_type: @child_regions.first.localized_region_type %>
 <% end %>
 
+<% if @region.facility_region? %>
+  <h4 class="mt-5 mb-32px">Facility activity</h4>
+  <%= render "facility_details" %>
+<% else %>
+  <%= render(RegistrationsAndFollowUpsComponent.new(@region,
+    current_admin: current_admin,
+    repository: @details_repository,
+    current_period: @period)) %>
+<% end %>
+
+<h4 class="mt-5 mb-32px">Cohort reports</h4>
+
+<div class="d-lg-flex">
+  <%= render Reports::CohortComponent.new(@cohort_period, @cohort_data) %>
+</div>
+
+<% if @region.facility_region? %>
+  <h4 class="mt-5 mb-32px">BP Recording Activity</h4>
+  <%= render "shared/recent_bp_log",
+              blood_pressures: @recent_blood_pressures,
+              display_model: :facility %>
+<% end %>
 
 <%= render "overview_footnotes" %>
 

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -214,56 +214,11 @@ RSpec.describe Reports::RegionsController, type: :controller do
     end
 
     context "when region has diabetes management enabled" do
-
-      it "contains a link to the diabetes management reports if the feature flag is enabled" do
+      it "contains a link to the diabetes management reports" do
         @facility.update(enable_diabetes_management: true)
-        Flipper.enable(:diabetes_management_reports)
         sign_in(cvho.email_authentication)
         get :show, params: {id: @facility_region.slug, report_scope: "facility"}
         assert_select "a[href*='diabetes']", count: 1
-      end
-
-      it "contains a link to the diabetes management reports if the feature flag is enabled for an individual user" do
-        enabled_user = create(:admin)
-        @facility.update(enable_diabetes_management: true)
-        Flipper.enable_actor(:diabetes_management_reports, enabled_user)
-
-        sign_in(enabled_user.email_authentication)
-        get :show, params: {id: @facility_region.slug, report_scope: "facility"}
-        assert_select "a[href*='diabetes']", count: 1
-      end
-
-      it "does not contain a link to the diabetes management reports if the feature flag is disabled" do
-        @facility.update(enable_diabetes_management: true)
-        Flipper.disable(:diabetes_management_reports)
-        sign_in(cvho.email_authentication)
-        get :show, params: {id: @facility_region.slug, report_scope: "facility"}
-        assert_select "a[href*='diabetes']", count: 0
-      end
-
-      it "does not contain a link to the diabetes management reports if the feature flag is disabled for an other individual user" do
-        enabled_user = create(:admin)
-        @facility.update(enable_diabetes_management: true)
-        Flipper.enable_actor(:diabetes_management_reports, enabled_user)
-
-        sign_in(cvho.email_authentication)
-        get :show, params: {id: @facility_region.slug, report_scope: "facility"}
-        assert_select "a[href*='diabetes']", count: 0
-      end
-    end
-
-    context "when region has diabetes management disabled" do
-      it "does not contain a link to the diabetes management report" do
-        @facility.update(enable_diabetes_management: false)
-        sign_in(cvho.email_authentication)
-
-        Flipper.enable(:diabetes_management_reports)
-        get :show, params: {id: @facility_region.slug, report_scope: "facility"}
-        assert_select "a[href*='diabetes']", count: 0
-
-        Flipper.disable(:diabetes_management_reports)
-        get :show, params: {id: @facility_region.slug, report_scope: "facility"}
-        assert_select "a[href*='diabetes']", count: 0
       end
     end
   end
@@ -661,33 +616,12 @@ RSpec.describe Reports::RegionsController, type: :controller do
 
     before do
       sign_in(cvho.email_authentication)
-      Flipper.enable(:diabetes_management_reports)
     end
 
-    context "when diabetes management is disabled in the region" do
-      it "raises a routing error" do
-        facility.update(enable_diabetes_management: false)
+    it "return diabetes reports page" do
+      get :diabetes, params: {id: facility_region.slug, report_scope: "facility"}
 
-        expect {
-          get :diabetes, params: {id: facility_region.slug, report_scope: "facility"}
-        }.to raise_error(ActionController::RoutingError)
-      end
-    end
-
-    context "when diabetes management is enabled in the region" do
-      it "return diabetes reports page" do
-        get :diabetes, params: {id: facility_region.slug, report_scope: "facility"}
-
-        expect(response).to have_http_status(:ok)
-      end
-
-      it "raises a routing error when feature flag is disabled" do
-        Flipper.disable(:diabetes_management_reports)
-
-        expect {
-          get :diabetes, params: {id: facility_region.slug, report_scope: "facility"}
-        }.to raise_error(ActionController::RoutingError)
-      end
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -214,9 +214,6 @@ RSpec.describe Reports::RegionsController, type: :controller do
     end
 
     context "when region has diabetes management enabled" do
-      before do
-        Flipper.disable(:diabetes_management_reports)
-      end
 
       it "contains a link to the diabetes management reports if the feature flag is enabled" do
         @facility.update(enable_diabetes_management: true)

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -544,10 +544,6 @@ RSpec.describe Region, type: :model do
     let(:disabled_district_region) { create(:region, region_type: :district, reparent_to: enabled_state_region) }
     let(:disabled_block_region) { create(:region, region_type: :block, reparent_to: enabled_district_region) }
 
-    before do
-      Flipper.enable(:diabetes_management_reports)
-    end
-
     context "region is a facility" do
       it "returns true if enable_diabetes_management is set to true for the facility" do
         facility_region = create(:region, region_type: :facility, source: facility_1, reparent_to: enabled_block_region)

--- a/spec/models/reports/region_summary_schema_spec.rb
+++ b/spec/models/reports/region_summary_schema_spec.rb
@@ -242,12 +242,6 @@ describe Reports::RegionSummarySchema, type: :model do
     let(:facility_2) { distict_with_facilities[:facility_2] }
     let(:period) { jan_2020..mar_2020 }
 
-    before :each do
-      Flipper.enable(:diabetes_management_reports)
-      facility_1.update(enable_diabetes_management: true)
-      facility_2.update(enable_diabetes_management: true)
-    end
-
     describe "#bs_below_200_rates" do
       it "returns the bs_below_200 rates over time for a region" do
         facility_1_patients = create_list(:patient, 4, :diabetes, assigned_facility: facility_1, recorded_at: jan_2019)

--- a/spec/models/reports/region_summary_schema_spec.rb
+++ b/spec/models/reports/region_summary_schema_spec.rb
@@ -46,8 +46,8 @@ describe Reports::RegionSummarySchema, type: :model do
 
     expect(result[facility_group_1.slug][jan_2020.to_period]).to include("cumulative_assigned_patients" => 5)
     expect(result[facility_group_1.slug][jan_2020.to_period]).to include("adjusted_controlled_under_care" => 3)
-    expect(result[facility_1.slug][jan_2020.to_period]).to include("adjusted_controlled_under_care" => 2)
-    expect(result[facility_2.slug][jan_2020.to_period]).to include("adjusted_controlled_under_care" => 1)
+    expect(result[facility_1.region.slug][jan_2020.to_period]).to include("adjusted_controlled_under_care" => 2)
+    expect(result[facility_2.region.slug][jan_2020.to_period]).to include("adjusted_controlled_under_care" => 1)
   end
 
   it "can return earliest patient recorded at" do
@@ -56,7 +56,7 @@ describe Reports::RegionSummarySchema, type: :model do
     refresh_views
 
     schema = described_class.new([facility.region], periods: range)
-    expect(schema.earliest_patient_recorded_at["facility-1"]).to eq(jan_2020)
+    expect(schema.earliest_patient_recorded_at[facility.region.slug]).to eq(jan_2020)
   end
 
   it "has cache key" do
@@ -241,6 +241,11 @@ describe Reports::RegionSummarySchema, type: :model do
     let(:facility_1) { distict_with_facilities[:facility_1] }
     let(:facility_2) { distict_with_facilities[:facility_2] }
     let(:period) { jan_2020..mar_2020 }
+
+    before :each do
+      facility_1.update(enable_diabetes_management: true)
+      facility_2.update(enable_diabetes_management: true)
+    end
 
     describe "#bs_below_200_rates" do
       it "returns the bs_below_200 rates over time for a region" do

--- a/spec/models/reports/region_summary_spec.rb
+++ b/spec/models/reports/region_summary_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
         described_class.call(facility_1)
       end
       expected_range = (jan_2020.to_period..Time.current.to_period)
-      expect(results["facility-1"].keys).to eq(expected_range.entries)
+      expect(results[facility_1.region.slug].keys).to eq(expected_range.entries)
     end
 
     context "explicit range provided" do
@@ -46,7 +46,7 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
           refresh_views
           described_class.call([facility_1, facility_2], range: explicit_range)
         end
-        expect(results["facility-1"].keys).to eq(expected_range.entries)
+        expect(results[facility_1.region.slug].keys).to eq(expected_range.entries)
       end
     end
 
@@ -118,8 +118,8 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
         diabetes_appts_scheduled_more_than_62_days
       ].map(&:to_s)
       (3.months.ago.to_period..now.to_period).each do |period|
-        expect(results["facility-1"][period].keys).to match_array(expected_keys)
-        counts = results["facility-1"][period].except("facility_region_slug", "month_date")
+        expect(results[facility_1.region.slug][period].keys).to match_array(expected_keys)
+        counts = results[facility_1.region.slug][period].except("facility_region_slug", "month_date")
         expect(counts.values).to all(be_an(Integer))
       end
     end
@@ -214,7 +214,7 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
       "February 1st 2020" => {"monthly_follow_ups" => 2},
       "March 1st 2020" => {"monthly_follow_ups" => 2}
     }.transform_keys!(&:to_period)
-    facility_1_results = described_class.call(facility_1, range: range)["facility-1"].transform_values { |values| values.slice("monthly_follow_ups") }
+    facility_1_results = described_class.call(facility_1, range: range)[facility_1.region.slug].transform_values { |values| values.slice("monthly_follow_ups") }
     expect(facility_1_results).to eq(expected_facility_1_follow_ups)
 
     expected_facility_2_follow_ups = {
@@ -225,7 +225,7 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
       "February 1st 2020" => {"monthly_follow_ups" => 0},
       "March 1st 2020" => {"monthly_follow_ups" => 0}
     }.transform_keys!(&:to_period)
-    facility_2_results = described_class.call([facility_2, facility_1], range: range)["facility-2"].transform_values { |values| values.slice("monthly_follow_ups") }
+    facility_2_results = described_class.call([facility_2, facility_1], range: range)[facility_2.region.slug].transform_values { |values| values.slice("monthly_follow_ups") }
     expect(facility_2_results).to eq(expected_facility_2_follow_ups)
 
     district_results = described_class.call(facility_group_1, range: range)[facility_group_1.region.slug].transform_values { |values| values.slice("monthly_follow_ups") }
@@ -293,6 +293,11 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
     let(:facility_1) { district_with_facilities[:facility_1] }
     let(:facility_2) { district_with_facilities[:facility_2] }
     let(:period) { jan_2020..mar_2020 }
+
+    before :each do
+      facility_1.update(enable_diabetes_management: true)
+      facility_2.update(enable_diabetes_management: true)
+    end
 
     it "returns the adjusted count of patients with bs <200 in a region" do
       facility_1_patients = create_list(:patient, 4, :diabetes, assigned_facility: facility_1, recorded_at: jan_2019)

--- a/spec/models/reports/region_summary_spec.rb
+++ b/spec/models/reports/region_summary_spec.rb
@@ -294,12 +294,6 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
     let(:facility_2) { district_with_facilities[:facility_2] }
     let(:period) { jan_2020..mar_2020 }
 
-    before :each do
-      Flipper.enable(:diabetes_management_reports)
-      facility_1.update(enable_diabetes_management: true)
-      facility_2.update(enable_diabetes_management: true)
-    end
-
     it "returns the adjusted count of patients with bs <200 in a region" do
       facility_1_patients = create_list(:patient, 4, :diabetes, assigned_facility: facility_1, recorded_at: jan_2019)
       create(:blood_sugar, :with_encounter, :random, :bs_below_200, patient: facility_1_patients.first, facility: facility_1, recorded_at: jan_2020 + 3.months)

--- a/spec/requests/reports/regions_controller_request_spec.rb
+++ b/spec/requests/reports/regions_controller_request_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "RegionsControllers", type: :request do
         expect(response.body).to include("CC Brooklyn")
         doc = Nokogiri::HTML(response.body)
         json = doc.search("#data-json")
-        data = Oj.load(json.text)
+        data = Oj.load(json.first.text)
 
         # spot check for now
         keys = ["adjusted_patient_counts", "uncontrolled_patients_rate"]


### PR DESCRIPTION
**Story card:** [sc-7827](https://app.shortcut.com/simpledotorg/story/7827/remove-the-feature-flag-code-for-diabetes-management)
**Story card:** [sc-8280](https://app.shortcut.com/simpledotorg/story/8280/remove-feature-flag-toggling-for-consolidated-hypertension-reports)

## Because

We have rolled out diabetes reports to all dashboard users

## This addresses

- Removes the usage of `diabetes_management_reports` flipper flag
- Diabetes reports will be shown for a region only if it has been enabled for it

## Test instructions

- Toggling `diabetes_management_reports` flag should make no difference
