### PR TITLE
Fix questionnaire swagger specs

### DIFF
--- a/spec/api/v4/questionnaire_responses_spec.rb
+++ b/spec/api/v4/questionnaire_responses_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-xdescribe "Questionnaire Responses v4 API", swagger_doc: "v4/swagger.json" do
+describe "Questionnaire Responses v4 API", swagger_doc: "v4/swagger.json" do
   path "/questionnaire_responses/sync" do
     post("Syncs Questionnaire Responses from Device to Server") do
       tags "Questionnaire Responses"
@@ -12,8 +12,28 @@ xdescribe "Questionnaire Responses v4 API", swagger_doc: "v4/swagger.json" do
 
       parameter name: :questionnaire_responses, in: :body, schema: Api::V4::Schema.questionnaire_responses_sync_from_user_request
 
-      response "200", "Questionnaire Responses created" do
+      let(:request_user) { create(:user) }
+      let(:request_facility) { create(:facility, facility_group: request_user.facility.facility_group) }
+      let(:HTTP_X_USER_ID) { request_user.id }
+      let(:HTTP_X_FACILITY_ID) { request_facility.id }
+      let(:Authorization) { "Bearer #{request_user.access_token}" }
+      let(:questionnaire_responses) { {questionnaire_responses: (1..3).map { build_questionnaire_response_payload }} }
+
+      response "200", "questionnaire responses created" do
         schema Api::V4::Schema.sync_from_user_errors
+        run_test!
+      end
+
+      response "200", "some, or no errors were found" do
+        let(:request_user) { create(:user) }
+        let(:request_facility) { create(:facility, facility_group: request_user.facility.facility_group) }
+        let(:HTTP_X_USER_ID) { request_user.id }
+        let(:HTTP_X_FACILITY_ID) { request_facility.id }
+        let(:Authorization) { "Bearer #{request_user.access_token}" }
+
+        schema Api::V4::Schema.sync_from_user_errors
+        let(:questionnaire_responses) { {questionnaire_responses: (1..3).map { build_invalid_questionnaire_response_payload }} }
+
         run_test!
       end
 
@@ -33,7 +53,15 @@ xdescribe "Questionnaire Responses v4 API", swagger_doc: "v4/swagger.json" do
       end
 
       response "200", "Questionnaires Synced to user device" do
+        let(:request_user) { create(:user) }
+        let(:request_facility) { create(:facility, facility_group: request_user.facility.facility_group) }
+        let(:HTTP_X_USER_ID) { request_user.id }
+        let(:HTTP_X_FACILITY_ID) { request_facility.id }
+        let(:Authorization) { "Bearer #{request_user.access_token}" }
+
         schema Api::V4::Schema.questionnaire_responses_sync_to_user_response
+        let(:process_token) { Base64.encode64({other_facilities_processed_since: 10.minutes.ago}.to_json) }
+        let(:limit) { 10 }
         run_test!
       end
 

--- a/spec/api/v4/questionnaire_responses_spec.rb
+++ b/spec/api/v4/questionnaire_responses_spec.rb
@@ -20,7 +20,6 @@ describe "Questionnaire Responses v4 API", swagger_doc: "v4/swagger.json" do
         let(:Authorization) { "Bearer #{request_user.access_token}" }
         let(:questionnaire_responses) { {questionnaire_responses: (1..3).map { build_questionnaire_response_payload }} }
 
-        schema Api::V4::Schema.sync_from_user_errors
         run_test!
       end
 
@@ -51,7 +50,7 @@ describe "Questionnaire Responses v4 API", swagger_doc: "v4/swagger.json" do
         parameter param
       end
 
-      response "200", "Questionnaires Synced to user device" do
+      response "200", "questionnaire responses synced to user device" do
         let(:request_user) { create(:user) }
         let(:request_facility) { create(:facility, facility_group: request_user.facility.facility_group) }
         let(:HTTP_X_USER_ID) { request_user.id }

--- a/spec/api/v4/questionnaire_responses_spec.rb
+++ b/spec/api/v4/questionnaire_responses_spec.rb
@@ -12,14 +12,14 @@ describe "Questionnaire Responses v4 API", swagger_doc: "v4/swagger.json" do
 
       parameter name: :questionnaire_responses, in: :body, schema: Api::V4::Schema.questionnaire_responses_sync_from_user_request
 
-      let(:request_user) { create(:user) }
-      let(:request_facility) { create(:facility, facility_group: request_user.facility.facility_group) }
-      let(:HTTP_X_USER_ID) { request_user.id }
-      let(:HTTP_X_FACILITY_ID) { request_facility.id }
-      let(:Authorization) { "Bearer #{request_user.access_token}" }
-      let(:questionnaire_responses) { {questionnaire_responses: (1..3).map { build_questionnaire_response_payload }} }
-
       response "200", "questionnaire responses created" do
+        let(:request_user) { create(:user) }
+        let(:request_facility) { create(:facility, facility_group: request_user.facility.facility_group) }
+        let(:HTTP_X_USER_ID) { request_user.id }
+        let(:HTTP_X_FACILITY_ID) { request_facility.id }
+        let(:Authorization) { "Bearer #{request_user.access_token}" }
+        let(:questionnaire_responses) { {questionnaire_responses: (1..3).map { build_questionnaire_response_payload }} }
+
         schema Api::V4::Schema.sync_from_user_errors
         run_test!
       end
@@ -30,10 +30,9 @@ describe "Questionnaire Responses v4 API", swagger_doc: "v4/swagger.json" do
         let(:HTTP_X_USER_ID) { request_user.id }
         let(:HTTP_X_FACILITY_ID) { request_facility.id }
         let(:Authorization) { "Bearer #{request_user.access_token}" }
+        let(:questionnaire_responses) { {questionnaire_responses: (1..3).map { build_questionnaire_response_payload }} }
 
         schema Api::V4::Schema.sync_from_user_errors
-        let(:questionnaire_responses) { {questionnaire_responses: (1..3).map { build_invalid_questionnaire_response_payload }} }
-
         run_test!
       end
 

--- a/spec/api/v4/questionnaires_spec.rb
+++ b/spec/api/v4/questionnaires_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-xdescribe "Questionnaires v4 API", swagger_doc: "v4/swagger.json" do
+describe "Questionnaires v4 API", swagger_doc: "v4/swagger.json" do
   path "/questionnaires/sync" do
     get "Syncs Questionnaires from Server to Device" do
       tags "Questionnaires"
@@ -11,13 +11,25 @@ xdescribe "Questionnaires v4 API", swagger_doc: "v4/swagger.json" do
       parameter name: "HTTP_X_FACILITY_ID", in: :header, type: :uuid
       parameter name: "Accept-Language", in: :header, type: :string
 
+      parameter name: "dsl_version", in: :query, type: :string, required: true
       Api::V4::Schema.sync_to_user_request.each do |param|
         parameter param
       end
-      parameter name: "dsl_version", in: :query, type: :string, required: true
+
+      let("Accept-Language") { "en-IN" }
+      let(:dsl_version) { 1 }
 
       response "200", "Questionnaires Synced to user device" do
+        let(:request_user) { create(:user) }
+        let(:request_facility) { create(:facility, facility_group: request_user.facility.facility_group) }
+        let(:HTTP_X_USER_ID) { request_user.id }
+        let(:HTTP_X_FACILITY_ID) { request_facility.id }
+        let(:Authorization) { "Bearer #{request_user.access_token}" }
+
         schema Api::V4::Schema.questionnaires_sync_to_user_response
+        let(:process_token) { Base64.encode64({current_facility_processed_since: 10.minutes.ago}.to_json) }
+        let(:limit) { 10 }
+
         run_test!
       end
 

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -810,7 +810,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Questionnaires Synced to user device",
+            "description": "questionnaire responses synced to user device",
             "schema": {
               "type": "object",
               "properties": {

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -750,7 +750,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Questionnaire Responses created",
+            "description": "some, or no errors were found",
             "schema": {
               "type": "object",
               "properties": {
@@ -869,6 +869,12 @@
             "type": "string"
           },
           {
+            "name": "dsl_version",
+            "in": "query",
+            "type": "string",
+            "required": true
+          },
+          {
             "name": "process_token",
             "type": "string",
             "format": "byte",
@@ -880,12 +886,6 @@
             "type": "integer",
             "description": "Number of record to retrieve (a.k.a batch-size)",
             "in": "query"
-          },
-          {
-            "name": "dsl_version",
-            "in": "query",
-            "type": "string",
-            "required": true
           }
         ],
         "responses": {


### PR DESCRIPTION
**Story card:** -

## Because

We had `xdescribed` some of the swagger specs for questionnaires and responses since the controllers were not implemented yet.

## This addresses

Fixes the swagger specs.
