### PR TITLE
Fix typo 'black' => 'blank' on drug stock entry form Simple app

### DIFF
--- a/app/views/webview/drug_stocks/new.html.erb
+++ b/app/views/webview/drug_stocks/new.html.erb
@@ -44,7 +44,7 @@
               <%= inline_file("check-mark-small.svg") %>
             </div>
             <p class="m-0px p-0px ta-left fw-regular fs-16px c-grey-dark">
-              Leave black if you don't know an amount
+              Leave blank if you don't know an amount
             </p>
           </div>
           <div class="d-flex ai-center">


### PR DESCRIPTION
**Story card:** [none]

## Because

Found a typo on the drug stock form page.

"Leave black..." instead of "Leave blank..."
[Slack link](https://simpledotorg.slack.com/archives/CFHKJ5WJY/p1672118172725519)

## This addresses

Correct wording

## Test instructions

Testing on demo app -> Go to drug stock entry form -> Text appears in the header block