### PR TITLE
[WIP] Docker increase passenger queue size to 200

### DIFF
--- a/.docker/config/nginx/webapp.conf
+++ b/.docker/config/nginx/webapp.conf
@@ -12,6 +12,7 @@ server {
   passenger_app_root /home/app;
   passenger_enabled on;
   passenger_app_env production;
+  passenger_max_request_queue_size 200;
   passenger_start_timeout 300;
   passenger_set_header X-Forwarded-Host $http_host;
 


### PR DESCRIPTION
**Story card:** [sc-9507](https://app.shortcut.com/simpledotorg/epic/9507)

## Because

Set passenger queue size to 200 in the docker Nginx config

## This addresses

Increase overall request handling capacity

## Test instructions

Enter detailed instructions for how to test this PR...