### PR TITLE
Fix BSNL DLT template lookup

### DIFF
--- a/app/models/messaging/bsnl/dlt_template.rb
+++ b/app/models/messaging/bsnl/dlt_template.rb
@@ -34,7 +34,9 @@ class Messaging::Bsnl::DltTemplate
   end
 
   def self.latest_name_of(dlt_template_name)
-    BSNL_TEMPLATES.dig(drop_version_number(dlt_template_name), "Latest_Template_Version")
+    BSNL_TEMPLATES
+      .transform_keys { |template_name| drop_version_number(template_name) }
+      .dig(drop_version_number(dlt_template_name), "Latest_Template_Version")
   end
 
   def self.drop_version_number(dlt_template_name)

--- a/spec/models/messaging/bsnl/dlt_template_spec.rb
+++ b/spec/models/messaging/bsnl/dlt_template_spec.rb
@@ -56,12 +56,12 @@ RSpec.describe Messaging::Bsnl::DltTemplate do
     it "finds the name of the latest version of a template if only versioned templates are present" do
       stub_const("Messaging::Bsnl::DltTemplate::BSNL_TEMPLATES", {
         "en.a.template.name.1" => {"Template_Id" => "a template id",
-                                 "Template_Keys" => %w[key_1 key_2],
-                                 "Non_Variable_Text_Length" => "10",
-                                 "Max_Length_Permitted" => "20",
-                                 "Version" => 1,
-                                 "Is_Latest_Version" => true,
-                                 "Latest_Template_Version" => "en.a.template.name.3"}
+                                   "Template_Keys" => %w[key_1 key_2],
+                                   "Non_Variable_Text_Length" => "10",
+                                   "Max_Length_Permitted" => "20",
+                                   "Version" => 1,
+                                   "Is_Latest_Version" => true,
+                                   "Latest_Template_Version" => "en.a.template.name.3"}
       })
 
       expect(described_class.latest_name_of("en.a.template.name")).to eq("en.a.template.name.3")

--- a/spec/models/messaging/bsnl/dlt_template_spec.rb
+++ b/spec/models/messaging/bsnl/dlt_template_spec.rb
@@ -52,6 +52,21 @@ RSpec.describe Messaging::Bsnl::DltTemplate do
       expect(described_class.latest_name_of("en.a.template.name")).to eq("en.a.template.name.3")
       expect(described_class.latest_name_of("en.a.template.name.2")).to eq("en.a.template.name.3")
     end
+
+    it "finds the name of the latest version of a template if only versioned templates are present" do
+      stub_const("Messaging::Bsnl::DltTemplate::BSNL_TEMPLATES", {
+        "en.a.template.name.1" => {"Template_Id" => "a template id",
+                                 "Template_Keys" => %w[key_1 key_2],
+                                 "Non_Variable_Text_Length" => "10",
+                                 "Max_Length_Permitted" => "20",
+                                 "Version" => 1,
+                                 "Is_Latest_Version" => true,
+                                 "Latest_Template_Version" => "en.a.template.name.3"}
+      })
+
+      expect(described_class.latest_name_of("en.a.template.name")).to eq("en.a.template.name.3")
+      expect(described_class.latest_name_of("en.a.template.name.2")).to eq("en.a.template.name.3")
+    end
   end
 
   describe ".drop_version_number" do


### PR DESCRIPTION
**Story card:** [sc-8551](https://app.shortcut.com/simpledotorg/story/8551/setup-jul-1-basic-variations-experiment)

## Because

The first batch of DLT templates (submitted in March) had a version-less name. The template lookup via notifications was relying on one of the templates to not have a version. In the latest templates, we explicitly gave version numbers to all templates. This caused templates to be not found from the notification string.

## This addresses

Fixes DLT template lookup to work when only versioned templates are present.
