### PR TITLE
BD User mistakenly switched to wrong facility [sc-9206]

### DIFF
--- a/db/data/20221130071823_move_bd_patients_to_different_facility.rb
+++ b/db/data/20221130071823_move_bd_patients_to_different_facility.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class MoveBdPatientsToDifferentFacility < ActiveRecord::Migration[6.1]
+  def up
+    return unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
+
+    Patient.where(
+      registration_facility_id: "fe48375c-7826-41dd-9110-d716a9181e8f",
+      registration_user_id: "ced029f9-4e06-40cd-b719-605c85a4b004"
+    )
+      .update_all(
+        registration_facility_id: "daff41a3-4922-41b0-a822-6fef2db07e68",
+        assigned_facility_id: "daff41a3-4922-41b0-a822-6fef2db07e68"
+      )
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-9206](https://app.shortcut.com/simpledotorg/story/9206)

## Because

A user in Bangladesh accidentally switched to the wrong facility and recorded many patients in the wrong location.

## This addresses

This user recorded patients at USC Biswanath instead of UHC Bishwanath .
All patients followed-up at or registered at USC Biswanath by user “FA, Fenchuganj” will have their records changed to UHC Bishwanath.

## Test instructions

Go to [this Metabase query](https://metabase.bd.simple.org/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoyLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjE5LCJmaWx0ZXIiOlsiYW5kIixbIj0iLFsiZmllbGQiLDM3NCxudWxsXSwiZmU0ODM3NWMtNzgyNi00MWRkLTkxMTAtZDcxNmE5MTgxZThmIl0sWyI9IixbImZpZWxkIiwzNjksbnVsbF0sImNlZDAyOWY5LTRlMDYtNDBjZC1iNzE5LTYwNWM4NWE0YjAwNCJdXX0sInR5cGUiOiJxdWVyeSJ9LCJkaXNwbGF5IjoidGFibGUiLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fSwib3JpZ2luYWxfY2FyZF9pZCI6bnVsbH0=) and you'll find 117 patients registered by user `FA, Fenchuganj` in facility `USC Biswanath`. They'll be moved to `UHC Bishwanath`. You can verify the UUIDs in Metabase.