### PR TITLE
Fix flaky current_age spec in PatientState

### DIFF
--- a/spec/models/reports/patient_state_spec.rb
+++ b/spec/models/reports/patient_state_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe Reports::PatientState, {type: :model, reporting_spec: true} do
 
       it "determines the current age of the patient given their dob, and prefers it even when age is present" do
         current_date = Timecop.unfreeze { Date.today }
-        patient = create(:patient, date_of_birth: current_date - 80.years, age: 58, recorded_at: 2.years.ago, age_updated_at: 2.years.ago)
+        patient = create(:patient, date_of_birth: current_date - 70.years, age: 58, recorded_at: 2.years.ago, age_updated_at: 2.years.ago)
         described_class.refresh
         with_reporting_time_zone do
-          expect(described_class.where(patient_id: patient.id).pluck(:current_age)).to all eq(80)
+          expect(described_class.where(patient_id: patient.id).pluck(:current_age)).to all eq(70)
         end
       end
     end


### PR DESCRIPTION
**Story card:** -

## Because

Something funky happened with [daylight savings in IST in Sept 1942](https://www.timeanddate.com/time/change/india?year=1942) due to which postgres's `age` calculation changes a bit for timestamps in that year. 

Postgres records these events in a [tzdata file](https://github.com/postgres/postgres/blob/ab3479bf55066f3dc827796f5bf1e957ffc97d2d/src/timezone/data/tzdata.zi#L633) internally and applies them while calculating age.

## This addresses

Changes the spec to use a non-controversial year.