### PR TITLE
Setup september 2022 IHCI SMSes

### DIFF
--- a/db/data/20220829130543_create_sept2022_ihci_experiments.rb
+++ b/db/data/20220829130543_create_sept2022_ihci_experiments.rb
@@ -1,0 +1,42 @@
+class CreateSept2022IhciExperiments < ActiveRecord::Migration[5.2]
+  def up
+    return unless CountryConfig.current_country?("India") && SimpleServer.env.production?
+
+    create_current_experiment
+    create_stale_experiment
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def create_current_experiment
+    ActiveRecord::Base.transaction do
+      Experimentation::Experiment.current_patients.create!(
+        name: "Current Patient Sept 2022 Basic Variations",
+        start_time: Date.parse("30 Aug 2022").beginning_of_day,
+        end_time: Date.parse("29 Sep 2022").end_of_day,
+        max_patients_per_day: 20_000
+      ).tap do |experiment|
+        group = experiment.treatment_groups.create!(description: "official_short_cascade")
+        group.reminder_templates.create!(message: "notifications.set03.official_short", remind_on_in_days: 3)
+        group.reminder_templates.create!(message: "notifications.set03.official_short", remind_on_in_days: 7)
+      end
+    end
+  end
+
+  def create_stale_experiment
+    ActiveRecord::Base.transaction do
+      Experimentation::Experiment.stale_patients.create!(
+        name: "Stale Patient Sept 2022 Basic Variations",
+        start_time: Date.parse("30 Aug 2022").beginning_of_day,
+        end_time: Date.parse("29 Sep 2022").end_of_day,
+        max_patients_per_day: 20_000
+      ).tap do |experiment|
+        group = experiment.treatment_groups.create!(description: "official_short_cascade")
+        group.reminder_templates.create!(message: "notifications.set02.official_short", remind_on_in_days: 0)
+        group.reminder_templates.create!(message: "notifications.set03.official_short", remind_on_in_days: 7)
+      end
+    end
+  end
+end

--- a/db/data/20220829130543_create_sept2022_ihci_experiments.rb
+++ b/db/data/20220829130543_create_sept2022_ihci_experiments.rb
@@ -14,8 +14,8 @@ class CreateSept2022IhciExperiments < ActiveRecord::Migration[5.2]
     ActiveRecord::Base.transaction do
       Experimentation::Experiment.current_patients.create!(
         name: "Current Patient Sept 2022 Basic Variations",
-        start_time: Date.parse("30 Aug 2022").beginning_of_day,
-        end_time: Date.parse("29 Sep 2022").end_of_day,
+        start_time: Date.parse("31 Aug 2022").beginning_of_day,
+        end_time: Date.parse("30 Sep 2022").end_of_day,
         max_patients_per_day: 20_000
       ).tap do |experiment|
         group = experiment.treatment_groups.create!(description: "official_short_cascade")
@@ -29,8 +29,8 @@ class CreateSept2022IhciExperiments < ActiveRecord::Migration[5.2]
     ActiveRecord::Base.transaction do
       Experimentation::Experiment.stale_patients.create!(
         name: "Stale Patient Sept 2022 Basic Variations",
-        start_time: Date.parse("30 Aug 2022").beginning_of_day,
-        end_time: Date.parse("29 Sep 2022").end_of_day,
+        start_time: Date.parse("31 Aug 2022").beginning_of_day,
+        end_time: Date.parse("30 Sep 2022").end_of_day,
         max_patients_per_day: 20_000
       ).tap do |experiment|
         group = experiment.treatment_groups.create!(description: "official_short_cascade")

--- a/spec/data/create_sept2022_ihci_experiments_spec.rb
+++ b/spec/data/create_sept2022_ihci_experiments_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe CreateSept2022IhciExperiments do
 
     expect(experiment).to be_current_patients
     expect(experiment.name).to eq("Current Patient Sept 2022 Basic Variations")
-    expect(experiment.start_time.to_date).to eq(Date.parse("Aug 30, 2022").to_date)
-    expect(experiment.end_time.to_date).to eq(Date.parse("Sep 29, 2022").to_date)
+    expect(experiment.start_time.to_date).to eq(Date.parse("Aug 31, 2022").to_date)
+    expect(experiment.end_time.to_date).to eq(Date.parse("Sep 30, 2022").to_date)
     expect(experiment.max_patients_per_day).to eq(20000)
 
     expect(experiment.reminder_templates.count).to eq(2)
@@ -31,8 +31,8 @@ RSpec.describe CreateSept2022IhciExperiments do
 
     expect(experiment).to be_stale_patients
     expect(experiment.name).to eq("Stale Patient Sept 2022 Basic Variations")
-    expect(experiment.start_time.to_date).to eq(Date.parse("Aug 30, 2022").to_date)
-    expect(experiment.end_time.to_date).to eq(Date.parse("Sep 29, 2022").to_date)
+    expect(experiment.start_time.to_date).to eq(Date.parse("Aug 31, 2022").to_date)
+    expect(experiment.end_time.to_date).to eq(Date.parse("Sep 30, 2022").to_date)
     expect(experiment.max_patients_per_day).to eq(20000)
 
     expect(experiment.reminder_templates.count).to eq(2)

--- a/spec/data/create_sept2022_ihci_experiments_spec.rb
+++ b/spec/data/create_sept2022_ihci_experiments_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+require Rails.root.join("db", "data", "20220829130543_create_sept2022_ihci_experiments")
+
+RSpec.describe CreateSept2022IhciExperiments do
+  it "creates the current experiment" do
+    allow(CountryConfig).to receive(:current_country?).with("India").and_return true
+    stub_const("SIMPLE_SERVER_ENV", "production")
+
+    described_class.new.up
+
+    experiment = Experimentation::CurrentPatientExperiment.first
+
+    expect(experiment).to be_current_patients
+    expect(experiment.name).to eq("Current Patient Sept 2022 Basic Variations")
+    expect(experiment.start_time.to_date).to eq(Date.parse("Aug 30, 2022").to_date)
+    expect(experiment.end_time.to_date).to eq(Date.parse("Sep 29, 2022").to_date)
+    expect(experiment.max_patients_per_day).to eq(20000)
+
+    expect(experiment.reminder_templates.count).to eq(2)
+    expect(experiment.reminder_templates.pluck(:message)).to all start_with("notifications.set03")
+    expect(experiment.reminder_templates.pluck(:remind_on_in_days)).to contain_exactly(3, 7)
+  end
+
+  it "creates the stale experiment" do
+    allow(CountryConfig).to receive(:current_country?).with("India").and_return true
+    stub_const("SIMPLE_SERVER_ENV", "production")
+
+    described_class.new.up
+
+    experiment = Experimentation::StalePatientExperiment.first
+
+    expect(experiment).to be_stale_patients
+    expect(experiment.name).to eq("Stale Patient Sept 2022 Basic Variations")
+    expect(experiment.start_time.to_date).to eq(Date.parse("Aug 30, 2022").to_date)
+    expect(experiment.end_time.to_date).to eq(Date.parse("Sep 29, 2022").to_date)
+    expect(experiment.max_patients_per_day).to eq(20000)
+
+    expect(experiment.reminder_templates.count).to eq(2)
+    expect(experiment.reminder_templates.where("remind_on_in_days = 0").pluck(:message)).to all start_with("notifications.set02")
+    expect(experiment.reminder_templates.where("remind_on_in_days > 0").pluck(:message)).to all start_with("notifications.set03")
+    expect(experiment.reminder_templates.pluck(:remind_on_in_days)).to contain_exactly(0, 7)
+  end
+end


### PR DESCRIPTION
**Story card:** -

## Because

`official_short` double messages were the most effective in the previous SMS experiments. We're sending `official_short` messages to all patients until we decide on further A/B strategies.
[Slack thread](https://simpledotorg.slack.com/archives/C01FMV58MEC/p1661268506177259?thread_ts=1660652845.862229&cid=C01FMV58MEC)

## This addresses

Sets up the september experiments with a double `official_short` cascade.
