### PR TITLE
Create PG extensions in separate schema for review apps

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ def is_running_migration?
   Rake.application.top_level_tasks.include?("db:migrate")
 end
 
+Rake::Task["db:structure:load"].enhance [:support_pg_extensions_in_heroku]
 Rake::Task["db:schema:load"].clear
 task "db:schema:load" do
   Rake::Task["db:structure:load"].invoke

--- a/lib/tasks/support_pg_extensions_in_heroku.rake
+++ b/lib/tasks/support_pg_extensions_in_heroku.rake
@@ -1,0 +1,16 @@
+task :support_pg_extensions_in_heroku do
+  # https://devcenter.heroku.com/changelog-items/2446
+  next unless (ENV["SIMPLE_SERVER_ENV"] == "android_review" || ENV["SIMPLE_SERVER_ENV"] == "review")
+
+  path = "db/structure.sql"
+  f = File.open(path)
+  contents = f.read.to_s
+  f.close
+
+  contents.gsub! "CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;", "CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA heroku_ext;"
+  contents.gsub! "CREATE EXTENSION IF NOT EXISTS ltree WITH SCHEMA public;", "CREATE EXTENSION IF NOT EXISTS ltree WITH SCHEMA heroku_ext;"
+  contents.gsub! "CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;", "CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA heroku_ext;"
+  contents.gsub! "public.ltree", "heroku_ext.ltree"
+
+  IO.write(path, contents)
+end


### PR DESCRIPTION
**Story card:** [sc-8965](https://app.shortcut.com/simpledotorg/story/8965/fix-breaking-heroku-deployments-because-of-change-in-pg-extensions-policy)

## Because

Heroku has mandated creating PG extensions in a `heroku_ext` schema and doesn't let us create them in the `public` schema anymore. https://devcenter.heroku.com/changelog-items/2446

## This addresses

Adds a hook to `db:structure:load` that modifies the file on review apps accordingly.

## Test instructions

Spin up an app with this PR.