### PR TITLE
Progress tab design alterations

### DIFF
--- a/app/assets/stylesheets/partials/_variables.scss
+++ b/app/assets/stylesheets/partials/_variables.scss
@@ -3,6 +3,7 @@ $accent-color: #ff3355; /* PINK */
 $red-light: #ffd6dd;
 $red: #ff3355;
 $red-dark: #b81631;
+$red-light-boxshadow: #ff9dae;
 
 $yellow-lightest: #fff8e0;
 $yellow-light: #ffeca8;

--- a/app/assets/stylesheets/partials/_variables.scss
+++ b/app/assets/stylesheets/partials/_variables.scss
@@ -29,13 +29,14 @@ $blue-light: #e9f3ff;
 $blue-mid: #9dcbf9;
 $blue: #0075eb;
 $blue-dark: #0c3966;
-$blue-light-dropshadow: #8fc2f5;
+$blue-light-boxshadow: #8fc2f5;
 
 $navy-light: #dbe2e8;
 $navy: #0c3966;
 
 $blue-green-light: #ebf7f7;
 $blue-green: #2fa7ae;
+$blue-green-light-boxshadow: #8dccce;
 
 $green-light: #e0ffed;
 $green-mid: #5cff9d;

--- a/app/assets/stylesheets/partials/_variables.scss
+++ b/app/assets/stylesheets/partials/_variables.scss
@@ -28,6 +28,7 @@ $blue-light: #e9f3ff;
 $blue-mid: #9dcbf9;
 $blue: #0075eb;
 $blue-dark: #0c3966;
+$blue-light-dropshadow: #8fc2f5;
 
 $navy-light: #dbe2e8;
 $navy: #0c3966;

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -934,8 +934,12 @@ footer p {
 .bgc-orange-new { background-color: $orange-new; }
 .bgc-orange-dark-new { background-color: $orange-dark-new; }
 /* BUTTON DROP SHADOWS */
-.bgc-blue-light-dropshadow {
-  box-shadow: 0px 2px 0px $blue-light-dropshadow,
+.bgc-blue-light-boxshadow {
+  box-shadow: 0px 2px 0px $blue-light-boxshadow, 0px 2px 2px rgba(0, 0, 0, 0.25);
+}
+
+.bgc-blue-green-light-boxshadow {
+  box-shadow: 0px 2px 0px $blue-green-light-boxshadow,
     0px 2px 2px rgba(0, 0, 0, 0.25);
 }
 

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -938,6 +938,11 @@ footer p {
   box-shadow: 0px 2px 0px $blue-light-dropshadow,
     0px 2px 2px rgba(0, 0, 0, 0.25);
 }
+
+.bgc-red-light-boxshadow {
+  box-shadow: 0px 2px 0px $red-light-boxshadow, 0px 2px 2px rgba(0, 0, 0, 0.25);
+}
+
 /* BORDERS */
 .b-none { border: none; }
 .b-grey-mid { border: 1px solid $grey-mid; }

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -1015,3 +1015,6 @@ box-shadow: 0px 2px 0px rgba(10, 71, 132, 0.18), 0px 2px 2px rgba(0, 0, 0, 0.25)
 /* OTHER */
 .pe-none { pointer-events: none; }
 .wb-break-word { word-break: break-word; }
+.tt-textshadow {
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -933,6 +933,11 @@ footer p {
 .bgc-yellow-dark-new { background-color: $yellow-dark-new; }
 .bgc-orange-new { background-color: $orange-new; }
 .bgc-orange-dark-new { background-color: $orange-dark-new; }
+/* BUTTON DROP SHADOWS */
+.bgc-blue-light-dropshadow {
+  box-shadow: 0px 2px 0px $blue-light-dropshadow,
+    0px 2px 2px rgba(0, 0, 0, 0.25);
+}
 /* BORDERS */
 .b-none { border: none; }
 .b-grey-mid { border: 1px solid $grey-mid; }

--- a/app/components/reports/daily_progress_component_v1.html.erb
+++ b/app/components/reports/daily_progress_component_v1.html.erb
@@ -1,13 +1,12 @@
 <div id="progress-daily-report" class="d-none">
   <div class="mb-8px pt-16px pb-16px bgc-white bs-card">
     <a
-      class="d-block w-24px h-24px mb-24px pl-16px"
+      class="d-inline-flex ai-center h-24px mb-24px pl-16px tt-uppercase"
       href="#"
       onclick="closeWindow('progress-daily-report', 'progress-start'); return false;"
     >
-      <div class="d-inline-block">
-        <%= inline_file("chevron-left.svg") %>
-      </div>
+      <%= inline_file("chevron-left.svg") %>
+      back
     </a>
     <div class="pr-16px pl-16px">
       <h1 class="m-0px mb-8px fw-bold fs-24px">

--- a/app/views/api/v3/analytics/user_analytics/_data_stacked_bar_graph.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_data_stacked_bar_graph.html.erb
@@ -42,7 +42,7 @@
       style="width: <%= bp_not_controlled %>%;"
       data-graph-element="stacked-bar"
     >
-      <p class="m-0px p-0px ta-center fw-bold fs-16px c-white pe-none" style="text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);">
+      <p class="m-0px p-0px ta-center fw-bold fs-16px c-white pe-none" style="text-shadow: 0 1px 3px rgba(0, 0, 0, 0.30);">
         <%= data[:uncontrolled_rate] %>%
       </p>
       <div

--- a/app/views/api/v3/analytics/user_analytics/_data_stacked_bar_graph.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_data_stacked_bar_graph.html.erb
@@ -42,7 +42,7 @@
       style="width: <%= bp_not_controlled %>%;"
       data-graph-element="stacked-bar"
     >
-      <p class="m-0px p-0px ta-center fw-bold fs-16px c-white pe-none" style="text-shadow: 0 1px 3px rgba(0, 0, 0, 0.30);">
+      <p class="m-0px p-0px ta-center fw-bold fs-16px c-white pe-none tt-textshadow">
         <%= data[:uncontrolled_rate] %>%
       </p>
       <div

--- a/app/views/api/v3/analytics/user_analytics/_data_stacked_bar_graph.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_data_stacked_bar_graph.html.erb
@@ -16,7 +16,7 @@
       style="width: <%= bp_controlled %>%;"
       data-graph-element="stacked-bar"
     >
-      <p class="m-0px p-0px ta-center fw-bold fs-16px c-black pe-none">
+      <p class="m-0px p-0px ta-center fw-bold fs-16px c-white pe-none">
         <%= data[:controlled_rate] %>%
       </p>
       <div
@@ -42,7 +42,7 @@
       style="width: <%= bp_not_controlled %>%;"
       data-graph-element="stacked-bar"
     >
-      <p class="m-0px p-0px ta-center fw-bold fs-16px c-black pe-none">
+      <p class="m-0px p-0px ta-center fw-bold fs-16px c-white pe-none" style="text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);">
         <%= data[:uncontrolled_rate] %>%
       </p>
       <div
@@ -68,7 +68,7 @@
       style="width: <%= visited_but_no_bp_taken %>%;"
       data-graph-element="stacked-bar"
     >
-      <p class="m-0px p-0px ta-center fw-bold fs-16px c-black pe-none">
+      <p class="m-0px p-0px ta-center fw-bold fs-16px c-white pe-none">
         <%= data[:no_bp_rate] %>%
       </p>
       <div

--- a/app/views/api/v3/analytics/user_analytics/_progress_hypertension_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_progress_hypertension_report.html.erb
@@ -1,13 +1,12 @@
 <div id="progress-hypertension-report" style="display: none;">
   <div class="mb-8px pt-16px pb-16px bgc-white bs-card">
     <a
-      class="d-block w-24px h-24px mb-24px pl-16px"
+      class="d-inline-flex ai-center h-24px mb-24px pl-16px tt-uppercase"
       href="#"
       onclick="closeWindow('progress-hypertension-report', 'progress-start'); return false;"
     >
-      <div class="d-inline-block">
-        <%= inline_file("chevron-left.svg") %>
-      </div>
+      <%= inline_file("chevron-left.svg") %>
+      back
     </a>
     <div class="pr-16px pl-16px">
       <h1 class="m-0px mb-8px fw-bold fs-24px">

--- a/app/views/api/v3/analytics/user_analytics/_progress_monthly_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_progress_monthly_report.html.erb
@@ -1,13 +1,12 @@
 <div id="progress-monthly-report" class="d-none">
   <div class="mb-8px pt-16px pb-16px bgc-white bs-card">
     <a
-      class="d-block w-24px h-24px mb-24px pl-16px"
+      class="d-inline-flex ai-center h-24px mb-24px pl-16px tt-uppercase"
       href="#"
       onclick="closeWindow('progress-monthly-report', 'progress-start'); return false;"
     >
-      <div class="d-inline-block">
-        <%= inline_file("chevron-left.svg") %>
-      </div>
+      <%= inline_file("chevron-left.svg") %>
+      back
     </a>
     <div class="pr-16px pl-16px">
       <h1 class="m-0px mb-8px fw-bold fs-24px">

--- a/app/views/api/v3/analytics/user_analytics/_progress_period_card.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_progress_period_card.html.erb
@@ -4,7 +4,7 @@
   </h1>
   <div class="d-flex ai-center jc-space-between">
     <a
-      class="f-1 d-flex fd-column ai-center jc-center h-96px mr-8px p-12px td-none bgc-blue-green-light br-8px"
+      class="f-1 d-flex fd-column ai-center jc-center h-96px mr-8px p-12px td-none bgc-blue-green-light bgc-blue-green-light-boxshadow br-8px"
       href="#"
       onclick="openWindow('progress-daily-report', 'progress-start'); return false;"
     >
@@ -16,7 +16,7 @@
       </p>
     </a>
     <a
-      class="p-relative f-1 d-flex fd-column ai-center jc-center h-96px mr-4px ml-4px p-12px td-none bgc-blue-light bgc-blue-light-dropshadow br-8px"
+      class="p-relative f-1 d-flex fd-column ai-center jc-center h-96px mr-4px ml-4px p-12px td-none bgc-blue-light bgc-blue-light-boxshadow br-8px"
       href="#"
       onclick="openWindow('progress-monthly-report', 'progress-start'); return false;"
     >

--- a/app/views/api/v3/analytics/user_analytics/_progress_period_card.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_progress_period_card.html.erb
@@ -16,7 +16,7 @@
       </p>
     </a>
     <a
-      class="p-relative f-1 d-flex fd-column ai-center jc-center h-96px mr-4px ml-4px p-12px td-none bgc-blue-light br-8px"
+      class="p-relative f-1 d-flex fd-column ai-center jc-center h-96px mr-4px ml-4px p-12px td-none bgc-blue-light bgc-blue-light-dropshadow br-8px"
       href="#"
       onclick="openWindow('progress-monthly-report', 'progress-start'); return false;"
     >

--- a/app/views/api/v3/analytics/user_analytics/_progress_reports_card.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_progress_reports_card.html.erb
@@ -7,7 +7,7 @@
   </p>
   <div class="d-flex ai-center jc-space-between">
     <a
-      class="f-1 d-flex fd-column ai-center jc-center h-96px mr-8px p-12px td-none bgc-red-light br-8px"
+      class="f-1 d-flex fd-column ai-center jc-center h-96px mr-8px p-12px td-none bgc-red-light bgc-red-light-boxshadow br-8px"
       href="#"
       onclick="openWindow('progress-hypertension-report', 'progress-start'); return false;"
     >


### PR DESCRIPTION
**Story card:** 
- Cohort report text color [9420](https://app.shortcut.com/simpledotorg/story/9420/change-text-colors-on-cohort-reports)
- Back text added to chevron (no story)
- Add drop shadow to buttons on home screen (no story)

# Because
Cohort report - inconsistent text colors
Back button - small, difficult to spot, not so clear
Drop-shadow - doesn't look much like a button

# This addresses

## Cohort reports bar text color
Text color changed to white to improve readability and make text color consistent
Text on yellow bar given a slight text-shadow to improve readability
### Before
![Screenshot 2022-11-03 at 12 03 54](https://user-images.githubusercontent.com/9541902/199961083-5792390c-ad33-486c-9d8b-0e61877cff6c.png)
### After
![Screenshot 2022-11-03 at 12 03 01](https://user-images.githubusercontent.com/9541902/199961096-fe2ca01f-5152-4ac2-b69d-a90b99f93151.png)


## Back text added to chevron
'< Back' change made to improve visibility of the back button.
Bonus: improved the clickable area of the button
### Before
![Screenshot 2022-11-04 at 11 27 27](https://user-images.githubusercontent.com/9541902/199962459-ef2bc405-7ef1-421b-82fd-e6bb95b9b7e9.png)

### After
![Screenshot 2022-11-04 at 11 27 41](https://user-images.githubusercontent.com/9541902/199962462-50ad5f70-c39c-4d72-adf3-31900a02443c.png)

## Drop shadow added to button on progress tab home screen
Improve the UX as they look like a clickable button.
### Before
![Screenshot 2022-11-04 at 11 31 29](https://user-images.githubusercontent.com/9541902/199963166-cc7468ba-2324-4e06-98b3-3971e21449dd.png)

### After
![Screenshot 2022-11-04 at 11 34 01](https://user-images.githubusercontent.com/9541902/199963193-0dc9c3fe-1145-4dc0-ba39-5948a052ce41.png)


# Test instructions

Server: head to a facility and press the 'progress' option.
Flipper tag required: `new_progress_tab_v1`

## Cohort
head to monthly report > scroll to the bottom

## Back button
Please check the button is standard across all reports: daily, monthly, hypertension

## Drop-shadow
Viewable on the home screen

Enter detailed instructions for how to test this PR...