### PR TITLE
Show previous financial year as default year for the first 3 months

### DIFF
--- a/app/components/progress_tab/yearly_report_component_v2.rb
+++ b/app/components/progress_tab/yearly_report_component_v2.rb
@@ -33,6 +33,7 @@ class ProgressTab::YearlyReportComponentV2 < ApplicationComponent
   memoize def last_n_years
     years = (SIMPLE_START_YEAR..Date.current.year).to_a.reverse
     if report_in_financial_year?
+      years.delete(Date.current.year) if Date.current.month < FINANCIAL_YEAR_START_MONTH
       years.push(SIMPLE_START_YEAR - 1)
     end
 

--- a/app/components/progress_tab/yearly_report_component_v2.rb
+++ b/app/components/progress_tab/yearly_report_component_v2.rb
@@ -31,11 +31,19 @@ class ProgressTab::YearlyReportComponentV2 < ApplicationComponent
   end
 
   memoize def last_n_years
-    years = (SIMPLE_START_YEAR..Date.current.year).to_a.reverse
     if report_in_financial_year?
-      years.delete(Date.current.year) if Date.current.month < FINANCIAL_YEAR_START_MONTH
-      years.push(SIMPLE_START_YEAR - 1)
+      start_year = SIMPLE_START_YEAR - 1
+      end_year = if Date.current.month < FINANCIAL_YEAR_START_MONTH
+        Date.current.year - 1
+      else
+        Date.current.year
+      end
+    else
+      start_year = SIMPLE_START_YEAR
+      end_year = Date.current.year
     end
+
+    years = (start_year..end_year).to_a.reverse
 
     years.each_with_object({}) do |year, hsh|
       hsh[year] = display_year(year)


### PR DESCRIPTION
**Story card:** [sc-9832](https://app.shortcut.com/simpledotorg/story/9832/remove-the-upcoming-financial-year-say-april-2023-march-2024-from-the-options-for-the-first-3-months-of-every-year)

## Because

Progress Yearly report has `April 2023 - March 2024` as an option(default option). As a result, the report shows " This report is coming soon"

## This addresses

Remove the upcoming financial year (say `April 2023 - March 2024`) from the options for the first 3 months of every year.

## Test instructions

- Make sure to enable flipper feature `yearly_reports_start_from_april`  
- Goto Reports > <facility region> > Progress > Yearly
- You should be able to see `April 2023 - March 2024` as the default option and corresponding report.