### PR TITLE
[Hotfix] Fix missing data for days for medication and ltfu graphs

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -116,7 +116,7 @@ class Reports::RegionsController < AdminController
     @cohort_period = Period.quarter(Time.current)
     @cohort_data = CohortService.new(region: @region, periods: @cohort_period.downto(5)).call
 
-    @data = @overview_data
+    @data = @overview_data.merge(@details_chart_data)
 
     respond_to do |format|
       format.html

--- a/app/views/reports/regions/_facility_details.html.erb
+++ b/app/views/reports/regions/_facility_details.html.erb
@@ -63,7 +63,7 @@
           <tr>
             <td class="row-title">
               <%= link_to resource.full_name, admin_user_path(resource, period: @period) %>
-            </td>,
+            </td>
             <td class="ta-right">
               <%= number_or_dash_with_delimiter(sum_registration_counts(@repository, slug: @region.slug, user_id: resource.id, diagnosis: :hypertension)) %>
             </td>

--- a/spec/models/reports/region_summary_schema_spec.rb
+++ b/spec/models/reports/region_summary_schema_spec.rb
@@ -109,12 +109,12 @@ describe Reports::RegionSummarySchema, type: :model do
       refresh_views
 
       schema = described_class.new(Region.where(id: facility.region), periods: range)
-      expect(schema.appts_scheduled_0_to_14_days_rates[facility.slug][range.last]).to eq(100)
-      expect(schema.appts_scheduled_15_to_31_days_rates[facility.slug][range.to_a.second]).to eq(100)
-      expect(schema.appts_scheduled_more_than_62_days_rates[facility.slug][range.first]).to eq(100)
-      expect(schema.diabetes_appts_scheduled_0_to_14_days_rates[facility.slug][range.last]).to eq(100)
-      expect(schema.diabetes_appts_scheduled_15_to_31_days_rates[facility.slug][range.to_a.second]).to eq(100)
-      expect(schema.diabetes_appts_scheduled_more_than_62_days_rates[facility.slug][range.first]).to eq(100)
+      expect(schema.appts_scheduled_0_to_14_days_rates[facility.region.slug][range.last]).to eq(100)
+      expect(schema.appts_scheduled_15_to_31_days_rates[facility.region.slug][range.to_a.second]).to eq(100)
+      expect(schema.appts_scheduled_more_than_62_days_rates[facility.region.slug][range.first]).to eq(100)
+      expect(schema.diabetes_appts_scheduled_0_to_14_days_rates[facility.region.slug][range.last]).to eq(100)
+      expect(schema.diabetes_appts_scheduled_15_to_31_days_rates[facility.region.slug][range.to_a.second]).to eq(100)
+      expect(schema.diabetes_appts_scheduled_more_than_62_days_rates[facility.region.slug][range.first]).to eq(100)
     end
 
     it "returns percentages of appointments scheduled in a month in the given range for appointments created in a given month" do


### PR DESCRIPTION
## Because

Days of medication, and ltfu graph are not rendering in hypertension reports due to missing data

## This addresses

Adds  the missing data so that the graphs can render properly