### PR TITLE
Bump heroku resource sizes

### DIFF
--- a/app.json
+++ b/app.json
@@ -176,16 +176,16 @@
   "formation": {
     "web": {
       "quantity": 1,
-      "size": "Hobby"
+      "size": "Eco"
     },
     "worker": {
       "quantity": 1,
-      "size": "Hobby"
+      "size": "Eco"
     }
   },
   "addons": [
-    "heroku-postgresql:hobby-dev",
-    "heroku-redis:hobby-dev"
+    "heroku-postgresql:mini",
+    "heroku-redis:mini"
   ],
   "buildpacks": [
     {


### PR DESCRIPTION
**Story card:** [sc-9029](https://app.shortcut.com/simpledotorg/story/9029/investigate-heroku-ending-free-tier-services-and-potential-non-profit-benefits)

## Because

Heroku has stopped supporting hobby (free) dynos. 

## This addresses

This bumps up our heroku review app configuration to use the basic paid tier.