### PR TITLE
Add 'back' text to yearly report

### DIFF
--- a/app/components/progress_tab/yearly_report_component_v2.html.erb
+++ b/app/components/progress_tab/yearly_report_component_v2.html.erb
@@ -1,13 +1,12 @@
 <div id="yearly-report-page" class="d-none">
   <div class="mb-8px pt-16px pb-16px bgc-white br-4px bs-card">
     <a
-      class="d-block w-24px h-24px mb-24px pl-16px"
+      class="d-inline-flex ai-center h-24px mb-24px pl-16px tt-uppercase"
       href="#"
       onclick="goToPage('yearly-report-page', 'home-page'); return false;"
     >
-      <div class="d-inline-block">
-        <%= inline_file("chevron-left.svg") %>
-      </div>
+      <%= inline_file("chevron-left.svg") %>
+      back
     </a>
     <div class="pr-16px pl-16px">
       <h1 class="m-0px mb-8px fw-bold fs-24px">


### PR DESCRIPTION
**Story card:** 
[9487](https://app.shortcut.com/simpledotorg/story/9487/add-back-text-to-yearly-report)

## Because

Yearly report needs 'back' text to match daily and monthly

## This addresses

Easier to find and navigate to main menu 

## Test instructions

Go to progress tab > yearly > see '< BACK' text