### PR TITLE
Fix rails logs in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,6 +61,9 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.active_job.queue_adapter = :inline
+
+  stdout_logger = ActiveSupport::TaggedLogging.new(JsonLogger.new($stdout))
+  config.logger.extend(JsonLogger.broadcast(stdout_logger))
 end
 
 # Set a longer session timeout to make things easier on developers


### PR DESCRIPTION
**Story card:** -

## Because

Rails logs stopped going to stdout after the rails 6 upgrade.

## This addresses

Unsure about the root cause from the rails 6 commit. This explicitly sets up STDOUT logs in development.