### PR TITLE
Fix daily follow ups cache warming

### DIFF
--- a/app/services/refresh_reporting_views.rb
+++ b/app/services/refresh_reporting_views.rb
@@ -53,7 +53,7 @@ class RefreshReportingViews
   end
 
   def self.refresh_daily_follow_ups_and_registrations
-    new(views: ["Reports::FacilityDailyFollowUpsAndRegistrations"]).call
+    new(views: ["Reports::FacilityDailyFollowUpAndRegistration"]).call
   end
 
   def self.refresh_v2


### PR DESCRIPTION
**Story card:** [sc-7017](https://app.shortcut.com/simpledotorg/story/7017/change-progress-counts-of-registrations-and-follow-ups-to-be-htn-only-dm-only-and-co-morbid-patients-i-e-htn-and-dm)

## Because

Typo in daily follow ups cache warming added in https://github.com/simpledotorg/simple-server/pull/4284. This would cause stale data to show up on all progress tabs.

## This addresses

Fixes the typo.