### PR TITLE
Add Swagger for Screening Reports MVP

### DIFF
--- a/app/schema/api/v4/models.rb
+++ b/app/schema/api/v4/models.rb
@@ -389,6 +389,31 @@ class Api::V4::Models
        required: %w[protocol_drug_id in_stock received]}
     end
 
+    def questionnaire_response
+      {type: :object,
+       properties: {
+         id: {"$ref" => "#/definitions/uuid"},
+         deleted_at: {"$ref" => "#/definitions/nullable_timestamp"},
+         created_at: {"$ref" => "#/definitions/timestamp"},
+         updated_at: {"$ref" => "#/definitions/timestamp"},
+         # TODO: Change non_empty_string to questionnaire_type enum.
+         questionnaire_type: {"$ref" => "#/definitions/non_empty_string"},
+         questionnaire_id: {"$ref" => "#/definitions/uuid"},
+         facility_id: {"$ref" => "#/definitions/uuid"},
+         user_id: {"$ref" => "#/definitions/nullable_uuid"},
+         content: {type: :object}
+       },
+       required: %w[id
+        created_at
+        updated_at
+        questionnaire_type
+        questionnaire_id
+        facility_id
+        user_id
+        content]
+      }
+    end
+
     def definitions
       {
         activate_user: activate_user,
@@ -425,6 +450,8 @@ class Api::V4::Models
         phone_numbers: array_of("phone_number"),
         prescription_drug: Api::V3::Models.prescription_drug,
         prescription_drugs: array_of("prescription_drug"),
+        questionnaire_response: Api::V4::Models.questionnaire_response,
+        questionnaire_responses: array_of("questionnaire_response"),
         teleconsultation: teleconsultation,
         teleconsultations: array_of("teleconsultation"),
         timestamp: timestamp,

--- a/app/schema/api/v4/schema.rb
+++ b/app/schema/api/v4/schema.rb
@@ -225,6 +225,14 @@ class Api::V4::Schema
        description: "List of available state names"}
     end
 
+    def questionnaire_responses_sync_from_user_request
+      sync_from_user_request(:questionnaire_responses)
+    end
+
+    def questionnaire_responses_sync_to_user_response
+      sync_to_user_response(:questionnaire_responses)
+    end
+
     def definitions
       {error: error,
        errors: Api::V4::Models.array_of("error"),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,6 +148,11 @@ Rails.application.routes.draw do
         post "/sync", to: "call_results#sync_from_user"
       end
 
+      scope :questionnaire_responses do
+        get "/sync", to: "questionnaire_responses#sync_to_user"
+        post "/sync", to: "questionnaire_responses#sync_from_user"
+      end
+
       namespace :analytics do
         resource :overdue_list, only: [:show]
       end

--- a/spec/requests/api/v4/questionnaire_responses_spec.rb
+++ b/spec/requests/api/v4/questionnaire_responses_spec.rb
@@ -1,0 +1,50 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v4/questionnaire_responses', type: :request do
+
+  path '/api/v4/questionnaire_responses/sync' do
+
+    get('Syncs questionnaire responses from server to device') do
+      tags "Questionnaire Responses"
+      security [access_token: [], user_id: [], facility_id: []]
+      parameter name: "HTTP_X_USER_ID", in: :header, type: :uuid
+      parameter name: "HTTP_X_FACILITY_ID", in: :header, type: :uuid
+      parameter name: :appointments, in: :body, schema: Api::V4::Schema.questionnaire_responses_sync_to_user_response
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+
+      include_examples "returns 403 for get requests for forbidden users"
+    end
+
+    post('Syncs questionnaire responses from device to server') do
+      tags "Questionnaire Responses"
+      security [access_token: [], user_id: [], facility_id: []]
+      parameter name: "HTTP_X_USER_ID", in: :header, type: :uuid
+      parameter name: "HTTP_X_FACILITY_ID", in: :header, type: :uuid
+      parameter name: :appointments, in: :body, schema: Api::V4::Schema.questionnaire_responses_sync_from_user_request
+
+      response(201, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+
+      include_examples "returns 403 for post requests for forbidden users", :questionnaire_responses
+    end
+  end
+end

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -995,6 +995,120 @@
           }
         }
       }
+    },
+    "/api/v4/questionnaire_responses/sync": {
+      "get": {
+        "summary": "Syncs questionnaire responses from server to device",
+        "tags": [
+          "Questionnaire Responses"
+        ],
+        "security": [
+          {
+            "access_token": [
+
+            ],
+            "user_id": [
+
+            ],
+            "facility_id": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "HTTP_X_USER_ID",
+            "in": "header",
+            "type": "uuid"
+          },
+          {
+            "name": "HTTP_X_FACILITY_ID",
+            "in": "header",
+            "type": "uuid"
+          },
+          {
+            "name": "appointments",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "questionnaire_responses": {
+                  "$ref": "#/definitions/questionnaire_responses"
+                },
+                "process_token": {
+                  "$ref": "#/definitions/process_token"
+                }
+              },
+              "required": [
+                "questionnaire_responses",
+                "process_token"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful"
+          },
+          "403": {
+            "description": "user is not allowed to sync"
+          }
+        }
+      },
+      "post": {
+        "summary": "Syncs questionnaire responses from device to server",
+        "tags": [
+          "Questionnaire Responses"
+        ],
+        "security": [
+          {
+            "access_token": [
+
+            ],
+            "user_id": [
+
+            ],
+            "facility_id": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "HTTP_X_USER_ID",
+            "in": "header",
+            "type": "uuid"
+          },
+          {
+            "name": "HTTP_X_FACILITY_ID",
+            "in": "header",
+            "type": "uuid"
+          },
+          {
+            "name": "appointments",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "questionnaire_responses": {
+                  "$ref": "#/definitions/questionnaire_responses"
+                }
+              },
+              "required": [
+                "questionnaire_responses"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "successful"
+          },
+          "403": {
+            "description": "user is not allowed to sync"
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -2516,6 +2630,57 @@
       ],
       "items": {
         "$ref": "#/definitions/prescription_drug"
+      }
+    },
+    "questionnaire_response": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "deleted_at": {
+          "$ref": "#/definitions/nullable_timestamp"
+        },
+        "created_at": {
+          "$ref": "#/definitions/timestamp"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/timestamp"
+        },
+        "questionnaire_type": {
+          "$ref": "#/definitions/non_empty_string"
+        },
+        "questionnaire_id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "facility_id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "user_id": {
+          "$ref": "#/definitions/nullable_uuid"
+        },
+        "content": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "id",
+        "created_at",
+        "updated_at",
+        "questionnaire_type",
+        "questionnaire_id",
+        "facility_id",
+        "user_id",
+        "content"
+      ]
+    },
+    "questionnaire_responses": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "$ref": "#/definitions/questionnaire_response"
       }
     },
     "teleconsultation": {


### PR DESCRIPTION
Co-authored-by: Prabhanshu Gupta <guptaprabhanshu1@gmail.com>

**Story card:** [sc-9758](https://app.shortcut.com/simpledotorg/story/9758/create-swagger-for-screening-reports-mvp)

## Because

Mobile devs can begin implementing the Sync APIs considering the Swagger as finalized contract.

## This addresses



## Test instructions

Checkout `sc-9758` branch locally, run rails server & go to the APIs
1. Questionnaires Sync to user - WIP
2. [Questionnaire-Responses Sync to user](http://127.0.0.1:3000/api-docs/index.html#tag/Questionnaire-Responses/paths/~1api~1v4~1questionnaire_responses~1sync/get)
3. [Questionnaire-Responses Sync from user](http://127.0.0.1:3000/api-docs/index.html#tag/Questionnaire-Responses/paths/~1api~1v4~1questionnaire_responses~1sync/post)