### PR TITLE
Progress tab: Daily follow ups and registration fixes

### DIFF
--- a/app/presenters/user_analytics_presenter.rb
+++ b/app/presenters/user_analytics_presenter.rb
@@ -58,7 +58,7 @@ class UserAnalyticsPresenter
           cohorts: cohort_stats,
           metadata: {
             is_diabetes_enabled: diabetes_enabled?,
-            last_updated_at: I18n.l(Time.current),
+            last_updated_at: I18n.l(RefreshReportingViews.last_updated_at),
             formatted_next_date: display_date(Time.current + 1.day),
             today_string: I18n.t(:today_str)
           }

--- a/app/presenters/user_analytics_presenter.rb
+++ b/app/presenters/user_analytics_presenter.rb
@@ -58,7 +58,7 @@ class UserAnalyticsPresenter
           cohorts: cohort_stats,
           metadata: {
             is_diabetes_enabled: diabetes_enabled?,
-            last_updated_at: I18n.l(RefreshReportingViews.last_updated_at),
+            last_updated_at: RefreshReportingViews.last_updated_at ? I18n.l(RefreshReportingViews.last_updated_at) : "",
             formatted_next_date: display_date(Time.current + 1.day),
             today_string: I18n.t(:today_str)
           }

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -45,7 +45,7 @@ module Reports
         },
         metadata: {
           is_diabetes_enabled: @diabetes_enabled,
-          last_updated_at: I18n.l(Time.current),
+          last_updated_at: last_updated_at,
           formatted_next_date: (Time.current + 1.day).to_s(:mon_year),
           today_string: I18n.t(:today_str)
         }

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -18,8 +18,8 @@
       <div class="mb-8px">
         <p class="fs-14px mt-8px">
           <%= t("progress_tab.last_updated_at",
-                date: display_date(@user_analytics.last_updated_at),
-                time: display_time(@user_analytics.last_updated_at))
+                date: display_date(@service.last_updated_at),
+                time: display_time(@service.last_updated_at))
           %>
         </p>
         <%= content_tag :div,

--- a/app/views/api/v3/analytics/user_analytics/show_v1.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show_v1.html.erb
@@ -89,7 +89,7 @@
         </div>
       </div>
     </div>
-    <%= render(Reports::DailyProgressComponentV1.new(@service, @user_analytics.last_updated_at, @current_user)) %>
+    <%= render(Reports::DailyProgressComponentV1.new(@service, @service.last_updated_at, @current_user)) %>
     <%= render partial: "api/v3/analytics/user_analytics/progress_monthly_report" %>
     <%= render partial: "api/v3/analytics/user_analytics/progress_hypertension_report" %>
 

--- a/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show_v2.html.erb
@@ -182,8 +182,8 @@
        @current_user,
        title: t("progress_tab.daily_report_title"),
        subtitle: t("progress_tab.last_updated_at",
-                   date: display_date(@user_analytics.last_updated_at),
-                   time:  display_time(@user_analytics.last_updated_at))
+                   date: display_date(@service.last_updated_at),
+                   time:  display_time(@service.last_updated_at))
        ))
     %>
     <%= render partial: "api/v3/analytics/user_analytics/period_report",

--- a/db/migrate/20221010104304_update_reporting_facility_daily_follow_ups_and_registrations_to_version_2.rb
+++ b/db/migrate/20221010104304_update_reporting_facility_daily_follow_ups_and_registrations_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateReportingFacilityDailyFollowUpsAndRegistrationsToVersion2 < ActiveRecord::Migration[6.1]
+  def change
+    update_view :reporting_facility_daily_follow_ups_and_registrations, version: 2, revert_to_version: 1
+  end
+end

--- a/db/migrate/20221010104304_update_reporting_facility_daily_follow_ups_and_registrations_to_version_2.rb
+++ b/db/migrate/20221010104304_update_reporting_facility_daily_follow_ups_and_registrations_to_version_2.rb
@@ -1,5 +1,5 @@
 class UpdateReportingFacilityDailyFollowUpsAndRegistrationsToVersion2 < ActiveRecord::Migration[6.1]
   def change
-    update_view :reporting_facility_daily_follow_ups_and_registrations, version: 2, revert_to_version: 1
+    update_view :reporting_facility_daily_follow_ups_and_registrations, version: 2, revert_to_version: 1, materialized: true
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,20 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
---
 -- Name: ltree; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -64,7 +50,7 @@ CREATE TYPE public.gender_enum AS ENUM (
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
 -- Name: accesses; Type: TABLE; Schema: public; Owner: -
@@ -1834,62 +1820,62 @@ CREATE MATERIALIZED VIEW public.reporting_facility_appointment_scheduled_days AS
 
 CREATE MATERIALIZED VIEW public.reporting_facility_daily_follow_ups_and_registrations AS
  WITH follow_up_blood_pressures AS (
-         SELECT DISTINCT ON (((date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bp.recorded_at))))::integer), bp.facility_id, p.id) p.id AS patient_id,
+         SELECT DISTINCT ON (((EXTRACT(doy FROM ((bp.recorded_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))))::integer), bp.facility_id, p.id) p.id AS patient_id,
             (p.gender)::public.gender_enum AS patient_gender,
             bp.id AS visit_id,
             'BloodPressure'::text AS visit_type,
             bp.facility_id,
             bp.user_id,
             bp.recorded_at AS visited_at,
-            (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bp.recorded_at))))::integer AS day_of_year
+            (EXTRACT(doy FROM ((bp.recorded_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))))::integer AS day_of_year
            FROM (public.patients p
-             JOIN public.blood_pressures bp ON (((p.id = bp.patient_id) AND (date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bp.recorded_at))) > date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
+             JOIN public.blood_pressures bp ON (((p.id = bp.patient_id) AND (date_trunc('day'::text, ((bp.recorded_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))) > date_trunc('day'::text, ((p.recorded_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)))))))
           WHERE ((p.deleted_at IS NULL) AND (bp.recorded_at > (CURRENT_TIMESTAMP - '30 days'::interval)))
         ), follow_up_blood_sugars AS (
-         SELECT DISTINCT ON (((date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at))))::integer), bs.facility_id, p.id) p.id AS patient_id,
+         SELECT DISTINCT ON (((EXTRACT(doy FROM ((bs.recorded_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))))::integer), bs.facility_id, p.id) p.id AS patient_id,
             (p.gender)::public.gender_enum AS patient_gender,
             bs.id AS visit_id,
             'BloodSugar'::text AS visit_type,
             bs.facility_id,
             bs.user_id,
             bs.recorded_at AS visited_at,
-            (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at))))::integer AS day_of_year
+            (EXTRACT(doy FROM ((bs.recorded_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))))::integer AS day_of_year
            FROM (public.patients p
-             JOIN public.blood_sugars bs ON (((p.id = bs.patient_id) AND (date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, bs.recorded_at))) > date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
+             JOIN public.blood_sugars bs ON (((p.id = bs.patient_id) AND (date_trunc('day'::text, ((bs.recorded_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))) > date_trunc('day'::text, ((p.recorded_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)))))))
           WHERE ((p.deleted_at IS NULL) AND (bs.recorded_at > (CURRENT_TIMESTAMP - '30 days'::interval)))
         ), follow_up_prescription_drugs AS (
-         SELECT DISTINCT ON (((date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at))))::integer), pd.facility_id, p.id) p.id AS patient_id,
+         SELECT DISTINCT ON (((EXTRACT(doy FROM ((pd.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))))::integer), pd.facility_id, p.id) p.id AS patient_id,
             (p.gender)::public.gender_enum AS patient_gender,
             pd.id AS visit_id,
             'PrescriptionDrug'::text AS visit_type,
             pd.facility_id,
             pd.user_id,
             pd.device_created_at AS visited_at,
-            (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at))))::integer AS day_of_year
+            (EXTRACT(doy FROM ((pd.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))))::integer AS day_of_year
            FROM (public.patients p
-             JOIN public.prescription_drugs pd ON (((p.id = pd.patient_id) AND (date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, pd.device_created_at))) > date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
+             JOIN public.prescription_drugs pd ON (((p.id = pd.patient_id) AND (date_trunc('day'::text, ((pd.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))) > date_trunc('day'::text, ((p.recorded_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)))))))
           WHERE ((p.deleted_at IS NULL) AND (pd.device_created_at > (CURRENT_TIMESTAMP - '30 days'::interval)))
         ), follow_up_appointments AS (
-         SELECT DISTINCT ON (((date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at))))::integer), app.creation_facility_id, p.id) p.id AS patient_id,
+         SELECT DISTINCT ON (((EXTRACT(doy FROM ((app.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))))::integer), app.creation_facility_id, p.id) p.id AS patient_id,
             (p.gender)::public.gender_enum AS patient_gender,
             app.id AS visit_id,
             'Appointment'::text AS visit_type,
             app.creation_facility_id AS facility_id,
             app.user_id,
             app.device_created_at AS visited_at,
-            (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at))))::integer AS day_of_year
+            (EXTRACT(doy FROM ((app.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))))::integer AS day_of_year
            FROM (public.patients p
-             JOIN public.appointments app ON (((p.id = app.patient_id) AND (date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, app.device_created_at))) > date_trunc('day'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at)))))))
+             JOIN public.appointments app ON (((p.id = app.patient_id) AND (date_trunc('day'::text, ((app.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))) > date_trunc('day'::text, ((p.recorded_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)))))))
           WHERE ((p.deleted_at IS NULL) AND (app.device_created_at > (CURRENT_TIMESTAMP - '30 days'::interval)))
         ), registered_patients AS (
-         SELECT DISTINCT ON (((date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at))))::integer), p.assigned_facility_id, p.id) p.id AS patient_id,
+         SELECT DISTINCT ON (((EXTRACT(doy FROM ((p.recorded_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))))::integer), p.registration_facility_id, p.id) p.id AS patient_id,
             (p.gender)::public.gender_enum AS patient_gender,
             p.id AS visit_id,
             'Registration'::text AS visit_type,
-            p.assigned_facility_id AS facility_id,
+            p.registration_facility_id AS facility_id,
             p.registration_user_id AS user_id,
             p.recorded_at AS visited_at,
-            (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, p.recorded_at))))::integer AS day_of_year
+            (EXTRACT(doy FROM ((p.recorded_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))))::integer AS day_of_year
            FROM public.patients p
           WHERE ((p.deleted_at IS NULL) AND (p.recorded_at > (CURRENT_TIMESTAMP - '30 days'::interval)))
         ), all_follow_ups AS (
@@ -1959,8 +1945,8 @@ CREATE MATERIALIZED VIEW public.reporting_facility_daily_follow_ups_and_registra
            FROM (registered_patients
              JOIN public.medical_histories mh ON ((registered_patients.patient_id = mh.patient_id)))
         ), daily_registered_patients AS (
-         SELECT DISTINCT ON (registered_patients_with_medical_histories.facility_id, (date(registered_patients_with_medical_histories.visited_at))) registered_patients_with_medical_histories.facility_id,
-            date(registered_patients_with_medical_histories.visited_at) AS visit_date,
+         SELECT DISTINCT ON (registered_patients_with_medical_histories.facility_id, (date(((registered_patients_with_medical_histories.visited_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))))) registered_patients_with_medical_histories.facility_id,
+            date(((registered_patients_with_medical_histories.visited_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))) AS visit_date,
             registered_patients_with_medical_histories.day_of_year,
             count(*) FILTER (WHERE ((registered_patients_with_medical_histories.hypertension = 'yes'::text) OR (registered_patients_with_medical_histories.diabetes = 'yes'::text))) AS daily_registrations_htn_or_dm,
             count(*) FILTER (WHERE ((registered_patients_with_medical_histories.hypertension = 'yes'::text) AND (registered_patients_with_medical_histories.diabetes = 'yes'::text))) AS daily_registrations_htn_and_dm,
@@ -1976,10 +1962,10 @@ CREATE MATERIALIZED VIEW public.reporting_facility_daily_follow_ups_and_registra
             (count(*) FILTER (WHERE ((registered_patients_with_medical_histories.diabetes = 'yes'::text) AND (registered_patients_with_medical_histories.patient_gender = 'male'::public.gender_enum))) - count(*) FILTER (WHERE ((registered_patients_with_medical_histories.hypertension = 'yes'::text) AND (registered_patients_with_medical_histories.diabetes = 'yes'::text) AND (registered_patients_with_medical_histories.patient_gender = 'male'::public.gender_enum)))) AS daily_registrations_dm_only_male,
             (count(*) FILTER (WHERE ((registered_patients_with_medical_histories.diabetes = 'yes'::text) AND (registered_patients_with_medical_histories.patient_gender = 'transgender'::public.gender_enum))) - count(*) FILTER (WHERE ((registered_patients_with_medical_histories.hypertension = 'yes'::text) AND (registered_patients_with_medical_histories.diabetes = 'yes'::text) AND (registered_patients_with_medical_histories.patient_gender = 'transgender'::public.gender_enum)))) AS daily_registrations_dm_only_transgender
            FROM registered_patients_with_medical_histories
-          GROUP BY registered_patients_with_medical_histories.facility_id, (date(registered_patients_with_medical_histories.visited_at)), registered_patients_with_medical_histories.day_of_year
+          GROUP BY registered_patients_with_medical_histories.facility_id, (date(((registered_patients_with_medical_histories.visited_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)))), registered_patients_with_medical_histories.day_of_year
         ), daily_follow_ups AS (
-         SELECT DISTINCT ON (all_follow_ups_with_medical_histories.facility_id, (date(all_follow_ups_with_medical_histories.visited_at))) all_follow_ups_with_medical_histories.facility_id,
-            date(all_follow_ups_with_medical_histories.visited_at) AS visit_date,
+         SELECT DISTINCT ON (all_follow_ups_with_medical_histories.facility_id, (date(((all_follow_ups_with_medical_histories.visited_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))))) all_follow_ups_with_medical_histories.facility_id,
+            date(((all_follow_ups_with_medical_histories.visited_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))) AS visit_date,
             all_follow_ups_with_medical_histories.day_of_year,
             count(*) FILTER (WHERE ((all_follow_ups_with_medical_histories.hypertension = 'yes'::text) OR (all_follow_ups_with_medical_histories.diabetes = 'yes'::text))) AS daily_follow_ups_htn_or_dm,
             count(*) FILTER (WHERE ((all_follow_ups_with_medical_histories.hypertension = 'yes'::text) AND (all_follow_ups_with_medical_histories.diabetes = 'yes'::text))) AS daily_follow_ups_htn_and_dm,
@@ -1995,7 +1981,7 @@ CREATE MATERIALIZED VIEW public.reporting_facility_daily_follow_ups_and_registra
             (count(*) FILTER (WHERE ((all_follow_ups_with_medical_histories.diabetes = 'yes'::text) AND (all_follow_ups_with_medical_histories.patient_gender = 'male'::public.gender_enum))) - count(*) FILTER (WHERE ((all_follow_ups_with_medical_histories.hypertension = 'yes'::text) AND (all_follow_ups_with_medical_histories.diabetes = 'yes'::text) AND (all_follow_ups_with_medical_histories.patient_gender = 'male'::public.gender_enum)))) AS daily_follow_ups_dm_only_male,
             (count(*) FILTER (WHERE ((all_follow_ups_with_medical_histories.diabetes = 'yes'::text) AND (all_follow_ups_with_medical_histories.patient_gender = 'transgender'::public.gender_enum))) - count(*) FILTER (WHERE ((all_follow_ups_with_medical_histories.hypertension = 'yes'::text) AND (all_follow_ups_with_medical_histories.diabetes = 'yes'::text) AND (all_follow_ups_with_medical_histories.patient_gender = 'transgender'::public.gender_enum)))) AS daily_follow_ups_dm_only_transgender
            FROM all_follow_ups_with_medical_histories
-          GROUP BY all_follow_ups_with_medical_histories.facility_id, (date(all_follow_ups_with_medical_histories.visited_at)), all_follow_ups_with_medical_histories.day_of_year
+          GROUP BY all_follow_ups_with_medical_histories.facility_id, (date(((all_follow_ups_with_medical_histories.visited_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)))), all_follow_ups_with_medical_histories.day_of_year
         ), last_30_days AS (
          SELECT (generate_series((CURRENT_TIMESTAMP - '30 days'::interval), CURRENT_TIMESTAMP, '1 day'::interval))::date AS date
         )
@@ -2006,7 +1992,7 @@ CREATE MATERIALIZED VIEW public.reporting_facility_daily_follow_ups_and_registra
     rf.district_region_id,
     rf.state_region_id,
     last_30_days.date AS visit_date,
-    (date_part('doy'::text, timezone(( SELECT current_setting('TIMEZONE'::text) AS current_setting), timezone('UTC'::text, (last_30_days.date)::timestamp with time zone))))::integer AS day_of_year,
+    (EXTRACT(doy FROM ((last_30_days.date AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting))))::integer AS day_of_year,
     COALESCE(daily_registered_patients.daily_registrations_htn_or_dm, (0)::bigint) AS daily_registrations_htn_or_dm,
     COALESCE(daily_registered_patients.daily_registrations_htn_only, (0)::bigint) AS daily_registrations_htn_only,
     COALESCE(daily_registered_patients.daily_registrations_htn_only_male, (0)::bigint) AS daily_registrations_htn_only_male,
@@ -6491,4 +6477,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221002080832'),
 ('20221002111845'),
 ('20221003084709'),
-('20221004092107');
+('20221004092107'),
+('20221010104304');
+
+

--- a/db/views/reporting_facility_daily_follow_ups_and_registrations_v02.sql
+++ b/db/views/reporting_facility_daily_follow_ups_and_registrations_v02.sql
@@ -1,0 +1,247 @@
+WITH follow_up_blood_pressures AS (
+    SELECT DISTINCT ON (day_of_year, facility_id, patient_id)
+        p.id AS patient_id,
+        p.gender::gender_enum AS patient_gender,
+        bp.id AS visit_id,
+        'BloodPressure' AS visit_type,
+        bp.facility_id,
+        bp.user_id,
+        bp.recorded_at AS visited_at,
+        cast(EXTRACT(DOY FROM bp.recorded_at AT TIME ZONE 'UTC' at time zone (SELECT current_setting('TIMEZONE'))) as integer) AS day_of_year
+    FROM patients p
+    INNER JOIN blood_pressures bp
+        ON p.id = bp.patient_id
+        AND date_trunc('day', bp.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+           > date_trunc('day', p.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+    WHERE p.deleted_at IS NULL
+      AND bp.recorded_at > current_timestamp - interval '30 day'
+),
+     follow_up_blood_sugars AS (
+         SELECT DISTINCT ON (day_of_year, facility_id, patient_id)
+             p.id AS patient_id,
+             p.gender::gender_enum AS patient_gender,
+             bs.id as visit_id,
+             'BloodSugar' AS visit_type,
+             bs.facility_id,
+             bs.user_id,
+             bs.recorded_at AS visited_at,
+             cast(EXTRACT(DOY FROM bs.recorded_at AT TIME ZONE 'UTC' at time zone (SELECT current_setting('TIMEZONE'))) as integer) AS day_of_year
+
+         FROM patients p
+         INNER JOIN blood_sugars bs
+             ON p.id = bs.patient_id
+             AND date_trunc('day', bs.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+                > date_trunc('day', p.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+         WHERE p.deleted_at IS NULL
+           AND bs.recorded_at > current_timestamp - interval '30 day'
+     ),
+     follow_up_prescription_drugs AS (
+         SELECT DISTINCT ON (day_of_year, facility_id, patient_id)
+             p.id AS patient_id,
+             p.gender::gender_enum AS patient_gender,
+             pd.id as visit_id,
+             'PrescriptionDrug' AS visit_type,
+             pd.facility_id,
+             pd.user_id,
+             pd.device_created_at AS visited_at,
+             cast(EXTRACT(DOY FROM pd.device_created_at AT TIME ZONE 'UTC' at time zone (SELECT current_setting('TIMEZONE'))) as integer) AS day_of_year
+         FROM patients p
+         INNER JOIN prescription_drugs pd
+             ON p.id = pd.patient_id
+             AND date_trunc('day', pd.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+                > date_trunc('day', p.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+         WHERE p.deleted_at IS NULL
+           AND pd.device_created_at > current_timestamp - interval '30 day'
+     ),
+     follow_up_appointments AS (
+         SELECT DISTINCT ON (day_of_year, facility_id, patient_id)
+             p.id AS patient_id,
+             p.gender::gender_enum AS patient_gender,
+             app.id as visit_id,
+             'Appointment' AS visit_type,
+             app.creation_facility_id AS facility_id,
+             app.user_id,
+             app.device_created_at AS visited_at,
+             cast(EXTRACT(DOY FROM app.device_created_at AT TIME ZONE 'UTC' at time zone (SELECT current_setting('TIMEZONE'))) as integer) AS day_of_year
+         FROM patients p
+         INNER JOIN appointments app
+             ON p.id = app.patient_id
+             AND date_trunc('day', app.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+                > date_trunc('day', p.recorded_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')))
+         WHERE p.deleted_at IS NULL
+           AND app.device_created_at > current_timestamp - interval '30 day'
+     ),
+     registered_patients AS (
+         SELECT DISTINCT ON (day_of_year, facility_id, patient_id)
+             p.id AS patient_id,
+             p.gender::gender_enum as patient_gender,
+             p.id as visit_id,
+             'Registration' as visit_type,
+             p.registration_facility_id as facility_id,
+             p.registration_user_id as user_id,
+             p.recorded_at as visited_at,
+             cast(EXTRACT(DOY FROM p.recorded_at AT TIME ZONE 'UTC' at time zone (SELECT current_setting('TIMEZONE'))) as integer) AS day_of_year
+         FROM patients p
+         WHERE p.deleted_at IS NULL
+           AND p.recorded_at > current_timestamp - interval '30 day'
+     ),
+     all_follow_ups AS (
+         SELECT *
+         FROM
+             follow_up_blood_pressures
+         UNION (select * FROM follow_up_blood_sugars)
+         UNION (select * FROM follow_up_prescription_drugs)
+         UNION (select * FROM follow_up_appointments)
+     ),
+     all_follow_ups_with_medical_histories AS (
+         SELECT DISTINCT ON (all_follow_ups.day_of_year, all_follow_ups.facility_id, all_follow_ups.patient_id)
+             all_follow_ups.patient_id,
+             all_follow_ups.patient_gender,
+             all_follow_ups.facility_id,
+             mh.diabetes,
+             mh.hypertension,
+             all_follow_ups.user_id,
+             all_follow_ups.visit_id,
+             all_follow_ups.visit_type,
+             all_follow_ups.visited_at,
+             all_follow_ups.day_of_year
+         FROM all_follow_ups
+         INNER JOIN medical_histories mh ON all_follow_ups.patient_id = mh.patient_id
+     ),
+
+     registered_patients_with_medical_histories AS (
+         SELECT DISTINCT ON (registered_patients.day_of_year, registered_patients.facility_id, registered_patients.patient_id)
+             registered_patients.patient_id,
+             registered_patients.patient_gender,
+             registered_patients.facility_id,
+             mh.diabetes,
+             mh.hypertension,
+             registered_patients.user_id,
+             registered_patients.visit_id,
+             registered_patients.visit_type,
+             registered_patients.visited_at,
+             registered_patients.day_of_year
+         FROM registered_patients
+         INNER JOIN medical_histories mh ON registered_patients.patient_id = mh.patient_id
+     ),
+
+     daily_registered_patients AS (
+         SELECT DISTINCT ON (facility_id, visit_date)
+             facility_id,
+             date(visited_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE'))) AS visit_date,
+             day_of_year,
+
+             count(*) FILTER (WHERE hypertension = 'yes' or diabetes = 'yes') AS daily_registrations_htn_or_dm,
+
+             count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes') AS daily_registrations_htn_and_dm,
+             count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'female') AS daily_registrations_htn_and_dm_female,
+             count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'male') AS daily_registrations_htn_and_dm_male,
+             count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'transgender') AS daily_registrations_htn_and_dm_transgender,
+
+             count(*) FILTER (WHERE hypertension = 'yes')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes') AS daily_registrations_htn_only,
+             count(*) FILTER (WHERE hypertension = 'yes' and patient_gender = 'female')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'female') AS daily_registrations_htn_only_female,
+             count(*) FILTER (WHERE hypertension = 'yes' and patient_gender = 'male')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'male') AS daily_registrations_htn_only_male,
+             count(*) FILTER (WHERE hypertension = 'yes' and patient_gender = 'transgender')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'transgender') AS daily_registrations_htn_only_transgender,
+
+             count(*) FILTER (WHERE diabetes = 'yes')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes') AS daily_registrations_dm_only,
+             count(*) FILTER (WHERE diabetes = 'yes' and patient_gender = 'female')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'female') AS daily_registrations_dm_only_female,
+             count(*) FILTER (WHERE diabetes = 'yes' and patient_gender = 'male')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'male') AS daily_registrations_dm_only_male,
+             count(*) FILTER (WHERE diabetes = 'yes' and patient_gender = 'transgender')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'transgender') AS daily_registrations_dm_only_transgender
+         FROM registered_patients_with_medical_histories
+         GROUP BY facility_id, date(visited_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE'))), day_of_year
+     ),
+
+     daily_follow_ups AS (
+         SELECT DISTINCT ON (facility_id, visit_date)
+             facility_id,
+             date(visited_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE'))) AS visit_date,
+             day_of_year,
+
+             count(*) FILTER (WHERE hypertension = 'yes' or diabetes = 'yes') AS daily_follow_ups_htn_or_dm,
+
+             count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes') AS daily_follow_ups_htn_and_dm,
+             count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'female') AS daily_follow_ups_htn_and_dm_female,
+             count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'male') AS daily_follow_ups_htn_and_dm_male,
+             count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'transgender') AS daily_follow_ups_htn_and_dm_transgender,
+
+             count(*) FILTER (WHERE hypertension = 'yes')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes') AS daily_follow_ups_htn_only,
+             count(*) FILTER (WHERE hypertension = 'yes' and patient_gender = 'female')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'female') AS daily_follow_ups_htn_only_female,
+             count(*) FILTER (WHERE hypertension = 'yes' and patient_gender = 'male')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'male') AS daily_follow_ups_htn_only_male,
+             count(*) FILTER (WHERE hypertension = 'yes' and patient_gender = 'transgender')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'transgender') AS daily_follow_ups_htn_only_transgender,
+
+             count(*) FILTER (WHERE diabetes = 'yes')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes') AS daily_follow_ups_dm_only,
+             count(*) FILTER (WHERE diabetes = 'yes' and patient_gender = 'female')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'female') AS daily_follow_ups_dm_only_female,
+             count(*) FILTER (WHERE diabetes = 'yes' and patient_gender = 'male')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'male') AS daily_follow_ups_dm_only_male,
+             count(*) FILTER (WHERE diabetes = 'yes' and patient_gender = 'transgender')
+                 - count(*) FILTER (WHERE hypertension = 'yes' and diabetes = 'yes' and patient_gender = 'transgender') AS daily_follow_ups_dm_only_transgender
+         FROM all_follow_ups_with_medical_histories
+         GROUP BY facility_id, date(visited_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE'))), day_of_year
+     ),
+
+     last_30_days AS (
+         SELECT generate_series(current_timestamp - interval '30 day', current_timestamp, interval  '1 day'):: date as date
+     )
+
+SELECT
+    rf.facility_region_slug,
+    rf.facility_id,
+    rf.facility_region_id,
+    rf.block_region_id,
+    rf.district_region_id,
+    rf.state_region_id,
+    last_30_days.date AS visit_date,
+    cast(EXTRACT(DOY FROM last_30_days.date AT TIME ZONE 'UTC' at time zone (SELECT current_setting('TIMEZONE'))) as integer)
+                      AS day_of_year,
+    coalesce(daily_registered_patients.daily_registrations_htn_or_dm,0) AS daily_registrations_htn_or_dm,
+    coalesce(daily_registered_patients.daily_registrations_htn_only,0) AS daily_registrations_htn_only,
+    coalesce(daily_registered_patients.daily_registrations_htn_only_male,0) AS daily_registrations_htn_only_male,
+    coalesce(daily_registered_patients.daily_registrations_htn_only_female,0) AS daily_registrations_htn_only_female,
+    coalesce(daily_registered_patients.daily_registrations_htn_only_transgender,0) AS daily_registrations_htn_only_transgender,
+    coalesce(daily_registered_patients.daily_registrations_dm_only,0) AS daily_registrations_dm_only,
+    coalesce(daily_registered_patients.daily_registrations_dm_only_male,0) AS daily_registrations_dm_only_male,
+    coalesce(daily_registered_patients.daily_registrations_dm_only_female,0) AS daily_registrations_dm_only_female,
+    coalesce(daily_registered_patients.daily_registrations_dm_only_transgender,0) AS daily_registrations_dm_only_transgender,
+    coalesce(daily_registered_patients.daily_registrations_htn_and_dm,0) AS daily_registrations_htn_and_dm,
+    coalesce(daily_registered_patients.daily_registrations_htn_and_dm_male,0) AS daily_registrations_htn_and_dm_male,
+    coalesce(daily_registered_patients.daily_registrations_htn_and_dm_female,0) AS daily_registrations_htn_and_dm_female,
+    coalesce(daily_registered_patients.daily_registrations_htn_and_dm_transgender,0) AS daily_registrations_htn_and_dm_transgender,
+    coalesce(daily_follow_ups.daily_follow_ups_htn_or_dm,0) AS daily_follow_ups_htn_or_dm,
+    coalesce(daily_follow_ups.daily_follow_ups_htn_only,0) AS daily_follow_ups_htn_only,
+    coalesce(daily_follow_ups.daily_follow_ups_htn_only_female,0) AS daily_follow_ups_htn_only_female,
+    coalesce(daily_follow_ups.daily_follow_ups_htn_only_male,0) AS daily_follow_ups_htn_only_male,
+    coalesce(daily_follow_ups.daily_follow_ups_htn_only_transgender,0) AS daily_follow_ups_htn_only_transgender,
+    coalesce(daily_follow_ups.daily_follow_ups_dm_only,0) AS daily_follow_ups_dm_only,
+    coalesce(daily_follow_ups.daily_follow_ups_dm_only_female,0) AS daily_follow_ups_dm_only_female,
+    coalesce(daily_follow_ups.daily_follow_ups_dm_only_male,0) AS daily_follow_ups_dm_only_male,
+    coalesce(daily_follow_ups.daily_follow_ups_dm_only_transgender,0) AS daily_follow_ups_dm_only_transgender,
+    coalesce(daily_follow_ups.daily_follow_ups_htn_and_dm,0) AS daily_follow_ups_htn_and_dm,
+    coalesce(daily_follow_ups.daily_follow_ups_htn_and_dm_male,0) AS daily_follow_ups_htn_and_dm_male,
+    coalesce(daily_follow_ups.daily_follow_ups_htn_and_dm_female,0) AS daily_follow_ups_htn_and_dm_female,
+    coalesce(daily_follow_ups.daily_follow_ups_htn_and_dm_transgender,0) AS daily_follow_ups_htn_and_dm_transgender
+
+FROM reporting_facilities rf
+INNER JOIN last_30_days
+-- ensure a row for every facility and day combination
+    ON TRUE
+LEFT OUTER JOIN daily_registered_patients
+    ON daily_registered_patients.visit_date = last_30_days.date
+    AND daily_registered_patients.facility_id = rf.facility_id
+LEFT OUTER JOIN daily_follow_ups
+    ON daily_follow_ups.visit_date = last_30_days.date
+    AND daily_follow_ups.facility_id = rf.facility_id
+ORDER BY visit_date DESC

--- a/spec/models/reports/facility_daily_follow_up_and_registration_spec.rb
+++ b/spec/models/reports/facility_daily_follow_up_and_registration_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Reports::FacilityDailyFollowUpAndRegistration, {type: :model, rep
     create(:blood_pressure, patient: patient_1, user: user, facility: facility, recorded_at: now)
     create(:blood_pressure, patient: patient_2, user: user, facility: facility, recorded_at: now)
     create(:blood_pressure, patient: patient_3, user: user, facility: facility, recorded_at: now)
-    create(:patient, :diabetes, gender: "male", recorded_at: now, registration_user: user, registration_facility: facility)
+    create(:patient, :diabetes, gender: "male", recorded_at: now, registration_user: user, registration_facility: facility, assigned_facility_id: create(:facility))
 
     described_class.refresh
 

--- a/spec/presenters/user_analytics_presenter_spec.rb
+++ b/spec/presenters/user_analytics_presenter_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe UserAnalyticsPresenter, type: :model do
           expect(data.dig(:metadata, :last_updated_at)).to eq(I18n.l(time))
         end
 
-        it "says unknown when the reporting views were last refreshed" do
+        it "is blank when the last refresh time is unavailable" do
           allow(RefreshReportingViews).to receive(:last_updated_at).and_return(nil)
           data = described_class.new(current_facility).statistics
 

--- a/spec/presenters/user_analytics_presenter_spec.rb
+++ b/spec/presenters/user_analytics_presenter_spec.rb
@@ -114,22 +114,19 @@ RSpec.describe UserAnalyticsPresenter, type: :model do
       let(:current_facility) { create(:facility, facility_group: current_user.facility.facility_group) }
 
       context "last_updated_at" do
-        it "has date for today if request was made today" do
+        it "has the date when the reporting views were last refreshed" do
+          time = 1.day.ago.to_time
+          allow(RefreshReportingViews).to receive(:last_updated_at).and_return(time)
           data = described_class.new(current_facility).statistics
 
-          expect(data.dig(:metadata, :last_updated_at).to_date)
-            .to eq(Time.current.to_date)
+          expect(data.dig(:metadata, :last_updated_at)).to eq(I18n.l(time))
         end
 
-        it "has the date at which the request was made" do
-          two_days_ago = 2.days.ago.to_date
+        it "says unknown when the reporting views were last refreshed" do
+          allow(RefreshReportingViews).to receive(:last_updated_at).and_return(nil)
+          data = described_class.new(current_facility).statistics
 
-          data = travel_to(two_days_ago) {
-            described_class.new(current_facility).statistics
-          }
-
-          expect(data.dig(:metadata, :last_updated_at).to_date)
-            .to eq(two_days_ago)
+          expect(data.dig(:metadata, :last_updated_at)).to eq("")
         end
       end
 


### PR DESCRIPTION
**Story card:** [sc-7017](https://app.shortcut.com/simpledotorg/story/7017/change-progress-counts-of-registrations-and-follow-ups-to-be-htn-only-dm-only-and-co-morbid-patients-i-e-htn-and-dm)

## Because

We found some bugs in the new matview added for daily follow ups and registrations in  https://github.com/simpledotorg/simple-server/pull/4284

## This addresses

- Fixes the registration facility ID calculation
- Fixes date grouping calculation for visit_date
- Fixes the `last_updated_at` (which was set to a fake data)