### PR TITLE
Progress tab: Update total overdue calls query

### DIFF
--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -50,7 +50,9 @@ module Reports
     end
 
     def total_registrations
-      total_counts[:monthly_registrations_htn_or_dm]
+      repository.cumulative_registrations[@facility.region.slug][@period] +
+        repository.cumulative_diabetes_registrations[@facility.region.slug][@period] -
+        repository.cumulative_hypertension_and_diabetes_registrations[@facility.region.slug][@period]
     end
 
     def total_follow_ups
@@ -58,7 +60,7 @@ module Reports
     end
 
     memoize def total_overdue_calls
-      Reports::FacilityState.where(facility: facility).pluck(:monthly_overdue_calls).compact.sum
+      CallResult.where(facility_id: @facility.id).count
     end
 
     def daily_statistics

--- a/db/migrate/20221121063116_add_index_on_call_result_facility_id.rb
+++ b/db/migrate/20221121063116_add_index_on_call_result_facility_id.rb
@@ -1,0 +1,7 @@
+class AddIndexOnCallResultFacilityId < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :call_results, [:facility_id], name: :index_call_results_on_facility_id, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5287,6 +5287,13 @@ CREATE INDEX index_call_results_deleted_at ON public.call_results USING btree (d
 
 
 --
+-- Name: index_call_results_on_facility_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_call_results_on_facility_id ON public.call_results USING btree (facility_id);
+
+
+--
 -- Name: index_call_results_patient_id_and_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6620,6 +6627,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221013131043'),
 ('20221024071410'),
 ('20221024071710'),
-('20221104075303');
+('20221104075303'),
+('20221121063116');
 
 


### PR DESCRIPTION
**Story cards:** 
[sc-9504](https://app.shortcut.com/simpledotorg/story/9504)
[sc-9505](https://app.shortcut.com/simpledotorg/story/9505/use-cumulative-registrations-to-show-the-total-number-of-patients-registered-in-the-progress-tab)

## This addresses

- Shows the total number of calls made to overdue patients in a facility
- Use cumulative registrations from the repository to show the total number of registered patients in a. facility

## Test instructions

- Goto Reports > any facility region > Progress > scroll down to achievement section
- Check if the total number of registered patients shown in the progress tab is consistent with the number on the dashboard
- Tally the total number of overdue calls with Metabase