### PR TITLE
Notify patients in select states in IHCI

### DIFF
--- a/.env.IN
+++ b/.env.IN
@@ -1,4 +1,4 @@
-EXPERIMENT_INCLUDED_STATES="Andhra Pradesh, Tamil Nadu, West Bengal"
+EXPERIMENT_ALLOWED_STATES="Andhra Pradesh, Tamil Nadu, West Bengal"
 HELP_SCREEN_SUPPORT_GROUP_URL="https://wa.me/916280258024/?text=I%20would%20like%20to%20ask%20a%20question%20about%20Simple.%20"
 HELP_SCREEN_SUPPORT_GROUP_NUMBER="+91 6280258024"
 HELP_SCREEN_SUPPORT_GROUP_ICON="icon_whatsapp_icon.svg"

--- a/.env.IN
+++ b/.env.IN
@@ -1,3 +1,4 @@
+EXPERIMENT_INCLUDED_STATES="Andhra Pradesh, Tamil Nadu, West Bengal"
 HELP_SCREEN_SUPPORT_GROUP_URL="https://wa.me/916280258024/?text=I%20would%20like%20to%20ask%20a%20question%20about%20Simple.%20"
 HELP_SCREEN_SUPPORT_GROUP_NUMBER="+91 6280258024"
 HELP_SCREEN_SUPPORT_GROUP_ICON="icon_whatsapp_icon.svg"

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -43,6 +43,7 @@ module Experimentation
                                              Time.current, MONITORING_BUFFER.ago
                                            ).select(:patient_id))
         .then { |patients| exclude_bangladesh_blocks(patients) }
+        .then { |patients| restrict_indian_states(patients) }
     end
 
     def self.exclude_bangladesh_blocks(patients)
@@ -52,6 +53,14 @@ module Experimentation
         .merge(Facility.with_block_region_id)
         .select("patients.*")
         .where.not(block_region: {id: excluded_block_ids.presence})
+    end
+
+    def self.restrict_indian_states(patients)
+      return patients unless CountryConfig.current_country?("India") && SimpleServer.env.production?
+      return patients unless ENV["EXPERIMENT_INCLUDED_STATES"].present?
+
+      states = ENV.fetch("EXPERIMENT_INCLUDED_STATES", "").split(",").map(&:strip)
+      patients.where(facilities: {state: states})
     end
 
     def self.excluded_block_ids

--- a/app/models/experimentation/notifications_experiment.rb
+++ b/app/models/experimentation/notifications_experiment.rb
@@ -43,7 +43,7 @@ module Experimentation
                                              Time.current, MONITORING_BUFFER.ago
                                            ).select(:patient_id))
         .then { |patients| exclude_bangladesh_blocks(patients) }
-        .then { |patients| restrict_indian_states(patients) }
+        .then { |patients| include_only_allowed_india_states(patients) }
     end
 
     def self.exclude_bangladesh_blocks(patients)
@@ -55,11 +55,11 @@ module Experimentation
         .where.not(block_region: {id: excluded_block_ids.presence})
     end
 
-    def self.restrict_indian_states(patients)
+    def self.include_only_allowed_india_states(patients)
       return patients unless CountryConfig.current_country?("India") && SimpleServer.env.production?
-      return patients unless ENV["EXPERIMENT_INCLUDED_STATES"].present?
+      return patients unless ENV["EXPERIMENT_ALLOWED_STATES"].present?
 
-      states = ENV.fetch("EXPERIMENT_INCLUDED_STATES", "").split(",").map(&:strip)
+      states = ENV.fetch("EXPERIMENT_ALLOWED_STATES", "").split(",").map(&:strip)
       patients.where(facilities: {state: states})
     end
 

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -179,6 +179,41 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
       expect(described_class.eligible_patients).to include(eligible_patient)
     end
 
+    it "only includes patients from states in India production" do
+      included_facility = create(:facility, state: "included_state")
+      excluded_facility = create(:facility, state: "excluded_state")
+      included_patient = create(:patient, age: 18, assigned_facility: included_facility)
+      excluded_patient = create(:patient, age: 18, assigned_facility: excluded_facility)
+      allow(Rails.application.config.country).to receive(:[]).with(:name).and_return("India")
+      stub_const("SIMPLE_SERVER_ENV", "production")
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:[]).with("EXPERIMENT_INCLUDED_STATES").and_return(included_facility.state)
+      allow(ENV).to receive(:fetch).with("EXPERIMENT_INCLUDED_STATES", "").and_return(included_facility.state)
+
+      expect(described_class.eligible_patients).not_to include(excluded_patient)
+      expect(described_class.eligible_patients).to include(included_patient)
+    end
+
+    it "includes patients from all states in non-IHCI envs" do
+      patient = create(:patient, age: 18)
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:[]).with("EXPERIMENT_INCLUDED_STATES").and_return(patient.assigned_facility.state)
+      allow(ENV).to receive(:fetch).with("EXPERIMENT_INCLUDED_STATES", "").and_return(patient.assigned_facility.state)
+
+      expect(described_class.eligible_patients).to include(patient)
+    end
+
+    it "includes patients from all states if the config isn't supplied" do
+      patient = create(:patient, age: 18)
+      allow(Rails.application.config.country).to receive(:[]).with(:name).and_return("India")
+      stub_const("SIMPLE_SERVER_ENV", "production")
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:[]).with("EXPERIMENT_INCLUDED_STATES").and_return(nil)
+      allow(ENV).to receive(:fetch).with("EXPERIMENT_INCLUDED_STATES", "").and_return("")
+
+      expect(described_class.eligible_patients).to include(patient)
+    end
+
     it "includes all patients if a country is not in the excluded blocks list" do
       eligible_patient = create(:patient, age: 18)
       allow(Rails.application.config.country).to receive(:[]).with(:name).and_return("Bangladesh")

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -187,8 +187,8 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
       allow(Rails.application.config.country).to receive(:[]).with(:name).and_return("India")
       stub_const("SIMPLE_SERVER_ENV", "production")
       allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:[]).with("EXPERIMENT_INCLUDED_STATES").and_return(included_facility.state)
-      allow(ENV).to receive(:fetch).with("EXPERIMENT_INCLUDED_STATES", "").and_return(included_facility.state)
+      allow(ENV).to receive(:[]).with("EXPERIMENT_ALLOWED_STATES").and_return(included_facility.state)
+      allow(ENV).to receive(:fetch).with("EXPERIMENT_ALLOWED_STATES", "").and_return(included_facility.state)
 
       expect(described_class.eligible_patients).not_to include(excluded_patient)
       expect(described_class.eligible_patients).to include(included_patient)
@@ -197,8 +197,8 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
     it "includes patients from all states in non-IHCI envs" do
       patient = create(:patient, age: 18)
       allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:[]).with("EXPERIMENT_INCLUDED_STATES").and_return(patient.assigned_facility.state)
-      allow(ENV).to receive(:fetch).with("EXPERIMENT_INCLUDED_STATES", "").and_return(patient.assigned_facility.state)
+      allow(ENV).to receive(:[]).with("EXPERIMENT_ALLOWED_STATES").and_return(patient.assigned_facility.state)
+      allow(ENV).to receive(:fetch).with("EXPERIMENT_ALLOWED_STATES", "").and_return(patient.assigned_facility.state)
 
       expect(described_class.eligible_patients).to include(patient)
     end
@@ -208,8 +208,8 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
       allow(Rails.application.config.country).to receive(:[]).with(:name).and_return("India")
       stub_const("SIMPLE_SERVER_ENV", "production")
       allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:[]).with("EXPERIMENT_INCLUDED_STATES").and_return(nil)
-      allow(ENV).to receive(:fetch).with("EXPERIMENT_INCLUDED_STATES", "").and_return("")
+      allow(ENV).to receive(:[]).with("EXPERIMENT_ALLOWED_STATES").and_return(nil)
+      allow(ENV).to receive(:fetch).with("EXPERIMENT_ALLOWED_STATES", "").and_return("")
 
       expect(described_class.eligible_patients).to include(patient)
     end


### PR DESCRIPTION
**Story card:** [sc-9556](https://app.shortcut.com/simpledotorg/story/9556/send-reminders-only-in-ap-tn-and-wb-in-ihci)

## Because

Restrict notifications to a select list of states in IHCI.

## This addresses

Adds a whitelist of states in India that will be included in criteria for eligibility in experiments.