### PR TITLE
Fix issues with sidekiq initialization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem "phonelib"
 gem "pry-rails"
 gem "rack-attack"
 gem "rack-mini-profiler", require: false
-gem "redis"
+gem "redis", "~> 4.7.1"
 gem "render_async"
 gem "request_store-sidekiq"
 gem "request_store"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,7 +476,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rb-readline (0.5.5)
-    redis (4.8.0)
+    redis (4.7.1)
     redis-prescription (1.0.0)
     regexp_parser (2.5.0)
     render_async (2.1.11)
@@ -770,7 +770,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-erd
   rb-readline
-  redis
+  redis (~> 4.7.1)
   render_async
   request_store
   request_store-sidekiq
@@ -818,4 +818,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.3.22
+   2.3.20

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -818,4 +818,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.3.20
+   2.3.22

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,8 @@
 require "sidekiq-unique-jobs"
 require "sidekiq/throttled"
 
+Dir.glob(Rails.root.join("lib", "sidekiq_middleware", "**", "*.rb")).sort.each { |f| require f }
+
 module SidekiqConfig
   DEFAULT_REDIS_POOL_SIZE = 12
 


### PR DESCRIPTION
## Because

Post updating to rails 6, sidekiq middleware doesn't auto reload. Also, Redis 4.8 print a lot of deprecation warnings, this PR downgrades Redis to 4.7.1

## Related Tickets 
- https://github.com/mperham/sidekiq/issues/4704
- https://github.com/mperham/sidekiq/issues/5485