### PR TITLE
Hide dm patient days

### DIFF
--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -90,7 +90,12 @@ DashboardReports = () => {
         legend: {
           display: false,
         },
+        hover: {
+          mode: "index",
+          intersect: false,
+        },
       },
+      plugins: [intersectDataVerticalLine],
     };
   };
 
@@ -535,7 +540,7 @@ DashboardReports = () => {
       });
 
       // This is a plugin and is expected to be loaded before creating this graph
-      config.plugins = [ChartDataLabels];
+      config.plugins = [ChartDataLabels, intersectDataVerticalLine];
       config.type = "bar";
       config.data = {
         labels: graphPeriods,
@@ -604,6 +609,8 @@ DashboardReports = () => {
       };
 
       config.options.tooltips = {
+        mode: "x",
+        intersect: false,
         displayColors: false,
         xAlign: "center",
         yAlign: "top",
@@ -631,6 +638,7 @@ DashboardReports = () => {
           },
         },
       };
+      config.options.hover.mode = "x";
 
       return config;
     },
@@ -737,7 +745,9 @@ DashboardReports = () => {
 
         if(!graphConfig.options.tooltips) {
             graphConfig.options.tooltips = {
-                enabled: false,
+          enabled: false,
+          mode: "index",
+          intersect: false,
                 custom: (tooltip) => {
                     let hoveredDatapoint = tooltip.dataPoints;
                     if (hoveredDatapoint)
@@ -868,6 +878,8 @@ Reports = function (withLtfu) {
     };
     controlledGraphConfig.options.tooltips = {
       enabled: false,
+      mode: "index",
+      intersect: false,
       custom: (tooltip) => {
         let hoveredDatapoint = tooltip.dataPoints;
         if (hoveredDatapoint)
@@ -989,6 +1001,8 @@ Reports = function (withLtfu) {
     };
     uncontrolledGraphConfig.options.tooltips = {
       enabled: false,
+      mode: "index",
+      intersect: false,
       custom: (tooltip) => {
         let hoveredDatapoint = tooltip.dataPoints;
         if (hoveredDatapoint)
@@ -1115,6 +1129,8 @@ Reports = function (withLtfu) {
     };
     missedVisitsConfig.options.tooltips = {
       enabled: false,
+      mode: "index",
+      intersect: false,
       custom: (tooltip) => {
         let hoveredDatapoint = tooltip.dataPoints;
         if (hoveredDatapoint)
@@ -1275,6 +1291,8 @@ Reports = function (withLtfu) {
     };
     cumulativeRegistrationsGraphConfig.options.tooltips = {
       enabled: false,
+      mode: "index",
+      intersect: false,
       custom: (tooltip) => {
         let hoveredDatapoint = tooltip.dataPoints;
         if (hoveredDatapoint)
@@ -1434,9 +1452,11 @@ Reports = function (withLtfu) {
         },
       ],
     };
+
     visitDetailsGraphConfig.options.tooltips = {
-      mode: "x",
       enabled: false,
+      mode: "index",
+      intersect: false,
       custom: (tooltip) => {
         let hoveredDatapoint = tooltip.dataPoints;
         if (hoveredDatapoint)
@@ -1630,7 +1650,12 @@ Reports = function (withLtfu) {
         legend: {
           display: false,
         },
+        hover: {
+          mode: "index",
+          intersect: false,
+        },
       },
+      plugins: [intersectDataVerticalLine],
     };
   };
 
@@ -1660,4 +1685,34 @@ Reports = function (withLtfu) {
   this.formatPercentage = (number) => {
     return (number || 0) + "%";
   };
+};
+
+// [plugin] vertical instersect line
+const intersectDataVerticalLine = {
+  id: "intersectDataVerticalLine",
+  beforeDraw: (chart) => {
+    if (chart.tooltip._active && chart.tooltip._active.length) {
+      const ctx = chart.ctx;
+      ctx.save();
+      const activePoint = chart.tooltip._active[0];
+      const chartArea = chart.chartArea;
+      // grey vertical hover line - full chart height
+      ctx.beginPath();
+      ctx.moveTo(activePoint._model.x, chartArea.top);
+      ctx.lineTo(activePoint._model.x, chartArea.bottom);
+      ctx.lineWidth = 2;
+      ctx.strokeStyle = "rgba(0,0,0, 0.1)";
+      ctx.stroke();
+      ctx.restore();
+      // colored vertical hover line - ['node' point to chart bottom] - only for line graphs (graphs with 1 data point)
+      if (chart.tooltip._active.length === 1) {
+        ctx.beginPath();
+        ctx.moveTo(activePoint._model.x, activePoint._model.y);
+        ctx.lineTo(activePoint._model.x, chartArea.bottom);
+        ctx.lineWidth = 2;
+        ctx.stroke();
+        ctx.restore();
+      }
+    }
+  },
 };

--- a/app/controllers/my_facilities/drug_stocks_controller.rb
+++ b/app/controllers/my_facilities/drug_stocks_controller.rb
@@ -17,10 +17,6 @@ class MyFacilities::DrugStocksController < AdminController
 
     if @facilities.present?
       create_drug_report
-
-      # Move diabetes to the end
-      @drugs_by_category["diabetes"] = @drugs_by_category.delete("diabetes") if @drugs_by_category["diabetes"]
-
       @report = @query.drug_stocks_report
     end
 

--- a/app/controllers/my_facilities/drug_stocks_controller.rb
+++ b/app/controllers/my_facilities/drug_stocks_controller.rb
@@ -17,6 +17,10 @@ class MyFacilities::DrugStocksController < AdminController
 
     if @facilities.present?
       create_drug_report
+
+      # Move diabetes to the end
+      @drugs_by_category["diabetes"] = @drugs_by_category.delete("diabetes") if @drugs_by_category["diabetes"]
+
       @report = @query.drug_stocks_report
     end
 

--- a/app/queries/drug_stocks_query.rb
+++ b/app/queries/drug_stocks_query.rb
@@ -76,7 +76,7 @@ class DrugStocksQuery
 
     custom_drug_category_order = CountryConfig.current.fetch(:custom_drug_category_order, [])
 
-    if custom_drug_category_order.to_set == drugs_by_category.keys.to_set
+    if (drugs_by_category.keys - custom_drug_category_order).empty?
       drugs_by_category.sort_by { |drug_category, _| custom_drug_category_order.find_index(drug_category) }.to_h
     else
       drugs_by_category.sort_by { |drug_category, _| drug_category }.to_h

--- a/app/views/my_facilities/drug_stocks/_drug_stocks_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_stocks_table.html.erb
@@ -51,7 +51,7 @@
         <% patient_days = @report.dig(:total_patient_days, drug_category, :patient_days) %>
         <% drugs.map do |drug| %>
           <% drug_stock = @report[:total_drugs_in_stock].dig(drug.rxnorm_code) %>
-          <% if drug_stock.present? && drug_category != "diabetes" %>
+          <% if drug_stock.present? %>
             <td class="type-number text-center" data-sort-column-key=<%= drug.id %>>
               <%= drug_stock %>
             </td>
@@ -60,17 +60,19 @@
           <% end %>
         <% end %>
 
-        <% if patient_days.present? %>
-          <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
-              data-template="<%= render "wide_tooltip_template" %>"
-              data-original-title="<%= render "drug_stocks_tooltip", report: @report.dig(:total_patient_days, drug_category) %>"
-              data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
-            <em class="<%= patient_days_css_class(patient_days) %>">
-              <%= patient_days %>
-            </em>
-          </td>
-        <% else %>
-          <td class="type-blank"><span>&#8212;</span></td>
+        <% unless drug_category == "diabetes" %>
+          <% if patient_days.present? %>
+            <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+                data-template="<%= render "wide_tooltip_template" %>"
+                data-original-title="<%= render "drug_stocks_tooltip", report: @report.dig(:total_patient_days, drug_category) %>"
+                data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
+              <em class="<%= patient_days_css_class(patient_days) %>">
+                <%= patient_days %>
+              </em>
+            </td>
+          <% else %>
+            <td class="type-blank"><span>&#8212;</span></td>
+          <% end %>
         <% end %>
       <% end %>
     </tr>
@@ -101,17 +103,20 @@
             <td class="type-blank"><span>&#8212;</span></td>
           <% end %>
         <% end %>
-        <% if patient_days.present? %>
-          <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
-              data-template="<%= render "wide_tooltip_template" %>"
-              data-original-title="<%= render "drug_stocks_tooltip", report: district_patient_days_report[drug_category] %>"
-              data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
-            <em class="<%= patient_days_css_class(patient_days) %>">
-              <%= patient_days %>
-            </em>
-          </td>
-        <% else %>
-          <td class="type-blank"><span>&#8212;</span></td>
+
+        <% unless drug_category == "diabetes" %>
+          <% if patient_days.present? %>
+            <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+                data-template="<%= render "wide_tooltip_template" %>"
+                data-original-title="<%= render "drug_stocks_tooltip", report: district_patient_days_report[drug_category] %>"
+                data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
+              <em class="<%= patient_days_css_class(patient_days) %>">
+                <%= patient_days %>
+              </em>
+            </td>
+          <% else %>
+            <td class="type-blank"><span>&#8212;</span></td>
+          <% end %>
         <% end %>
       <% end %>
     </tr>
@@ -137,17 +142,20 @@
               <td class="type-blank"><span>&#8212;</span></td>
             <% end %>
           <% end %>
-          <% if patient_days.present? %>
-            <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
-                data-template="<%= render "wide_tooltip_template" %>"
-                data-original-title="<%= render "drug_stocks_tooltip", report: block_patient_days_report[drug_category] %>"
-                data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
-              <em class="<%= patient_days_css_class(patient_days) %>">
-                <%= patient_days %>
-              </em>
-            </td>
-          <% else %>
-            <td class="type-blank"><span>&#8212;</span></td>
+
+          <% unless drug_category == "diabetes" %>
+            <% if patient_days.present? %>
+              <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+                  data-template="<%= render "wide_tooltip_template" %>"
+                  data-original-title="<%= render "drug_stocks_tooltip", report: block_patient_days_report[drug_category] %>"
+                  data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
+                <em class="<%= patient_days_css_class(patient_days) %>">
+                  <%= patient_days %>
+                </em>
+              </td>
+            <% else %>
+              <td class="type-blank"><span>&#8212;</span></td>
+            <% end %>
           <% end %>
         <% end %>
       </tr>
@@ -169,17 +177,19 @@
           <% end %>
         <% end %>
 
-        <% if patient_days.present? %>
-          <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
-              data-template="<%= render "wide_tooltip_template" %>"
-              data-original-title="<%= render "drug_stocks_tooltip", report: @report.dig(:facilities_total_patient_days, drug_category) %>"
-              data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
-            <em class="<%= patient_days_css_class(patient_days) %>">
-              <%= patient_days %>
-            </em>
-          </td>
-        <% else %>
-          <td class="type-blank"><span>&#8212;</span></td>
+        <% unless drug_category == "diabetes" %>
+          <% if patient_days.present? %>
+            <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+                data-template="<%= render "wide_tooltip_template" %>"
+                data-original-title="<%= render "drug_stocks_tooltip", report: @report.dig(:facilities_total_patient_days, drug_category) %>"
+                data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
+              <em class="<%= patient_days_css_class(patient_days) %>">
+                <%= patient_days %>
+              </em>
+            </td>
+          <% else %>
+            <td class="type-blank"><span>&#8212;</span></td>
+          <% end %>
         <% end %>
       <% end %>
     </tr>
@@ -209,17 +219,19 @@
               <td class="type-blank"><span>&#8212;</span></td>
             <% end %>
           <% end %>
-          <% if patient_days.present? %>
-            <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
-                data-template="<%= render "wide_tooltip_template" %>"
-                data-original-title="<%= render "drug_stocks_tooltip", report: facility_patient_days_report[drug_category] %>"
-                data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
-              <em class="<%= patient_days_css_class(patient_days) %>">
-                <%= patient_days %>
-              </em>
-            </td>
-          <% else %>
-            <td class="type-blank"><span>&#8212;</span></td>
+          <% unless drug_category == "diabetes" %>
+            <% if patient_days.present? %>
+              <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+                  data-template="<%= render "wide_tooltip_template" %>"
+                  data-original-title="<%= render "drug_stocks_tooltip", report: facility_patient_days_report[drug_category] %>"
+                  data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
+                <em class="<%= patient_days_css_class(patient_days) %>">
+                  <%= patient_days %>
+                </em>
+              </td>
+            <% else %>
+              <td class="type-blank"><span>&#8212;</span></td>
+            <% end %>
           <% end %>
         <% end %>
       </tr>

--- a/app/views/my_facilities/drug_stocks/_drug_stocks_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_stocks_table.html.erb
@@ -3,9 +3,12 @@
     <colgroup>
       <col>
       <col>
-      <% @drugs_by_category.map do |_drug_category, drugs| %>
-        <col class="table-divider">
-        <% drugs.map do |_drug| %>
+      <% @drugs_by_category.map do |drug_category, drugs| %>
+        <% drugs.each_with_index.map do |_drug, index| %>
+          <col class="<%= "table-divider" if index.zero? %>">
+        <% end %>
+
+        <% unless drug_category == "diabetes" %>
           <col>
         <% end %>
       <% end %>
@@ -15,7 +18,11 @@
     <tr>
       <th colspan="2"></th>
       <% @drugs_by_category.map do |drug_category, drugs| %>
-        <th colspan=<%= drugs.count.next.to_s %>><%= protocol_drug_labels[drug_category][:full] %></th>
+        <% if drug_category == "diabetes" %>
+          <th colspan=<%= drugs.count.to_s %>><%= protocol_drug_labels[drug_category][:full] %></th>
+        <% else %>
+          <th colspan=<%= drugs.count.next.to_s %>><%= protocol_drug_labels[drug_category][:full] %></th>
+        <% end %>
       <% end %>
     </tr>
     <tr data-sort-method="thead" class="sorts">
@@ -26,9 +33,11 @@
             <%= drug.name %><br> <%= drug.dosage %>
           </th>
         <% end %>
-        <th class="row-label sort-label sticky" data-sort-method="number" data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
-          Patient<br>days
-        </th>
+        <% unless drug_category == "diabetes" %>
+          <th class="row-label sort-label sticky" data-sort-method="number" data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
+            Patient<br>days
+          </th>
+        <% end %>
       <% end %>
       <th class="mobile sticky"></th>
     </tr>
@@ -42,7 +51,7 @@
         <% patient_days = @report.dig(:total_patient_days, drug_category, :patient_days) %>
         <% drugs.map do |drug| %>
           <% drug_stock = @report[:total_drugs_in_stock].dig(drug.rxnorm_code) %>
-          <% if drug_stock.present? %>
+          <% if drug_stock.present? && drug_category != "diabetes" %>
             <td class="type-number text-center" data-sort-column-key=<%= drug.id %>>
               <%= drug_stock %>
             </td>

--- a/config/initializers/country_config.rb
+++ b/config/initializers/country_config.rb
@@ -13,7 +13,7 @@ class CountryConfig
       sms_country_code: ENV["SMS_COUNTRY_CODE"] || "+91",
       supported_genders: %w[male female transgender],
       patient_line_list_show_zone: false,
-      custom_drug_category_order: %w[hypertension_ccb hypertension_arb hypertension_diuretic],
+      custom_drug_category_order: %w[hypertension_ccb hypertension_arb hypertension_diuretic diabetes],
       maharashtra_dhis2_data_elements: {
         monthly_registrations_male: "F0cPY1T9lNs.tY82VK3LTQq",
         monthly_registrations_female: "F0cPY1T9lNs.VHbljVQ8REF",

--- a/lib/seed/runner.rb
+++ b/lib/seed/runner.rb
@@ -116,6 +116,7 @@ module Seed
         user = facility.users.first
         facility.protocol.protocol_drugs.where(stock_tracked: true).each do |protocol_drug|
           attrs << FactoryBot.attributes_for(:drug_stock,
+            for_end_of_month: 1.month.ago.end_of_month,
             facility_id: facility.id,
             user_id: user.id,
             protocol_drug_id: protocol_drug.id,


### PR DESCRIPTION
**Story card:** 
* https://app.shortcut.com/simpledotorg/story/9179
* https://app.shortcut.com/simpledotorg/story/9178/hide-patient-days-from-csv-download
* https://app.shortcut.com/simpledotorg/story/9177/hide-patient-days-column-for-diabetes-drug-stock-section

## Because

West Bengal has added DM drugs to drug stock, but there aren't good coefficients to calculate patient days yet.

## This addresses

Hides patient days for diabetes drugs for now. Once countries start coming up with coefficients, we can switch this logic to instead hide patient days when coeffs are not configured. For now, this unblocks WB faster, and we don't know if anyone else will use DM drug stocks yet.

We also move DM drugs to be the last section in the drug stock report. This PR achieves that by:
* Adding "diabetes" to the custom country config drug category order
* Updating the ordering logic to be applied if the reporting categories are a _subset_ of the custom order, not necessarily exactly equal to the custom order.

<img width="1439" alt="Screen Shot 2022-10-19 at 11 13 13 AM" src="https://user-images.githubusercontent.com/4241399/196606708-8bae26d1-62db-4263-93f3-5f1d778e32a0.png">

## Test instructions

Create Diabetes drugs in a medication protocol
* Set category to "Diabetes"
* Set Stock Tracked to "Yes"
View a drug stock report for an area using the protocol
Create some drug stocks, entering DM drug info as well
Ensure that
* Patient days columns are not shown for DM drugs in dashboard
* Patient days columns are not shown for DM drugs in download
* DM drugs are the last section
* All column headers and datapoints line up correctly in tables and downloads
