### PR TITLE
Fix breaking CSS due to incomaptible bootstrap_form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "auto_strip_attributes"
 gem "bcrypt", "~> 3.1"
 gem "bcrypt_pbkdf", "~> 1.1"
 gem "bootsnap", require: false
-gem "bootstrap_form", ">= 4.5.0"
+gem "bootstrap_form", "~> 4.5.0"
 gem "bootstrap-datepicker-rails", "~> 1.9"
 gem "bootstrap-select-rails"
 gem "bootstrap", "~> 4.5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     bootstrap-datepicker-rails (1.9.0.1)
       railties (>= 3.0)
     bootstrap-select-rails (1.13.8)
-    bootstrap_form (5.1.0)
+    bootstrap_form (4.5.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
     brpoplpush-redis_script (0.1.2)
@@ -703,7 +703,7 @@ DEPENDENCIES
   bootstrap (~> 4.5.0)
   bootstrap-datepicker-rails (~> 1.9)
   bootstrap-select-rails
-  bootstrap_form (>= 4.5.0)
+  bootstrap_form (~> 4.5.0)
   byebug
   capistrano (~> 3.17)
   capistrano-db-tasks

--- a/app/assets/stylesheets/partials/_navigation.scss
+++ b/app/assets/stylesheets/partials/_navigation.scss
@@ -124,6 +124,11 @@ Navigation
   }
 }
 
+.navigation-development {
+  /* To keep rack-mini-profiler on top of the nav */
+  z-index: 2147483642 !important;
+}
+
 nav.breadcrumb {
   background: transparent;
   padding-left: 0;


### PR DESCRIPTION
**Story card:** -

## Because

`bootstrap_form` got upgraded from v4 to v5 during the [rails upgrade](https://github.com/simpledotorg/simple-server/pull/4240). The `bootstrap` gem is still at v4. This is breaking some form fields.

## This addresses

Downgrades `bootstrap_form` to v4. Bootstrap v5 is considerably different from v4 so this does not upgrade bootstrap at the moment.

Before
![image](https://user-images.githubusercontent.com/16774200/194088821-29f1dec9-e3cc-49dd-af56-e21618461ef1.png)

After
![image](https://user-images.githubusercontent.com/16774200/194089168-531a5541-8c11-428e-9a25-d0fa741827c0.png)

