### PR TITLE
Reports: Fix treatment outcomes card

### DIFF
--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -1317,14 +1317,17 @@ Reports = function (withLtfu) {
       registrationsPeriodEndNode.innerHTML = periodInfo.bp_control_end_date;
       registrationsMonthEndNode.innerHTML = period;
 
+      if(hypertensionOnlyRegistrationsNode) {
+        hypertensionOnlyRegistrationsNode.innerHTML = this.formatNumberWithCommas(
+            cumulativeRegistrations - cumulativeHypertensionAndDiabetesRegistrations
+        );
+      }
 
-      hypertensionOnlyRegistrationsNode.innerHTML = this.formatNumberWithCommas(
-          cumulativeRegistrations - cumulativeHypertensionAndDiabetesRegistrations
-      );
-
-      hypertensionAndDiabetesOnlyRegistrationsNode.innerHTML = this.formatNumberWithCommas(
-          cumulativeHypertensionAndDiabetesRegistrations
-      );
+      if(hypertensionAndDiabetesOnlyRegistrationsNode) {
+        hypertensionAndDiabetesOnlyRegistrationsNode.innerHTML = this.formatNumberWithCommas(
+            cumulativeHypertensionAndDiabetesRegistrations
+        );
+      }
     };
 
     const populateCumulativeRegistrationsGraphDefault = () => {


### PR DESCRIPTION
**Story card:** [sc-9091](https://app.shortcut.com/simpledotorg/story/9091/treatment-outcomes-card-is-blank-for-facilities-with-dm-disabled)

## Because
Treatment outcomes card is blank for regions with DM disabled. This happens due to an unrelated JS bug.
<img width="500" alt="image" src="https://user-images.githubusercontent.com/16774200/194861108-7685215a-61b1-4930-bbfa-85483bb9c1bf.png">

## This addresses
In DM-enabled regions we show a breakdown of registrations by HTN and DM. On DM-disabled facilities we don't show this data element and the JS breaks because it can't find the `data-` attribute on the page.

<img width="209" alt="image" src="https://user-images.githubusercontent.com/16774200/194860316-52b5f91f-4cc9-478e-822d-81ddc7c30268.png">

Fixes `reports.js` to handle this case.
