### PR TITLE
Add indexes to bsnl_delivery_details

### DIFF
--- a/db/migrate/20221011071921_add_bsnl_delivery_detail_indices.rb
+++ b/db/migrate/20221011071921_add_bsnl_delivery_detail_indices.rb
@@ -1,0 +1,6 @@
+class AddBsnlDeliveryDetailIndices < ActiveRecord::Migration[6.1]
+  def change
+    add_index :bsnl_delivery_details, :message_id, unique: true, name: :index_bsnl_delivery_details_message_id
+    add_index :bsnl_delivery_details, :deleted_at, unique: true, name: :index_bsnl_delivery_details_deleted_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5180,6 +5180,20 @@ CREATE INDEX index_bp_months_patient_recorded_at ON public.latest_blood_pressure
 
 
 --
+-- Name: index_bsnl_delivery_details_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_bsnl_delivery_details_deleted_at ON public.bsnl_delivery_details USING btree (deleted_at);
+
+
+--
+-- Name: index_bsnl_delivery_details_message_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_bsnl_delivery_details_message_id ON public.bsnl_delivery_details USING btree (message_id);
+
+
+--
 -- Name: index_call_results_deleted_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6478,6 +6492,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221002111845'),
 ('20221003084709'),
 ('20221004092107'),
-('20221010104304');
+('20221010104304'),
+('20221011071921');
 
 

--- a/spec/factories/bsnl_delivery_details.rb
+++ b/spec/factories/bsnl_delivery_details.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :bsnl_delivery_detail do
-    message_id { "1000000" }
+    sequence(:message_id) { |n| "#{n}000000" }
     message_status { "0" }
     recipient_number { Faker::PhoneNumber.phone_number }
     dlt_template_id { "14071640000000000000" }


### PR DESCRIPTION
**Story card:** -

## Because

We update bsnl delivery statuses by looking them up by `message_id`. There's no index on the column and the queries are slow and expensive.

[Sample query from 10 Oct](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20env%3Aindia-production%20service%3Apostgres%20operation_name%3Apostgres.query%20resource_name%3A%22SELECT%20bsnl_delivery_details%20.%20%2A%20FROM%20bsnl_delivery_details%20WHERE%20bsnl_delivery_details%20.%20deleted_at%20IS%20%3F%20AND%20bsnl_delivery_details%20.%20message_id%20%3D%20%3F%20LIMIT%20%3F%22&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40_duration.by_service&historicalData=true&spanID=213253031407820721&spanType=service-entry&timeHint=1665410418987&trace=AgAAAYPCMkkrxmGV2wAAAAAAAAAYAAAAAEFZUENNbDVzQUFBemFzNTR0c3ZmRnZBRwAAACQAAAAAMDE4M2MyNmYtMDZmYS00NTFkLTllZmMtZTI1MzY3ODM1MzM0&traceID=500022589970482643&start=1665389526674&end=1665415932067&paused=true)

## This addresses

Adds an index on `message_id` and `deleted_at` on `bsnl_delivery_details`.