### PR TITLE
Default to zero when registered patients is nil

### DIFF
--- a/app/views/api/v3/analytics/user_analytics/_progress_cohort_report.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/_progress_cohort_report.html.erb
@@ -30,7 +30,7 @@
     <% @user_analytics.statistics.dig(:cohorts).each do |cohort| %>
       <div class="card cohort">
         <h6>
-          <%= cohort[:registered] %> <%= raw t("analytics.patient", count: cohort[:registered]) %>
+          <%= registered_patients = cohort[:registered] || 0 %> <%= raw t("analytics.patient", count: registered_patients) %>
           <%= raw t("analytics.registered_in") %> <%= cohort[:registration_period] %>
         </h6>
         <div style="font-size: 16px; margin: 8px 0 12px 0;">
@@ -38,7 +38,7 @@
         </div>
         <table class="cohort-bars">
           <tr>
-            <% if cohort[:registered].blank? %>
+            <% if registered_patients.zero? %>
               <td class="cohort-none">
                   <%= raw t("analytics.no_patients") %>
               </td>


### PR DESCRIPTION
**Story card:** [sc-9496](https://app.shortcut.com/simpledotorg/story/9496/progress-tab-default-to-zero-when-registered-patients-are-nil)

## Because

The cohort reports in the old progress tab break when the number of registered patients is zero

## This addresses

Defaults to zero when the number of registered patients is zero

## Test instructions

- Goto Reports> `Choose a facility with zero registered patients at some quarter`> Progress tab > Cohort Reports
- Check if the Cohort reports are rendered as expected

*Before:*
<img width="250" alt="Screenshot 2022-11-17 at 2 31 17 PM" src="https://user-images.githubusercontent.com/32141642/202402465-01871d6b-dc77-4850-ab2d-8cc97a35ef19.png">

*After:*
<img width="250" alt="Screenshot 2022-11-17 at 2 30 57 PM" src="https://user-images.githubusercontent.com/32141642/202402487-186e43a5-5537-4867-99da-10612db80eb3.png">

