### PR TITLE
Include discarded appointments when filling patient IDs in call results

### DIFF
--- a/app/transformers/api/v4/call_result_transformer.rb
+++ b/app/transformers/api/v4/call_result_transformer.rb
@@ -11,7 +11,7 @@ class Api::V4::CallResultTransformer < Api::V4::Transformer
     def add_fallback_patient_id(payload)
       return payload if payload["patient_id"].present?
 
-      appointment = Appointment.find_by(id: payload["appointment_id"])
+      appointment = Appointment.with_discarded.find_by(id: payload["appointment_id"])
       payload.merge("patient_id" => appointment&.patient_id)
     end
 

--- a/spec/transformers/api/v4/call_result_transformer_spec.rb
+++ b/spec/transformers/api/v4/call_result_transformer_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe Api::V4::CallResultTransformer do
         )["patient_id"]).to eq(appointment.patient_id)
       end
 
+      it "includes discarded appointments while filling up fallback patient_id" do
+        appointment = create(:appointment, deleted_at: Time.now)
+        expect(Api::V4::CallResultTransformer.from_request(
+          {"appointment_id" => appointment.id, "patient_id" => nil}
+        )["patient_id"]).to eq(appointment.patient_id)
+      end
+
       it "returns the hash as is if the appointment is missing" do
         expect(Api::V4::CallResultTransformer.from_request(
           {"appointment_id" => SecureRandom.uuid, "patient_id" => nil}


### PR DESCRIPTION
**Story card:** [sc-9057](https://app.shortcut.com/simpledotorg/story/9057/add-sync-to-user-endpoint-for-call-results)

## Because
We added a `patient_id` attribute to call results and started intelligently filling it for older app versions using the appointment in https://github.com/simpledotorg/simple-server/pull/4238. We don't include discarded appointments while looking up though.

## This addresses

Includes discarded appointments in lookup.
