### PR TITLE
[maintenance] Remove unnecessary headers from API controller specs

### DIFF
--- a/spec/controllers/api/v3/appointments_controller_spec.rb
+++ b/spec/controllers/api/v3/appointments_controller_spec.rb
@@ -11,12 +11,6 @@ RSpec.describe Api::V3::AppointmentsController, type: :controller do
   let(:update_payload) { ->(appointment) { updated_appointment_payload appointment } }
   let(:number_of_schema_errors_in_invalid_payload) { 2 }
 
-  before :each do
-    request.env["X_USER_ID"] = request_user.id
-    request.env["X_FACILITY_ID"] = request_facility.id
-    request.env["HTTP_AUTHORIZATION"] = "Bearer #{request_user.access_token}"
-  end
-
   def create_record(options = {})
     facility = options[:facility] || create(:facility, facility_group: request_facility_group)
     patient = create(:patient, registration_facility: facility)

--- a/spec/controllers/api/v3/blood_pressures_controller_spec.rb
+++ b/spec/controllers/api/v3/blood_pressures_controller_spec.rb
@@ -11,12 +11,6 @@ RSpec.describe Api::V3::BloodPressuresController, type: :controller do
   let(:update_payload) { ->(blood_pressure) { updated_blood_pressure_payload(blood_pressure) } }
   let(:number_of_schema_errors_in_invalid_payload) { 3 }
 
-  before :each do
-    request.env["X_USER_ID"] = request_user.id
-    request.env["X_FACILITY_ID"] = request_facility.id
-    request.env["HTTP_AUTHORIZATION"] = "Bearer #{request_user.access_token}"
-  end
-
   def create_record(options = {})
     facility = options[:facility] || create(:facility, facility_group: request_facility_group)
     patient = create(:patient, registration_facility: facility)

--- a/spec/controllers/api/v3/blood_sugars_controller_spec.rb
+++ b/spec/controllers/api/v3/blood_sugars_controller_spec.rb
@@ -11,12 +11,6 @@ RSpec.describe Api::V3::BloodSugarsController, type: :controller do
   let(:update_payload) { ->(blood_sugar) { updated_blood_sugar_payload(blood_sugar) } }
   let(:number_of_schema_errors_in_invalid_payload) { 2 }
 
-  before :each do
-    request.env["X_USER_ID"] = request_user.id
-    request.env["X_FACILITY_ID"] = request_facility.id
-    request.env["HTTP_AUTHORIZATION"] = "Bearer #{request_user.access_token}"
-  end
-
   def create_record(options = {})
     facility = options[:facility] || create(:facility, facility_group: request_facility_group)
     patient = create(:patient, registration_facility: facility)

--- a/spec/controllers/api/v3/medical_histories_controller_spec.rb
+++ b/spec/controllers/api/v3/medical_histories_controller_spec.rb
@@ -11,12 +11,6 @@ RSpec.describe Api::V3::MedicalHistoriesController, type: :controller do
   let(:update_payload) { ->(medical_history) { updated_medical_history_payload medical_history } }
   let(:number_of_schema_errors_in_invalid_payload) { 2 }
 
-  before :each do
-    request.env["X_USER_ID"] = request_user.id
-    request.env["X_FACILITY_ID"] = request_facility.id
-    request.env["HTTP_AUTHORIZATION"] = "Bearer #{request_user.access_token}"
-  end
-
   def create_record(options = {})
     facility = create(:facility, facility_group: request_facility_group)
     patient = build(:patient, registration_facility: facility)

--- a/spec/controllers/api/v3/medical_histories_controller_spec.rb
+++ b/spec/controllers/api/v3/medical_histories_controller_spec.rb
@@ -95,10 +95,7 @@ RSpec.describe Api::V3::MedicalHistoriesController, type: :controller do
       }
     end
 
-    before :each do
-      request.env["HTTP_X_USER_ID"] = request_user.id
-      request.env["HTTP_X_FACILITY_ID"] = request_facility.id
-    end
+    before { set_authentication_headers }
 
     context "with a pre-existing medical history" do
       let(:patient) { create(:patient) }

--- a/spec/controllers/api/v4/blood_sugars_controller_spec.rb
+++ b/spec/controllers/api/v4/blood_sugars_controller_spec.rb
@@ -11,12 +11,6 @@ RSpec.describe Api::V4::BloodSugarsController, type: :controller do
   let(:update_payload) { ->(blood_sugar) { updated_blood_sugar_payload(blood_sugar) } }
   let(:number_of_schema_errors_in_invalid_payload) { 2 }
 
-  before :each do
-    request.env["X_USER_ID"] = request_user.id
-    request.env["X_FACILITY_ID"] = request_facility.id
-    request.env["HTTP_AUTHORIZATION"] = "Bearer #{request_user.access_token}"
-  end
-
   def create_record(options = {})
     facility = options[:facility] || create(:facility, facility_group: request_facility_group)
     patient = create(:patient, registration_facility: facility)

--- a/spec/controllers/api/v4/teleconsultations_controller_spec.rb
+++ b/spec/controllers/api/v4/teleconsultations_controller_spec.rb
@@ -3,11 +3,6 @@ require "rails_helper"
 RSpec.describe Api::V4::TeleconsultationsController, type: :controller do
   let(:request_user) { create(:user, teleconsultation_facilities: [create(:facility)]) }
   let(:request_facility) { create(:facility, facility_group: request_user.facility.facility_group) }
-  before :each do
-    request.env["X_USER_ID"] = request_user.id
-    request.env["X_FACILITY_ID"] = request_facility.id
-    request.env["HTTP_AUTHORIZATION"] = "Bearer #{request_user.access_token}"
-  end
 
   let(:model) { Teleconsultation }
 
@@ -43,7 +38,7 @@ RSpec.describe Api::V4::TeleconsultationsController, type: :controller do
     end
 
     it "does not allow sync_from_user requests to the controller with invalid user_id and access_token" do
-      request.env["X_USER_ID"] = "invalid user id"
+      request.env["HTTP_X_USER_ID"] = "invalid user id"
       request.env["HTTP_AUTHORIZATION"] = "invalid access token"
       post :sync_from_user, params: empty_payload
 

--- a/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
+++ b/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
@@ -34,7 +34,7 @@ RSpec.shared_examples "a sync controller that authenticates user requests: sync_
       expect(response.status).not_to eq(401)
     end
     it "does not allow sync_from_user requests to the controller with invalid user_id and access_token" do
-      request.env["X_USER_ID"] = "invalid user id"
+      request.env["HTTP_X_USER_ID"] = "invalid user id"
       request.env["HTTP_AUTHORIZATION"] = "invalid access token"
       post :sync_from_user, params: empty_payload
 
@@ -84,7 +84,7 @@ RSpec.shared_examples "a sync controller that authenticates user requests: sync_
     end
 
     it "does not allow sync_to_user requests to the controller with invalid user_id and access_token" do
-      request.env["X_USER_ID"] = "invalid user id"
+      request.env["HTTP_X_USER_ID"] = "invalid user id"
       request.env["HTTP_AUTHORIZATION"] = "invalid access token"
       get :sync_to_user, params: empty_payload
 


### PR DESCRIPTION
**Story card:** -

## Because

Some of our API controller specs explicitly setup the wrong authorization headers which is confusing.

## This addresses

Removes extra headers setup across all controller specs.