### PR TITLE
Remove orientation form Questionnaire Layout DSL

### DIFF
--- a/app/schema/api/v4/models/questionnaires/monthly_screening_report.rb
+++ b/app/schema/api/v4/models/questionnaires/monthly_screening_report.rb
@@ -5,9 +5,6 @@ class Api::V4::Models::Questionnaires::MonthlyScreeningReport
         type: "group",
         id: "2e8ce537-616c-4c4c-a651-ad065d05f220",
         view_type: "view_group",
-        display_properties: {
-          orientation: "vertical"
-        },
         item: [
           {
             type: "display",
@@ -19,9 +16,6 @@ class Api::V4::Models::Questionnaires::MonthlyScreeningReport
             id: "964f8d0f-ecaf-4b9e-87e8-62614ff5c7db",
             type: "group",
             view_type: "input_view_group",
-            display_properties: {
-              orientation: "horizontal"
-            },
             item: [
               {
                 type: "integer",
@@ -57,9 +51,6 @@ class Api::V4::Models::Questionnaires::MonthlyScreeningReport
             type: "group",
             id: "b39903c9-04e2-4fd8-9218-6ff5e5cf6466",
             view_type: "input_view_group",
-            display_properties: {
-              orientation: "horizontal"
-            },
             item: [
               {
                 type: "integer",

--- a/app/schema/api/v4/models/questionnaires/version1.rb
+++ b/app/schema/api/v4/models/questionnaires/version1.rb
@@ -18,7 +18,6 @@ class Api::V4::Models::Questionnaires::Version1
           type: {type: :string, enum: %w[group]},
           id: {"$ref" => "#/definitions/uuid"},
           view_type: {type: :string, enum: %w[view_group]},
-          display_properties: display_properties,
           item: {
             type: :array,
             items: {
@@ -30,7 +29,7 @@ class Api::V4::Models::Questionnaires::Version1
             }
           }
         },
-        required: %w[type id view_type display_properties item]
+        required: %w[type id view_type item]
       }
     end
 
@@ -41,7 +40,6 @@ class Api::V4::Models::Questionnaires::Version1
           type: {type: :string, enum: %w[group]},
           id: {"$ref" => "#/definitions/uuid"},
           view_type: {type: :string, enum: %w[input_view_group]},
-          display_properties: display_properties,
           item: {
             type: :array,
             items: {
@@ -51,7 +49,7 @@ class Api::V4::Models::Questionnaires::Version1
             }
           }
         },
-        required: %w[type id view_type display_properties item]
+        required: %w[type id view_type item]
       }
     end
 
@@ -99,16 +97,6 @@ class Api::V4::Models::Questionnaires::Version1
           }
         },
         required: %w[type id link_id text view_type validations]
-      }
-    end
-
-    def display_properties
-      {
-        type: :object,
-        properties: {
-          orientation: {type: :string, enum: %w[horizontal vertical]}
-        },
-        required: %w[orientation]
       }
     end
   end

--- a/spec/factories/questionnaires.rb
+++ b/spec/factories/questionnaires.rb
@@ -8,9 +8,6 @@ FactoryBot.define do
       {
         type: "group",
         view_type: "view_group",
-        display_properties: {
-          orientation: "vertical"
-        },
         item: []
       }
     }

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -2827,9 +2827,6 @@
         "type": "group",
         "id": "2e8ce537-616c-4c4c-a651-ad065d05f220",
         "view_type": "view_group",
-        "display_properties": {
-          "orientation": "vertical"
-        },
         "item": [
           {
             "type": "display",
@@ -2841,9 +2838,6 @@
             "id": "964f8d0f-ecaf-4b9e-87e8-62614ff5c7db",
             "type": "group",
             "view_type": "input_view_group",
-            "display_properties": {
-              "orientation": "horizontal"
-            },
             "item": [
               {
                 "type": "integer",
@@ -2879,9 +2873,6 @@
             "type": "group",
             "id": "b39903c9-04e2-4fd8-9218-6ff5e5cf6466",
             "view_type": "input_view_group",
-            "display_properties": {
-              "orientation": "horizontal"
-            },
             "item": [
               {
                 "type": "integer",
@@ -2935,21 +2926,6 @@
             "view_group"
           ]
         },
-        "display_properties": {
-          "type": "object",
-          "properties": {
-            "orientation": {
-              "type": "string",
-              "enum": [
-                "horizontal",
-                "vertical"
-              ]
-            }
-          },
-          "required": [
-            "orientation"
-          ]
-        },
         "item": {
           "type": "array",
           "items": {
@@ -2971,7 +2947,6 @@
         "type",
         "id",
         "view_type",
-        "display_properties",
         "item"
       ]
     },
@@ -2993,21 +2968,6 @@
             "input_view_group"
           ]
         },
-        "display_properties": {
-          "type": "object",
-          "properties": {
-            "orientation": {
-              "type": "string",
-              "enum": [
-                "horizontal",
-                "vertical"
-              ]
-            }
-          },
-          "required": [
-            "orientation"
-          ]
-        },
         "item": {
           "type": "array",
           "items": {
@@ -3023,7 +2983,6 @@
         "type",
         "id",
         "view_type",
-        "display_properties",
         "item"
       ]
     },


### PR DESCRIPTION
- Orientation is redundant and can be inferred from the count of objects in a group
- More than 1 items in group imply horizontal orientation
- For vertical orientation, create 2 separate groups

**Story card:** [sc-10088](https://app.shortcut.com/simpledotorg/story/10088/remove-orientation-from-questionnaire-dsl)
