### PR TITLE
Use ubuntu 20 on heroku review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,6 +9,7 @@
   "scripts": {
     "postdeploy": "./bin/heroku-setup"
   },
+  "stack": "heroku-20",
   "env": {
     "SECRET_KEY_BASE": {
       "description": "A secret key for verifying the integrity of signed cookies.",


### PR DESCRIPTION
**Story card:** -

## Because

`heroku-22` (ubuntu 22) is the default image on review apps but it doesn't support ruby 2.7.4. 
We'll need to use `heroku-20` https://devcenter.heroku.com/articles/heroku-20-stack

## This addresses

Uses heroku-20 as the stack for heroku apps.