### PR TITLE
Add check for if `new_progress_tab` is enabled for a single actor

### DIFF
--- a/app/components/reports/daily_progress_component.html.erb
+++ b/app/components/reports/daily_progress_component.html.erb
@@ -1,4 +1,4 @@
-<% if Flipper.enabled?(:new_progress_tab) %>
+<% if Flipper.enabled?(:new_progress_tab, current_user) || Flipper.enabled?(:new_progress_tab) %>
   <div id="progress-daily-report" class="d-none">
     <div class="mb-8px pt-16px pb-16px bgc-white bs-card">
       <a

--- a/app/components/reports/daily_progress_component.rb
+++ b/app/components/reports/daily_progress_component.rb
@@ -7,14 +7,15 @@ class Reports::DailyProgressComponent < ViewComponent::Base
   DAYS_AGO = 29
   DAY_FORMAT = ApplicationHelper::STANDARD_DATE_DISPLAY_FORMAT
 
-  attr_reader :service
+  attr_reader :service, :current_user
 
-  def initialize(service, last_updated_at)
+  def initialize(service, last_updated_at, current_user)
     @service = service
     @now = Date.current
     @start = @now - DAYS_AGO
     @region = service.region
     @last_updated_at = DateTime.parse(last_updated_at).to_date.strftime("%d-%b-%y at %I:%M %P")
+    @current_user = current_user
   end
 
   delegate :daily_follow_ups, :daily_registrations, to: :service

--- a/app/components/reports/monthly_progress_component.html.erb
+++ b/app/components/reports/monthly_progress_component.html.erb
@@ -1,4 +1,4 @@
-<% if Flipper.enabled?(:new_progress_tab) %>
+<% if Flipper.enabled?(:new_progress_tab, current_user) || Flipper.enabled?(:new_progress_tab) %>
   <div data-element="monthly_<%= @dimension.indicator %>_table" data-dimension-field="<%= @dimension.field %>" class="<% if @dimension.field == 'monthly_registrations_all' || @dimension.field == 'monthly_follow_ups_all' %>d-block<% else %>d-none<% end %>">
     <div class="d-flex ai-center jc-space-between pb-3px bb-grey-mid mb-4px">
       <h3 class="m-0px p-0px ta-left fw-medium fs-16px c-grey-darkest">

--- a/app/components/reports/monthly_progress_component.rb
+++ b/app/components/reports/monthly_progress_component.rb
@@ -7,13 +7,15 @@ class Reports::MonthlyProgressComponent < ViewComponent::Base
   attr_reader :range
   attr_reader :monthly_counts
   attr_reader :total_counts
+  attr_reader :current_user
 
-  def initialize(dimension, service:)
+  def initialize(dimension, service:, current_user:)
     @dimension = dimension
     @monthly_counts = service.monthly_counts
     @total_counts = service.total_counts
     @region = service.region
     @range = service.range.reverse_each
+    @current_user = current_user
   end
 
   def diagnosis_group_class

--- a/app/components/reports/progress_control_component.html.erb
+++ b/app/components/reports/progress_control_component.html.erb
@@ -1,4 +1,4 @@
-<% if Flipper.enabled?(:new_progress_tab) %>
+<% if Flipper.enabled?(:new_progress_tab, current_user) || Flipper.enabled?(:new_progress_tab) %>
   <div class="mb-8px p-16px bgc-white bs-card">
     <div class="p-relative d-flex ai-center mb-8px" data-element-type="header">
       <div class="d-flex ai-center" data-element-type="header-title">

--- a/app/components/reports/progress_control_component.rb
+++ b/app/components/reports/progress_control_component.rb
@@ -4,12 +4,13 @@ class Reports::ProgressControlComponent < ViewComponent::Base
   include AssetsHelper
   include ActionView::Helpers::NumberHelper
 
-  attr_reader :control_range, :repository
+  attr_reader :control_range, :repository, :current_user
 
-  def initialize(service)
+  def initialize(service, current_user)
     @repository = service.control_rates_repository
     @control_range = repository.range
     @region = service.region
+    @current_user = current_user
   end
 
   def control_summary

--- a/app/controllers/api/v3/analytics/user_analytics_controller.rb
+++ b/app/controllers/api/v3/analytics/user_analytics_controller.rb
@@ -7,14 +7,15 @@ class Api::V3::Analytics::UserAnalyticsController < Api::V3::AnalyticsController
   layout false
 
   def show
+    @current_user = current_user
     @period = Period.month(Date.current)
     @user_analytics = UserAnalyticsPresenter.new(current_facility)
     @service = Reports::FacilityProgressService.new(current_facility, @period)
 
     @total_follow_ups_dimension = Reports::FacilityProgressDimension.new(:follow_ups, diagnosis: :all, gender: :all)
     @total_registrations_dimension = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :all, gender: :all)
-    @total_follow_ups = Reports::MonthlyProgressComponent.new(@total_follow_ups_dimension, service: @service).total_count
-    @total_registrations = Reports::MonthlyProgressComponent.new(@total_registrations_dimension, service: @service).total_count
+    @total_follow_ups = Reports::MonthlyProgressComponent.new(@total_follow_ups_dimension, service: @service, current_user: @current_user).total_count
+    @total_registrations = Reports::MonthlyProgressComponent.new(@total_registrations_dimension, service: @service, current_user: @current_user).total_count
 
     @is_diabetes_enabled = current_facility.diabetes_enabled?
 
@@ -26,7 +27,7 @@ class Api::V3::Analytics::UserAnalyticsController < Api::V3::AnalyticsController
     end
 
     respond_to do |format|
-      if Flipper.enabled?(:new_progress_tab)
+      if Flipper.enabled?(:new_progress_tab, current_user) || Flipper.enabled?(:new_progress_tab)
         format.html { render :show_v2 }
       else
         format.html { render :show }

--- a/app/controllers/reports/progress_controller.rb
+++ b/app/controllers/reports/progress_controller.rb
@@ -7,14 +7,15 @@ class Reports::ProgressController < AdminController
   before_action :find_region
 
   def show
+    @current_user = current_user
     @current_facility = @region
     @user_analytics = UserAnalyticsPresenter.new(@region)
     @service = Reports::FacilityProgressService.new(current_facility, @period)
 
     @total_follow_ups_dimension = Reports::FacilityProgressDimension.new(:follow_ups, diagnosis: :all, gender: :all)
     @total_registrations_dimension = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :all, gender: :all)
-    @total_follow_ups = Reports::MonthlyProgressComponent.new(@total_follow_ups_dimension, service: @service).total_count
-    @total_registrations = Reports::MonthlyProgressComponent.new(@total_registrations_dimension, service: @service).total_count
+    @total_follow_ups = Reports::MonthlyProgressComponent.new(@total_follow_ups_dimension, service: @service, current_user: @current_user).total_count
+    @total_registrations = Reports::MonthlyProgressComponent.new(@total_registrations_dimension, service: @service, current_user: @current_user).total_count
     @drug_stocks = DrugStock.latest_for_facilities_grouped_by_protocol_drug(current_facility, @for_end_of_month)
 
     @is_diabetes_enabled = current_facility.diabetes_enabled?

--- a/app/views/api/v3/analytics/user_analytics/_progress_hypertension_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_progress_hypertension_report.html.erb
@@ -26,7 +26,7 @@
       <%= t("progress_tab.diagnosis_report.patient_treatment_outcomes.section_title") %>
     </h3>
   </div>
-  <%= render(Reports::ProgressControlComponent.new(@service)) %>
+  <%= render(Reports::ProgressControlComponent.new(@service, @current_user)) %>
   <%= render(Reports::ProgressUncontrolledComponent.new(@service)) %>
   <%= render(Reports::ProgressMissedVisitsComponent.new(@service)) %>
   <% if @drug_stocks_query %>

--- a/app/views/api/v3/analytics/user_analytics/_progress_monthly_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_progress_monthly_report.html.erb
@@ -29,7 +29,7 @@
     </p>
     <%= render partial: "api/v3/analytics/user_analytics/progress_monthly_period_dropdown", locals: { element_id: "registrations" } %>
     <% @service.dimension_combinations_for(:registrations).each do |dimension| %>
-      <%= render(Reports::MonthlyProgressComponent.new(dimension, service: @service)) %>
+      <%= render(Reports::MonthlyProgressComponent.new(dimension, service: @service, current_user: @current_user)) %>
     <% end %>
   </div>
   <div class="mb-8px p-16px bgc-white br-4px bs-card">
@@ -43,7 +43,7 @@
     </p>
     <%= render partial: "api/v3/analytics/user_analytics/progress_monthly_period_dropdown", locals: { element_id: "follow_ups" } %>
     <% @service.dimension_combinations_for(:follow_ups).each do |dimension| %>
-      <%= render(Reports::MonthlyProgressComponent.new(dimension, service: @service)) %>
+      <%= render(Reports::MonthlyProgressComponent.new(dimension, service: @service, current_user: @current_user)) %>
     <% end %>
   </div>
 </div>

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -16,7 +16,7 @@
   <body class="bgc-grey-lightest">
     <div id="progress-start">
       <div class="mb-8px">
-        <% if Flipper.enabled?(:new_progress_tab) %>
+        <% if Flipper.enabled?(:new_progress_tab, @current_user) || Flipper.enabled?(:new_progress_tab) %>
           <%= render partial: "api/v3/analytics/user_analytics/progress_period_card" %>
         <% else %>
           <p class="fs-14px mt-8px">
@@ -27,7 +27,7 @@
                          data: { statistics: @service.daily_statistics },
                          style: "display: none" do %>
          <% end %>
-          <%= render(Reports::DailyProgressComponent.new(@service, @user_analytics.last_updated_at)) %>
+          <%= render(Reports::DailyProgressComponent.new(@service, @user_analytics.last_updated_at, @current_user)) %>
           <div class="mb-8px p-16px bgc-white bs-card">
             <div class="d-flex ai-center">
               <h3 class="m-0px mr-4px fw-bold fs-24px c-black">
@@ -46,7 +46,7 @@
                       locals: { data_table_name: registrations_table_name,
                                 is_diabetes_enabled: current_facility.diabetes_enabled? } %>
             <% @service.dimension_combinations_for(:registrations).each do |dimension| %>
-              <%= render(Reports::MonthlyProgressComponent.new(dimension, service: @service)) %>
+              <%= render(Reports::MonthlyProgressComponent.new(dimension, service: @service, current_user: @current_user)) %>
             <% end %>
           </div>
           <div class="mb-8px p-16px bgc-white bs-card">
@@ -67,11 +67,11 @@
                       locals: { data_table_name: follow_ups_table_name,
                                 is_diabetes_enabled: current_facility.diabetes_enabled? } %>
             <% @service.dimension_combinations_for(:follow_ups).each do |dimension| %>
-              <%= render(Reports::MonthlyProgressComponent.new(dimension, service: @service)) %>
+              <%= render(Reports::MonthlyProgressComponent.new(dimension, service: @service, current_user: @current_user)) %>
             <% end %>
           </div>
         <% end %>
-        <% if Flipper.enabled?(:new_progress_tab) %>
+        <% if Flipper.enabled?(:new_progress_tab, @current_user) || Flipper.enabled?(:new_progress_tab) %>
           <%= render partial: "api/v3/analytics/user_analytics/progress_reports_card" %> 
         <% end %>
         <% if current_facility_group.region.feature_enabled?(:drug_stocks) && controller_name == "user_analytics" %>
@@ -97,8 +97,8 @@
             %>
           </div>
         <% end %>
-        <% unless Flipper.enabled?(:new_progress_tab) %>
-          <%= render(Reports::ProgressControlComponent.new(@service)) %>
+        <% unless Flipper.enabled?(:new_progress_tab, @current_user) || Flipper.enabled?(:new_progress_tab) %>
+          <%= render(Reports::ProgressControlComponent.new(@service, @current_user)) %>
           <div class="card">
             <a href="#" onclick="openWindow('progress-cohort-report', 'progress-start'); return false" class="nav-next">
               Cohort report
@@ -150,8 +150,8 @@
         </div>
       </div>
     </div>
-    <% if Flipper.enabled?(:new_progress_tab) %>
-      <%= render(Reports::DailyProgressComponent.new(@service, @user_analytics.last_updated_at)) %>
+    <% if Flipper.enabled?(:new_progress_tab, @current_user) || Flipper.enabled?(:new_progress_tab) %>
+      <%= render(Reports::DailyProgressComponent.new(@service, @user_analytics.last_updated_at, @current_user)) %>
       <%= render partial: "api/v3/analytics/user_analytics/progress_monthly_report" %>
       <%= render partial: "api/v3/analytics/user_analytics/progress_hypertension_report" %>
     <% else %>

--- a/spec/components/reports/daily_progress_component_spec.rb
+++ b/spec/components/reports/daily_progress_component_spec.rb
@@ -3,9 +3,10 @@ require "rails_helper"
 RSpec.describe Reports::DailyProgressComponent, type: :component do
   it "renders successfully" do
     facility = create(:facility)
+    user = create(:user)
     service = Reports::FacilityProgressService.new(facility, Period.current)
 
-    component = described_class.new(service, "29 Mar 2022")
+    component = described_class.new(service, "29 Mar 2022", user)
     current_date = component.display_date(Date.current)
     expect(render_inline(component).to_html).to include(current_date)
   end
@@ -13,11 +14,12 @@ RSpec.describe Reports::DailyProgressComponent, type: :component do
   context "last_30_days" do
     it "returns last 30 days from current date" do
       facility = create(:facility)
+      user = create(:user)
       service = Reports::FacilityProgressService.new(facility, Period.current)
       Timecop.freeze do
         today = Date.current
         start = today - 29
-        component = described_class.new(service, "29 Mar 2022")
+        component = described_class.new(service, "29 Mar 2022", user)
         expect(component.last_30_days.size).to eq(30)
         expect(component.last_30_days.first).to eq(today)
         expect(component.last_30_days.last).to eq(start)

--- a/spec/components/reports/monthly_progress_component_spec.rb
+++ b/spec/components/reports/monthly_progress_component_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe Reports::MonthlyProgressComponent, type: :component do
     refresh_views
 
     dimension = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :all, gender: :all)
-    component = described_class.new(dimension, service: service)
+    component = described_class.new(dimension, service: service, current_user: user)
     expect(component.total_count).to eq(2)
     dimension = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :hypertension, gender: :female)
-    component = described_class.new(dimension, service: service)
+    component = described_class.new(dimension, service: service, current_user: user)
     expect(component.total_count).to eq(1)
   end
 
@@ -35,7 +35,7 @@ RSpec.describe Reports::MonthlyProgressComponent, type: :component do
     Timecop.freeze(jan_2022) do
       refresh_views
       dimension = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :all, gender: :all)
-      component = described_class.new(dimension, service: service)
+      component = described_class.new(dimension, service: service, current_user: user)
 
       expect(component.total_count).to eq(1)
       expect(component.monthly_count(november_2021_period)).to eq(1)
@@ -49,12 +49,12 @@ RSpec.describe Reports::MonthlyProgressComponent, type: :component do
     Timecop.freeze(jan_2022) do
       refresh_views
       male = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :hypertension, gender: :male)
-      male_component = described_class.new(male, service: service)
+      male_component = described_class.new(male, service: service, current_user: user)
       expect(male_component.monthly_count(november_2021_period)).to eq(0)
       expect(male_component.monthly_count(december_2021_period)).to be_nil
 
       female = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :hypertension, gender: :female)
-      female_component = described_class.new(female, service: service)
+      female_component = described_class.new(female, service: service, current_user: user)
       expect(female_component.monthly_count(november_2021_period)).to eq(1)
       expect(female_component.monthly_count(december_2021_period)).to be_nil
     end
@@ -62,11 +62,11 @@ RSpec.describe Reports::MonthlyProgressComponent, type: :component do
 
   it "returns valid diagnosis gender classes" do
     dimension = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :hypertension, gender: :male)
-    component = described_class.new(dimension, service: service)
+    component = described_class.new(dimension, service: service, current_user: user)
     expect(component.diagnosis_group_class).to eq("hypertension:male")
 
     dimension = Reports::FacilityProgressDimension.new(:registrations, diagnosis: :diabetes, gender: :all)
-    component = described_class.new(dimension, service: service)
+    component = described_class.new(dimension, service: service, current_user: user)
     expect(component.diagnosis_group_class).to eq("diabetes:all")
   end
 end

--- a/spec/components/reports/progress_control_component_spec.rb
+++ b/spec/components/reports/progress_control_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Reports::ProgressControlComponent, type: :component do
       end
       refresh_views
       service = Reports::FacilityProgressService.new(facility, Period.current)
-      component = described_class.new(service)
+      component = described_class.new(service, user)
       expect(component.control_summary).to eq("2 of 2 patients")
     end
   end


### PR DESCRIPTION
## **Story** [8962](https://app.shortcut.com/simpledotorg/story/8962)

## Because

The check for if `new_progress_tab` is enabled for a single actor was missing

## This addresses

Adds check for if `new_progress_tab` is enabled for a single actor

## Test instructions

> Settings> Flipper> Enable feature flag `new_progress_tab` for a single actor
> Sign in as that actor
> You should be able to see the new progress tab

## Note
These changes are for development purposes and will be reverted once the feature is released