### PR TITLE
Fix prescription drug seeder

### DIFF
--- a/lib/seed/prescription_drug_seeder.rb
+++ b/lib/seed/prescription_drug_seeder.rb
@@ -27,7 +27,7 @@ module Seed
     end
 
     def prescription_drugs_to_create
-      (0...config.max_prescription_drugs_to_create_per_encounter).to_a.sample
+      (0...config.max_prescription_drugs_to_create_per_encounter).to_a.sample.to_i
     end
 
     def call


### PR DESCRIPTION
**Story card:** -

## Because

`db:seed` breaks while running prescription drug seeder on review apps, because the function to return the number of drugs to generate returns a `nil` instead of a `0`.

## This addresses

Fixes the function in the seed script to unblock breaking android review apps.
