### PR TITLE
Delete old QA environment deploy config

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,1 +1,0 @@
-server "ec2-13-235-3-72.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db sidekiq cron]


### PR DESCRIPTION
**Story card:** [9506](https://app.shortcut.com/simpledotorg/epic/9506)

## Because

QA environment is migrated to k8s and the deploy config is no longer used
