### PR TITLE
Added Facilty ID to the bottom of a facilty's Settings page

### DIFF
--- a/app/views/admin/facilities/show.html.erb
+++ b/app/views/admin/facilities/show.html.erb
@@ -111,3 +111,8 @@
     <div><i class="fas fa-angle-left light"></i> No users <i class="fas fa-angle-right light"></i></div>
   <% end %>
 </div>
+
+<div class="card">
+  <h2>Simple facility ID</h2>
+  <div><%= @facility.id %></div>
+</div>


### PR DESCRIPTION
**Story card:** No story

## Because

It's annoying to have to ask Server Devs to pull facility IDs for tasks. 

## This addresses

Shows the "Simple Facility ID" at the bottom of the Facility's settings page.

## Test instructions

See if it shows the correct ID at the bottom of every facility's 'show' page.

See the bottom of this screenshot.

<img width="1567" alt="image" src="https://user-images.githubusercontent.com/711809/193772961-2befd182-cc91-415c-8f21-e926649834c2.png">
