### PR TITLE
Fix diabetes treatment outcome description

### DIFF
--- a/app/components/dashboard/diabetes/treatment_outcomes_card_component.html.erb
+++ b/app/components/dashboard/diabetes/treatment_outcomes_card_component.html.erb
@@ -25,7 +25,8 @@
 
               <p class="m-0px c-black">
                 <span data-key="<%= treatment_outcome[:count] %>" data-format="numberWithCommas"></span>
-                patients with no visit from
+                <%= treatment_outcome[:description] %>
+                from
                 <span data-key="startDate"></span>
                 to
                 <span data-key="endDate"></span>

--- a/app/components/dashboard/diabetes/treatment_outcomes_card_component.html.erb
+++ b/app/components/dashboard/diabetes/treatment_outcomes_card_component.html.erb
@@ -1,5 +1,5 @@
 <div id="diabetes-visit-details"
-     class="pt-20px px-20px mt-8px mx-0px mb-16px bg-white br-4px bs-small d-lg-flex fd-lg-column
+     class="pt-20px p-20px mt-8px mx-0px mb-16px bg-white br-4px bs-small d-lg-flex fd-lg-column
           justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black w-print-16cm">
 
   <%= render Dashboard::Card::TitleComponent.new(title: 'Treatment status of patients under care') %>

--- a/app/components/dashboard/diabetes/treatment_outcomes_card_component.html.erb
+++ b/app/components/dashboard/diabetes/treatment_outcomes_card_component.html.erb
@@ -1,5 +1,5 @@
 <div id="diabetes-visit-details"
-     class="pt-20px p-20px mt-8px mx-0px mb-16px bg-white br-4px bs-small d-lg-flex fd-lg-column
+     class="p-20px mt-8px mx-0px mb-16px bg-white br-4px bs-small d-lg-flex fd-lg-column
           justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black w-print-16cm">
 
   <%= render Dashboard::Card::TitleComponent.new(title: 'Treatment status of patients under care') %>

--- a/app/components/dashboard/diabetes/treatment_outcomes_card_component.rb
+++ b/app/components/dashboard/diabetes/treatment_outcomes_card_component.rb
@@ -31,6 +31,7 @@ class Dashboard::Diabetes::TreatmentOutcomesCardComponent < ApplicationComponent
       count: "diabetesMissedVisits",
       class: "c-blue",
       title: "Missed visits",
+      description: "patients with no visit",
       tooltip: {
         numerator: t("diabetes_missed_visits_copy.numerator"),
         denominator: t("diabetes_denominator_copy", region_name: @region.name)
@@ -39,6 +40,7 @@ class Dashboard::Diabetes::TreatmentOutcomesCardComponent < ApplicationComponent
        count: "visitButNoBSMeasure",
        class: "c-grey-dark",
        title: "Visit but no blood sugar taken",
+       description: "patients with a visit but no blood sugar taken",
        tooltip: {
          numerator: t("visit_but_no_bs_taken_copy.numerator"),
          denominator: t("diabetes_denominator_copy", region_name: @region.name)
@@ -47,6 +49,7 @@ class Dashboard::Diabetes::TreatmentOutcomesCardComponent < ApplicationComponent
        count: "bsOver300Patients",
        class: "c-red",
        title: "Blood sugar &ge;300".html_safe,
+       description: "patients with blood sugar ≥300 taken",
        tooltip: {
          numerator: t("bs_over_200_copy.bs_over_300.numerator"),
          denominator: t("diabetes_denominator_copy", region_name: @region.name)
@@ -54,6 +57,7 @@ class Dashboard::Diabetes::TreatmentOutcomesCardComponent < ApplicationComponent
       {key: "bs200to300Rate",
        count: "bs200to300Patients",
        title: "Blood sugar 200-299",
+       description: "patients with blood sugar 200-299 taken",
        class: "c-amber",
        tooltip: {numerator: t("bs_over_200_copy.bs_200_to_299.numerator"),
                  denominator: t("diabetes_denominator_copy", region_name: @region.name)}},
@@ -61,6 +65,7 @@ class Dashboard::Diabetes::TreatmentOutcomesCardComponent < ApplicationComponent
        count: "bsBelow200Patients",
        class: "c-green-dark",
        title: "Blood sugar &lt;200".html_safe,
+       description: "patients with blood sugar <200 taken",
        tooltip: {numerator: t("bs_below_200_copy.numerator"),
                  denominator: t("diabetes_denominator_copy", region_name: @region.name)}}]
   end


### PR DESCRIPTION
**Story card:** [sc-9093](https://app.shortcut.com/simpledotorg/story/9093/error-with-dm-descriptions-on-the-dashboard-in-treatment-status-of-patients-under-care)

## Because

The description of all the treatment outcomes was the same.

## This addresses

Add a discrete description to each of the treatment outcomes.

## Other Changes
 
Fix padding of the diabetes treatment outcome card

## Test instructions

- Checkout to this branch
- Reports > <Any Region> > Diabetes > Treatment Outcome Card
- You should see discrete definitions for each outcome

Before
<img width="1363" alt="Screenshot 2022-09-12 at 2 50 16 PM" src="https://user-images.githubusercontent.com/32141642/189618357-602078e6-b881-411e-b07d-563377da3cd8.png">


After
<img width="1363" alt="Screenshot 2022-09-12 at 2 48 01 PM" src="https://user-images.githubusercontent.com/32141642/189617945-91162bf5-b7b8-413a-9efa-3ee8d885e829.png">
