### PR TITLE
Design fixes

### DIFF
--- a/app/components/dashboard/diabetes/measurement_child_comparison_table_component.html.erb
+++ b/app/components/dashboard/diabetes/measurement_child_comparison_table_component.html.erb
@@ -9,7 +9,7 @@
   ) do |c| %>
     <%= c.tooltip({ "Types of blood sugars measured" => t("bs_measurement_details_copy.numerator", region_name: @region.name) }) %>
   <% end %>
-  <div class="table-responsive-md oy-scroll w-100">
+  <div class="table-responsive">
     <%= render Dashboard::Card::TableComponent.new(id: "measurementChildComparisonTable") do |table| %>
       <% table.column_group do %>
         <colgroup>

--- a/app/components/dashboard/diabetes/measurement_child_comparison_table_component.html.erb
+++ b/app/components/dashboard/diabetes/measurement_child_comparison_table_component.html.erb
@@ -9,8 +9,7 @@
   ) do |c| %>
     <%= c.tooltip({ "Types of blood sugars measured" => t("bs_measurement_details_copy.numerator", region_name: @region.name) }) %>
   <% end %>
-
-  <div class="table-responsive-md">
+  <div class="table-responsive-md oy-scroll w-100">
     <%= render Dashboard::Card::TableComponent.new(id: "measurementChildComparisonTable") do |table| %>
       <% table.column_group do %>
         <colgroup>

--- a/app/components/dashboard/diabetes/measurement_child_comparison_table_component.html.erb
+++ b/app/components/dashboard/diabetes/measurement_child_comparison_table_component.html.erb
@@ -1,4 +1,4 @@
-<div class="card mb-0">
+<div class="card mb-16px">
   <%= render Dashboard::Card::TitleComponent.new(
     title: "Types of blood sugars measured",
     subtitle: t("bs_measurement_details_copy.reports_card_subtitle",
@@ -48,8 +48,7 @@
                 <%= number_to_percentage(total[:rate] || 0, precision: 0) %>
               </em>
             </td>
-
-            <td class="ta-left">
+            <td class="ta-right">
               <%= number_or_dash_with_delimiter(total[:count]) %>
             </td>
           <% end %>
@@ -76,8 +75,7 @@
                   <%= number_to_percentage(total[:rate] || 0, precision: 0) %>
                 </em>
               </td>
-
-              <td class="ta-left">
+              <td class="ta-right">
                 <%= number_or_dash_with_delimiter(total[:count]) %>
               </td>
             <% end %>

--- a/app/components/dashboard/diabetes/registrations_and_follow_ups_table_component.html.erb
+++ b/app/components/dashboard/diabetes/registrations_and_follow_ups_table_component.html.erb
@@ -1,10 +1,9 @@
-<div class="card pr-0 pr-md-3 pb-inside-avoid">
+<div class="card pr-md-3 pb-inside-avoid">
   <%= render Dashboard::Card::TitleComponent.new(title: "Diabetes patient registrations and follow-ups") do |c| %>
     <%= c.tooltip({ "Monthly registered patients" => t("registered_diabetes_patients_copy.monthly_registered_patients", region_name: region.name),
                     "Follow-up patients" => t(:diabetes_follow_up_patients_copy, region_name: region.name) }) %>
   <% end %>
-
-  <div class="table-responsive-md">
+  <div class="table-responsive">
     <%= render Dashboard::Card::TableComponent.new(id: "diabetesRegistrationsAndFollowUpsTable") do |table| %>
       <% table.column_group do %>
         <colgroup>


### PR DESCRIPTION
**Story card:** None
Jamie bug list - https://rtsl.monday.com/boards/2648270782/pulses/3575560575 

## Because

Number alignements
Margin fix
Overflow bug when using smaller screen

## This addresses

Numbers listed in tables should be aligned right
There is a margin bug between this element and the element below
Before:
<img width="1408" alt="Screenshot 2022-11-29 at 11 58 35" src="https://user-images.githubusercontent.com/9541902/204456583-585bd997-e32f-43d9-9ff9-89374d4f4476.png">
After fix:
<img width="1405" alt="Screenshot 2022-11-29 at 12 02 04" src="https://user-images.githubusercontent.com/9541902/204456629-2e108f11-f920-403b-97c1-c50422749103.png">

Overflow bug before:
<img width="286" alt="Screenshot 2022-11-29 at 12 29 09" src="https://user-images.githubusercontent.com/9541902/204460653-68ac4603-a34d-40cc-a9fc-9434232b1efa.png">
Overflow bug after:
<img width="265" alt="Screenshot 2022-11-29 at 12 30 29" src="https://user-images.githubusercontent.com/9541902/204460764-a74f0379-d72e-4ec6-8239-ed433424463f.png">

Also fixed overflow bug with patient reg and follow-ups block (DM only)
<img width="907" alt="Screenshot 2022-11-29 at 13 43 17" src="https://user-images.githubusercontent.com/9541902/204475013-ed75ca6f-72cb-4fff-8d0e-20db129050c0.png">
<img width="725" alt="Screenshot 2022-11-29 at 13 29 19" src="https://user-images.githubusercontent.com/9541902/204475039-d2c60179-d581-4b3d-ab02-0346ff83647d.png">

## Test instructions

Go to simple dashboard > reports > 'diabetes' (for any region/district/facility)

Check spacing at full screen

Check horizontal scrolling at small widths

