### PR TITLE
Dashboard facility level 'facility activity' design fixes

### DIFF
--- a/app/components/dashboard/diabetes/healthcare_worker_activity_component.html.erb
+++ b/app/components/dashboard/diabetes/healthcare_worker_activity_component.html.erb
@@ -9,7 +9,7 @@
     <%= render Dashboard::Card::TableComponent.new(id: "measurementChildComparisonTable") do |table| %>
       <% table.column_group do %>
         <colgroup>
-          <col>
+          <col class="table-first-col">
           <col>
           <col class="table-divider">
           <col class="table-divider">
@@ -38,8 +38,7 @@
             <td class="row-title">
               <%= link_to user.full_name, admin_user_path(user, period: @period) %>
             </td>
-
-            <td class="ta-center">
+            <td class="ta-right">
               <%= number_or_dash_with_delimiter(user_registrations_count(user)) %>
             </td>
 

--- a/app/views/reports/regions/_facility_details.html.erb
+++ b/app/views/reports/regions/_facility_details.html.erb
@@ -10,7 +10,7 @@
   <div class="table-responsive-md">
     <table class="analytics-table table-compact">
       <colgroup>
-          <col class="table-first-col">
+        <col class="table-first-col">
           <col>
           <col class="table-divider">
           <col class="table-divider">

--- a/app/views/reports/regions/_facility_details.html.erb
+++ b/app/views/reports/regions/_facility_details.html.erb
@@ -176,7 +176,7 @@
     <div class="table-responsive-md">
       <table class="analytics-table table-compact">
         <colgroup>
-          <col>
+          <col class="table-first-col">
           <col>
           <col class="table-divider">
           <col class="table-divider">

--- a/app/views/reports/regions/_facility_details.html.erb
+++ b/app/views/reports/regions/_facility_details.html.erb
@@ -230,16 +230,16 @@
             <td class="row-title">
               <%= link_to resource.full_name, admin_user_path(resource, period: @period) %>
             </td>
-            <td class="ta-center">
+              <td class="ta-right">
               <%= number_or_dash_with_delimiter(sum_registration_counts(@repository, slug: @region.slug, user_id: resource.id, diagnosis: :hypertension)) %>
             </td>
             <% @details_period_range.each do |period| %>
-              <td class="ta-center">
+                <td class="ta-right">
                 <%= number_or_dash_with_delimiter(@repository.monthly_registrations_by_user.dig(@region.slug, period, resource.id)) %>
               </td>
             <% end %>
             <% @details_period_range.each do |period| %>
-              <td class="ta-center">
+                <td class="ta-right">
                 <%= number_or_dash_with_delimiter(@repository.bp_measures_by_user.dig(@region.slug, period, resource.id)) %>
               </td>
             <% end %>


### PR DESCRIPTION
**Story card:** 

None (monday - https://rtsl.monday.com/boards/2648270782/pulses/3494472243)

## Because

Alignment of numbers in the tables are centered 
'users' column feels off with different widths

## This addresses

Numbers in tables should be right aligned
'Users' columns now has the same width for consistency

Hypertension
Before:
<img width="1103" alt="Screenshot 2022-11-29 at 15 35 00" src="https://user-images.githubusercontent.com/9541902/204500048-79233ef5-4478-4fbf-951a-c81753a63d6f.png">

After:
<img width="1091" alt="Screenshot 2022-11-29 at 15 35 58" src="https://user-images.githubusercontent.com/9541902/204500068-5d16ecb3-5724-40c8-9f73-3bdcc1ebd792.png">

Diabetes
Before:
<img width="1106" alt="Screenshot 2022-11-29 at 15 37 14" src="https://user-images.githubusercontent.com/9541902/204500714-350741fd-0ed3-41e0-bbbf-76c82d6fd422.png">

After:
<img width="1088" alt="Screenshot 2022-11-29 at 15 39 57" src="https://user-images.githubusercontent.com/9541902/204500939-59a9506a-2d3c-4472-b1d2-6d27a89f70ea.png">

## Test instructions

Dashboard > reports > facility ('facility level' - lowest level) > 'Compare performance' section.

Check BOTH hypertension and diabetes pages.

All numbers in both tables should be right aligned
'Users' columns should have the same width
