### PR TITLE
Fix rendering issue on estimated population coverage card

### DIFF
--- a/app/components/dashboard/diabetes/coverage_card_component.html.erb
+++ b/app/components/dashboard/diabetes/coverage_card_component.html.erb
@@ -6,7 +6,8 @@
         subtitle: "All individuals and patients with diabetes in #{region.name}") %>
       <%= render(Dashboard::PopulationCoverageComponent.new(
         region: region,
-        data: { cumulative_registrations: data.dig(:cumulative_diabetes_registrations, period) },
+        cumulative_registrations: data.dig(:cumulative_diabetes_registrations, period),
+        tooltip_copy: total_estimated_diabetic_population_copy(region),
         diagnosis: :diabetes,
         estimated_population: @region.estimated_diabetes_population,
         current_admin: current_admin)) %>

--- a/app/components/dashboard/diabetes/coverage_card_component.rb
+++ b/app/components/dashboard/diabetes/coverage_card_component.rb
@@ -1,4 +1,6 @@
 class Dashboard::Diabetes::CoverageCardComponent < ApplicationComponent
+  include DashboardHelper
+
   attr_reader :region
   attr_reader :data
   attr_reader :period

--- a/app/components/dashboard/hypertension/coverage_card_component.html.erb
+++ b/app/components/dashboard/hypertension/coverage_card_component.html.erb
@@ -6,9 +6,8 @@
         subtitle: "All individuals and patients with Hypertension in #{region.name}") %>
       <%= render(Dashboard::PopulationCoverageComponent.new(
         region: region,
-        data: {
-          cumulative_registrations: data.dig(:cumulative_registrations, period)
-        },
+        cumulative_registrations: data.dig(:cumulative_registrations, period),
+        tooltip_copy: total_estimated_hypertensive_population_copy(region),
         diagnosis: :hypertension,
         estimated_population: @region.estimated_population,
         current_admin: current_admin)) %>

--- a/app/components/dashboard/hypertension/coverage_card_component.rb
+++ b/app/components/dashboard/hypertension/coverage_card_component.rb
@@ -1,4 +1,6 @@
 class Dashboard::Hypertension::CoverageCardComponent < ApplicationComponent
+  include DashboardHelper
+
   attr_reader :region
   attr_reader :data
   attr_reader :period

--- a/app/components/dashboard/population_coverage_component.html.erb
+++ b/app/components/dashboard/population_coverage_component.html.erb
@@ -61,17 +61,7 @@
 <div class="d-flex ai-center jc-between">
   <p class="mb-8px fw-bold">
     Total est. population with <%= diagnosis %>
-    <span class="p-relative t-1px">
-      <i
-        class="fas fa-question-circle fs-14px c-grey-dark"
-        data-toggle="tooltip"
-        data-placement="right"
-        data-trigger="hover click"
-        data-html="true"
-        title="<%= total_estimated_population_tooltip_copy %>"
-      >
-      </i>
-    </span>
+    <%= render Dashboard::Card::TooltipComponent.new(tooltip_copy) %>
   </p>
   <p class="mb-8px">
     <% if show_coverage %>

--- a/app/components/dashboard/population_coverage_component.rb
+++ b/app/components/dashboard/population_coverage_component.rb
@@ -1,27 +1,23 @@
 class Dashboard::PopulationCoverageComponent < ApplicationComponent
-  include DashboardHelper
-
   attr_reader :region
-  attr_reader :data
+  attr_reader :cumulative_registrations
   attr_reader :diagnosis
   attr_reader :estimated_population
   attr_reader :current_admin
+  attr_reader :tooltip_copy
 
-  def initialize(region:, data:, diagnosis:, estimated_population:, current_admin:)
+  def initialize(region:, cumulative_registrations:, diagnosis:, estimated_population:, current_admin:, tooltip_copy:)
     @region = region
-    @data = data
+    @cumulative_registrations = cumulative_registrations
     @estimated_population = estimated_population
     @diagnosis = diagnosis
     @current_admin = current_admin
+    @tooltip_copy = tooltip_copy
   end
 
   def accessible_region?(region, action)
     return true if region.region_type == "facility"
     helpers.accessible_region?(region, action)
-  end
-
-  def cumulative_registrations
-    data[:cumulative_registrations]
   end
 
   def show_coverage
@@ -35,15 +31,7 @@ class Dashboard::PopulationCoverageComponent < ApplicationComponent
   end
 
   def population_coverage_percentage
-    number_to_percentage(region.estimated_diabetes_population.diabetes_patient_coverage_rate, precision: 0)
-  end
-
-  def total_estimated_population_tooltip_copy
-    case diagnosis
-    when :hypertension
-      total_estimated_hypertensive_population_copy(region)
-    when :diabetes
-      total_estimated_diabetic_population_copy(region)
-    end
+    return 0 unless estimated_population.present?
+    number_to_percentage(estimated_population.patient_coverage_rate(cumulative_registrations), precision: 0)
   end
 end


### PR DESCRIPTION
**Story card:** [sc-8921](https://app.shortcut.com/simpledotorg/story/8921/hi-urr1fpdgd-amp-urcql83gf-when-we-are-trying-to-open-the-report-page-of-any-district-and-st)

## Because

When regions don't have an estimated population, it throws a template rendering error

## This addresses

Added nil check

## Other changes

- Refactored coverage component to use tooltip component
- Made coverage component independent of diagnosis

## Test instructions

- Checkout to branch > Reports
- Visit a region without an estimated population and it should render without any errors