### PR TITLE
Add Sri Lanka config to facility locales

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -310,6 +310,7 @@ class Facility < ApplicationRecord
       "telangana" => "te-IN",
       "uttar pradesh" => "hi-IN",
       "west bengal" => "bn-IN"
-    }
+    },
+    "sri lanka" => {"default" => "si-LK"}
   }.freeze
 end

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -483,6 +483,11 @@ RSpec.describe Facility, type: :model do
       facility = create(:facility, country: "Pakistan")
       expect(facility.locale).to eq "en"
     end
+
+    it "is Sinhala for Sri Lanka" do
+      facility = create(:facility, country: "Sri Lanka")
+      expect(facility.locale).to eq "si-LK"
+    end
   end
 
   describe "#localized_facility_size" do


### PR DESCRIPTION
**Story card:** [sc-7521](https://app.shortcut.com/simpledotorg/story/7521/enable-sms-notifications-in-sri-lanka)

## Because

We want to start sending SMSs in Sinhala in Sri Lanka

## This addresses

Adds Sinhala to facility locales.