### PR TITLE
Add drug stock config for Odisha

### DIFF
--- a/config/data/drug_stock_config.yml
+++ b/config/data/drug_stock_config.yml
@@ -169,6 +169,20 @@ Nagaland:
       new_patient_coefficient: 0.06
       '331132': 1
       '197499': 2
+Odisha:
+  load_coefficient: 1
+  drug_categories:
+    hypertension_ccb:
+      new_patient_coefficient: 1.4
+      '329528': 1
+      '329526': 2
+    hypertension_arb:
+      new_patient_coefficient: 0.37
+      '316764': 1
+      '316765': 2
+    hypertension_diuretic:
+      new_patient_coefficient: 0.05
+      '429503': 0.5
 Puducherry:
   load_coefficient: 1
   drug_categories:


### PR DESCRIPTION
**Story card:** [sc-9362](https://app.shortcut.com/simpledotorg/story/9362)

## Because

Odisha wants to use drug stock. Slack thread: https://simpledotorg.slack.com/archives/CFHKJ5WJY/p1666963037665449?thread_ts=1665643975.365749&cid=CFHKJ5WJY

## This addresses

Adds coefficients for calculating patient days in Odisha.