### PR TITLE
Add coverage percentage to Hypertension Indicators table on the dashboard

### DIFF
--- a/app/assets/stylesheets/partials/_reports.scss
+++ b/app/assets/stylesheets/partials/_reports.scss
@@ -638,9 +638,6 @@
   .mb-lg-24px {
     margin-bottom: 24px;
   }
-  .ml-4px {
-    margin-left: 4px;
-  }
   .ml-lg-8px {
     margin-left: 8px;
   }

--- a/app/assets/stylesheets/partials/_reports.scss
+++ b/app/assets/stylesheets/partials/_reports.scss
@@ -638,6 +638,9 @@
   .mb-lg-24px {
     margin-bottom: 24px;
   }
+  .ml-4px {
+    margin-left: 4px;
+  }
   .ml-lg-8px {
     margin-left: 8px;
   }

--- a/app/components/dashboard/population_coverage_component.html.erb
+++ b/app/components/dashboard/population_coverage_component.html.erb
@@ -30,14 +30,14 @@
     <% if accessible_region?(@region, :manage) %>
       <div class="mb-16px p-12px br-4px bg-blue-light">
         <p class="m-0px fs-14px c-black">
-          Add the estimated <%= diagnosis %> population to see the coverage rate.
+          <%= t("population_coverage.add_missing_estimate.accessible_region", diagnosis: diagnosis) %>
         </p>
         <%= link_to "+ Add population", edit_admin_facility_group_path(@region.source), :class => "fs-14px" %>
       </div>
     <% else %>
       <div class="mb-16px p-12px br-4px bg-yellow-light">
         <p class="m-0px fs-14px c-black">
-          Ask a Dashboard admin to add the est. population with <%= diagnosis %> for <%= @region.name %> to see the <%= diagnosis %> coverage rate.
+          <%= t("population_coverage.add_missing_estimate.inaccessible_region", diagnosis: diagnosis, region_name: @region.name) %>
         </p>
       </div>
     <% end %>
@@ -45,14 +45,14 @@
     <% if current_admin.accessible_district_regions(:manage).to_set.superset?(@region.district_regions.to_set) %>
       <div class="mb-16px p-12px br-4px bg-blue-light">
         <p class="m-0px fs-14px c-black">
-          Add the estimated population of <%= diagnosis %> patients for all <%= @region.child_region_type.pluralize %> to see the coverage rate.
+          <%= t("population_coverage.add_missing_child_estimate.accessible_region", diagnosis: diagnosis, child_type: @region.child_region_type.pluralize) %>
         </p>
         <%= link_to "+ Add #{@region.child_region_type} populations", "/admin/facilities", :class => "fs-14px" %>
       </div>
     <% else %>
       <div class="mb-16px p-12px br-4px bg-yellow-light">
         <p class="m-0px fs-14px c-black">
-          Ask a Dashboard admin to add the est. population with <%= diagnosis %> for all districts in <%= @region.name %> to see the <%= diagnosis %> coverage rate.
+          <%= t("population_coverage.add_missing_child_estimate.inaccessible_region", diagnosis: diagnosis, child_type: @region.child_region_type.pluralize) %>
         </p>
       </div>
     <% end %>

--- a/app/models/region_access.rb
+++ b/app/models/region_access.rb
@@ -9,25 +9,15 @@ class RegionAccess
     @memoized = memoized
   end
 
-  def accessible_region?(region, action)
-    public_send("accessible_#{region.region_type}?", region, action)
-  end
-
   # An admin can view a state if they have view_reports access to any of the state's districts
-  def accessible_state?(region, action)
+  def accessible_region?(region, action)
     return true if user.power_user?
     accessible_region_ids(region.region_type, action).include?(region.id)
   end
 
-  def accessible_district?(region, action)
-    return true if user.power_user?
-    accessible_region_ids(region.region_type, action).include?(region.id)
-  end
-
-  def accessible_block?(region, action)
-    return true if user.power_user?
-    accessible_region_ids(region.region_type, action).include?(region.id)
-  end
+  alias_method :accessible_state?, :accessible_region?
+  alias_method :accessible_district?, :accessible_region?
+  alias_method :accessible_block?, :accessible_region?
 
   private
 

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -119,13 +119,13 @@
         <% if @region.state_region? && @region.estimated_population && @region.estimated_population.population_available_for_all_districts? %>
           <% coverage_rate = number_to_percentage(@region.estimated_population.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)), precision: 0) %>
           <% estimated_population = number_with_delimiter(@region.estimated_population.population) %>
-          <td class="type-percent d-flex"
+            <td class="type-percent d-inline-flex align-center w-full ws-nowrap"
               data-sort-column-key="population-coverage"
               data-sort="<%= coverage_rate %>"
               data-toggle="tooltip"
               title="<%= "#{number_with_delimiter(@data.dig(:cumulative_registrations, @period))} / #{estimated_population} covered" %>">
-            <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good"><%= coverage_rate %></em>
-            of <%= estimated_population %>
+              <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good mr-4px"><%= coverage_rate %></em>
+              of <%= estimated_population %>
           </td>
         <% else %>
             <td
@@ -197,13 +197,13 @@
           <% if @region.state_region? && child.estimated_population.present? %>
             <% coverage_rate = number_to_percentage(child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)), precision: 0) %>
             <% estimated_population = number_with_delimiter(child.estimated_population.population) %>
-            <td class="type-percent d-flex"
+              <td class="type-percent d-inline-flex align-center w-full ws-nowrap"
                 data-sort-column-key="population-coverage"
                 data-sort="<%= coverage_rate %>"
                 data-toggle="tooltip"
                 title="<%= "#{number_with_delimiter(result.dig(:cumulative_registrations, @period))} / #{estimated_population} covered" %>">
-              <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good"><%= coverage_rate %></em>
-              of <%= estimated_population %>
+                <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good mr-4px"><%= coverage_rate %></em>
+                of <%= estimated_population %>
             </td>
           <% else %>
               <td

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -110,10 +110,10 @@
           <%= @region.name %>
         </td>
         <td class="ta-right">
-          <%= number_with_delimiter(@data.dig(:cumulative_registrations, @period)) %>
+          <%= number_with_delimiter(@data.dig(:registrations, @period)) %>
         </td>
         <td class="ta-right">
-          <%= number_with_delimiter(@data.dig(:registrations, @period)) %>
+          <%= number_with_delimiter(@data.dig(:cumulative_registrations, @period)) %>
         </td>
         <%= can_manage_region = accessible_region?(@region, :manage) %>
         <% if @region.state_region? && @region.estimated_population && @region.estimated_population.population_available_for_all_districts? %>

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -116,25 +116,28 @@
           <%= number_with_delimiter(@data.dig(:cumulative_registrations, @period)) %>
         </td>
         <%= can_manage_region = accessible_region?(@region, :manage) %>
-        <% if @region.state_region? && @region.estimated_population && @region.estimated_population.population_available_for_all_districts? %>
-          <% coverage_rate = number_to_percentage(@region.estimated_population.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)), precision: 0) %>
-          <% estimated_population = number_with_delimiter(@region.estimated_population.population) %>
+        <% if @region.state_region? %>
+          <% if @region.estimated_population && @region.estimated_population.population_available_for_all_districts? %>
+            <% coverage_rate = number_to_percentage(@region.estimated_population.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)), precision: 0) %>
+            <% estimated_population = number_with_delimiter(@region.estimated_population.population) %>
             <td class="type-percent d-inline-flex align-center w-full ws-nowrap"
-              data-sort-column-key="population-coverage"
-              data-sort="<%= coverage_rate %>"
-              data-toggle="tooltip"
-              title="<%= "#{number_with_delimiter(@data.dig(:cumulative_registrations, @period))} / #{estimated_population} patients" %>">
+                data-sort-column-key="population-coverage"
+                data-sort="<%= coverage_rate %>"
+                data-toggle="tooltip"
+                title="<%= "#{number_with_delimiter(@data.dig(:cumulative_registrations, @period))} / #{estimated_population} patients" %>">
               <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good mr-4px"><%= coverage_rate %></em>
               of <%= estimated_population %>
-          </td>
-        <% else %>
+            </td>
+          <% else %>
             <td
               data-sort-column-key="population-coverage"
               data-sort="<%= coverage_rate %>"
               data-toggle="tooltip"
               title="<%= can_manage_region ?
                            t("population_coverage.add_missing_child_estimate.accessible_region", diagnosis: :hypertension, child_type: @region.child_region_type.pluralize) :
-                           t("population_coverage.add_missing_child_estimate.inaccessible_region", diagnosis: :hypertension, region_name: @region.name, child_type: @region.child_region_type.pluralize) %>">-</td>
+                           t("population_coverage.add_missing_child_estimate.inaccessible_region", diagnosis: :hypertension, region_name: @region.name, child_type: @region.child_region_type.pluralize) %>">-
+            </td>
+          <% end %>
         <% end %>
         <td
           class="type-percent"
@@ -194,25 +197,28 @@
           <td class="ta-right">
             <%= number_with_delimiter(result.dig(:cumulative_registrations, @period)) %>
           </td>
-          <% if @region.state_region? && child.estimated_population.present? %>
-            <% coverage_rate = number_to_percentage(child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)), precision: 0) %>
-            <% estimated_population = number_with_delimiter(child.estimated_population.population) %>
+          <% if @region.state_region? %>
+            <% if child.estimated_population.present? %>
+              <% coverage_rate = number_to_percentage(child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)), precision: 0) %>
+              <% estimated_population = number_with_delimiter(child.estimated_population.population) %>
               <td class="type-percent d-inline-flex align-center w-full ws-nowrap"
-                data-sort-column-key="population-coverage"
-                data-sort="<%= coverage_rate %>"
-                data-toggle="tooltip"
-                title="<%= "#{number_with_delimiter(result.dig(:cumulative_registrations, @period))} / #{estimated_population} patients" %>">
+                  data-sort-column-key="population-coverage"
+                  data-sort="<%= coverage_rate %>"
+                  data-toggle="tooltip"
+                  title="<%= "#{number_with_delimiter(result.dig(:cumulative_registrations, @period))} / #{estimated_population} patients" %>">
                 <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good mr-4px"><%= coverage_rate %></em>
                 of <%= estimated_population %>
-            </td>
-          <% else %>
+              </td>
+            <% else %>
               <td
                 data-sort-column-key="population-coverage"
                 data-sort="0"
                 data-toggle="tooltip"
                 title="<%= can_manage_region ?
                              t("population_coverage.add_missing_estimate.accessible_region_with_region_name", diagnosis: :hypertension, region_name: child.name) :
-                             t("population_coverage.add_missing_estimate.inaccessible_region", diagnosis: :hypertension, region_name: @region.name) %>">-</td>
+                             t("population_coverage.add_missing_estimate.inaccessible_region", diagnosis: :hypertension, region_name: @region.name) %>">-
+              </td>
+            <% end %>
           <% end %>
           <td
             class="type-percent"

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -9,6 +9,7 @@
         <col class="table-divider">
         <col>
         <col class="table-divider">
+        <col class="table-divider">
         <col>
         <col class="table-divider">
         <col>
@@ -26,6 +27,9 @@
                        "Monthly registered patients" => t("registered_patients_copy.monthly_registered_patients", region_name: @region.name)
                      }
           %>
+        </th>
+        <th colspan="1" class="sticky nowrap">
+          Coverage
         </th>
         <th colspan="2" class="sticky nowrap">
           BP controlled
@@ -69,6 +73,9 @@
           Percent
         </th>
         <th class="row-label sort-label sort-label-small" data-sort-method="number">
+          Percent
+        </th>
+        <th class="row-label sort-label sort-label-small" data-sort-method="number">
           Total
         </th>
         <th class="row-label sort-label sort-label-small" data-sort-method="number">
@@ -95,6 +102,16 @@
         </td>
         <td class="ta-right">
           <%= number_with_delimiter(@data.dig(:registrations, @period)) %>
+        </td>
+        <td class="type-percent"
+            data-sort-column-key="population-coverage"
+            data-sort="<%= @region.estimated_population&.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)) %>"
+            data-toggle="tooltip"
+            title="<%= number_with_delimiter(@data.dig(:cumulative_registrations, @period)) %> / <%= number_with_delimiter( @region.estimated_population&.population) %> patients"
+        >
+          <em data-rate="<%= @region.estimated_population&.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)) %>" class="high-is-good">
+            <%= number_to_percentage(@region.estimated_population&.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)), precision: 0) %>
+          </em> of <%= @region.estimated_population&.population %>
         </td>
         <td
           class="type-percent"
@@ -153,6 +170,16 @@
           </td>
           <td class="ta-right">
             <%= number_with_delimiter(result.dig(:registrations, @period)) %>
+          </td>
+          <td class="type-percent"
+              data-sort-column-key="population-coverage"
+              data-sort="<%= child.estimated_population&.patient_coverage_rate(result.dig(:cumulative_registrations, @period)) %>"
+              data-toggle="tooltip"
+              title="<%= number_with_delimiter(result.dig(:cumulative_registrations, @period)) %> / <%= number_with_delimiter( child.estimated_population&.population) %> patients"
+          >
+            <em data-rate="<%= child.estimated_population&.patient_coverage_rate(result.dig(:cumulative_registrations, @period)) %>" class="high-is-good">
+              <%= number_to_percentage(child.estimated_population&.patient_coverage_rate(result.dig(:cumulative_registrations, @period)), precision: 0) %>
+            </em> of <%= child.estimated_population&.population %>
           </td>
           <td
             class="type-percent"

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -126,7 +126,6 @@
                 data-toggle="tooltip"
                 title="<%= "#{number_with_delimiter(@data.dig(:cumulative_registrations, @period))} / #{estimated_population} patients" %>">
                 <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good"><%= coverage_rate %></em>
-              of <%= estimated_population %>
             </td>
           <% else %>
             <td
@@ -207,7 +206,6 @@
                   data-toggle="tooltip"
                   title="<%= "#{number_with_delimiter(result.dig(:cumulative_registrations, @period))} / #{estimated_population} patients" %>">
                   <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good"><%= coverage_rate %></em>
-                of <%= estimated_population %>
               </td>
             <% else %>
               <td

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -123,7 +123,7 @@
               data-sort-column-key="population-coverage"
               data-sort="<%= coverage_rate %>"
               data-toggle="tooltip"
-              title="<%= "#{number_with_delimiter(@data.dig(:cumulative_registrations, @period))} / #{estimated_population} covered" %>">
+              title="<%= "#{number_with_delimiter(@data.dig(:cumulative_registrations, @period))} / #{estimated_population} patients" %>">
               <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good mr-4px"><%= coverage_rate %></em>
               of <%= estimated_population %>
           </td>
@@ -201,7 +201,7 @@
                 data-sort-column-key="population-coverage"
                 data-sort="<%= coverage_rate %>"
                 data-toggle="tooltip"
-                title="<%= "#{number_with_delimiter(result.dig(:cumulative_registrations, @period))} / #{estimated_population} covered" %>">
+                title="<%= "#{number_with_delimiter(result.dig(:cumulative_registrations, @period))} / #{estimated_population} patients" %>">
                 <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good mr-4px"><%= coverage_rate %></em>
                 of <%= estimated_population %>
             </td>

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -103,16 +103,20 @@
         <td class="ta-right">
           <%= number_with_delimiter(@data.dig(:registrations, @period)) %>
         </td>
-        <td class="type-percent"
-            data-sort-column-key="population-coverage"
-            data-sort="<%= @region.estimated_population&.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)) %>"
-            data-toggle="tooltip"
-            title="<%= number_with_delimiter(@data.dig(:cumulative_registrations, @period)) %> / <%= number_with_delimiter( @region.estimated_population&.population) %> patients"
-        >
-          <em data-rate="<%= @region.estimated_population&.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)) %>" class="high-is-good">
-            <%= number_to_percentage(@region.estimated_population&.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)), precision: 0) %>
-          </em> of <%= @region.estimated_population&.population %>
-        </td>
+        <% if @region.estimated_population.present? %>
+          <td class="type-percent"
+              data-sort-column-key="population-coverage"
+              data-sort="<%= @region.estimated_population.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)) %>"
+              data-toggle="tooltip"
+              title="<%= number_with_delimiter(@data.dig(:cumulative_registrations, @period)) %> / <%= number_with_delimiter( @region.estimated_population.population) %> patients"
+          >
+            <em data-rate="<%= @region.estimated_population.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)) %>" class="high-is-good">
+              <%= number_to_percentage(@region.estimated_population.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)), precision: 0) %>
+            </em> of <%= @region.estimated_population.population %>
+          </td>
+        <% else %>
+            <td class="type-percent">-</td>
+        <% end %>
         <td
           class="type-percent"
           data-sort-column-key="total-patients-<%= @period %>"
@@ -171,16 +175,20 @@
           <td class="ta-right">
             <%= number_with_delimiter(result.dig(:registrations, @period)) %>
           </td>
-          <td class="type-percent"
-              data-sort-column-key="population-coverage"
-              data-sort="<%= child.estimated_population&.patient_coverage_rate(result.dig(:cumulative_registrations, @period)) %>"
-              data-toggle="tooltip"
-              title="<%= number_with_delimiter(result.dig(:cumulative_registrations, @period)) %> / <%= number_with_delimiter( child.estimated_population&.population) %> patients"
-          >
-            <em data-rate="<%= child.estimated_population&.patient_coverage_rate(result.dig(:cumulative_registrations, @period)) %>" class="high-is-good">
-              <%= number_to_percentage(child.estimated_population&.patient_coverage_rate(result.dig(:cumulative_registrations, @period)), precision: 0) %>
-            </em> of <%= child.estimated_population&.population %>
-          </td>
+          <% if child.estimated_population.present? %>
+            <td class="type-percent"
+                data-sort-column-key="population-coverage"
+                data-sort="<%= child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)) %>"
+                data-toggle="tooltip"
+                title="<%= number_with_delimiter(result.dig(:cumulative_registrations, @period)) %> / <%= number_with_delimiter( child.estimated_population.population) %> patients"
+            >
+              <em data-rate="<%= child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)) %>" class="high-is-good">
+                <%= number_to_percentage(child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)), precision: 0) %>
+              </em> of <%= child.estimated_population.population %>
+            </td>
+          <% else %>
+            <td class="type-percent"> - </td>
+          <% end %>
           <td
             class="type-percent"
             data-sort-column-key="total-patients-<%= @period %>"

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -120,12 +120,12 @@
           <% if @region.estimated_population && @region.estimated_population.population_available_for_all_districts? %>
             <% coverage_rate = number_to_percentage(@region.estimated_population.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)), precision: 0) %>
             <% estimated_population = number_with_delimiter(@region.estimated_population.population) %>
-            <td class="type-percent d-inline-flex align-center w-full ws-nowrap"
+              <td class="type-percent"
                 data-sort-column-key="population-coverage"
                 data-sort="<%= coverage_rate %>"
                 data-toggle="tooltip"
                 title="<%= "#{number_with_delimiter(@data.dig(:cumulative_registrations, @period))} / #{estimated_population} patients" %>">
-              <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good mr-4px"><%= coverage_rate %></em>
+                <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good"><%= coverage_rate %></em>
               of <%= estimated_population %>
             </td>
           <% else %>
@@ -201,12 +201,12 @@
             <% if child.estimated_population.present? %>
               <% coverage_rate = number_to_percentage(child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)), precision: 0) %>
               <% estimated_population = number_with_delimiter(child.estimated_population.population) %>
-              <td class="type-percent d-inline-flex align-center w-full ws-nowrap"
+                <td class="type-percent"
                   data-sort-column-key="population-coverage"
                   data-sort="<%= coverage_rate %>"
                   data-toggle="tooltip"
                   title="<%= "#{number_with_delimiter(result.dig(:cumulative_registrations, @period))} / #{estimated_population} patients" %>">
-                <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good mr-4px"><%= coverage_rate %></em>
+                  <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good"><%= coverage_rate %></em>
                 of <%= estimated_population %>
               </td>
             <% else %>

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -128,7 +128,7 @@
             of <%= estimated_population %>
           </td>
         <% else %>
-          <td class="type-percent d-flex"
+            <td
               data-sort-column-key="population-coverage"
               data-sort="<%= coverage_rate %>"
               data-toggle="tooltip"
@@ -206,7 +206,7 @@
               of <%= estimated_population %>
             </td>
           <% else %>
-            <td class="type-percent d-flex"
+              <td
                 data-sort-column-key="population-coverage"
                 data-sort="0"
                 data-toggle="tooltip"

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -189,10 +189,10 @@
             <% end %>
           </td>
           <td class="ta-right">
-            <%= number_with_delimiter(result.dig(:cumulative_registrations, @period)) %>
+            <%= number_with_delimiter(result.dig(:registrations, @period)) %>
           </td>
           <td class="ta-right">
-            <%= number_with_delimiter(result.dig(:registrations, @period)) %>
+            <%= number_with_delimiter(result.dig(:cumulative_registrations, @period)) %>
           </td>
           <% if @region.state_region? && child.estimated_population.present? %>
             <% coverage_rate = number_to_percentage(child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)), precision: 0) %>

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -104,15 +104,14 @@
           <%= number_with_delimiter(@data.dig(:registrations, @period)) %>
         </td>
         <% if @region.estimated_population.present? %>
-          <td class="type-percent"
+          <% coverage_rate =  number_to_percentage(@region.estimated_population.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)), precision: 0) %>
+          <% estimated_population = number_with_delimiter(@region.estimated_population.population) %>
+          <td class="type-percent d-flex"
               data-sort-column-key="population-coverage"
-              data-sort="<%= @region.estimated_population.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)) %>"
+              data-sort="<%= coverage_rate %>"
               data-toggle="tooltip"
-              title="<%= number_with_delimiter(@data.dig(:cumulative_registrations, @period)) %> / <%= number_with_delimiter( @region.estimated_population.population) %> patients"
-          >
-            <em data-rate="<%= @region.estimated_population.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)) %>" class="high-is-good">
-              <%= number_to_percentage(@region.estimated_population.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)), precision: 0) %>
-            </em> of <%= @region.estimated_population.population %>
+              title="<%= "#{number_with_delimiter(@data.dig(:cumulative_registrations, @period))} / #{estimated_population}} patients" %>">
+            <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good"><%= coverage_rate %></em> of <%= estimated_population %>
           </td>
         <% else %>
             <td class="type-percent">-</td>
@@ -176,18 +175,17 @@
             <%= number_with_delimiter(result.dig(:registrations, @period)) %>
           </td>
           <% if child.estimated_population.present? %>
-            <td class="type-percent"
+            <% coverage_rate =  number_to_percentage(child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)), precision: 0) %>
+            <% estimated_population = number_with_delimiter(child.estimated_population.population) %>
+            <td class="type-percent d-flex"
                 data-sort-column-key="population-coverage"
-                data-sort="<%= child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)) %>"
+                data-sort="<%= coverage_rate %>"
                 data-toggle="tooltip"
-                title="<%= number_with_delimiter(result.dig(:cumulative_registrations, @period)) %> / <%= number_with_delimiter( child.estimated_population.population) %> patients"
-            >
-              <em data-rate="<%= child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)) %>" class="high-is-good">
-                <%= number_to_percentage(child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)), precision: 0) %>
-              </em> of <%= child.estimated_population.population %>
+                title="<%= "#{number_with_delimiter(result.dig(:cumulative_registrations, @period))} / #{estimated_population}} patients" %>">
+              <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good"><%= coverage_rate %></em> of <%= estimated_population %>
             </td>
           <% else %>
-            <td class="type-percent"> - </td>
+            <td class="type-percent">-</td>
           <% end %>
           <td
             class="type-percent"

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -35,8 +35,8 @@
             Coverage
             <%= render "definition_tooltip",
                        definitions: {
-                         "Total registered patients" => t("registered_patients_copy.total_registered_patients", region_name: @region.name),
-                         "Estimated population" => t("population_coverage.denominator", diagnosis: :hypertension, region_name: @region.name)
+                         "Numerator" => t("population_coverage.numerator", diagnosis: :hypertension),
+                         "Denominator" => t("population_coverage.denominator", diagnosis: :hypertension)
                        }
             %>
           </th>

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -8,7 +8,9 @@
         <col class="table-first-col">
         <col class="table-divider">
         <col>
-        <col class="table-divider">
+        <% if @region.state_region? %>
+          <col class="table-divider">
+        <% end %>
         <col class="table-divider">
         <col>
         <col class="table-divider">
@@ -28,9 +30,17 @@
                      }
           %>
         </th>
-        <th colspan="1" class="sticky nowrap">
-          Coverage
-        </th>
+        <% if @region.state_region? %>
+          <th colspan="1" class="sticky nowrap">
+            Coverage
+            <%= render "definition_tooltip",
+                       definitions: {
+                         "Total registered patients" => t("registered_patients_copy.total_registered_patients", region_name: @region.name),
+                         "Estimated population" => t("population_coverage.denominator", diagnosis: :hypertension, region_name: @region.name)
+                       }
+            %>
+          </th>
+        <% end %>
         <th colspan="2" class="sticky nowrap">
           BP controlled
           <%= render "definition_tooltip",
@@ -64,14 +74,16 @@
           <%= localized_region_type.capitalize %>
         </th>
         <th class="row-label sort-label sort-label-small" data-sort-method="number">
-          Total
-        </th>
-        <th class="row-label sort-label sort-label-small" data-sort-method="number">
           <%= @period.to_s %>
         </th>
         <th class="row-label sort-label sort-label-small" data-sort-method="number">
-          Percent
+          Total
         </th>
+        <% if @region.state_region? %>
+          <th class="row-label sort-label sort-label-small" data-sort-method="number">
+            Percent
+          </th>
+        <% end %>
         <th class="row-label sort-label sort-label-small" data-sort-method="number">
           Percent
         </th>
@@ -103,18 +115,26 @@
         <td class="ta-right">
           <%= number_with_delimiter(@data.dig(:registrations, @period)) %>
         </td>
-        <% if @region.estimated_population.present? %>
-          <% coverage_rate =  number_to_percentage(@region.estimated_population.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)), precision: 0) %>
+        <%= can_manage_region = accessible_region?(@region, :manage) %>
+        <% if @region.state_region? && @region.estimated_population && @region.estimated_population.population_available_for_all_districts? %>
+          <% coverage_rate = number_to_percentage(@region.estimated_population.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)), precision: 0) %>
           <% estimated_population = number_with_delimiter(@region.estimated_population.population) %>
           <td class="type-percent d-flex"
               data-sort-column-key="population-coverage"
               data-sort="<%= coverage_rate %>"
               data-toggle="tooltip"
-              title="<%= "#{number_with_delimiter(@data.dig(:cumulative_registrations, @period))} / #{estimated_population}} patients" %>">
-            <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good"><%= coverage_rate %></em> of <%= estimated_population %>
+              title="<%= "#{number_with_delimiter(@data.dig(:cumulative_registrations, @period))} / #{estimated_population} covered" %>">
+            <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good"><%= coverage_rate %></em>
+            of <%= estimated_population %>
           </td>
         <% else %>
-            <td class="type-percent">-</td>
+          <td class="type-percent d-flex"
+              data-sort-column-key="population-coverage"
+              data-sort="<%= coverage_rate %>"
+              data-toggle="tooltip"
+              title="<%= can_manage_region ?
+                           t("population_coverage.add_missing_child_estimate.accessible_region", diagnosis: :hypertension, child_type: @region.child_region_type.pluralize) :
+                           t("population_coverage.add_missing_child_estimate.inaccessible_region", diagnosis: :hypertension, region_name: @region.name, child_type: @region.child_region_type.pluralize) %>">-</td>
         <% end %>
         <td
           class="type-percent"
@@ -174,18 +194,25 @@
           <td class="ta-right">
             <%= number_with_delimiter(result.dig(:registrations, @period)) %>
           </td>
-          <% if child.estimated_population.present? %>
-            <% coverage_rate =  number_to_percentage(child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)), precision: 0) %>
+          <% if @region.state_region? && child.estimated_population.present? %>
+            <% coverage_rate = number_to_percentage(child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)), precision: 0) %>
             <% estimated_population = number_with_delimiter(child.estimated_population.population) %>
             <td class="type-percent d-flex"
                 data-sort-column-key="population-coverage"
                 data-sort="<%= coverage_rate %>"
                 data-toggle="tooltip"
-                title="<%= "#{number_with_delimiter(result.dig(:cumulative_registrations, @period))} / #{estimated_population}} patients" %>">
-              <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good"><%= coverage_rate %></em> of <%= estimated_population %>
+                title="<%= "#{number_with_delimiter(result.dig(:cumulative_registrations, @period))} / #{estimated_population} covered" %>">
+              <em data-rate="<%= coverage_rate.to_i %>" class="high-is-good"><%= coverage_rate %></em>
+              of <%= estimated_population %>
             </td>
           <% else %>
-            <td class="type-percent">-</td>
+            <td class="type-percent d-flex"
+                data-sort-column-key="population-coverage"
+                data-sort="0"
+                data-toggle="tooltip"
+                title="<%= can_manage_region ?
+                             t("population_coverage.add_missing_estimate.accessible_region_with_region_name", diagnosis: :hypertension, region_name: child.name) :
+                             t("population_coverage.add_missing_estimate.inaccessible_region", diagnosis: :hypertension, region_name: @region.name) %>">-</td>
           <% end %>
           <td
             class="type-percent"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,15 @@ en:
     reports_card_subtitle: "Monthly and total hypertension patients registered in %{region_name}"
     monthly_registered_patients: "Hypertension patients registered during a month in %{region_name}."
     total_registered_patients: "Total hypertension patients registered in %{region_name}."
+  population_coverage:
+    denominator: "All individuals and patients with %{diagnosis} in %{region_name}"
+    add_missing_estimate:
+      accessible_region: "Add the estimated %{diagnosis} population to see the coverage rate."
+      accessible_region_with_region_name: "Add the estimated %{diagnosis} population for %{region_name} to see the coverage rate."
+      inaccessible_region: "Ask a Dashboard admin to add the est. population with %{diagnosis} for %{@region_name} to see the %{diagnosis} coverage rate."
+    add_missing_child_estimate:
+      accessible_region: "Add the estimated population of %{diagnosis} patients for all %{child_type} to see the coverage rate."
+      inaccessible_region: "Ask a Dashboard admin to add the est. population with %{diagnosis} for all %{child_type} in %{@region.name} to see the %{diagnosis} coverage rate."
   registered_diabetes_patients_copy:
     reports_card_subtitle: "Monthly and total diabetes patient registrations and follow-up visits in %{region_name}"
     monthly_registered_patients: "Diabetes patients registered during a month in %{region_name}."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,10 +111,10 @@ en:
     add_missing_estimate:
       accessible_region: "Add the estimated %{diagnosis} population to see the coverage rate."
       accessible_region_with_region_name: "Add the estimated %{diagnosis} population for %{region_name} to see the coverage rate."
-      inaccessible_region: "Ask a Dashboard admin to add the est. population with %{diagnosis} for %{@region_name} to see the %{diagnosis} coverage rate."
+      inaccessible_region: "Ask a Dashboard admin to add the estimated population with %{diagnosis} for %{@region_name} to see the %{diagnosis} coverage rate."
     add_missing_child_estimate:
       accessible_region: "Add the estimated population of %{diagnosis} patients for all %{child_type} to see the coverage rate."
-      inaccessible_region: "Ask a Dashboard admin to add the est. population with %{diagnosis} for all %{child_type} in %{@region.name} to see the %{diagnosis} coverage rate."
+      inaccessible_region: "Ask a Dashboard admin to add the estimated population with %{diagnosis} for all %{child_type} in %{@region.name} to see the %{diagnosis} coverage rate."
   registered_diabetes_patients_copy:
     reports_card_subtitle: "Monthly and total diabetes patient registrations and follow-up visits in %{region_name}"
     monthly_registered_patients: "Diabetes patients registered during a month in %{region_name}."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,7 +107,8 @@ en:
     monthly_registered_patients: "Hypertension patients registered during a month in %{region_name}."
     total_registered_patients: "Total hypertension patients registered in %{region_name}."
   population_coverage:
-    denominator: "All individuals and patients with %{diagnosis} in %{region_name}"
+    numerator: "Total %{diagnosis} patients registered."
+    denominator: "Total estimated population with %{diagnosis}."
     add_missing_estimate:
       accessible_region: "Add the estimated %{diagnosis} population to see the coverage rate."
       accessible_region_with_region_name: "Add the estimated %{diagnosis} population for %{region_name} to see the coverage rate."


### PR DESCRIPTION
**Story card:** [sc-9941](https://app.shortcut.com/simpledotorg/story/9941/include-percentage-of-registration-beside-cumulative-registration-in-dashboard)

## Because

West Bengal has requested that on the dashboard we are able to show the percentage of patients registered against the total hypertensive population to enable CVHOs immediately identify how many more patients of the estimated hypertension population need to be reached. 

## This addresses

Adds a column in the Hypertension Indicators table on the Report page for states and organisations with % registration coverage across the region's estimated hypertensive population.

## Test instructions

- Go to a state/organization's hypertension report page
- Add estimated populations
- Check the Hypertension Indicators table for the coverage %s split across subregions