### PR TITLE
Use sender id for Alpha sms

### DIFF
--- a/app/services/messaging/alpha_sms/api.rb
+++ b/app/services/messaging/alpha_sms/api.rb
@@ -1,4 +1,5 @@
 class Messaging::AlphaSms::Api
+  SENDER_ID = ENV["ALPHA_SMS_SENDER_ID"]
   HOST = "api.sms.net.bd"
   URL_PATHS = {
     send_sms: "/sendsms",
@@ -13,7 +14,7 @@ class Messaging::AlphaSms::Api
   end
 
   def send_sms(recipient_number:, message:)
-    post(URL_PATHS[:send_sms], msg: message, to: recipient_number)
+    post(URL_PATHS[:send_sms], msg: message, to: recipient_number, sender_id: SENDER_ID)
   end
 
   def get_message_status_report(request_id)

--- a/app/services/messaging/alpha_sms/api.rb
+++ b/app/services/messaging/alpha_sms/api.rb
@@ -1,5 +1,4 @@
 class Messaging::AlphaSms::Api
-  SENDER_ID = ENV["ALPHA_SMS_SENDER_ID"]
   HOST = "api.sms.net.bd"
   URL_PATHS = {
     send_sms: "/sendsms",
@@ -14,7 +13,7 @@ class Messaging::AlphaSms::Api
   end
 
   def send_sms(recipient_number:, message:)
-    post(URL_PATHS[:send_sms], msg: message, to: recipient_number, sender_id: SENDER_ID)
+    post(URL_PATHS[:send_sms], msg: message, to: recipient_number, sender_id: sender_id)
   end
 
   def get_message_status_report(request_id)
@@ -29,6 +28,10 @@ class Messaging::AlphaSms::Api
 
   def api_key
     ENV["ALPHA_SMS_API_KEY"]
+  end
+
+  def sender_id
+    ENV["ALPHA_SMS_SENDER_ID"]
   end
 
   def post(path, body = {})

--- a/doc/wiki/feature-flags.md
+++ b/doc/wiki/feature-flags.md
@@ -16,11 +16,11 @@ to facility the launch of a new feature, and may reference the Simple team's int
 | disregard_messaging_window | No | When enabled, Simple Server will send reminder messages to patients as soon as they are scheduled, disregarding the configured time window for patient messaging (eg 10am-6pm). |
 | drug_stocks | Yes | When enabled, the Simple Dashboard and app will allow configuration and submission of drug stock reports. |
 | exotel_whitelist_api | Yes | When enabled, Simple Server will validate patient phone numbers with Exotel on a nightly basis to determine the phone number type (eg. mobile) as well as assess whether any of the phone numbers are part of Do-Not-Disturb lists. |
-| experiment | Yes | When enabled, Simple Server will send experimental patient reminder messages based on any running patient reminder A/B experiments. |
+| experiment | Yes | When enabled, Simple Server will send experimental patient reminder messages based on any running patient reminder A/B experiments. This shouldn't be enabled in combination with `notifications`. |
 | fixed_otp | No | When enabled, Simple Server will freeze all app user OTPs to `000000`. Intended for use in test environments only. |
 | force_mark_patient_mobile_numbers | Yes | When enabled, Simple Server will automatically mark all patient phone numbers as "mobile" on a nightly basis. Disable this if patient phone number types are validated through other means (eg. Exotel API in India). |
 | generate_encounter_id_endpoint | No | When enabled, the Simple API exposes a "generate_id" endpoint on the encounters sync resource. This endpoint would be used if encounter records were created client-side. |
-| notifications | Yes | When enabled, Simple Server will send patient reminder messages. |
+| notifications | Yes | When enabled, Simple Server will send patient reminder messages. This shouldn't be enabled in combination with `experiment`. |
 | organization_reports | Yes | When enabled, the Simple Dashboard will allow users to view a top-level report for the whole organization. |
 | skip_api_validation | Yes | When enabled, Simple Server will not perform JSON validation of incoming API requests. This makes the API endpoints much more performant, but should only be enabled if all API clients are trusted (Simple app only). |
 | sync_encounters | Yes | When enabled, encounters can be synced between app and server like any other standard sync resource. |

--- a/spec/services/messaging/alpha_sms/api_spec.rb
+++ b/spec/services/messaging/alpha_sms/api_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Messaging::AlphaSms::Api do
   def stub_credentials
     allow(ENV).to receive(:[]).and_call_original
     allow(ENV).to receive(:[]).with("ALPHA_SMS_API_KEY").and_return("ABCDEF")
+    allow(ENV).to receive(:[]).with("ALPHA_SMS_SENDER_ID").and_return("AAAAAA")
   end
 
   describe "#new" do
@@ -23,7 +24,8 @@ RSpec.describe Messaging::AlphaSms::Api do
       expect(request.with(body: {
         api_key: "ABCDEF",
         msg: message,
-        to: recipient_number
+        to: recipient_number,
+        sender_id: "AAAAAA"
       })).to have_been_made
     end
 


### PR DESCRIPTION
**Story card:** [sc-9255](https://app.shortcut.com/simpledotorg/story/9255/get-sender-id-from-nhf-and-add-to-apis)

## Because

We obtained an alphabetic sender ID for using in bangladesh through Alpha SMS. 

## This addresses

Uses the sender ID in the API.