### PR TITLE
Bump heroku resource sizes

### DIFF
--- a/app.json
+++ b/app.json
@@ -176,11 +176,11 @@
   "formation": {
     "web": {
       "quantity": 1,
-      "size": "Eco"
+      "size": "Basic"
     },
     "worker": {
       "quantity": 1,
-      "size": "Eco"
+      "size": "Basic"
     }
   },
   "addons": [


### PR DESCRIPTION
**Story card:** [sc-9029](https://app.shortcut.com/simpledotorg/story/9029/investigate-heroku-ending-free-tier-services-and-potential-non-profit-benefits)

## Because

Follow up to https://github.com/simpledotorg/simple-server/pull/4651.

## This addresses

`Eco` resources are not supported for teams, change it to `Basic`.
