### PR TITLE
Configure drug calculation coefficients from the protocol page

### DIFF
--- a/app/controllers/admin/protocols_controller.rb
+++ b/app/controllers/admin/protocols_controller.rb
@@ -42,6 +42,31 @@ class Admin::ProtocolsController < AdminController
     redirect_to admin_protocols_url, notice: "Medication list was successfully deleted"
   end
 
+  def configure_coefficients
+    @coefficients = ProtocolDrugCalculationCoefficient.find_by(protocol_params[:id]).coefficients
+    if @coefficients.absent?
+      @coefficients = {
+        "load_coefficient": 0,
+      }
+      categories = Set.new
+      @protocol.protocol_drugs.each do |drug|
+        @coefficients[drug[:rxnorm_code]] = 0
+        categories.add(drug[:drug_category])
+      end
+      categories.each do |category|
+        @coefficients[category] = 0
+      end
+    end
+  end
+
+  def submit_coefficients
+    if @coefficients.save
+      redirect_to [:admin, @coefficients], notice: "Medication list was successfully configured"
+    else
+      render :configure_coefficients # renders with errors poopulated
+    end
+  end
+
   private
 
   def set_protocol


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

## Because

Currently, CVHOs send protocol coefficients to devs, who then manually add them to a config yaml. This feature will enable CVHOs to directly add/edit them from the dashboard

## This addresses

This PR adds a configure button to the protocol page, which opens up a view with fields to add protocol-level, drug-category-level and drug-level coefficients. Onn submission, the upadted coefficients will be reflected in the drug stock reports.

In case of errors in report calculation, a button to redirect the user to the correct protocol's `configure` page will pop up.

## Test instructions

WIP