### PR TITLE
Progress Tab: Add missing border

### DIFF
--- a/app/components/progress_tab/breakdown_table_component.html.erb
+++ b/app/components/progress_tab/breakdown_table_component.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <div class="d-flex ai-center jc-space-between <% if include_bottom_border %>pb-3px bb-grey-mid<% end %> mb-4px">
+  <div class="d-flex ai-center jc-space-between pb-3px bb-grey-mid mb-4px">
     <h3 class="m-0px p-0px ta-left fw-medium fs-16px c-grey-darkest">
       <%= title %>
     </h3>


### PR DESCRIPTION
**Story card:** [sc-9495](https://app.shortcut.com/simpledotorg/story/9495/add-missing-border)

## Because

Borderline after the heading `Hypertension and diabetes` was in the breakdown table

## This addresses

Adds the borderline after the heading `Hypertension and diabetes` was in the breakdown table

## Test instructions

- Ensure the `new-progress-tab-v2` Flipper flag is turned on
- Goto Reports > <facility - region> > Progress tab > Daily/Monthly/Yearly reports
- Check if you can see the border as shown in the screenshot

Before:
<img width="250" alt="Screenshot 2022-11-15 at 6 29 09 PM" src="https://user-images.githubusercontent.com/32141642/201927866-c8bb6a1b-2c37-4bde-a56b-9a24c0009687.png">

After:
<img width="250" alt="Screenshot 2022-11-15 at 6 28 40 PM" src="https://user-images.githubusercontent.com/32141642/201927876-d51124a8-9c5d-420d-a311-dba88543ae20.png">
