### PR TITLE
Diable diabetes downloads in block region

### DIFF
--- a/app/components/dashboard/diabetes/downloads_dropdown_component.html.erb
+++ b/app/components/dashboard/diabetes/downloads_dropdown_component.html.erb
@@ -1,8 +1,15 @@
 <div class="dropdown show mb-24px bs-small mb-lg-0">
-  <a class="btn btn-sm dropdown-toggle c-black bg-white" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    <i class="fa fa-arrow-circle-down w-16px ta-center mr-4px c-blue"></i>
-    Downloads (DM)
-  </a>
+  <% if region.region_type.in?(%w[block]) %>
+    <a class="btn btn-sm dropdown-toggle c-grey-medium bg-white disabled" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <i class="fa fa-arrow-circle-down w-16px ta-center mr-4px c-grey-medium"></i>
+      Downloads (DM)
+    </a>
+  <% else %>
+    <a class="btn btn-sm dropdown-toggle c-black bg-white" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <i class="fa fa-arrow-circle-down w-16px ta-center mr-4px c-blue"></i>
+      Downloads (DM)
+    </a>
+  <% end %>
 
   <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
 


### PR DESCRIPTION
Story card: [sc-8822](https://app.shortcut.com/simpledotorg/story/8822/disable-diabetes-downloads-in-the-block-region)

## Because

The block region does not have any downloadable reports. We have to disable the download button for diabetes in the block region

## This addresses

Disables the diabetes downloads in the block region

## Test instructions

- Check out this branch
- Go to the diabetes reports in a block region
- You should see the disabled downloads button