### PR TITLE
Remove `coming-soon` from Registrations card

### DIFF
--- a/app/components/dashboard/diabetes/registrations_and_follow_ups_graph_component.html.erb
+++ b/app/components/dashboard/diabetes/registrations_and_follow_ups_graph_component.html.erb
@@ -41,7 +41,8 @@
     <%= c.footer do %>
       <div class="p-relative px-20px mb-12px">
         <p class="m-0px c-grey-dark c-print-black">
-          <strong data-key="cumulativeDiabetesOnlyRegistrations" data-format="numberWithCommas"></strong> DM-only, <strong class="ml-8px" data-key="cumulativeHypertensionAndDiabetesRegistrations" data-format="numberWithCommas">00</strong> DM+HTN (Coming soon)
+          <strong data-key="cumulativeDiabetesOnlyRegistrations" data-format="numberWithCommas"></strong> DM-only,
+          <strong class="ml-8px" data-key="cumulativeHypertensionAndDiabetesRegistrations" data-format="numberWithCommas"></strong> DM+HTN
         </p>
       </div>
     <% end %>


### PR DESCRIPTION
**Story card:** [sc-8933](https://app.shortcut.com/simpledotorg/story/8933/remove-coming-soon-from-registrations-card)

## Because

The word `coming-soon` is shown in the Registration card's footnote

## This addresses

Remove the word `coming-soon` from the card

## Test instructions

- Check out this branch 
- Go to Reports>`<any region>`> Diabetes
- You should not see the word `coming-soon` in the Registrations card