### PR TITLE
Add facility-level toggle for Monthly Screening Reports

### DIFF
--- a/app/controllers/admin/facilities_controller.rb
+++ b/app/controllers/admin/facilities_controller.rb
@@ -151,6 +151,7 @@ class Admin::FacilitiesController < AdminController
       :latitude,
       :longitude,
       :enable_diabetes_management,
+      :enable_monthly_screening_reports,
       :monthly_estimated_opd_load,
       :zone,
       :enable_teleconsultation,

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -122,6 +122,7 @@ class Facility < ApplicationRecord
       message: "must be added to enable teleconsultation"
     }
   validates :enable_diabetes_management, inclusion: {in: [true, false]}
+  validates :enable_monthly_screening_reports, inclusion: {in: [true, false]}
   validate :valid_block, if: -> { !generating_seed_data && facility_group.present? }
   validates :short_name, presence: true
   validates :short_name, length: {minimum: 1, maximum: SHORT_NAME_MAX_LENGTH}

--- a/app/parsers/csv/facilities_parser.rb
+++ b/app/parsers/csv/facilities_parser.rb
@@ -23,7 +23,8 @@ class Csv::FacilitiesParser
     latitude: "latitude (optional)",
     longitude: "longitude (optional)",
     facility_size: "size (optional)",
-    enable_diabetes_management: "enable_diabetes_management (true/false)"
+    enable_diabetes_management: "enable_diabetes_management (true/false)",
+    enable_monthly_screening_reports: "enable_monthly_screening_reports (true/false)"
   }
 
   def self.parse(*args)
@@ -58,9 +59,9 @@ class Csv::FacilitiesParser
     COLUMNS
       .map { |attr, col_name| [attr, row[col_name]] }
       .to_h
-      .yield_self { |attrs| attrs.merge(set_region_data(attrs)) }
-      .yield_self { |attrs| attrs.merge(set_facility_size(attrs)) }
-      .yield_self { |attrs| attrs.merge(set_blanks_to_false(attrs)) }
+      .then { |attrs| attrs.merge(set_region_data(attrs)) }
+      .then { |attrs| attrs.merge(set_facility_size(attrs)) }
+      .then { |attrs| attrs.merge(set_blanks_to_false(attrs)) }
   end
 
   def set_region_data(facility_attrs)
@@ -81,16 +82,15 @@ class Csv::FacilitiesParser
   end
 
   def facility_sizes
-    # {
-    #   "Localized facility size" => "facility_size",
-    # }
+    # { "Localized facility size" => "facility_size" }
     @facility_sizes ||= Facility.facility_sizes.transform_values { |size| Facility.localized_facility_size(size) }.invert
   end
 
   def set_blanks_to_false(facility_attrs)
     {
       enable_teleconsultation: facility_attrs[:enable_teleconsultation] || false,
-      enable_diabetes_management: facility_attrs[:enable_diabetes_management] || false
+      enable_diabetes_management: facility_attrs[:enable_diabetes_management] || false,
+      enable_monthly_screening_reports: facility_attrs[:enable_monthly_screening_reports] || false
     }
   end
 

--- a/app/transformers/api/v3/facility_transformer.rb
+++ b/app/transformers/api/v3/facility_transformer.rb
@@ -9,9 +9,11 @@ class Api::V3::FacilityTransformer
           "teleconsultation_isd_code",
           "teleconsultation_phone_numbers",
           "organization_name",
-          "facility_group_name")
+          "facility_group_name",
+          "enable_monthly_screening_reports")
         .merge(config: {enable_diabetes_management: facility.enable_diabetes_management,
-                        enable_teleconsultation: facility.enable_teleconsultation},
+                        enable_teleconsultation: facility.enable_teleconsultation,
+                        enable_monthly_screening_reports: facility.enable_monthly_screening_reports},
           protocol_id: facility.protocol.try(:id))
     end
   end

--- a/app/views/admin/facilities/_form.html.erb
+++ b/app/views/admin/facilities/_form.html.erb
@@ -43,6 +43,8 @@
         <%= form.check_box :enable_diabetes_management, id: :facility_enable_diabetes_management %>
         <h3 class="mt-5">Teleconsultation enabled?</h3>
         <%= form.check_box :enable_teleconsultation, id: :facility_enable_teleconsultation, onclick: "new FacilityTeleconsultFields().toggleTeleconsultationFields()" %>
+        <h3 class="mt-5">Monthly Screening Reports enabled?</h3>
+        <%= form.check_box :enable_monthly_screening_reports, id: :facility_enable_monthly_screening_reports %>
 
         <span class="teleconsultation-fields">
           <div id="teleconsultation-fields" class="mt-4" style=<%= "#{'display:none' unless @facility[:enable_teleconsultation]}" %>>

--- a/app/views/admin/facilities/_form.html.erb
+++ b/app/views/admin/facilities/_form.html.erb
@@ -43,7 +43,7 @@
         <%= form.check_box :enable_diabetes_management, id: :facility_enable_diabetes_management %>
         <h3 class="mt-5">Teleconsultation enabled?</h3>
         <%= form.check_box :enable_teleconsultation, id: :facility_enable_teleconsultation, onclick: "new FacilityTeleconsultFields().toggleTeleconsultationFields()" %>
-        <h3 class="mt-5">Monthly Screening Reports enabled?</h3>
+        <h3 class="mt-5">Monthly screening reports enabled?</h3>
         <%= form.check_box :enable_monthly_screening_reports, id: :facility_enable_monthly_screening_reports %>
 
         <span class="teleconsultation-fields">

--- a/app/views/admin/facilities/show.html.erb
+++ b/app/views/admin/facilities/show.html.erb
@@ -57,8 +57,9 @@
   <div class="col-md-3 d-flex">
     <div class="card flex-fill">
       <h3>Features</h3>
-      Diabetes Management: <%= @facility.diabetes_enabled? ? "Enabled" : "Disabled" %>
-      Teleconsultation:    <%= @facility.teleconsultation_enabled? ? "Enabled" : "Disabled" %>
+      Diabetes Management: <%= @facility.diabetes_enabled? ? "Enabled" : "Disabled" %><br>
+      Teleconsultation:    <%= @facility.teleconsultation_enabled? ? "Enabled" : "Disabled" %><br>
+      Monthly Screening Reports: <%= @facility.enable_monthly_screening_reports ? "Enabled" : "Disabled" %>
     </div>
   </div>
 </div>

--- a/db/migrate/20230124063249_add_enable_monthly_screening_reports_to_facilities.rb
+++ b/db/migrate/20230124063249_add_enable_monthly_screening_reports_to_facilities.rb
@@ -1,0 +1,5 @@
+class AddEnableMonthlyScreeningReportsToFacilities < ActiveRecord::Migration[6.1]
+  def change
+    add_column :facilities, :enable_monthly_screening_reports, :boolean, default: false, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -205,7 +205,8 @@ CREATE TABLE public.facilities (
     facility_size character varying NOT NULL,
     monthly_estimated_opd_load integer,
     enable_teleconsultation boolean DEFAULT false NOT NULL,
-    short_name character varying NOT NULL
+    short_name character varying NOT NULL,
+    enable_monthly_screening_reports boolean DEFAULT false NOT NULL
 );
 
 
@@ -6729,6 +6730,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230103063720'),
 ('20230104104248'),
 ('20230105064908'),
-('20230123125608');
+('20230123125608'),
+('20230124063249');
 
 

--- a/public/documents/upload_facilities.csv
+++ b/public/documents/upload_facilities.csv
@@ -1,1 +1,1 @@
-organization,facility_group,facility_name,facility_short_name,facility_type,street_address (optional),village_or_colony (optional),zone_or_block,district,pin (optional),latitude (optional),longitude (optional),size (optional),enable_diabetes_management (true/false)
+organization,facility_group,facility_name,facility_short_name,facility_type,street_address (optional),village_or_colony (optional),zone_or_block,district,pin (optional),latitude (optional),longitude (optional),size (optional),enable_diabetes_management (true/false),enable_monthly_screening_reports (true/false)

--- a/spec/controllers/admin/facilities_controller_spec.rb
+++ b/spec/controllers/admin/facilities_controller_spec.rb
@@ -131,7 +131,8 @@ RSpec.describe Admin::FacilitiesController, type: :controller do
           short_name: "short name",
           pin: "999999",
           zone: block.name,
-          monthly_estimated_opd_load: 500).except(:id, :slug)
+          monthly_estimated_opd_load: 500,
+          enable_monthly_screening_reports: true).except(:id, :slug)
       end
 
       it "updates the requested facility" do

--- a/spec/factories/facilities.rb
+++ b/spec/factories/facilities.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     facility_size { Facility.facility_sizes[:small] }
     facility_group
     enable_diabetes_management { [true, false].sample }
+    enable_monthly_screening_reports { false }
     enable_teleconsultation { false }
     monthly_estimated_opd_load { 300 }
 

--- a/spec/fixtures/files/upload_facilities_invalid_test.csv
+++ b/spec/fixtures/files/upload_facilities_invalid_test.csv
@@ -1,2 +1,2 @@
-organization,facility_group,facility_name,facility_short_name,facility_type,street_address (optional),village_or_colony (optional),zone_or_block,district,state,pin (optional),latitude (optional),longitude (optional),size (optional),enable_diabetes_management (true/false)
-OrgOne,FGOne,Test Facility,TF,CHC,,,,Bhatinda,Punjab,,,,,false
+organization,facility_group,facility_name,facility_short_name,facility_type,street_address (optional),village_or_colony (optional),zone_or_block,district,state,pin (optional),latitude (optional),longitude (optional),size (optional),enable_diabetes_management (true/false),enable_monthly_screening_reports (true/false)
+OrgOne,FGOne,Test Facility,TF,CHC,,,,Bhatinda,Punjab,,,,,false,false

--- a/spec/fixtures/files/upload_facilities_test.csv
+++ b/spec/fixtures/files/upload_facilities_test.csv
@@ -1,3 +1,3 @@
-organization,facility_group,facility_name,facility_short_name,facility_type,street_address (optional),village_or_colony (optional),zone_or_block,district,pin (optional),latitude (optional),longitude (optional),size (optional),enable_diabetes_management (true/false)
-OrgOne,FGTwo,Test Facility,TF,CHC,,,Zone 1,Bhatinda,,,,community,true
-OrgOne,FGTwo,Test Facility 2,TF2,CHC,,,Zone 2,Bhatinda,,,,large,
+organization,facility_group,facility_name,facility_short_name,facility_type,street_address (optional),village_or_colony (optional),zone_or_block,district,pin (optional),latitude (optional),longitude (optional),size (optional),enable_diabetes_management (true/false),enable_monthly_screening_reports (true/false)
+OrgOne,FGTwo,Test Facility,TF,CHC,,,Zone 1,Bhatinda,,,,community,true,true
+OrgOne,FGTwo,Test Facility 2,TF2,CHC,,,Zone 2,Bhatinda,,,,large,,

--- a/spec/fixtures/files/upload_facilities_with_localized_sizes_test.csv
+++ b/spec/fixtures/files/upload_facilities_with_localized_sizes_test.csv
@@ -1,3 +1,3 @@
-organization,facility_group,facility_name,facility_short_name,facility_type,street_address (optional),village_or_colony (optional),zone_or_block,district,state,pin (optional),latitude (optional),longitude (optional),size (optional),enable_diabetes_management (true/false)
-OrgOne,FGTwo,Test Facility,TF,CHC,,,Zone 1,Bhatinda,Punjab,,,,HWC/SC,true
-OrgOne,FGTwo,Test Facility 2,TF2,CHC,,,Zone 2,Bhatinda,Punjab,,,,SDH/DH,
+organization,facility_group,facility_name,facility_short_name,facility_type,street_address (optional),village_or_colony (optional),zone_or_block,district,state,pin (optional),latitude (optional),longitude (optional),size (optional),enable_diabetes_management (true/false),enable_monthly_screening_reports (true/false)
+OrgOne,FGTwo,Test Facility,TF,CHC,,,Zone 1,Bhatinda,Punjab,,,,HWC/SC,true,true
+OrgOne,FGTwo,Test Facility 2,TF2,CHC,,,Zone 2,Bhatinda,Punjab,,,,SDH/DH,,

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -231,6 +231,7 @@ RSpec.describe Facility, type: :model do
   describe "Validations" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:district) }
+    it { is_expected.to validate_inclusion_of(:enable_monthly_screening_reports).in_array([true, false]).with_message("not in #{[true, false].join(", ")}") }
 
     context "validate state presence only if facility_group exists" do
       let(:subject) { Facility.new(facility_group: create(:facility_group)) }

--- a/spec/parsers/csv/facilities_parser_spec.rb
+++ b/spec/parsers/csv/facilities_parser_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Csv::FacilitiesParser do
         district: "Bhatinda",
         country: "India",
         facility_size: "community",
-        enable_diabetes_management: true)
+        enable_diabetes_management: true,
+        enable_monthly_screening_reports: true)
 
       expect(facilities.second).to have_attributes(organization_name: "OrgOne",
         facility_group_name: "FGTwo",


### PR DESCRIPTION
**Story card:** [sc-9782](https://app.shortcut.com/simpledotorg/story/9782)

## Because

Admins can enable/disable monthly screening reports for 1 facility or multiple facilities in bulk.

## This addresses

Enabling/disabling monthly screening reports for 1 facility or multiple facilities in bulk.

## Test instructions

1. Toggle `Monthly Screening Reports enabled?` facility from admin page
2. Verify the field is present with correct value in the Facilities Sync API `http://127.0.0.1:3000/api/v3/facilities/sync?limit=1000`