### PR TITLE
Hide user-wise follow up counts in facility reports

### DIFF
--- a/app/views/reports/regions/_facility_details.html.erb
+++ b/app/views/reports/regions/_facility_details.html.erb
@@ -33,9 +33,11 @@
           <th colspan="6">
             Monthly registered patients
           </th>
+          <% unless Flipper.enabled?(:hide_facility_follow_up_patients_per_user) %>
           <th colspan="6">
             Follow-up patients per user
           </th>
+          <% end %>
         </tr>
         <tr class="sorts" data-sort-method="thead">
           <th class="row-label sort-label sort-label-small sticky" data-sort-default>
@@ -49,10 +51,12 @@
               <%= period %>
             </th>
           <% end %>
-          <% @details_period_range.each do |period| %>
-            <th class="row-label sort-label sort-label-small sticky" data-sort-method="number">
-              <%= period %>
-            </th>
+          <% unless Flipper.enabled?(:hide_facility_follow_up_patients_per_user) %>
+            <% @details_period_range.each do |period| %>
+              <th class="row-label sort-label sort-label-small sticky" data-sort-method="number">
+                <%= period %>
+              </th>
+            <% end %>
           <% end %>
         </tr>
       </thead>
@@ -72,11 +76,13 @@
                 <%= number_or_dash_with_delimiter(@repository.monthly_registrations_by_user.dig(@region.slug, period, resource.id)) %>
               </td>
             <% end %>
-            <% @details_period_range.each do |period| %>
-              <td class="ta-right">
-                <%= val = @repository.hypertension_follow_ups(group_by: "blood_pressures.user_id").dig(@region.slug, period, resource.id)
-                  number_or_dash_with_delimiter(val) %>
-              </td>
+            <% unless Flipper.enabled?(:hide_facility_follow_up_patients_per_user) %>
+              <% @details_period_range.each do |period| %>
+                <td class="ta-right">
+                  <%= val = @repository.hypertension_follow_ups(group_by: "blood_pressures.user_id").dig(@region.slug, period, resource.id)
+                      number_or_dash_with_delimiter(val) %>
+                </td>
+              <% end %>
             <% end %>
           </tr>
         <% end %>

--- a/doc/wiki/feature-flags.md
+++ b/doc/wiki/feature-flags.md
@@ -26,3 +26,5 @@ to facility the launch of a new feature, and may reference the Simple team's int
 | sync_encounters | Yes | When enabled, encounters can be synced between app and server like any other standard sync resource. |
 | automated_telemed_report | Yes | When enabled, a monthly report on telemedicine activity in Simple will be sent via email to the configured recipients. |
 | whatsapp_appointment_reminders | Yes | When enabled, patient reminder messages will be attempted via Whatsapp first, before falling back to SMS. |
+| monthly_screening_reports | Yes | When enabled, a cron job will run on first of every month and pre-fill screening reports with follow-up data from previous month. |
+| hide_facility_follow_up_patients_per_user | Yes | When enabled, hides the follow-up patients per user section in facility level dashboard reports. |


### PR DESCRIPTION
**Story card:** [sc-9349](https://app.shortcut.com/simpledotorg/story/9349/investigate-slow-facility-level-reports)

## Because

Facility level reports take too long to render. Users can reload the page multiple times due to unresponsiveness which causes passenger queues to fill up. This causes downtime.

## This addresses

The slowness comes from the follow up counts by user section. This query is not cached and is aggregated in realtime.

This PR hides this section (and avoids making that query) until we figure out an optimization to avoid intermittent downtimes.

**Before**
<img width="1386" alt="image" src="https://user-images.githubusercontent.com/16774200/219028574-b60b0d2f-73ef-4ef6-b62f-f4ca4b94b11b.png">

**After**
<img width="1393" alt="image" src="https://user-images.githubusercontent.com/16774200/219028671-8bc0145d-ef8d-47d1-9f59-22070a422aa6.png">

