### PR TITLE
Use registration_period to get the registration quarter

### DIFF
--- a/app/components/reports/cohort_component.html.erb
+++ b/app/components/reports/cohort_component.html.erb
@@ -26,7 +26,7 @@
           </h6>
           <p class="mb-2 fs-14px c-grey-dark c-print-black">
             <% unless cohort["registered"] == 0 %>
-              <%= number_with_delimiter(cohort["registered"]) %> <%= "patient".pluralize(cohort["registered"]) %> registered in <%= cohort["patients_registered"] %>
+              <%= number_with_delimiter(cohort["registered"]) %> <%= "patient".pluralize(cohort["registered"]) %> registered in <%= cohort["registration_period"] %>
             <% else %>
               <span class="fw-bold">
                 No data


### PR DESCRIPTION
**Story card:** [sc-9171](https://app.shortcut.com/simpledotorg/story/9171/previous-quarter-missing-in-cohort-report)

## Because

The wrong key was used to get the registration quarter in cohort reports

## This addresses

Use registration_period to get the registration quarter

## Test instructions

- Checkout to branch > <Region> > Cohort Reports
- You should see the registration quarter in the cohort reports

Before
<img width="1335" alt="Screenshot 2022-09-16 at 2 21 38 PM" src="https://user-images.githubusercontent.com/32141642/190598180-3855247c-e1ce-4a6a-97ca-20410eac7e68.png">

After
<img width="1335" alt="Screenshot 2022-09-16 at 2 18 09 PM" src="https://user-images.githubusercontent.com/32141642/190598207-1f3871f4-6a2c-4ba7-9b1d-0c9987d2ab2a.png">