### PR TITLE
Change telemed report frequency

### DIFF
--- a/app/mailers/telemed_report_mailer.rb
+++ b/app/mailers/telemed_report_mailer.rb
@@ -11,7 +11,7 @@ class TelemedReportMailer < ApplicationMailer
       content: report_csv
     }
 
-    if Flipper.enabled?(:weekly_telemed_report) && @recipient_emails
+    if Flipper.enabled?(:automated_telemed_report) && @recipient_emails
       mail(to: @recipient_emails, subject: @subject)
     end
   end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -116,8 +116,8 @@ every :day, at: local("05:45 am"), roles: [:cron] do
   runner "Experimentation::Runner.call;AppointmentNotification::ScheduleExperimentReminders.call"
 end
 
-every :monday, at: local("06:00 am"), roles: [:cron] do
-  if Flipper.enabled?(:weekly_telemed_report)
+every 1.month, at: local("06:00 am"), roles: [:cron] do
+  if Flipper.enabled?(:monthly_telemed_report)
     rake "reports:telemedicine"
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -117,7 +117,7 @@ every :day, at: local("05:45 am"), roles: [:cron] do
 end
 
 every 1.month, at: local("06:00 am"), roles: [:cron] do
-  if Flipper.enabled?(:monthly_telemed_report)
+  if Flipper.enabled?(:automated_telemed_report)
     rake "reports:telemedicine"
   end
 end

--- a/doc/wiki/feature-flags.md
+++ b/doc/wiki/feature-flags.md
@@ -24,5 +24,5 @@ to facility the launch of a new feature, and may reference the Simple team's int
 | organization_reports | Yes | When enabled, the Simple Dashboard will allow users to view a top-level report for the whole organization. |
 | skip_api_validation | Yes | When enabled, Simple Server will not perform JSON validation of incoming API requests. This makes the API endpoints much more performant, but should only be enabled if all API clients are trusted (Simple app only). |
 | sync_encounters | Yes | When enabled, encounters can be synced between app and server like any other standard sync resource. |
-| weekly_telemed_report | Yes | When enabled, a weekly report on telemedicine activity in Simple will be sent via email to the configured recipients. |
+| monthly_telemed_report | Yes | When enabled, a monthly report on telemedicine activity in Simple will be sent via email to the configured recipients. |
 | whatsapp_appointment_reminders | Yes | When enabled, patient reminder messages will be attempted via Whatsapp first, before falling back to SMS. |

--- a/doc/wiki/feature-flags.md
+++ b/doc/wiki/feature-flags.md
@@ -24,5 +24,5 @@ to facility the launch of a new feature, and may reference the Simple team's int
 | organization_reports | Yes | When enabled, the Simple Dashboard will allow users to view a top-level report for the whole organization. |
 | skip_api_validation | Yes | When enabled, Simple Server will not perform JSON validation of incoming API requests. This makes the API endpoints much more performant, but should only be enabled if all API clients are trusted (Simple app only). |
 | sync_encounters | Yes | When enabled, encounters can be synced between app and server like any other standard sync resource. |
-| monthly_telemed_report | Yes | When enabled, a monthly report on telemedicine activity in Simple will be sent via email to the configured recipients. |
+| automated_telemed_report | Yes | When enabled, a monthly report on telemedicine activity in Simple will be sent via email to the configured recipients. |
 | whatsapp_appointment_reminders | Yes | When enabled, patient reminder messages will be attempted via Whatsapp first, before falling back to SMS. |

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -5,8 +5,8 @@ require "tasks/scripts/telemedicine_reports_v2"
 namespace :reports do
   desc "Generates the telemedicine report"
   task telemedicine: :environment do
-    period_start = Date.today.prev_occurring(:monday).beginning_of_day
-    period_end = period_start.next_occurring(:sunday).end_of_day
+    period_start = (Date.today - 1.month).beginning_of_month
+    period_end = period_start.end_of_month
 
     report = TelemedicineReportsV2.new(period_start, period_end)
     report.generate

--- a/lib/tasks/scripts/telemedicine_reports.rb
+++ b/lib/tasks/scripts/telemedicine_reports.rb
@@ -59,7 +59,7 @@ class TelemedicineReports
   end
 
   def generate
-    if Flipper.enabled?(:weekly_telemed_report) && ENV.fetch("MIXPANEL_API_SECRET")
+    if Flipper.enabled?(:automated_telemed_report) && ENV.fetch("MIXPANEL_API_SECRET")
       parse_mixpanel
       assemble_report_data
       email_report

--- a/lib/tasks/scripts/telemedicine_reports_v2.rb
+++ b/lib/tasks/scripts/telemedicine_reports_v2.rb
@@ -13,7 +13,7 @@ class TelemedicineReportsV2
   end
 
   def generate
-    if Flipper.enabled?(:weekly_telemed_report)
+    if Flipper.enabled?(:automated_telemed_report)
       assemble_report_data
       email_report
     end

--- a/spec/lib/tasks/scripts/telemedicine_reports_spec.rb
+++ b/spec/lib/tasks/scripts/telemedicine_reports_spec.rb
@@ -3,7 +3,7 @@ require "tasks/scripts/telemedicine_reports"
 
 RSpec.describe TelemedicineReports do
   before do
-    allow(Flipper).to receive(:enabled?).with(:weekly_telemed_report).and_return(true)
+    allow(Flipper).to receive(:enabled?).with(:automated_telemed_report).and_return(true)
     allow(ENV).to receive(:fetch).with("TELEMED_REPORT_EMAILS").and_return("test@example.com")
     allow(ENV).to receive(:fetch).with("MIXPANEL_API_SECRET").and_return("fake_api_secret")
     allow_any_instance_of(described_class).to receive(:fetch_mixpanel_data).and_return(File.read("spec/fixtures/files/telemed_report_input.csv"))

--- a/spec/lib/tasks/scripts/telemedicine_reports_v2_spec.rb
+++ b/spec/lib/tasks/scripts/telemedicine_reports_v2_spec.rb
@@ -3,7 +3,7 @@ require "tasks/scripts/telemedicine_reports_v2"
 
 RSpec.describe TelemedicineReportsV2 do
   before do
-    allow(Flipper).to receive(:enabled?).with(:weekly_telemed_report).and_return(true)
+    allow(Flipper).to receive(:enabled?).with(:automated_telemed_report).and_return(true)
     allow(ENV).to receive(:fetch).with("TELEMED_REPORT_EMAILS").and_return("test@example.com")
     allow_any_instance_of(ActionMailer::MessageDelivery).to receive(:deliver_later)
   end


### PR DESCRIPTION
**Story card:** -

## Because

We want to send the telemed report every month instead of every week.

## This addresses

Changes the frequency to once a month.