### PR TITLE
Dashboard: Quarterly report 'visit but no bp' and 'missed visits' order reversed

### DIFF
--- a/app/components/reports/cohort_component.html.erb
+++ b/app/components/reports/cohort_component.html.erb
@@ -65,16 +65,6 @@
                   <%= (cohort["uncontrolled"] > 1 && uncontrolled_percent == 0) ? "< 1" : uncontrolled_percent %>%
                 </td>
                 <td
-                  class="bar bar-4 bar-missed-visits"
-                  data-toggle="tooltip"
-                  data-placement="top"
-                  data-trigger="hover focus click"
-                  title="<%= number_with_delimiter(cohort["missed_visits"]) %> <%= "patient".pluralize(cohort["missed_visits"]) %> missed visit"
-                  style="width: <%= missed_visits_percent %>%; min-width: 3em;"
-                >
-                  <%= (cohort["missed_visits"] > 0 && missed_visits_percent == 0) ? "< 1" : missed_visits_percent %>%
-                </td>
-                <td
                   class="bar bar-no-bp"
                   data-toggle="tooltip"
                   data-placement="top"
@@ -83,6 +73,16 @@
                   style="width: <%= no_bp_percent %>%; min-width: 3em;"
                 >
                   <%= (cohort["no_bp"] > 0 && no_bp_percent == 0) ? "<1" : no_bp_percent %>%
+                </td>
+                <td
+                  class="bar bar-4 bar-missed-visits"
+                  data-toggle="tooltip"
+                  data-placement="top"
+                  data-trigger="hover focus click"
+                  title="<%= number_with_delimiter(cohort["missed_visits"]) %> <%= "patient".pluralize(cohort["missed_visits"]) %> missed visit"
+                  style="width: <%= missed_visits_percent %>%; min-width: 3em;"
+                >
+                  <%= (cohort["missed_visits"] > 0 && missed_visits_percent == 0) ? "< 1" : missed_visits_percent %>%
                 </td>
               <% else %>
                 <td class="bar bar-none w-100pt">
@@ -105,12 +105,12 @@
       BP not controlled
     </p>
     <p class="mb-8px c-black mr-lg-4 mb-lg-0">
-      <span class="p-relative t-1px d-inline-block w-12px h-12px mr-4px br-2px bg-blue"></span>
-      Missed visits
-    </p>
-    <p class="mb-8px c-black mb-lg-0">
       <span class="p-relative t-1px d-inline-block w-12px h-12px mr-4px br-2px bg-grey-medium"></span>
       Visit but no BP taken
+    </p>
+    <p class="mb-8px c-black mb-lg-0">
+      <span class="p-relative t-1px d-inline-block w-12px h-12px mr-4px br-2px bg-blue"></span>
+      Missed visits
     </p>
   </div>
 </div>


### PR DESCRIPTION
**Story card:** None

## Because

The order of the quarterly report is blocks is shown differently between the dashboard (reports) and the app (progress-tab).

## This addresses

Dashboard shows 'visit but no BP recorded' last while the 'progress-tab' shows 'missed visits' last.
![Screenshot 2022-09-23 at 12 53 22](https://user-images.githubusercontent.com/9541902/191957506-df69693a-dc92-48c9-bd0a-7cf82716a847.png)



It makes more sense to follow the app layout where "patient has visited" blocks sit next to one another and the missed visits sit at the end.

## Test instructions

Go to any facility or region report page: http://localhost:3000/reports/regions - then select any region or facility

Scroll the bottom of the page its the last block under 'cohort reports'

![Screenshot 2022-09-23 at 13 01 11](https://user-images.githubusercontent.com/9541902/191957449-347e3b8a-7f5c-4577-b435-36da7c314bf7.png)