### PR TITLE
[Quick fix]Fix org level diabetes link

### DIFF
--- a/app/components/dashboard/hypertension/downloads_dropdown_component.rb
+++ b/app/components/dashboard/hypertension/downloads_dropdown_component.rb
@@ -12,7 +12,6 @@ class Dashboard::Hypertension::DownloadsDropdownComponent < ApplicationComponent
 
   def region_download_path
     reports_region_download_path(
-      region,
       report_scope: report_scope,
       period: :quarter,
       format: :csv

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -35,7 +35,7 @@
           <span class="nav-link">Hypertension report</span>
         <% end %>
         <% if @region.diabetes_management_enabled? %>
-          <%= link_to "Diabetes", reports_region_diabetes_path(@region, report_scope: params[:report_scope]), class: "nav-link #{active_action?("diabetes")}" %>
+          <%= link_to "Diabetes", reports_region_diabetes_path, class: "nav-link #{active_action?("diabetes")}" %>
         <% end %>
         <% if @region.facility_region? && current_admin.feature_enabled?(:dashboard_progress_reports) %>
             <%= link_to "Progress", reports_progress_path(@region), :class => "nav-link" %>


### PR DESCRIPTION
## Because

The organization-level diabetes link is broken. Organization-level slug and region-level slug for `Sri Lanka is different.

## This addresses

This is a workaround for fix. 