### PR TITLE
Show activerecord logs only when rails server is run

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,8 +62,10 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :inline
 
-  stdout_logger = ActiveSupport::TaggedLogging.new(JsonLogger.new($stdout))
-  config.logger.extend(JsonLogger.broadcast(stdout_logger))
+  server do
+    stdout_logger = ActiveSupport::TaggedLogging.new(JsonLogger.new($stdout))
+    config.logger.extend(JsonLogger.broadcast(stdout_logger))
+  end
 end
 
 # Set a longer session timeout to make things easier on developers


### PR DESCRIPTION
**Story card:** -

## Because

Follow up to https://github.com/simpledotorg/simple-server/pull/4324. We added activerecord logs in development explicitly, however that's made rake tasks noisy.

## This addresses

Add [a rails tie hook](https://api.rubyonrails.org/classes/Rails/Railtie.html) to only initialise activerecord logs when rails server is run. 
