### PR TITLE
Updated copy of "Calls made to overdue patients" tooltip

### DIFF
--- a/app/components/registrations_and_follow_ups_component.html.erb
+++ b/app/components/registrations_and_follow_ups_component.html.erb
@@ -116,7 +116,7 @@
   <div class="card w-100pt mt-0 pr-0 pr-md-3 pb-inside-avoid">
     <div class="mb-24px mb-lg-24px">
       <h3>
-        Calling overdue patients
+        Calls made to overdue patients
       </h3>
         <p class="mb-0px c-grey-dark c-print-black">
           <%= t("call_results_copy.monthly_overdue_calls_made") %>

--- a/app/views/reports/regions/_facility_details.html.erb
+++ b/app/views/reports/regions/_facility_details.html.erb
@@ -92,7 +92,7 @@
       Healthcare worker activity
     </h3>
     <%= render "definition_tooltip",
-                definitions: { "Overdue patients contacted" => t("call_results_copy.monthly_overdue_calls_made", region_name: @region.name),
+                definitions: { "Calls made to overdue patients" => t("call_results_copy.monthly_overdue_calls_made", region_name: @region.name),
                               "BP measures taken" => t("bp_measures_taken_copy", region_name: @region.name) } %>
   </div>
   <div class="table-responsive-md">


### PR DESCRIPTION
Tiny copy fix to make tooltip consistent with the UI copy change from last week.

**Story card:** No card

## Because

We made the text more clear in the "Calls made to overdue patients" card that the count is how many 'result of calls' were marked, not how many unique patients were called. This had caused confusion for Ethiopia team and others.

## This addresses

Text consistency.

## Test instructions

Shouldn't break the Facility Report page.