### PR TITLE
Cache warmer performance improvements #2

### DIFF
--- a/app/jobs/reports/region_cache_warmer_job.rb
+++ b/app/jobs/reports/region_cache_warmer_job.rb
@@ -4,7 +4,7 @@ class Reports::RegionCacheWarmerJob
 
   sidekiq_options queue: :default
   sidekiq_throttle(
-    concurrency: { limit: 2 }
+    concurrency: {limit: 1}
   )
 
   def perform(region_type, limit, offset)

--- a/app/jobs/reports/region_cache_warmer_job.rb
+++ b/app/jobs/reports/region_cache_warmer_job.rb
@@ -1,0 +1,33 @@
+class Reports::RegionCacheWarmerJob
+  include Sidekiq::Worker
+  include Sidekiq::Throttled::Worker
+
+  sidekiq_options queue: :default
+  sidekiq_throttle(
+    concurrency: { limit: 2 }
+  )
+
+  def perform(region_type, limit, offset)
+    if Flipper.enabled?(:disable_region_cache_warmer)
+      Rails.logger.info "Cache warmer disabled via flipper - exiting"
+      return
+    end
+
+    Rails.logger.info "Warming repository cache for #{region_type}, limit: #{limit}, offset: #{offset}"
+    warm_cache(region_type, limit, offset)
+    Rails.logger.info "Finished warming repository cache for #{region_type}, limit: #{limit}, offset: #{offset}"
+  end
+
+  def warm_cache(region_type, limit, offset)
+    RequestStore.store[:bust_cache] = true
+    Time.use_zone(Period::REPORTING_TIME_ZONE) do
+      period = Reports.default_period
+      regions = Region.where(region_type: region_type).limit(limit).offset(offset)
+      range = (period.advance(months: -23)..period)
+
+      Reports::Repository.new(regions, periods: range).warm_cache
+    end
+  ensure
+    RequestStore.store[:bust_cache] = false
+  end
+end

--- a/app/jobs/reports/region_cache_warmer_job.rb
+++ b/app/jobs/reports/region_cache_warmer_job.rb
@@ -4,7 +4,7 @@ class Reports::RegionCacheWarmerJob
 
   sidekiq_options queue: :default
   sidekiq_throttle(
-    concurrency: {limit: 1}
+    concurrency: {limit: 2}
   )
 
   def perform(region_type, limit, offset)

--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -142,7 +142,6 @@ module Reports
         blood_sugar_measures_by_user
         monthly_registrations_by_user(diagnosis: :hypertension)
         monthly_registrations_by_user(diagnosis: :diabetes)
-        monthly_registrations_by_gender
         overdue_calls_by_user
       end
     end

--- a/app/services/refresh_reporting_views.rb
+++ b/app/services/refresh_reporting_views.rb
@@ -107,6 +107,7 @@ class RefreshReportingViews
         klass = name.constantize
         klass.refresh
       end
+      Statsd.instance.flush
     end
   end
 
@@ -114,7 +115,9 @@ class RefreshReportingViews
     name = "refresh_reporting_views.#{operation}"
     benchmark(name) do
       Datadog::Tracing.trace("refresh_matview", resource: operation) do |span|
-        yield
+        Statsd.instance.time(name) do
+          yield
+        end
       end
     end
   end

--- a/app/services/reports/region_cache_warmer.rb
+++ b/app/services/reports/region_cache_warmer.rb
@@ -14,6 +14,11 @@ module Reports
     end
 
     def call
+      if Flipper.enabled?(:disable_region_cache_warmer)
+        Rails.logger.info "Cache warmer disabled via flipper - exiting"
+        return
+      end
+
       Rails.logger.info "Starting queuing cache warming jobs"
 
       Region::REGION_TYPES.excluding("root").each do |region_type|

--- a/app/services/reports/region_cache_warmer.rb
+++ b/app/services/reports/region_cache_warmer.rb
@@ -1,69 +1,36 @@
 module Reports
   class RegionCacheWarmer
     prepend SentryHandler
+    BATCH_SIZE = 250
 
-    def self.call
-      new.call
+    def self.call(*args)
+      new(*args).call
     end
 
-    attr_reader :name
-    attr_reader :period
+    attr_reader :batch_size
 
-    def initialize(period: Reports.default_period)
-      @period = period
-      @name = self.class.name.to_s
-      notify "Starting #{name} warming"
+    def initialize(batch_size: BATCH_SIZE)
+      @batch_size = batch_size
     end
 
     def call
-      if Flipper.enabled?(:disable_region_cache_warmer)
-        notify "disabled via flipper - exiting"
-        return
-      end
-      RequestStore.store[:bust_cache] = true
+      Rails.logger.info "Starting queuing cache warming jobs"
 
-      warm_caches
-
-      notify "Finished all caching for #{name}"
-    ensure
-      RequestStore.store[:bust_cache] = false
-    end
-
-    private
-
-    def warm_caches
-      Time.use_zone(Period::REPORTING_TIME_ZONE) do
-        Region::REGION_TYPES.reject { |t| t == "root" }.each do |region_type|
-          Datadog::Tracing.trace("region_cache_warmer.warm_repository_cache", resource: region_type) do |span|
-            Region.public_send("#{region_type}_regions").find_in_batches do |batch|
-              warm_repository_caches(batch)
-            end
-            Statsd.instance.flush
-          end
+      Region::REGION_TYPES.excluding("root").each do |region_type|
+        Region.where(region_type: region_type).in_batches(of: batch_size).each_with_index do |_, batch_index|
+          queue_job(region_type, batch_index)
         end
       end
-    end
 
-    def warm_repository_caches(regions)
-      region_type = regions.first.region_type
-      notify "Starting warming cache for repository cache for batch of #{region_type} regions"
-      range = (period.advance(months: -23)..period)
-      repo = Repository.new(regions, periods: range)
-      repo.warm_cache
-      Statsd.instance.increment("region_cache_warmer.#{region_type}.warm_repository_cache.region_count", regions.count)
+      Rails.logger.info "Finished queueing cache warming jobs"
     end
 
     private
 
-    def notify(msg, extra = {})
-      data = {
-        logger: {
-          name: name
-        },
-        class: name,
-        module: "reports"
-      }.merge(extra).merge(msg: msg)
-      Rails.logger.info data
+    def queue_job(region_type, batch_index)
+      limit = batch_size
+      offset =  batch_index * batch_size
+      RegionCacheWarmerJob.perform_async(region_type, limit, offset)
     end
   end
 end

--- a/app/services/reports/region_cache_warmer.rb
+++ b/app/services/reports/region_cache_warmer.rb
@@ -1,7 +1,7 @@
 module Reports
   class RegionCacheWarmer
     prepend SentryHandler
-    BATCH_SIZE = 100
+    BATCH_SIZE = 250
 
     def self.call(*args)
       new(*args).call

--- a/app/services/reports/region_cache_warmer.rb
+++ b/app/services/reports/region_cache_warmer.rb
@@ -1,7 +1,7 @@
 module Reports
   class RegionCacheWarmer
     prepend SentryHandler
-    BATCH_SIZE = 250
+    BATCH_SIZE = 100
 
     def self.call(*args)
       new(*args).call
@@ -29,7 +29,7 @@ module Reports
 
     def queue_job(region_type, batch_index)
       limit = batch_size
-      offset =  batch_index * batch_size
+      offset = batch_index * batch_size
       RegionCacheWarmerJob.perform_async(region_type, limit, offset)
     end
   end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -96,7 +96,7 @@ every :day, at: local("02:30 am"), roles: [:cron] do
   runner "RecordCounterJob.perform_async"
 end
 
-every :day, at: local("02:30 am"), roles: [:cron] do
+every :day, at: local("04:30 am"), roles: [:cron] do
   runner "Reports::RegionCacheWarmer.call"
 end
 

--- a/db/migrate/20221024071410_add_reporting_facility_state_region_indexes.rb
+++ b/db/migrate/20221024071410_add_reporting_facility_state_region_indexes.rb
@@ -1,0 +1,8 @@
+class AddReportingFacilityStateRegionIndexes < ActiveRecord::Migration[6.1]
+  def change
+    add_index :reporting_facility_states, [:month_date, :organization_region_id], name: :index_fs_month_date_organization
+    add_index :reporting_facility_states, [:month_date, :state_region_id], name: :index_fs_month_date_state
+    add_index :reporting_facility_states, [:month_date, :district_region_id], name: :index_fs_month_date_district
+    add_index :reporting_facility_states, [:month_date, :block_region_id], name: :index_fs_month_date_block
+  end
+end

--- a/db/migrate/20221024071410_add_reporting_facility_state_region_indexes.rb
+++ b/db/migrate/20221024071410_add_reporting_facility_state_region_indexes.rb
@@ -1,8 +1,8 @@
 class AddReportingFacilityStateRegionIndexes < ActiveRecord::Migration[6.1]
   def change
-    add_index :reporting_facility_states, [:month_date, :organization_region_id], name: :index_fs_month_date_organization
-    add_index :reporting_facility_states, [:month_date, :state_region_id], name: :index_fs_month_date_state
-    add_index :reporting_facility_states, [:month_date, :district_region_id], name: :index_fs_month_date_district
-    add_index :reporting_facility_states, [:month_date, :block_region_id], name: :index_fs_month_date_block
+    add_index :reporting_facility_states, [:organization_region_id, :month_date], name: :index_fs_organization_month_date
+    add_index :reporting_facility_states, [:state_region_id, :month_date], name: :index_fs_state_month_date
+    add_index :reporting_facility_states, [:district_region_id, :month_date], name: :index_fs_district_month_date
+    add_index :reporting_facility_states, [:block_region_id, :month_date], name: :index_fs_block_month_date
   end
 end

--- a/db/migrate/20221024071710_add_reporting_overdue_calls_indexes.rb
+++ b/db/migrate/20221024071710_add_reporting_overdue_calls_indexes.rb
@@ -1,0 +1,6 @@
+class AddReportingOverdueCallsIndexes < ActiveRecord::Migration[6.1]
+  def change
+    add_index :reporting_overdue_calls, [:call_result_created_at], name: :index_overdue_calls_call_result_created_at
+    add_index :reporting_overdue_calls, [:appointment_facility_region_id], name: :index_overdue_calls_appointment_facility
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5483,10 +5483,38 @@ CREATE UNIQUE INDEX index_fs_dimensions_month_date_facility_region_id ON public.
 
 
 --
+-- Name: index_fs_month_date_block; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_fs_month_date_block ON public.reporting_facility_states USING btree (month_date, block_region_id);
+
+
+--
+-- Name: index_fs_month_date_district; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_fs_month_date_district ON public.reporting_facility_states USING btree (month_date, district_region_id);
+
+
+--
+-- Name: index_fs_month_date_organization; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_fs_month_date_organization ON public.reporting_facility_states USING btree (month_date, organization_region_id);
+
+
+--
 -- Name: index_fs_month_date_region_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_fs_month_date_region_id ON public.reporting_facility_states USING btree (month_date, facility_region_id);
+
+
+--
+-- Name: index_fs_month_date_state; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_fs_month_date_state ON public.reporting_facility_states USING btree (month_date, state_region_id);
 
 
 --
@@ -5627,6 +5655,20 @@ CREATE INDEX index_organizations_on_deleted_at ON public.organizations USING btr
 --
 
 CREATE UNIQUE INDEX index_organizations_on_slug ON public.organizations USING btree (slug);
+
+
+--
+-- Name: index_overdue_calls_appointment_facility; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_overdue_calls_appointment_facility ON public.reporting_overdue_calls USING btree (appointment_facility_region_id);
+
+
+--
+-- Name: index_overdue_calls_call_result_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_overdue_calls_call_result_created_at ON public.reporting_overdue_calls USING btree (call_result_created_at);
 
 
 --
@@ -6490,6 +6532,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221010104304'),
 ('20221011064211'),
 ('20221011071921'),
-('20221011124316');
+('20221011124316'),
+('20221024071410'),
+('20221024071710');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5469,6 +5469,13 @@ CREATE UNIQUE INDEX index_flipper_gates_on_feature_key_and_key_and_value ON publ
 
 
 --
+-- Name: index_fs_block_month_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_fs_block_month_date ON public.reporting_facility_states USING btree (block_region_id, month_date);
+
+
+--
 -- Name: index_fs_dimensions_facility_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5483,24 +5490,10 @@ CREATE UNIQUE INDEX index_fs_dimensions_month_date_facility_region_id ON public.
 
 
 --
--- Name: index_fs_month_date_block; Type: INDEX; Schema: public; Owner: -
+-- Name: index_fs_district_month_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_fs_month_date_block ON public.reporting_facility_states USING btree (month_date, block_region_id);
-
-
---
--- Name: index_fs_month_date_district; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_fs_month_date_district ON public.reporting_facility_states USING btree (month_date, district_region_id);
-
-
---
--- Name: index_fs_month_date_organization; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_fs_month_date_organization ON public.reporting_facility_states USING btree (month_date, organization_region_id);
+CREATE INDEX index_fs_district_month_date ON public.reporting_facility_states USING btree (district_region_id, month_date);
 
 
 --
@@ -5511,10 +5504,17 @@ CREATE UNIQUE INDEX index_fs_month_date_region_id ON public.reporting_facility_s
 
 
 --
--- Name: index_fs_month_date_state; Type: INDEX; Schema: public; Owner: -
+-- Name: index_fs_organization_month_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_fs_month_date_state ON public.reporting_facility_states USING btree (month_date, state_region_id);
+CREATE INDEX index_fs_organization_month_date ON public.reporting_facility_states USING btree (organization_region_id, month_date);
+
+
+--
+-- Name: index_fs_state_month_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_fs_state_month_date ON public.reporting_facility_states USING btree (state_region_id, month_date);
 
 
 --

--- a/spec/jobs/region_cache_warmer_job_spec.rb
+++ b/spec/jobs/region_cache_warmer_job_spec.rb
@@ -1,0 +1,128 @@
+require "rails_helper"
+
+RSpec.describe Reports::RegionCacheWarmerJob, type: :job do
+  describe "#perform" do
+    before do
+      memory_store = ActiveSupport::Cache.lookup_store(:memory_store)
+
+      allow(Rails).to receive(:cache).and_return(memory_store)
+      Rails.cache.clear
+    end
+
+    around do |ex|
+      with_reporting_time_zone { ex.run }
+    end
+
+    it "skips caching if disabled via Flipper" do
+      Flipper.enable(:disable_region_cache_warmer)
+      expect(Reports::Repository).to receive(:new).never
+      described_class.new.perform(:facility, 0, 0)
+    end
+
+    it "sets bust cache to false before running queries" do
+      allow(RequestStore.store).to receive(:[]=).and_call_original
+      expect(RequestStore.store).to receive(:[]=).with(:bust_cache, true).ordered
+      expect(RequestStore.store).to receive(:[]=).with(:bust_cache, false).ordered
+
+      described_class.new.perform(:facility, 0, 0)
+    end
+
+    it "new data is cached with every run of the cache warmer" do
+      facility_group = create(:facility_group)
+      user = create(:user, organization: facility_group.organization)
+      facility_1 = create(:facility, facility_group: facility_group)
+      slug = facility_1.region.slug
+      patient = Timecop.freeze(Time.parse("June 1, 2020 00:00:00+00:00")) do
+        user = create(:user, organization: facility_group.organization)
+        create(:patient, registration_facility: facility_1, registration_user: user)
+      end
+      Timecop.freeze(Time.parse("August 1, 2020 00:00:00+00:00")) do
+        create(:bp_with_encounter, :under_control, facility: facility_1, patient: patient, user: user)
+      end
+
+      Timecop.freeze("September 1st 2020 00:04:00+00:00:00") do
+        RefreshReportingViews.call
+        described_class.perform_async(:facility, 1000, 0)
+        described_class.drain
+        repo = Reports::Repository.new(facility_1, periods: Period.current.downto(6))
+        expect(repo.cumulative_assigned_patients[slug][Period.current]).to eq(1)
+        expect(repo.uncontrolled[slug][Period.current]).to eq(0)
+        expect(repo.controlled[slug][Period.current]).to eq(1)
+      end
+      Timecop.freeze("September 2nd 2020 00:04:00+00:00:00") do
+        create(:patient, registration_facility: facility_1, registration_user: user)
+        create(:bp_with_encounter, :hypertensive, facility: facility_1, patient: patient, user: user)
+        RefreshReportingViews.call
+        described_class.perform_async(:facility, 1000, 0)
+        described_class.drain
+        repo = Reports::Repository.new(facility_1, periods: Period.current.downto(6))
+        expect(repo.cumulative_assigned_patients[slug][Period.current]).to eq(2)
+        expect(repo.uncontrolled[slug][Period.current]).to eq(1)
+        expect(repo.controlled[slug][Period.current]).to eq(0)
+      end
+    end
+
+    it "caches all non root/org regions in the v2 schema" do
+      facility_group = create(:facility_group)
+      facility_1 = create(:facility, facility_group: facility_group)
+      user = create(:user, organization: facility_group.organization)
+      patient = create(:patient, registration_facility: facility_1, recorded_at: 2.months.ago, registration_user: user)
+      create(:bp_with_encounter, :under_control, facility: facility_1, patient: patient, recorded_at: 15.days.ago)
+
+      RefreshReportingViews.call
+      described_class.perform_async(:facility, 1000, 0)
+      described_class.drain
+
+      repo = Reports::Repository.new(facility_1, periods: Period.current)
+      expect(repo.schema).to receive(:controlled).never # ensure the cache is hit and we don't retrieve counts again for the rate calc
+      repo.controlled_rates
+      repo.controlled_rates(with_ltfu: true)
+    end
+
+    it "caches all the result of repository methods" do
+      facility_group = create(:facility_group)
+      facility = create(:facility, facility_group: facility_group)
+      user = create(:user, organization: facility_group.organization)
+      patient = create(:patient, registration_facility: facility, recorded_at: 2.months.ago, registration_user: user)
+      create(:bp_with_encounter, :under_control, facility: facility, patient: patient, recorded_at: 15.days.ago)
+      create(:blood_sugar_with_encounter, :bs_below_200, facility: facility, patient: patient, recorded_at: 15.days.ago)
+
+      cache_keys = Rails.cache.instance_variable_get(:@data).keys
+      expect(cache_keys).to be_empty
+
+      RefreshReportingViews.call
+      described_class.perform_async(:facility, 1000, 0)
+      described_class.drain
+
+      Reports::Repository.new(facility, periods: Period.current)
+      cache_keys = Rails.cache.instance_variable_get(:@data).keys
+
+      expect(cache_keys).to_not be_empty
+
+      expected_keys_in_cache = [
+        /bp_measures_by_user/,
+        /blood_sugar_measures_by_user/,
+        /monthly_registrations_by_user\/group_by\/registration_user_id\/period_type\/month\/diagnosis\/hypertension/,
+        /monthly_registrations_by_user\/group_by\/registration_user_id\/period_type\/month\/diagnosis\/diabetes/,
+        /overdue_calls_by_user/
+      ]
+
+      expected_keys_in_cache.each do |expected_key|
+        expect(cache_keys.any? { |key| key.match(expected_key) }).to eq true
+      end
+    end
+
+    it "refreshes cache by region type, limit and offset" do
+      regions = create_list(:facility, 5).map(&:region)
+      allow(Reports::Repository).to receive(:new).and_call_original
+
+      expect(Reports::Repository).to receive(:new).with(regions.take(3), any_args)
+      described_class.perform_async(:facility, 3, 0)
+      described_class.drain
+
+      expect(Reports::Repository).to receive(:new).with(regions[2..3], any_args)
+      described_class.perform_async(:facility, 2, 2)
+      described_class.drain
+    end
+  end
+end

--- a/spec/services/reports/region_cache_warmer_spec.rb
+++ b/spec/services/reports/region_cache_warmer_spec.rb
@@ -110,7 +110,6 @@ RSpec.describe Reports::RegionCacheWarmer, type: :model do
         /blood_sugar_measures_by_user/,
         /monthly_registrations_by_user\/group_by\/registration_user_id\/period_type\/month\/diagnosis\/hypertension/,
         /monthly_registrations_by_user\/group_by\/registration_user_id\/period_type\/month\/diagnosis\/diabetes/,
-        /monthly_registrations_by_gender/,
         /overdue_calls_by_user/
       ]
 

--- a/spec/services/reports/region_cache_warmer_spec.rb
+++ b/spec/services/reports/region_cache_warmer_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Reports::RegionCacheWarmer, type: :model do
+  it "skips caching if disabled via Flipper" do
+    Flipper.enable(:disable_region_cache_warmer)
+    expect(Reports::Repository).to receive(:new).never
+    described_class.new.call
+  end
+
   it "calls RegionCacheWarmerJob in batches with limits and offsets" do
     batch_size = 2
     organization = create(:organization)

--- a/spec/services/reports/region_cache_warmer_spec.rb
+++ b/spec/services/reports/region_cache_warmer_spec.rb
@@ -1,121 +1,24 @@
 require "rails_helper"
 
 RSpec.describe Reports::RegionCacheWarmer, type: :model do
-  let(:facility_group) { create(:facility_group) }
-  let(:user) { create(:user, organization: facility_group.organization) }
-  let(:june_1_2020) { Time.parse("June 1, 2020 00:00:00+00:00") }
-  let(:august_1_2020) { Time.parse("August 1, 2020 00:00:00+00:00") }
-
-  before do
-    memory_store = ActiveSupport::Cache.lookup_store(:memory_store)
-
-    allow(Rails).to receive(:cache).and_return(memory_store)
-    Rails.cache.clear
-  end
-
-  around do |ex|
-    with_reporting_time_zone { ex.run }
-  end
-
-  it "skips caching if disabled via Flipper" do
-    Flipper.enable(:disable_region_cache_warmer)
-    expect(Reports::Repository).to receive(:new).never
-    Reports::RegionCacheWarmer.call
-  end
-
-  it "sets bust cache to false before running queries" do
-    allow(RequestStore.store).to receive(:[]=)
-    warmer = Reports::RegionCacheWarmer.new
-    expect(RequestStore.store).to receive(:[]=).with(:bust_cache, true).ordered
-    expect(warmer).to receive(:warm_caches).once.ordered
-    expect(RequestStore.store).to receive(:[]=).with(:bust_cache, false).ordered
-
-    warmer.call
-  end
-
-  it "new data is cached with every run of the cache warmer" do
-    facility_1 = create(:facility, facility_group: facility_group)
-    slug = facility_1.region.slug
-    patient = Timecop.freeze(june_1_2020) do
-      user = create(:user, organization: facility_group.organization)
-      create(:patient, registration_facility: facility_1, registration_user: user)
-    end
-    Timecop.freeze(august_1_2020) do
-      create(:bp_with_encounter, :under_control, facility: facility_1, patient: patient, user: user)
+  it "calls RegionCacheWarmerJob in batches with limits and offsets" do
+    batch_size = 2
+    organization = create(:organization)
+    states = create_list(:region, 5, :state, reparent_to: organization.region)
+    states.each do |state|
+      create_list(:facility_group, 2, organization: organization, state: state.name)
     end
 
-    Timecop.freeze("September 1st 2020 00:04:00+00:00:00") do
-      RefreshReportingViews.call
-      described_class.call
-      repo = Reports::Repository.new(facility_1, periods: Period.current.downto(6))
-      expect(repo.cumulative_assigned_patients[slug][Period.current]).to eq(1)
-      expect(repo.uncontrolled[slug][Period.current]).to eq(0)
-      expect(repo.controlled[slug][Period.current]).to eq(1)
-    end
-    Timecop.freeze("September 2st 2020 00:04:00+00:00:00") do
-      create(:patient, registration_facility: facility_1, registration_user: user)
-      create(:bp_with_encounter, :hypertensive, facility: facility_1, patient: patient, user: user)
-      RefreshReportingViews.call
-      described_class.call
-      repo = Reports::Repository.new(facility_1, periods: Period.current.downto(6))
-      expect(repo.cumulative_assigned_patients[slug][Period.current]).to eq(2)
-      expect(repo.uncontrolled[slug][Period.current]).to eq(1)
-      expect(repo.controlled[slug][Period.current]).to eq(0)
-    end
-  end
+    expect(Reports::RegionCacheWarmerJob).to receive(:perform_async).with("organization", batch_size, 0).exactly(1).times
+    expect(Reports::RegionCacheWarmerJob).to receive(:perform_async).with("state", batch_size, 0).exactly(1).times
+    expect(Reports::RegionCacheWarmerJob).to receive(:perform_async).with("state", batch_size, 2).exactly(1).times
+    expect(Reports::RegionCacheWarmerJob).to receive(:perform_async).with("state", batch_size, 4).exactly(1).times
+    expect(Reports::RegionCacheWarmerJob).to receive(:perform_async).with("district", batch_size, 0).exactly(1).times
+    expect(Reports::RegionCacheWarmerJob).to receive(:perform_async).with("district", batch_size, 2).exactly(1).times
+    expect(Reports::RegionCacheWarmerJob).to receive(:perform_async).with("district", batch_size, 4).exactly(1).times
+    expect(Reports::RegionCacheWarmerJob).to receive(:perform_async).with("district", batch_size, 6).exactly(1).times
+    expect(Reports::RegionCacheWarmerJob).to receive(:perform_async).with("district", batch_size, 8).exactly(1).times
 
-  it "completes successfully" do
-    facility = create(:facility, facility_group: facility_group)
-    create(:patient, registration_facility: facility, registration_user: user)
-    RefreshReportingViews.call
-    Reports::RegionCacheWarmer.call
-  end
-
-  context "warm_repository_cache" do
-    it "caches all non root/org regions in the v2 schema" do
-      facility_1 = create(:facility, facility_group: facility_group)
-      user = create(:user, organization: facility_group.organization)
-      patient = create(:patient, registration_facility: facility_1, recorded_at: 2.months.ago, registration_user: user)
-      create(:bp_with_encounter, :under_control, facility: facility_1, patient: patient, recorded_at: 15.days.ago)
-
-      RefreshReportingViews.call
-
-      described_class.call
-      repo = Reports::Repository.new(facility_1, periods: Period.current)
-      expect(repo.schema).to receive(:controlled).never # ensure the cache is hit and we don't retrieve counts again for the rate calc
-      repo.controlled_rates
-      repo.controlled_rates(with_ltfu: true)
-    end
-
-    it "caches all the result of repository methods" do
-      facility = create(:facility, facility_group: facility_group)
-      user = create(:user, organization: facility_group.organization)
-      patient = create(:patient, registration_facility: facility, recorded_at: 2.months.ago, registration_user: user)
-      create(:bp_with_encounter, :under_control, facility: facility, patient: patient, recorded_at: 15.days.ago)
-      create(:blood_sugar_with_encounter, :bs_below_200, facility: facility, patient: patient, recorded_at: 15.days.ago)
-
-      cache_keys = Rails.cache.instance_variable_get(:@data).keys
-      expect(cache_keys).to be_empty
-
-      RefreshReportingViews.call
-
-      described_class.call
-      Reports::Repository.new(facility, periods: Period.current)
-      cache_keys = Rails.cache.instance_variable_get(:@data).keys
-
-      expect(cache_keys).to_not be_empty
-
-      expected_keys_in_cache = [
-        /bp_measures_by_user/,
-        /blood_sugar_measures_by_user/,
-        /monthly_registrations_by_user\/group_by\/registration_user_id\/period_type\/month\/diagnosis\/hypertension/,
-        /monthly_registrations_by_user\/group_by\/registration_user_id\/period_type\/month\/diagnosis\/diabetes/,
-        /overdue_calls_by_user/
-      ]
-
-      expected_keys_in_cache.each do |expected_key|
-        expect(cache_keys.any? { |key| key.match(expected_key) }).to eq true
-      end
-    end
+    described_class.call(batch_size: batch_size)
   end
 end


### PR DESCRIPTION
**Story card:** [sc-9236](https://app.shortcut.com/simpledotorg/story/9236/parallelize-cache-warming)

## Because

The cache warmer cron job takes a long time to complete which runs into peak traffic hours. This leads to requests going to the cron server returning [5xxes](https://simpledotorg.slack.com/archives/C012BDG130D/p1664603549089529).

## This addresses

Adds some improvements suggested in https://github.com/simpledotorg/simple-server/pull/4312

- Adds missing indexes for reporting queries
- Remove more metrics that don't need caching
- Parallelises cache refresh using sidekiq. We will run throttle this to run 2 jobs at a time and increase the concurrency if the box isn't affected.

