### PR TITLE
Add registrations breakdown to diabetes reports

### DIFF
--- a/app/components/dashboard/diabetes/registrations_and_follow_ups_graph_component.html.erb
+++ b/app/components/dashboard/diabetes/registrations_and_follow_ups_graph_component.html.erb
@@ -41,7 +41,7 @@
     <%= c.footer do %>
       <div class="p-relative px-20px mb-12px">
         <p class="m-0px c-grey-dark c-print-black">
-          <strong>00</strong> DM-only, <strong class="ml-8px">00</strong> DM+HTN (Coming soon)
+          <strong data-key="cumulativeDiabetesOnlyRegistrations"></strong> DM-only, <strong class="ml-8px" data-key="cumulativeHypertensionAndDiabetesRegistrations">00</strong> DM+HTN (Coming soon)
         </p>
       </div>
     <% end %>

--- a/app/components/dashboard/diabetes/registrations_and_follow_ups_graph_component.rb
+++ b/app/components/dashboard/diabetes/registrations_and_follow_ups_graph_component.rb
@@ -13,6 +13,8 @@ class Dashboard::Diabetes::RegistrationsAndFollowUpsGraphComponent < Application
     {cumulativeDiabetesRegistrations: data[:cumulative_diabetes_registrations],
      monthlyDiabetesRegistrations: data[:diabetes_registrations],
      monthlyDiabetesFollowups: data[:monthly_diabetes_followups],
+     cumulativeHypertensionAndDiabetesRegistrations: data[:cumulative_hypertension_and_diabetes_registrations],
+     cumulativeDiabetesOnlyRegistrations: cumulativeDiabetesOnlyRegistrations,
      **period_data}
   end
 
@@ -29,5 +31,14 @@ class Dashboard::Diabetes::RegistrationsAndFollowUpsGraphComponent < Application
 
   def period_info(key)
     data[:period_info].map { |k, v| [k, v[key]] }.to_h
+  end
+
+  def cumulativeDiabetesOnlyRegistrations
+    cumulative_diabetes_registrations = data[:cumulative_diabetes_registrations]
+    cumulative_hypertension_and_diabetes_registrations = data[:cumulative_hypertension_and_diabetes_registrations]
+
+    cumulative_hypertension_and_diabetes_registrations.map do |period, value|
+      [period, cumulative_diabetes_registrations[period] - value]
+    end.to_h
   end
 end


### PR DESCRIPTION
## Because

A refactoring PR introduced regression on the dashboard that removed the comorbid counts from diabetes reports