### PR TITLE
Fix heroku android review apps

### DIFF
--- a/lib/tasks/support_pg_extensions_in_heroku.rake
+++ b/lib/tasks/support_pg_extensions_in_heroku.rake
@@ -14,6 +14,7 @@ task :support_pg_extensions_in_heroku do
   contents.gsub! "public.gen_random_uuid()", "heroku_ext.gen_random_uuid()"
   contents.gsub! "public.subpath", "heroku_ext.subpath"
   contents.gsub! "public.=", "heroku_ext.="
+  contents.gsub! "COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';", ""
 
   IO.write(path, contents)
 end


### PR DESCRIPTION
**Story card:** -

## Because

Heroku review apps are failing with 
```
psql:/app/db/structure.sql:23: ERROR:  must be owner of extension plpgsql
```
This is because of https://help.heroku.com/AHH2KNSR/why-do-i-get-postgres-extension-errors-when-i-run-rake-db-structure-load-or-rake-db-setup

[Slack thread](https://simpledotorg.slack.com/archives/CFK2PHJ1L/p1665389890727829)
## This addresses

Removes comment on plpgsql for heroku specifically. 