### PR TITLE
Progress tab: Daily numbers performance improvement

### DIFF
--- a/config/initializers/prosopite.rb
+++ b/config/initializers/prosopite.rb
@@ -1,3 +1,2 @@
 # Use https://github.com/charkost/prosopite to log N+1 queries
-
-Prosopite.rails_logger = true
+Prosopite.rails_logger = true unless Rails.env.production?

--- a/db/migrate/20221011064211_update_daily_follow_up_and_registration_index.rb
+++ b/db/migrate/20221011064211_update_daily_follow_up_and_registration_index.rb
@@ -1,0 +1,7 @@
+class UpdateDailyFollowUpAndRegistrationIndex < ActiveRecord::Migration[6.1]
+  def change
+    add_index :reporting_facility_daily_follow_ups_and_registrations,  [:facility_region_id, :visit_date], unique: true, name: "index_df_facility_region_id_visit_date"
+    remove_index :reporting_facility_daily_follow_ups_and_registrations, name: :fd_far_facility_id
+    remove_index :reporting_facility_daily_follow_ups_and_registrations, name: :fd_far_visit_date
+  end
+end

--- a/db/migrate/20221011064211_update_daily_follow_up_and_registration_index.rb
+++ b/db/migrate/20221011064211_update_daily_follow_up_and_registration_index.rb
@@ -1,6 +1,6 @@
 class UpdateDailyFollowUpAndRegistrationIndex < ActiveRecord::Migration[6.1]
   def change
-    add_index :reporting_facility_daily_follow_ups_and_registrations,  [:facility_region_id, :visit_date], unique: true, name: "index_df_facility_region_id_visit_date"
+    add_index :reporting_facility_daily_follow_ups_and_registrations, [:facility_region_id, :visit_date], unique: true, name: "index_df_facility_region_id_visit_date"
     remove_index :reporting_facility_daily_follow_ups_and_registrations, name: :fd_far_facility_id
     remove_index :reporting_facility_daily_follow_ups_and_registrations, name: :fd_far_visit_date
   end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4928,24 +4928,10 @@ CREATE UNIQUE INDEX cphc_facility_mappings_unique_cphc_record ON public.cphc_fac
 
 
 --
--- Name: fd_far_facility_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX fd_far_facility_id ON public.reporting_facility_daily_follow_ups_and_registrations USING btree (facility_id);
-
-
---
 -- Name: fd_far_facility_id_visit_date; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX fd_far_facility_id_visit_date ON public.reporting_facility_daily_follow_ups_and_registrations USING btree (facility_id, visit_date);
-
-
---
--- Name: fd_far_visit_date; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX fd_far_visit_date ON public.reporting_facility_daily_follow_ups_and_registrations USING btree (visit_date);
 
 
 --
@@ -5254,6 +5240,13 @@ CREATE INDEX index_deduplication_logs_on_user_id ON public.deduplication_logs US
 --
 
 CREATE INDEX index_device_created_at_on_appts ON public.appointments USING btree (device_created_at);
+
+
+--
+-- Name: index_df_facility_region_id_visit_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_df_facility_region_id_visit_date ON public.reporting_facility_daily_follow_ups_and_registrations USING btree (facility_region_id, visit_date);
 
 
 --
@@ -6478,6 +6471,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221002111845'),
 ('20221003084709'),
 ('20221004092107'),
-('20221010104304');
+('20221010104304'),
+('20221011064211');
 
 


### PR DESCRIPTION
**Story card:** [sc-7017](https://app.shortcut.com/simpledotorg/story/7017/change-progress-counts-of-registrations-and-follow-ups-to-be-htn-only-dm-only-and-co-morbid-patients-i-e-htn-and-dm)

## Because

We indexed `reporting_facility_daily_follow_ups_and_registrations` by `facility_id` but we actually look up by `facility_region_id`. This has caused increased DB CPU due to sync traffic.

[Sample request trace](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20env%3Aindia-production%20service%3Asimple_server%20operation_name%3Arack.request%20resource_name%3A%22Api%3A%3AV3%3A%3AAnalytics%3A%3AUserAnalyticsController%23show%22&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40_duration.by_service&historicalData=true&saved-view-id=1250636&spanID=1861489344414961921&spanType=service-entry&timeHint=1665403609445&trace=AgAAAYPBymFl_UJY7QAAAAAAAAAYAAAAAEFZUEJ5blRpQUFDZEROTlJOamh2VzJ3eQAAACQAAAAAMDE4M2MyNmYtMDZmYS00NTFkLTllZmMtZTI1MzY3ODM1MzM0&traceID=3633389190088176919&start=1665385812779&end=1665472212779&paused=false)

## This addresses

- Fixes the indexes on the table.
- Removes a repeated query
