### PR TITLE
Hide drug stock subtitle when patient_days is error

### DIFF
--- a/app/components/progress_tab/drug_stock_component.html.erb
+++ b/app/components/progress_tab/drug_stock_component.html.erb
@@ -10,7 +10,9 @@
       <%= protocol_drug_labels[category][:full] %>
     </h3>
     <p class="m-0px mb-16px p-0px ta-left fw-regular fs-16px lh-150 <%= patient_days_css_class(patient_days, prefix: "c") %>">
-      <%= patient_days %> days of drug stock
+      <% unless patient_days == "error" %>
+        <%= patient_days %> days of drug stock
+      <%end %>
     </p>
     <% drugs.each_with_index do |drug, index| %>
       <% drug_stock = drug_stocks_query.drugs_in_stock_by_facility_id.dig([current_facility.id, drug.rxnorm_code]) %>


### PR DESCRIPTION
**Story card:** [sc-9155](https://app.shortcut.com/simpledotorg/story/9155/drug-stock-reports-show-error-days-of-drug-stock-need-a-fix)

## Because

The subtitle under drug stock was confusing and not user-friendly. 

## This addresses

Hide subtitle when ever a drug is not in formula or other configuration error. 

## Test instructions

1. Check out this branch
2. Make sure `new_progress_tab_v2` is enabled
3. goto `http://localhost:3000/api/v3/analytics/user_analytics.html`. Use ModHeader or Postman to add necessary headers
4. See more details [here](https://github.com/simpledotorg/simple-server#testing-web-views)
5. You should be able to see the progress tab reports and verify if the subtitle is shown only when patient_days is not error

## Screenshots

**Before:**
<img width="248" alt="Screenshot 2022-09-14 at 7 56 36 PM" src="https://user-images.githubusercontent.com/32141642/190183298-05913061-3a5e-4169-b0b9-c1f804e6f214.png">

**After:**
<img width="264" alt="Screenshot 2022-09-14 at 7 55 54 PM" src="https://user-images.githubusercontent.com/32141642/190183323-675a8f22-375c-4030-a6fa-6c5d800f0d3e.png">
