### PR TITLE
Use device_created_at to pick latest overdue appointment

### DIFF
--- a/db/migrate/20220902104533_update_patient_summaries_to_version_9.rb
+++ b/db/migrate/20220902104533_update_patient_summaries_to_version_9.rb
@@ -1,0 +1,5 @@
+class UpdatePatientSummariesToVersion9 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :patient_summaries, version: 9, revert_to_version: 8
+  end
+end

--- a/db/migrate/20220902114057_update_materialized_patient_summaries_to_version_2.rb
+++ b/db/migrate/20220902114057_update_materialized_patient_summaries_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateMaterializedPatientSummariesToVersion2 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :materialized_patient_summaries, version: 2, revert_to_version: 1, materialized: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1145,7 +1145,7 @@ CREATE MATERIALIZED VIEW public.patient_registrations_per_day_per_facilities AS
 
 CREATE VIEW public.patient_summaries AS
  SELECT p.recorded_at,
-    concat(date_part('year'::text, p.recorded_at), ' Q', date_part('quarter'::text, p.recorded_at)) AS registration_quarter,
+    concat(date_part('year'::text, p.recorded_at), ' Q', EXTRACT(quarter FROM p.recorded_at)) AS registration_quarter,
     p.full_name,
         CASE
             WHEN (p.date_of_birth IS NOT NULL) THEN date_part('year'::text, age((p.date_of_birth)::timestamp with time zone))
@@ -1166,7 +1166,7 @@ CREATE VIEW public.patient_summaries AS
     latest_blood_pressure.systolic AS latest_blood_pressure_systolic,
     latest_blood_pressure.diastolic AS latest_blood_pressure_diastolic,
     latest_blood_pressure.recorded_at AS latest_blood_pressure_recorded_at,
-    concat(date_part('year'::text, latest_blood_pressure.recorded_at), ' Q', date_part('quarter'::text, latest_blood_pressure.recorded_at)) AS latest_blood_pressure_quarter,
+    concat(date_part('year'::text, latest_blood_pressure.recorded_at), ' Q', EXTRACT(quarter FROM latest_blood_pressure.recorded_at)) AS latest_blood_pressure_quarter,
     latest_blood_pressure_facility.name AS latest_blood_pressure_facility_name,
     latest_blood_pressure_facility.facility_type AS latest_blood_pressure_facility_type,
     latest_blood_pressure_facility.district AS latest_blood_pressure_district,
@@ -1174,7 +1174,7 @@ CREATE VIEW public.patient_summaries AS
     latest_blood_sugar.blood_sugar_type AS latest_blood_sugar_type,
     latest_blood_sugar.blood_sugar_value AS latest_blood_sugar_value,
     latest_blood_sugar.recorded_at AS latest_blood_sugar_recorded_at,
-    concat(date_part('year'::text, latest_blood_sugar.recorded_at), ' Q', date_part('quarter'::text, latest_blood_sugar.recorded_at)) AS latest_blood_sugar_quarter,
+    concat(date_part('year'::text, latest_blood_sugar.recorded_at), ' Q', EXTRACT(quarter FROM latest_blood_sugar.recorded_at)) AS latest_blood_sugar_quarter,
     latest_blood_sugar_facility.name AS latest_blood_sugar_facility_name,
     latest_blood_sugar_facility.facility_type AS latest_blood_sugar_facility_type,
     latest_blood_sugar_facility.district AS latest_blood_sugar_district,
@@ -1287,7 +1287,7 @@ CREATE VIEW public.patient_summaries AS
             a.creation_facility_id
            FROM public.appointments a
           WHERE (a.patient_id = p.id)
-          ORDER BY a.scheduled_date DESC
+          ORDER BY a.device_created_at DESC
          LIMIT 1) next_appointment ON (true))
      LEFT JOIN public.facilities next_appointment_facility ON ((next_appointment_facility.id = next_appointment.facility_id)))
   WHERE (p.deleted_at IS NULL);
@@ -6079,6 +6079,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220414134624'),
 ('20220519201430'),
 ('20220524112732'),
-('20220718091454');
+('20220718091454'),
+('20220902104533');
 
 

--- a/db/views/materialized_patient_summaries_v02.sql
+++ b/db/views/materialized_patient_summaries_v02.sql
@@ -1,0 +1,138 @@
+SELECT p.recorded_at,
+       CONCAT(date_part('year', p.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE
+                                (SELECT current_setting('TIMEZONE'))), ' Q', EXTRACT(QUARTER
+                                                                                     FROM p.recorded_at AT TIME ZONE
+                                                                                          'UTC' AT TIME ZONE
+                                                                                          (SELECT current_setting('TIMEZONE')))) AS registration_quarter,
+       p.full_name,
+       (CASE
+            WHEN p.date_of_birth IS NOT NULL THEN date_part('year', age(p.date_of_birth))
+            ELSE floor(p.age + date_part('year', age(p.age_updated_at AT TIME ZONE 'UTC' AT TIME ZONE
+                                                     (SELECT current_setting('TIMEZONE')))))
+           END)                                                                                                                  AS current_age,
+       p.gender,
+       p.status,
+       latest_phone_number.number                                                                                                AS latest_phone_number,
+       addresses.village_or_colony                                                                                               AS village_or_colony,
+       addresses.street_address                                                                                                  AS street_address,
+       addresses.district                                                                                                        AS district,
+       addresses.state                                                                                                           AS state,
+       addresses.zone                                                                                                            AS block,
+       reg_facility.name                                                                                                         AS registration_facility_name,
+       reg_facility.facility_type                                                                                                AS registration_facility_type,
+       reg_facility.district                                                                                                     AS registration_district,
+       reg_facility.state                                                                                                        AS registration_state,
+       p.assigned_facility_id                                                                                                    AS assigned_facility_id,
+       assigned_facility.name                                                                                                    AS assigned_facility_name,
+       assigned_facility.facility_type                                                                                           AS assigned_facility_type,
+       assigned_facility.district                                                                                                AS assigned_facility_district,
+       assigned_facility.state                                                                                                   AS assigned_facility_state,
+       latest_blood_pressure.systolic                                                                                            AS latest_blood_pressure_systolic,
+       latest_blood_pressure.diastolic                                                                                           AS latest_blood_pressure_diastolic,
+       latest_blood_pressure.recorded_at                                                                                         AS latest_blood_pressure_recorded_at,
+       CONCAT(date_part('year', latest_blood_pressure.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE
+                                (SELECT current_setting('TIMEZONE'))), ' Q', EXTRACT(QUARTER
+                                                                                     FROM
+                                                                                     latest_blood_pressure.recorded_at AT TIME ZONE
+                                                                                     'UTC' AT TIME ZONE
+                                                                                     (SELECT current_setting('TIMEZONE'))))      AS latest_blood_pressure_quarter,
+       latest_blood_pressure_facility.name                                                                                       AS latest_blood_pressure_facility_name,
+       latest_blood_pressure_facility.facility_type                                                                              AS latest_blood_pressure_facility_type,
+       latest_blood_pressure_facility.district                                                                                   AS latest_blood_pressure_district,
+       latest_blood_pressure_facility.state                                                                                      AS latest_blood_pressure_state,
+       latest_blood_sugar.id                                                                                                     AS latest_blood_sugar_id,
+       latest_blood_sugar.blood_sugar_type                                                                                       AS latest_blood_sugar_type,
+       latest_blood_sugar.blood_sugar_value                                                                                      AS latest_blood_sugar_value,
+       latest_blood_sugar.recorded_at                                                                                            AS latest_blood_sugar_recorded_at,
+       CONCAT(date_part('year', latest_blood_sugar.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE
+                                (SELECT current_setting('TIMEZONE'))), ' Q', EXTRACT(QUARTER
+                                                                                     FROM
+                                                                                     latest_blood_sugar.recorded_at AT TIME ZONE
+                                                                                     'UTC' AT TIME ZONE
+                                                                                     (SELECT current_setting('TIMEZONE'))))      AS latest_blood_sugar_quarter,
+       latest_blood_sugar_facility.name                                                                                          AS latest_blood_sugar_facility_name,
+       latest_blood_sugar_facility.facility_type                                                                                 AS latest_blood_sugar_facility_type,
+       latest_blood_sugar_facility.district                                                                                      AS latest_blood_sugar_district,
+       latest_blood_sugar_facility.state                                                                                         AS latest_blood_sugar_state,
+       greatest(0,
+                date_part('day', NOW() - next_scheduled_appointment.scheduled_date))                                             AS days_overdue,
+       next_scheduled_appointment.id                                                                                             AS next_scheduled_appointment_id,
+       next_scheduled_appointment.scheduled_date                                                                                 AS next_scheduled_appointment_scheduled_date,
+       next_scheduled_appointment.status                                                                                         AS next_scheduled_appointment_status,
+       next_scheduled_appointment.remind_on                                                                                      AS next_scheduled_appointment_remind_on,
+       next_scheduled_appointment_facility.id                                                                                    AS next_scheduled_appointment_facility_id,
+       next_scheduled_appointment_facility.name                                                                                  AS next_scheduled_appointment_facility_name,
+       next_scheduled_appointment_facility.facility_type                                                                         AS next_scheduled_appointment_facility_type,
+       next_scheduled_appointment_facility.district                                                                              AS next_scheduled_appointment_district,
+       next_scheduled_appointment_facility.state                                                                                 AS next_scheduled_appointment_state,
+       (CASE
+            WHEN next_scheduled_appointment.scheduled_date IS NULL THEN 0
+            WHEN next_scheduled_appointment.scheduled_date > date_trunc('day', NOW() - interval '30 days') THEN 0
+            WHEN (latest_blood_pressure.systolic >= 180
+                OR latest_blood_pressure.diastolic >= 110) THEN 1
+            WHEN ((mh.prior_heart_attack = 'yes'
+                OR mh.prior_stroke = 'yes')
+                AND (latest_blood_pressure.systolic >= 140
+                    OR latest_blood_pressure.diastolic >= 90)) THEN 1
+            WHEN ((latest_blood_sugar.blood_sugar_type = 'random'
+                AND latest_blood_sugar.blood_sugar_value >= 300)
+                OR (latest_blood_sugar.blood_sugar_type = 'post_prandial'
+                    AND latest_blood_sugar.blood_sugar_value >= 300)
+                OR (latest_blood_sugar.blood_sugar_type = 'fasting'
+                    AND latest_blood_sugar.blood_sugar_value >= 200)
+                OR (latest_blood_sugar.blood_sugar_type = 'hba1c'
+                    AND latest_blood_sugar.blood_sugar_value >= 9.0)) THEN 1
+            ELSE 0
+           END)                                                                                                                  AS risk_level,
+       latest_bp_passport.id                                                                                                     AS latest_bp_passport_id,
+       latest_bp_passport.identifier                                                                                             AS latest_bp_passport_identifier,
+       mh.hypertension                                                                                                           AS hypertension,
+       mh.diabetes                                                                                                               AS diabetes,
+       p.id
+FROM patients p
+         LEFT OUTER JOIN addresses ON addresses.id = p.address_id
+         LEFT OUTER JOIN facilities reg_facility ON reg_facility.id = p.registration_facility_id
+         LEFT OUTER JOIN facilities assigned_facility ON assigned_facility.id = p.assigned_facility_id
+         LEFT OUTER JOIN
+     (SELECT DISTINCT ON (patient_id) *
+      FROM medical_histories
+      WHERE deleted_at IS NULL) AS mh ON mh.patient_id = p.id
+         LEFT OUTER JOIN
+     (SELECT DISTINCT ON (patient_id) *
+      FROM patient_phone_numbers
+      WHERE deleted_at IS NULL
+      ORDER BY patient_id,
+               device_created_at DESC) AS latest_phone_number ON latest_phone_number.patient_id = p.id
+         LEFT OUTER JOIN
+     (SELECT DISTINCT ON (patient_id) *
+      FROM blood_pressures
+      WHERE deleted_at IS NULL
+      ORDER BY patient_id,
+               recorded_at DESC) AS latest_blood_pressure ON latest_blood_pressure.patient_id = p.id
+         LEFT OUTER JOIN facilities latest_blood_pressure_facility
+                         ON latest_blood_pressure_facility.id = latest_blood_pressure.facility_id
+         LEFT OUTER JOIN
+     (SELECT DISTINCT ON (patient_id) *
+      FROM blood_sugars
+      WHERE deleted_at IS NULL
+      ORDER BY patient_id,
+               recorded_at DESC) AS latest_blood_sugar ON latest_blood_sugar.patient_id = p.id
+         LEFT OUTER JOIN facilities latest_blood_sugar_facility
+                         ON latest_blood_sugar_facility.id = latest_blood_sugar.facility_id
+         LEFT OUTER JOIN
+     (SELECT DISTINCT ON (patient_id) *
+      FROM patient_business_identifiers
+      WHERE identifier_type = 'simple_bp_passport'
+        AND deleted_at IS NULL
+      ORDER BY patient_id,
+               device_created_at DESC) AS latest_bp_passport ON latest_bp_passport.patient_id = p.id
+         LEFT OUTER JOIN
+     (SELECT DISTINCT ON (patient_id) *
+      FROM appointments
+      WHERE deleted_at IS NULL
+      ORDER BY patient_id, device_created_at DESC) AS next_scheduled_appointment ON next_scheduled_appointment.patient_id = p.id
+                                                                     AND next_scheduled_appointment.status = 'scheduled'
+         LEFT OUTER JOIN facilities next_scheduled_appointment_facility
+                         ON next_scheduled_appointment_facility.id = next_scheduled_appointment.facility_id
+                         AND next_scheduled_appointment.status = 'scheduled'
+WHERE p.deleted_at IS NULL;

--- a/db/views/patient_summaries_v09.sql
+++ b/db/views/patient_summaries_v09.sql
@@ -1,0 +1,125 @@
+SELECT
+p.recorded_at,
+CONCAT(date_part('year', p.recorded_at), ' Q', EXTRACT(QUARTER FROM p.recorded_at)) AS registration_quarter,
+p.full_name,
+(
+    CASE
+      WHEN p.date_of_birth IS NOT NULL THEN date_part('year', age(p.date_of_birth))
+      ELSE p.age + date_part('years', age(NOW(), p.age_updated_at))
+    END
+) AS current_age,
+p.gender,
+p.status,
+p.assigned_facility_id AS assigned_facility_id,
+latest_phone_number.number AS latest_phone_number,
+addresses.village_or_colony AS village_or_colony,
+addresses.street_address AS street_address,
+addresses.district AS district,
+addresses.state AS state,
+reg_facility.name AS registration_facility_name,
+reg_facility.facility_type AS registration_facility_type,
+reg_facility.district AS registration_district,
+reg_facility.state AS registration_state,
+latest_blood_pressure.systolic AS latest_blood_pressure_systolic,
+latest_blood_pressure.diastolic AS latest_blood_pressure_diastolic,
+latest_blood_pressure.recorded_at AS latest_blood_pressure_recorded_at,
+CONCAT(date_part('year', latest_blood_pressure.recorded_at), ' Q', EXTRACT(QUARTER FROM latest_blood_pressure.recorded_at)) AS latest_blood_pressure_quarter,
+latest_blood_pressure_facility.name AS latest_blood_pressure_facility_name,
+latest_blood_pressure_facility.facility_type AS latest_blood_pressure_facility_type,
+latest_blood_pressure_facility.district AS latest_blood_pressure_district,
+latest_blood_pressure_facility.state AS latest_blood_pressure_state,
+latest_blood_sugar.blood_sugar_type AS latest_blood_sugar_type,
+latest_blood_sugar.blood_sugar_value AS latest_blood_sugar_value,
+latest_blood_sugar.recorded_at AS latest_blood_sugar_recorded_at,
+CONCAT(date_part('year', latest_blood_sugar.recorded_at), ' Q', EXTRACT(QUARTER FROM latest_blood_sugar.recorded_at)) AS latest_blood_sugar_quarter,
+latest_blood_sugar_facility.name AS latest_blood_sugar_facility_name,
+latest_blood_sugar_facility.facility_type AS latest_blood_sugar_facility_type,
+latest_blood_sugar_facility.district AS latest_blood_sugar_district,
+latest_blood_sugar_facility.state AS latest_blood_sugar_state,
+greatest(0, date_part('day', NOW() - next_appointment.scheduled_date)) AS days_overdue,
+next_appointment.id AS next_appointment_id,
+next_appointment.scheduled_date AS next_appointment_scheduled_date,
+next_appointment.status AS next_appointment_status,
+next_appointment.cancel_reason AS next_appointment_cancel_reason,
+next_appointment.remind_on AS next_appointment_remind_on,
+next_appointment_facility.id AS next_appointment_facility_id,
+next_appointment_facility.name AS next_appointment_facility_name,
+next_appointment_facility.facility_type AS next_appointment_facility_type,
+next_appointment_facility.district AS next_appointment_district,
+next_appointment_facility.state AS next_appointment_state,
+
+(
+    CASE
+      WHEN next_appointment.scheduled_date IS NULL THEN 0
+      WHEN next_appointment.scheduled_date > date_trunc('day', NOW() - interval '30 days') THEN 0
+      WHEN (latest_blood_pressure.systolic >= 180 OR latest_blood_pressure.diastolic >= 110) THEN 1
+      WHEN (
+        (mh.prior_heart_attack = 'yes' OR mh.prior_stroke = 'yes')
+        AND (latest_blood_pressure.systolic >= 140 OR latest_blood_pressure.diastolic >= 90)
+      ) THEN 1
+      WHEN (
+        (latest_blood_sugar.blood_sugar_type = 'random' AND latest_blood_sugar.blood_sugar_value >= 300)
+        OR (latest_blood_sugar.blood_sugar_type = 'post_prandial' AND latest_blood_sugar.blood_sugar_value >= 300)
+        OR (latest_blood_sugar.blood_sugar_type = 'fasting' AND latest_blood_sugar.blood_sugar_value >= 200)
+        OR (latest_blood_sugar.blood_sugar_type = 'hba1c' AND latest_blood_sugar.blood_sugar_value >= 9.0)
+      ) THEN 1
+      ELSE 0
+    END
+) AS risk_level,
+
+latest_bp_passport.id AS latest_bp_passport_id,
+latest_bp_passport.identifier AS latest_bp_passport_identifier,
+
+p.id
+
+FROM patients p
+
+LEFT OUTER JOIN addresses ON addresses.id = p.address_id
+LEFT OUTER JOIN facilities reg_facility ON reg_facility.id = p.registration_facility_id
+LEFT OUTER JOIN medical_histories mh ON mh.patient_id = p.id
+
+LEFT JOIN LATERAL (
+    SELECT *
+    FROM patient_phone_numbers ppn
+    WHERE ppn.patient_id = p.id
+    ORDER by ppn.device_created_at desc
+    LIMIT 1
+) latest_phone_number ON TRUE
+
+LEFT JOIN LATERAL (
+    SELECT *
+    FROM blood_pressures bp
+    WHERE bp.patient_id = p.id
+    ORDER by bp.recorded_at desc
+    LIMIT 1
+) latest_blood_pressure ON TRUE
+LEFT OUTER JOIN facilities latest_blood_pressure_facility ON latest_blood_pressure_facility.id = latest_blood_pressure.facility_id
+
+LEFT JOIN LATERAL (
+    SELECT *
+    FROM blood_sugars bs
+    WHERE bs.patient_id = p.id
+    ORDER by bs.recorded_at desc
+    LIMIT 1
+) latest_blood_sugar ON TRUE
+LEFT OUTER JOIN facilities latest_blood_sugar_facility ON latest_blood_sugar_facility.id = latest_blood_sugar.facility_id
+
+LEFT JOIN LATERAL (
+    SELECT *
+    FROM patient_business_identifiers bp_passport
+    WHERE identifier_type = 'simple_bp_passport'
+    AND bp_passport.patient_id = p.id
+    ORDER by bp_passport.device_created_at desc
+    LIMIT 1
+) latest_bp_passport ON TRUE
+
+LEFT JOIN LATERAL (
+    SELECT *
+    FROM appointments a
+    WHERE a.patient_id = p.id
+    ORDER by a.device_created_at DESC
+    LIMIT 1
+) next_appointment ON TRUE
+
+LEFT OUTER JOIN facilities next_appointment_facility ON next_appointment_facility.id = next_appointment.facility_id
+WHERE p.deleted_at IS NULL;

--- a/spec/models/materialized_patient_summary_spec.rb
+++ b/spec/models/materialized_patient_summary_spec.rb
@@ -181,6 +181,13 @@ describe MaterializedPatientSummary, type: :model do
       expect(patient_summary.next_scheduled_appointment_district).to eq(next_appointment.facility.district)
       expect(patient_summary.next_scheduled_appointment_state).to eq(next_appointment.facility.state)
     end
+
+    it "doesn't include next appointment if there's no scheduled appointment" do
+      next_appointment.update(status: :visited)
+      refresh_view
+
+      expect(patient_summary.reload.days_overdue).to eq(0)
+    end
   end
 
   describe "Risk level" do

--- a/spec/models/materialized_patient_summary_spec.rb
+++ b/spec/models/materialized_patient_summary_spec.rb
@@ -168,6 +168,13 @@ describe MaterializedPatientSummary, type: :model do
       expect(patient_summary.next_scheduled_appointment_scheduled_date).to eq(next_appointment.scheduled_date)
     end
 
+    it "includes next appointment date based on device_created_at" do
+      create(:appointment, patient: patient, user: user, facility: facility,
+             device_created_at: 10.days.ago, scheduled_date: next_appointment.scheduled_date - 10.days)
+
+      expect(patient_summary.next_scheduled_appointment_scheduled_date).to eq(next_appointment.scheduled_date)
+    end
+
     it "includes next appointment facility details", :aggregate_failures do
       expect(patient_summary.next_scheduled_appointment_facility_name).to eq(next_appointment.facility.name)
       expect(patient_summary.next_scheduled_appointment_facility_type).to eq(next_appointment.facility.facility_type)

--- a/spec/models/patient_summary_spec.rb
+++ b/spec/models/patient_summary_spec.rb
@@ -21,7 +21,6 @@ describe PatientSummary, type: :model do
 
     let!(:old_passport) { create(:patient_business_identifier, patient: patient, device_created_at: old_date) }
 
-    let!(:scheduled_appointment) { create(:appointment, patient: patient, scheduled_date: 60.days.from_now) }
     let!(:next_appointment) { create(:appointment, patient: patient, scheduled_date: 30.days.from_now) }
 
     let(:med_history) { create(:medical_history, patient: patient) }
@@ -111,6 +110,8 @@ describe PatientSummary, type: :model do
       end
 
       it "includes next appointment date" do
+        _future_scheduled_appointment = create(:appointment, patient: patient, scheduled_date: 60.days.from_now,
+                                              device_created_at: next_appointment.device_created_at - 10.days)
         expect(patient_summary.next_appointment_id).to eq(next_appointment.id)
         expect(patient_summary.next_appointment_scheduled_date).to eq(next_appointment.scheduled_date)
       end

--- a/spec/models/patient_summary_spec.rb
+++ b/spec/models/patient_summary_spec.rb
@@ -21,7 +21,8 @@ describe PatientSummary, type: :model do
 
     let!(:old_passport) { create(:patient_business_identifier, patient: patient, device_created_at: old_date) }
 
-    let!(:next_appointment) { create(:appointment, patient: patient) }
+    let!(:scheduled_appointment) { create(:appointment, patient: patient, scheduled_date: 60.days.from_now) }
+    let!(:next_appointment) { create(:appointment, patient: patient, scheduled_date: 30.days.from_now) }
 
     let(:med_history) { create(:medical_history, patient: patient) }
 
@@ -110,6 +111,7 @@ describe PatientSummary, type: :model do
       end
 
       it "includes next appointment date" do
+        expect(patient_summary.next_appointment_id).to eq(next_appointment.id)
         expect(patient_summary.next_appointment_scheduled_date).to eq(next_appointment.scheduled_date)
       end
 


### PR DESCRIPTION
**Story card:** [sc-9056](https://app.shortcut.com/simpledotorg/story/9056/use-the-latest-appointment-by-device-created-at-for-calculating-patient-overdueness)

## Because

We use the latest scheduled_date to find a patient's latest overdue appointment. If a user creates many appointments for a patient, we should use the latest created appointment and not the one that's farthest into the future (latest scheduled appointment) to evaluate overdueness.

## This addresses

Updates the "overdue" calculation for a patient in overdue list and line list SQL to:
- Find the latest appointment for a patient by `device_created_at` (instead of `scheduled_date`)
- Call a patient overdue if the status of _this_ appointment is `scheduled` or `cancelled` and the `scheduled_date` has passed

