### PR TITLE
Progress tab design alteratons

### DIFF
--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -1004,3 +1004,4 @@ box-shadow: 0px 2px 0px rgba(10, 71, 132, 0.18), 0px 2px 2px rgba(0, 0, 0, 0.25)
 .tt-white-yellow-bg-text-shadow {
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }
+

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -1001,3 +1001,6 @@ box-shadow: 0px 2px 0px rgba(10, 71, 132, 0.18), 0px 2px 2px rgba(0, 0, 0, 0.25)
 /* OTHER */
 .pe-none { pointer-events: none; }
 .wb-break-word { word-break: break-word; }
+.tt-white-yellow-bg-text-shadow {
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}

--- a/app/assets/stylesheets/user_analytics.scss
+++ b/app/assets/stylesheets/user_analytics.scss
@@ -985,7 +985,7 @@ box-shadow: 0px 2px 0px rgba(10, 71, 132, 0.18), 0px 2px 2px rgba(0, 0, 0, 0.25)
 /* FORM FIELDS */
 .bs-border-box { box-sizing: border-box; }
 .o-none:focus { outline: none; }
-.chevron-down-icon { background: $blue-light url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTQgNkw4IDEwTDEyIDYiIHN0cm9rZT0iIzAwNzVFQiIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+Cg==) no-repeat 97% 52% }
+.chevron-down-icon { background: $blue-light url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTQgNkw4IDEwTDEyIDYiIHN0cm9rZT0iIzAwNzVFQiIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+Cg==) no-repeat right 16px center }
 .a-none { -moz-appearance: none; -webkit-appearance: none; appearance: none; }
 /* SCROLL */
 .sb-auto { scroll-behavior: auto; }

--- a/app/components/progress_tab/daily_progress_component_v2.html.erb
+++ b/app/components/progress_tab/daily_progress_component_v2.html.erb
@@ -1,13 +1,12 @@
 <div id="daily-report-page" class="d-none">
   <div class="mb-8px pt-16px pb-16px bgc-white br-4px bs-card">
     <a
-      class="d-block w-24px h-24px mb-24px pl-16px"
+      class="d-inline-flex ai-center h-24px mb-24px pl-16px tt-uppercase"
       href="#"
       onclick="goToPage('daily-report-page', 'home-page'); return false;"
     >
-      <div class="d-inline-block">
-        <%= inline_file("chevron-left.svg") %>
-      </div>
+      <%= inline_file("chevron-left.svg") %>
+      back
     </a>
     <div class="pr-16px pl-16px">
       <h1 class="m-0px mb-8px fw-bold fs-24px">

--- a/app/components/progress_tab/hypertension/diagnosis_report_component.html.erb
+++ b/app/components/progress_tab/hypertension/diagnosis_report_component.html.erb
@@ -1,13 +1,12 @@
 <div id="hypertension-report" class="d-none">
   <div class="mb-8px pt-16px pb-16px bgc-white bs-card">
     <a
-      class="d-block w-24px h-24px mb-24px pl-16px"
+      class="d-inline-flex ai-center h-24px mb-24px pl-16px tt-uppercase"
       href="#"
       onclick="goToPage('hypertension-report', 'home-page'); return false;"
     >
-      <div class="d-inline-block">
-        <%= inline_file("chevron-left.svg") %>
-      </div>
+      <%= inline_file("chevron-left.svg") %>
+      back
     </a>
     <div class="pr-16px pl-16px">
       <h1 class="m-0px mb-8px fw-bold fs-24px">

--- a/app/components/progress_tab/monthly_report_component_v2.html.erb
+++ b/app/components/progress_tab/monthly_report_component_v2.html.erb
@@ -1,13 +1,12 @@
 <div id="monthly-report-page" class="d-none">
   <div class="mb-8px pt-16px pb-16px bgc-white br-4px bs-card">
     <a
-      class="d-block w-24px h-24px mb-24px pl-16px"
+      class="d-inline-flex ai-center h-24px mb-24px pl-16px tt-uppercase"
       href="#"
       onclick="goToPage('monthly-report-page', 'home-page'); return false;"
     >
-      <div class="d-inline-block">
-        <%= inline_file("chevron-left.svg") %>
-      </div>
+      <%= inline_file("chevron-left.svg") %>
+      back
     </a>
     <div class="pr-16px pl-16px">
       <h1 class="m-0px mb-8px fw-bold fs-24px">

--- a/app/views/api/v3/analytics/user_analytics/_data_stacked_bar_graph.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_data_stacked_bar_graph.html.erb
@@ -16,7 +16,7 @@
       style="width: <%= bp_controlled %>%;"
       data-graph-element="stacked-bar"
     >
-      <p class="m-0px p-0px ta-center fw-bold fs-16px c-black pe-none">
+      <p class="m-0px p-0px ta-center fw-bold fs-16px c-white pe-none">
         <%= data[:controlled_rate] %>%
       </p>
       <div
@@ -42,7 +42,7 @@
       style="width: <%= bp_not_controlled %>%;"
       data-graph-element="stacked-bar"
     >
-      <p class="m-0px p-0px ta-center fw-bold fs-16px c-black pe-none">
+      <p class="m-0px p-0px ta-center fw-bold fs-16px c-white pe-none">
         <%= data[:uncontrolled_rate] %>%
       </p>
       <div
@@ -68,7 +68,7 @@
       style="width: <%= visited_but_no_bp_taken %>%;"
       data-graph-element="stacked-bar"
     >
-      <p class="m-0px p-0px ta-center fw-bold fs-16px c-black pe-none">
+      <p class="m-0px p-0px ta-center fw-bold fs-16px c-white pe-none">
         <%= data[:no_bp_rate] %>%
       </p>
       <div

--- a/app/views/api/v3/analytics/user_analytics/_data_stacked_bar_graph.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_data_stacked_bar_graph.html.erb
@@ -42,7 +42,7 @@
       style="width: <%= bp_not_controlled %>%;"
       data-graph-element="stacked-bar"
     >
-      <p class="m-0px p-0px ta-center fw-bold fs-16px c-white pe-none">
+      <p class="m-0px p-0px ta-center fw-bold fs-16px c-white pe-none tt-white-yellow-bg-text-shadow">
         <%= data[:uncontrolled_rate] %>%
       </p>
       <div


### PR DESCRIPTION
**Story card:** 

[[9484] Cohort text color](https://app.shortcut.com/simpledotorg/story/9484/design-improve-the-font-colors-on-the-cohort-report)
[[9482] Back text added to 'Daily', 'Monthly' and 'Hypertension' reports](https://app.shortcut.com/simpledotorg/story/9482/design-add-back-text-next-to-chevron-in-all-reports)
No story - improved CSS for dropdowns

## Because

Design alterations for progress tab: Improving UX

## This addresses

- Cohort bar chart text colors changed to white for consistency, yellow bar text given a slight text-shadow for improved contrast
- Addition of 'back' text next to chevrons on the 'daily', 'monthly' and 'hypertension' report pages
- fix to CSS for down chevron icon on dropdowns
- - previously this was positioned using % so on wider screens the down-chevron would float further away from the right edge of the dropdown element. This now has a fixed position in relation to the right edge

## Test instructions

1. Ensure to turn on the feature flag -new_progress_tab_v2
2. Goto Reports -> -> Progress
3. Check:

'Cohort report': Go to 'hyopertension report' then scroll to the bottom.
All text inside of the color blocks of the bar chart should be white. The yellow block should have a very faint drop-shadow
before: 
![Screenshot 2022-11-03 at 12 03 54](https://user-images.githubusercontent.com/9541902/201185247-79834b3e-dcdf-430e-9349-61171d550ab6.png)
after:
![Screenshot 2022-11-10 at 18 50 57](https://user-images.githubusercontent.com/9541902/201184138-2d578569-ba98-4ece-ac67-6c8850174a9a.png)

'Back' text shows on the top of all 3 reports:
- daily report
- monthly report
- hypertension report

![Screenshot 2022-11-10 at 18 51 31](https://user-images.githubusercontent.com/9541902/201183699-5a90080b-251c-49a6-8a60-2dded2375a5a.png)
![Screenshot 2022-11-10 at 18 51 23](https://user-images.githubusercontent.com/9541902/201183702-4449b6fb-493e-4eb1-a7ff-256cf6577d33.png)
![Screenshot 2022-11-10 at 18 51 13](https://user-images.githubusercontent.com/9541902/201183703-d5c47ceb-9ea9-4afe-ba8e-13f3de83233a.png)

Improved CSS for all dropdowns, places to check:
- daily report
- monthly report
- enter drug stock
If you can widen the screen

before:
![Screenshot 2022-11-10 at 18 50 28](https://user-images.githubusercontent.com/9541902/201184891-2caace76-e977-4593-9ae1-c59a21141260.png)
![Screenshot 2022-11-10 at 18 50 37](https://user-images.githubusercontent.com/9541902/201185657-e9ebea3d-fec4-4332-9310-7623a707ad62.png)
after:
![Screenshot 2022-11-10 at 18 49 49](https://user-images.githubusercontent.com/9541902/201184869-14a601b9-ee2f-4905-bdbc-876bee41d643.png)
![Screenshot 2022-11-10 at 18 49 35](https://user-images.githubusercontent.com/9541902/201185681-9da886b3-4f1b-451e-8436-7075e82e4e69.png)
