### PR TITLE
Add blood sugar type breakdown for BS Over 200 graph

### DIFF
--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -1017,12 +1017,9 @@ Reports = function (withLtfu) {
         "[data-registrations-period-end]"
       );
 
-      const bs200T0300RbsPPBSPercentNode = cardNode.querySelector("[data-over-300-rbs-ppbs]");
-      const bsOver300RbsPPBSPercentNode = cardNode.querySelector("[data-bs-200-to-300-rbs-ppbs]");
-      const bs200T0300FastingPercentNode = cardNode.querySelector("[data-over-300-fasting]");
-      const bsOver300FastingPercentNode = cardNode.querySelector("[data-bs-200-to-300-fasting]");
-      const bs200T0300Hba1cPercentNode = cardNode.querySelector("[data-over-300-hba1c]");
-      const bsOver300Hba1cPercentNode = cardNode.querySelector("[data-bs-200-to-300-rbs-hba1c]");
+      const rbsPPBSPercentNode = cardNode.querySelector("[data-rbs-ppbs]");
+      const fastingPercentNode = cardNode.querySelector("[data-fasting]");
+      const hba1cPercentNode = cardNode.querySelector("[data-hba1c]");
 
       const periodInfo = data.periodInfo[period];
       const adjustedPatientCounts = adjustedPatients[period];
@@ -1056,26 +1053,16 @@ Reports = function (withLtfu) {
         (node) => (node.innerHTML = periodInfo.bp_control_registration_date)
       );
 
-      const bs200To300breakdown = data.bs200To300BreakdownRates[period];
-      const bsOver300breakdown = data.bsOver300BreakdownRates[period];
+      const breakdown = data.bsOver200BreakdownRates[period];
 
-      bs200T0300RbsPPBSPercentNode.innerHTML = this.formatPercentage(
-          bs200To300breakdown ? bs200To300breakdown["random"] + bs200To300breakdown["post_prandial"] : 0
+      rbsPPBSPercentNode.innerHTML = this.formatPercentage(
+          breakdown["random"] + breakdown["post_prandial"]
       );
-      bsOver300RbsPPBSPercentNode.innerHTML = this.formatPercentage(
-          bsOver300breakdown ? bsOver300breakdown["random"] + bsOver300breakdown["post_prandial"] : 0
+      fastingPercentNode.innerHTML = this.formatPercentage(
+          breakdown["fasting"]
       );
-      bs200T0300FastingPercentNode.innerHTML = this.formatPercentage(
-          bs200To300breakdown ? bs200To300breakdown["fasting"] : 0
-      );
-      bsOver300FastingPercentNode.innerHTML = this.formatPercentage(
-          bsOver300breakdown ? bsOver300breakdown["fasting"] : 0
-      );
-      bs200T0300Hba1cPercentNode.innerHTML = this.formatPercentage(
-          bs200To300breakdown ? bs200To300breakdown["hba1c"] : 0
-      );
-      bsOver300Hba1cPercentNode.innerHTML = this.formatPercentage(
-          bsOver300breakdown ? bsOver300breakdown["hba1c"] : 0
+      hba1cPercentNode.innerHTML = this.formatPercentage(
+          breakdown["hba1c"]
       );
     };
 
@@ -1712,8 +1699,7 @@ Reports = function (withLtfu) {
       bsBelow200Rate: jsonData.bs_below_200_rates,
       bsBelow200WithLtfuRate: jsonData.bs_below_200_with_ltfu_rates,
       bsBelow200BreakdownRates: jsonData.bs_below_200_breakdown_rates,
-      bs200To300BreakdownRates: jsonData.bs_200_to_300_breakdown_rates,
-      bsOver300BreakdownRates: jsonData.bs_over_300_breakdown_rates,
+      bsOver200BreakdownRates: jsonData.bs_over_200_breakdown_rates,
       bs200to300Patients: jsonData.bs_200_to_300_patients,
       bs200to300Rate: jsonData.bs_200_to_300_rates,
       bs200to300WithLtfuRate: jsonData.bs_200_to_300_with_ltfu_rates,

--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -1017,6 +1017,13 @@ Reports = function (withLtfu) {
         "[data-registrations-period-end]"
       );
 
+      const bs200T0300RbsPPBSPercentNode = cardNode.querySelector("[data-over-300-rbs-ppbs]");
+      const bsOver300RbsPPBSPercentNode = cardNode.querySelector("[data-bs-200-to-300-rbs-ppbs]");
+      const bs200T0300FastingPercentNode = cardNode.querySelector("[data-over-300-fasting]");
+      const bsOver300FastingPercentNode = cardNode.querySelector("[data-bs-200-to-300-fasting]");
+      const bs200T0300Hba1cPercentNode = cardNode.querySelector("[data-over-300-hba1c]");
+      const bsOver300Hba1cPercentNode = cardNode.querySelector("[data-bs-200-to-300-rbs-hba1c]");
+
       const periodInfo = data.periodInfo[period];
       const adjustedPatientCounts = adjustedPatients[period];
 
@@ -1047,6 +1054,28 @@ Reports = function (withLtfu) {
       );
       registrationsPeriodEndNodes.forEach(
         (node) => (node.innerHTML = periodInfo.bp_control_registration_date)
+      );
+
+      const bs200To300breakdown = data.bs200To300BreakdownRates[period];
+      const bsOver300breakdown = data.bsOver300BreakdownRates[period];
+
+      bs200T0300RbsPPBSPercentNode.innerHTML = this.formatPercentage(
+          bs200To300breakdown ? bs200To300breakdown["random"] + bs200To300breakdown["post_prandial"] : 0
+      );
+      bsOver300RbsPPBSPercentNode.innerHTML = this.formatPercentage(
+          bsOver300breakdown ? bsOver300breakdown["random"] + bsOver300breakdown["post_prandial"] : 0
+      );
+      bs200T0300FastingPercentNode.innerHTML = this.formatPercentage(
+          bs200To300breakdown ? bs200To300breakdown["fasting"] : 0
+      );
+      bsOver300FastingPercentNode.innerHTML = this.formatPercentage(
+          bsOver300breakdown ? bsOver300breakdown["fasting"] : 0
+      );
+      bs200T0300Hba1cPercentNode.innerHTML = this.formatPercentage(
+          bs200To300breakdown ? bs200To300breakdown["hba1c"] : 0
+      );
+      bsOver300Hba1cPercentNode.innerHTML = this.formatPercentage(
+          bsOver300breakdown ? bsOver300breakdown["hba1c"] : 0
       );
     };
 
@@ -1683,6 +1712,8 @@ Reports = function (withLtfu) {
       bsBelow200Rate: jsonData.bs_below_200_rates,
       bsBelow200WithLtfuRate: jsonData.bs_below_200_with_ltfu_rates,
       bsBelow200BreakdownRates: jsonData.bs_below_200_breakdown_rates,
+      bs200To300BreakdownRates: jsonData.bs_200_to_300_breakdown_rates,
+      bsOver300BreakdownRates: jsonData.bs_over_300_breakdown_rates,
       bs200to300Patients: jsonData.bs_200_to_300_patients,
       bs200to300Rate: jsonData.bs_200_to_300_rates,
       bs200to300WithLtfuRate: jsonData.bs_200_to_300_with_ltfu_rates,

--- a/app/models/reports/region_summary_schema.rb
+++ b/app/models/reports/region_summary_schema.rb
@@ -397,6 +397,17 @@ module Reports
       end
     end
 
+    memoize def diabetes_blood_sugar_over_200_breakdown_rates
+      region_period_cached_query(__method__) do |entry|
+        bs_over_200_counts = BloodSugar.blood_sugar_types.keys.map do |blood_sugar_type|
+          [blood_sugar_type,
+            diabetes_under_care(:bs_200_to_300, blood_sugar_type)[entry.region.slug][entry.period] +
+              diabetes_under_care(:bs_over_300, blood_sugar_type)[entry.region.slug][entry.period]]
+        end
+        rounded_percentages(bs_over_200_counts.to_h)
+      end
+    end
+
     memoize def diabetes_treatment_outcome_breakdown_counts(blood_sugar_risk_state)
       region_period_cached_query(__method__, blood_sugar_risk_state: blood_sugar_risk_state) do |entry|
         {

--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -106,7 +106,6 @@ module Reports
       diabetes_blood_sugar_over_200_breakdown_rates
       diabetes_patients_with_bs_taken_breakdown_rates
       diabetes_patients_with_bs_taken_breakdown_counts
-      diabetes_patients_with_bs_taken_breakdown_counts
     ]
 
     def warm_cache

--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -103,8 +103,9 @@ module Reports
 
     DELEGATED_BREAKDOWNS = %i[
       diabetes_treatment_outcome_breakdown_rates
-      diabetes_treatment_outcome_breakdown_counts
+      diabetes_blood_sugar_over_200_breakdown_rates
       diabetes_patients_with_bs_taken_breakdown_rates
+      diabetes_patients_with_bs_taken_breakdown_counts
       diabetes_patients_with_bs_taken_breakdown_counts
     ]
 

--- a/app/presenters/reports/repository_presenter.rb
+++ b/app/presenters/reports/repository_presenter.rb
@@ -47,6 +47,7 @@ module Reports
         bs_below_200_breakdown_rates: diabetes_treatment_outcome_breakdown_rates(:bs_below_200)[slug],
         bs_200_to_300_breakdown_rates: diabetes_treatment_outcome_breakdown_rates(:bs_200_to_300)[slug],
         bs_over_300_breakdown_rates: diabetes_treatment_outcome_breakdown_rates(:bs_over_300)[slug],
+        bs_over_200_breakdown_rates: diabetes_blood_sugar_over_200_breakdown_rates[slug],
         bs_200_to_300_patients: bs_200_to_300_patients[slug],
         bs_200_to_300_rates: bs_200_to_300_rates[slug],
         bs_200_to_300_with_ltfu_rates: bs_200_to_300_rates(with_ltfu: true)[slug],

--- a/app/views/reports/regions/diabetes.html.erb
+++ b/app/views/reports/regions/diabetes.html.erb
@@ -62,13 +62,13 @@
         <div class="p-relative px-20px mb-12px">
           <p class="m-0px c-grey-dark c-print-black">
             <strong>
-              <span class="c-print-black c-green-dark"  data-rbs-ppbs=""></span>
+              <span data-rbs-ppbs=""></span>
             </strong> RBS/PPBS, &nbsp;
             <strong>
-              <span class="c-print-black c-green-dark"  data-fasting=""></span>
+              <span data-fasting=""></span>
             </strong> Fasting, &nbsp;
             <strong>
-              <span class="c-print-black c-green-dark"  data-hba1c=""></span>
+              <span data-hba1c=""></span>
             </strong> HbA1c
           </p>
         </div>
@@ -220,16 +220,13 @@
         <div class="p-relative px-20px mb-12px">
           <p class="m-0px c-grey-dark c-print-black">
             <strong>
-              <span class="c-print-black c-red" data-over-300-rbs-ppbs=""></span>
-              <span class="c-print-black c-amber" data-bs-200-to-300-rbs-ppbs=""></span>
+              <span data-rbs-ppbs=""></span>
             </strong> RBS/PPBS, &nbsp;
             <strong>
-              <span class="c-print-black c-red" data-over-300-fasting=""></span>
-              <span class="c-print-black c-amber" data-bs-200-to-300-fasting=""></span>
+              <span data-fasting=""></span>
             </strong> Fasting, &nbsp;
             <strong>
-              <span class="c-print-black c-red" data-over-300-hba1c=""></span>
-              <span class="c-print-black c-amber" data-bs-200-to-300-rbs-hba1c=""></span>
+              <span data-hba1c=""></span>
             </strong> HbA1c
           </p>
         </div>

--- a/app/views/reports/regions/diabetes.html.erb
+++ b/app/views/reports/regions/diabetes.html.erb
@@ -62,13 +62,13 @@
         <div class="p-relative px-20px mb-12px">
           <p class="m-0px c-grey-dark c-print-black">
             <strong>
-              <span data-rbs-ppbs=""></span>
+              <span class="c-print-black c-green-dark"  data-rbs-ppbs=""></span>
             </strong> RBS/PPBS, &nbsp;
             <strong>
-              <span data-fasting=""></span>
+              <span class="c-print-black c-green-dark"  data-fasting=""></span>
             </strong> Fasting, &nbsp;
             <strong>
-              <span data-hba1c=""></span>
+              <span class="c-print-black c-green-dark"  data-hba1c=""></span>
             </strong> HbA1c
           </p>
         </div>
@@ -215,6 +215,26 @@
           </div>
         </div>
       </div>
+
+      <div>
+        <div class="p-relative px-20px mb-12px">
+          <p class="m-0px c-grey-dark c-print-black">
+            <strong>
+              <span class="c-print-black c-red" data-over-300-rbs-ppbs=""></span>
+              <span class="c-print-black c-amber" data-bs-200-to-300-rbs-ppbs=""></span>
+            </strong> RBS/PPBS, &nbsp;
+            <strong>
+              <span class="c-print-black c-red" data-over-300-fasting=""></span>
+              <span class="c-print-black c-amber" data-bs-200-to-300-fasting=""></span>
+            </strong> Fasting, &nbsp;
+            <strong>
+              <span class="c-print-black c-red" data-over-300-hba1c=""></span>
+              <span class="c-print-black c-amber" data-bs-200-to-300-rbs-hba1c=""></span>
+            </strong> HbA1c
+          </p>
+        </div>
+      </div>
+
       <div>
       </div>
     </div>


### PR DESCRIPTION
**Story card:** [sc-8229](https://app.shortcut.com/simpledotorg/story/8229/add-breakdown-by-blood-sugar-type-for-bs-200-graph)

## Because

We want to show the breakdown of a BS over 200 trends by blood sugar type

## This addresses

Updates the view and report js to add these breakdowns to bs over 200 graph

## Test instructions

You should see the breakdown count at the bottom of the BS over 200 graph. The percentages should change as you hover over the graph

![Screenshot from 2022-07-18 13-51-42](https://user-images.githubusercontent.com/3933133/179473586-ea95c164-9493-4d83-a158-ffbf0b147027.png)
