### PR TITLE
Update webdriver gem to 5.2.0 version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -140,6 +140,6 @@ group :test do
   gem "puma"
   gem "rspec-sidekiq"
   gem "simplecov", require: false
-  gem "webdrivers"
+  gem "webdrivers", ">= 5.2.0"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -573,7 +573,7 @@ GEM
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
     scientist (1.6.3)
-    selenium-webdriver (4.4.0)
+    selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -664,7 +664,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.0.0)
+    webdrivers (5.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
@@ -814,7 +814,7 @@ DEPENDENCIES
   uuidtools
   view_component
   web-console (>= 3.3.0)
-  webdrivers
+  webdrivers (>= 5.2.0)
   webmock
   webpacker (= 6.0.0.rc.6)
   whenever

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There is one possible caveat to this -- if you see any problems with google-prot
 
 ```
 gem uninstall google-protobuf
-gem install google-protobuf -v 3.17.3 --platform=ruby
+gem install google-protobuf -v 3.21.5 --platform=ruby
 ```
 
 Then rerun bundler and everything will work. This is being tracked over in https://github.com/protocolbuffers/protobuf/issues/8682, hopefully there will be a better fix soon.

--- a/README.md
+++ b/README.md
@@ -92,9 +92,13 @@ set up the application step by step. You can do so as follows.
 
 First, you need to [install ruby](https://www.ruby-lang.org/en/documentation/installation). It is recommended to use [rbenv](https://github.com/rbenv/rbenv) to manage ruby versions. Note that we currently use Bundler version 2.3.22, so that is also hardcoded below.
 
+Next, [install NodeJS v18.11.0](https://nodejs.org/en/) using [nvm](https://github.com/nvm-sh/nvm).
+
 ```bash
 gem install bundler -v 2.3.22
 bundle _2.3.22_ install
+brew install nvm
+nvm install 18.11.0
 rake yarn:install
 rails db:setup
 ```

--- a/bin/setup
+++ b/bin/setup
@@ -8,7 +8,8 @@ set -euo pipefail
 BUNDLER_VERSION=2.3.22
 
 init (){
-  verify_ruby_version && verify_bundled_gems && verify_yarn_packages
+  verify_ruby_version && verify_node_version
+  verify_bundled_gems && verify_yarn_packages
   verify_foreman
   verify_postgres && verify_database_migrations
   configure_parallel_testing
@@ -98,11 +99,28 @@ verify_ruby_version (){
   has_ruby_version || install_ruby_version
 }
 
+verify_node_version (){
+  echo 'Checking for node version'
+  has_node_version || install_nodejs
+}
+
 verify_bundled_gems (){
   echo 'Updating gems...'
   {
     (gem list -i -v ${BUNDLER_VERSION} bundler || gem install bundler -v ${BUNDLER_VERSION}) && bundle _${BUNDLER_VERSION}_ install --binstubs=./bundle/bin
   } 2>&1
+}
+
+has_node_version (){
+  INSTALLED_NODE_VERSION=$(node -v)
+  [ "$INSTALLED_NODE_VERSION" == "v18.11.0" ]
+}
+
+install_nodejs (){
+  echo 'Installing NodeJS...'
+  brew install nvm
+  nvm install 18.11.0
+  node -v
 }
 
 verify_yarn_packages (){


### PR DESCRIPTION
- Reason: https://github.com/SeleniumHQ/selenium/issues/11066
- https://github.com/titusfortner/webdrivers/issues/237

**Story card:** [sc-9383](https://app.shortcut.com/simpledotorg/story/9383/onboard-akshat)

## Because

Issues faced when setting up `simple-server` on local machine

## This addresses

Failing tests

## Test instructions

