### PR TITLE
Change Date to Period

### DIFF
--- a/app/components/progress_tab/monthly_report_component_v2.html.erb
+++ b/app/components/progress_tab/monthly_report_component_v2.html.erb
@@ -32,7 +32,7 @@
             <%= t("progress_tab.period_report.registered_patients_card.title") %>
           </h2>
           <p class="m-0px p-0px ta-right fw-medium fs-18px c-black">
-            <%= total_registrations(date.to_date) %>
+            <%= total_registrations(Period.month(date.to_date)) %>
           </p>
         </div>
         <p class="m-0px mb-24px p-0px ta-left fw-normal fs-16px lh-150 c-grey-dark">
@@ -51,7 +51,7 @@
             <%= t("progress_tab.period_report.follow_up_patients_card.title") %>
           </h2>
           <p class="m-0px p-0px ta-right fw-medium fs-18px c-black">
-            <%= total_follow_ups(date.to_date) %>
+            <%= total_follow_ups(Period.month(date.to_date)) %>
           </p>
         </div>
         <p class="m-0px mb-24px p-0px ta-left fw-normal fs-16px lh-150 c-grey-dark">


### PR DESCRIPTION
## Because

- Total monthly registered number and total follow-up number were missing 

## This addresses

- Add the total monthly registered number and total follow-up number

## Test instructions

- Ensure `new-progress-tab-v2` Flipper flag is turned on
- Goto Reports > <facility - region> > Progress tab > Monthly reports

BEFORE 

<img width="259" alt="Screenshot 2022-11-11 at 2 18 12 PM" src="https://user-images.githubusercontent.com/32141642/201302192-031f855d-aeb7-41bb-9569-11878799f82a.png">

AFTER

<img width="259" alt="Screenshot 2022-11-11 at 2 17 43 PM" src="https://user-images.githubusercontent.com/32141642/201302174-b6c82755-ac79-414f-b2bf-363c432af16a.png">
