### PR TITLE
Progress Tab: Include current month data in Patient treatment status

### DIFF
--- a/app/components/progress_tab/hypertension/control_component.rb
+++ b/app/components/progress_tab/hypertension/control_component.rb
@@ -4,11 +4,10 @@ class ProgressTab::Hypertension::ControlComponent < ApplicationComponent
   include AssetsHelper
   include ActionView::Helpers::NumberHelper
 
-  attr_reader :control_range, :repository, :current_user
+  attr_reader :repository, :current_user
 
   def initialize(service, current_user)
-    @repository = service.control_rates_repository
-    @control_range = repository.range
+    @repository = service.repository
     @region = service.region
     @current_user = current_user
   end

--- a/app/components/progress_tab/hypertension/missed_visits_component.rb
+++ b/app/components/progress_tab/hypertension/missed_visits_component.rb
@@ -4,11 +4,10 @@ class ProgressTab::Hypertension::MissedVisitsComponent < ApplicationComponent
   include AssetsHelper
   include ActionView::Helpers::NumberHelper
 
-  attr_reader :control_range, :repository
+  attr_reader :repository
 
   def initialize(service)
-    @repository = service.control_rates_repository
-    @control_range = repository.range
+    @repository = service.repository
     @region = service.region
   end
 

--- a/app/components/progress_tab/hypertension/uncontrolled_component.rb
+++ b/app/components/progress_tab/hypertension/uncontrolled_component.rb
@@ -4,11 +4,10 @@ class ProgressTab::Hypertension::UncontrolledComponent < ApplicationComponent
   include AssetsHelper
   include ActionView::Helpers::NumberHelper
 
-  attr_reader :control_range, :repository
+  attr_reader :repository
 
   def initialize(service)
-    @repository = service.control_rates_repository
-    @control_range = repository.range
+    @repository = service.repository
     @region = service.region
   end
 


### PR DESCRIPTION
**Story card:** [sc-9344](https://app.shortcut.com/simpledotorg/story/9344)

## Because

Current month data was not included in the Progress tab - Patient treatment status

## This addresses

Includes current month data in the Progress tab - Patient treatment status

## Test instructions

- Ensure the feature flag - `new_progress_tab_v1` is enabled
- Go to Reports>region>progress
- Click hypertension reports. You should see current month data in the Progress tab - Patient treatment status

Before

<img width="257" alt="Screenshot 2022-10-26 at 12 21 21 PM" src="https://user-images.githubusercontent.com/32141642/197955263-2c2c0c80-42e4-4068-bc0b-238170d32a1e.png">

After

<img width="257" alt="Screenshot 2022-10-26 at 12 21 49 PM" src="https://user-images.githubusercontent.com/32141642/197955253-61c850a0-0f3b-4f44-9a3a-c640c538b231.png">
