### PR TITLE
Update Questionnaire layout DSL

### DIFF
--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -43,7 +43,7 @@ class Questionnaire < ApplicationRecord
 
   def layout_schema
     # TODO: When dsl_version is incremented, insert a switch here.
-    Api::V4::Models::Questionnaires::Version1.group.merge(
+    Api::V4::Models::Questionnaires::Version1.view_group.merge(
       definitions: Api::V4::Schema.all_definitions
     )
   end

--- a/app/schema/api/v4/models.rb
+++ b/app/schema/api/v4/models.rb
@@ -396,7 +396,7 @@ class Api::V4::Models
          questionnaire_type: {type: :string, enum: Questionnaire.questionnaire_types.keys},
          layout: {
            oneOf: [
-             {"$ref" => "#/definitions/questionnaire_group_dsl_1"}
+             {"$ref" => "#/definitions/questionnaire_view_group_dsl_1"}
            ]
          },
          deleted_at: {"$ref" => "#/definitions/nullable_timestamp"}

--- a/app/schema/api/v4/models/questionnaires/monthly_screening_report.rb
+++ b/app/schema/api/v4/models/questionnaires/monthly_screening_report.rb
@@ -16,15 +16,25 @@ class Api::V4::Models::Questionnaires::MonthlyScreeningReport
             view_type: "sub_header"
           },
           {
-            type: "integer",
-            id: "3bda5cb0-de8e-463e-9d7c-54a7215e4077",
-            link_id: "monthly_screening_reports.outpatient_department_visits",
-            text: "Outpatient department visits",
-            view_type: "input_field",
-            validations: {
-              min: 0,
-              max: 1_000_000
-            }
+            id: "964f8d0f-ecaf-4b9e-87e8-62614ff5c7db",
+            type: "group",
+            view_type: "input_view_group",
+            display_properties: {
+              orientation: "horizontal"
+            },
+            item: [
+              {
+                type: "integer",
+                id: "3bda5cb0-de8e-463e-9d7c-54a7215e4077",
+                link_id: "monthly_screening_reports.outpatient_department_visits",
+                text: "Outpatient department visits",
+                view_type: "input_field",
+                validations: {
+                  min: 0,
+                  max: 1_000_000
+                }
+              }
+            ]
           },
           {
             type: "display",
@@ -46,7 +56,7 @@ class Api::V4::Models::Questionnaires::MonthlyScreeningReport
           {
             type: "group",
             id: "b39903c9-04e2-4fd8-9218-6ff5e5cf6466",
-            view_type: "view_group",
+            view_type: "input_view_group",
             display_properties: {
               orientation: "horizontal"
             },

--- a/app/schema/api/v4/models/questionnaires/version1.rb
+++ b/app/schema/api/v4/models/questionnaires/version1.rb
@@ -2,14 +2,15 @@ class Api::V4::Models::Questionnaires::Version1
   class << self
     def definitions
       {
-        questionnaire_group_dsl_1: group,
+        questionnaire_view_group_dsl_1: view_group,
+        questionnaire_input_view_group_dsl_1: input_view_group,
         questionnaire_display_dsl_1: display,
         questionnaire_line_break_dsl_1: line_break,
         questionnaire_integer_input_dsl_1: integer_input
       }
     end
 
-    def group
+    def view_group
       {
         type: :object,
         example: Api::V4::Models::Questionnaires::MonthlyScreeningReport.layout,
@@ -17,20 +18,34 @@ class Api::V4::Models::Questionnaires::Version1
           type: {type: :string, enum: %w[group]},
           id: {"$ref" => "#/definitions/uuid"},
           view_type: {type: :string, enum: %w[view_group]},
-          display_properties: {
-            type: :object,
-            properties: {
-              orientation: {type: :string, enum: %w[horizontal vertical]}
-            },
-            required: %w[orientation]
-          },
+          display_properties: display_properties,
           item: {
             type: :array,
             items: {
               oneOf: [
-                {"$ref" => "#/definitions/questionnaire_group_dsl_1"},
+                {"$ref" => "#/definitions/questionnaire_input_view_group_dsl_1"},
                 {"$ref" => "#/definitions/questionnaire_display_dsl_1"},
-                {"$ref" => "#/definitions/questionnaire_line_break_dsl_1"},
+                {"$ref" => "#/definitions/questionnaire_line_break_dsl_1"}
+              ]
+            }
+          }
+        },
+        required: %w[type id view_type display_properties item]
+      }
+    end
+
+    def input_view_group
+      {
+        type: :object,
+        properties: {
+          type: {type: :string, enum: %w[group]},
+          id: {"$ref" => "#/definitions/uuid"},
+          view_type: {type: :string, enum: %w[input_view_group]},
+          display_properties: display_properties,
+          item: {
+            type: :array,
+            items: {
+              oneOf: [
                 {"$ref" => "#/definitions/questionnaire_integer_input_dsl_1"}
               ]
             }
@@ -84,6 +99,16 @@ class Api::V4::Models::Questionnaires::Version1
           }
         },
         required: %w[type id link_id text view_type validations]
+      }
+    end
+
+    def display_properties
+      {
+        type: :object,
+        properties: {
+          orientation: {type: :string, enum: %w[horizontal vertical]}
+        },
+        required: %w[orientation]
       }
     end
   end

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Questionnaire, type: :model do
       }.to change { Questionnaire.count }.by 3
     end
 
-    it "validates the layout using the swagger schema" do
-      questionnaire = build(:questionnaire)
+    it "validates the specimen layout using the swagger schema" do
+      questionnaire = build(:questionnaire, layout: Api::V4::Models::Questionnaires::MonthlyScreeningReport.layout)
       expect(questionnaire).to receive(:validate_layout).and_call_original
 
       questionnaire.save!

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -2744,7 +2744,7 @@
         "layout": {
           "oneOf": [
             {
-              "$ref": "#/definitions/questionnaire_group_dsl_1"
+              "$ref": "#/definitions/questionnaire_view_group_dsl_1"
             }
           ]
         },
@@ -2821,7 +2821,7 @@
         "$ref": "#/definitions/questionnaire_response"
       }
     },
-    "questionnaire_group_dsl_1": {
+    "questionnaire_view_group_dsl_1": {
       "type": "object",
       "example": {
         "type": "group",
@@ -2838,15 +2838,25 @@
             "view_type": "sub_header"
           },
           {
-            "type": "integer",
-            "id": "3bda5cb0-de8e-463e-9d7c-54a7215e4077",
-            "link_id": "monthly_screening_reports.outpatient_department_visits",
-            "text": "Outpatient department visits",
-            "view_type": "input_field",
-            "validations": {
-              "min": 0,
-              "max": 1000000
-            }
+            "id": "964f8d0f-ecaf-4b9e-87e8-62614ff5c7db",
+            "type": "group",
+            "view_type": "input_view_group",
+            "display_properties": {
+              "orientation": "horizontal"
+            },
+            "item": [
+              {
+                "type": "integer",
+                "id": "3bda5cb0-de8e-463e-9d7c-54a7215e4077",
+                "link_id": "monthly_screening_reports.outpatient_department_visits",
+                "text": "Outpatient department visits",
+                "view_type": "input_field",
+                "validations": {
+                  "min": 0,
+                  "max": 1000000
+                }
+              }
+            ]
           },
           {
             "type": "display",
@@ -2868,7 +2878,7 @@
           {
             "type": "group",
             "id": "b39903c9-04e2-4fd8-9218-6ff5e5cf6466",
-            "view_type": "view_group",
+            "view_type": "input_view_group",
             "display_properties": {
               "orientation": "horizontal"
             },
@@ -2945,14 +2955,63 @@
           "items": {
             "oneOf": [
               {
-                "$ref": "#/definitions/questionnaire_group_dsl_1"
+                "$ref": "#/definitions/questionnaire_input_view_group_dsl_1"
               },
               {
                 "$ref": "#/definitions/questionnaire_display_dsl_1"
               },
               {
                 "$ref": "#/definitions/questionnaire_line_break_dsl_1"
-              },
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "type",
+        "id",
+        "view_type",
+        "display_properties",
+        "item"
+      ]
+    },
+    "questionnaire_input_view_group_dsl_1": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "group"
+          ]
+        },
+        "id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "view_type": {
+          "type": "string",
+          "enum": [
+            "input_view_group"
+          ]
+        },
+        "display_properties": {
+          "type": "object",
+          "properties": {
+            "orientation": {
+              "type": "string",
+              "enum": [
+                "horizontal",
+                "vertical"
+              ]
+            }
+          },
+          "required": [
+            "orientation"
+          ]
+        },
+        "item": {
+          "type": "array",
+          "items": {
+            "oneOf": [
               {
                 "$ref": "#/definitions/questionnaire_integer_input_dsl_1"
               }


### PR DESCRIPTION
**Story card:** [sc-10010](https://app.shortcut.com/simpledotorg/story/10010/update-monthly-screening-reports-questionnaire-layout?vc_group_by=day&ct_workflow=all&cf_workflow=500000031)

## Because

1. Android needs to separate a `view_group` from an `input_view_group`.
2. An input field cannot be independent, but always be a part of input_view_group. Reason for this is margins & padding around it.

## This addresses

Questionnaire DSL rendering issues on mobile