### PR TITLE
Additional fix for max width

### DIFF
--- a/app/views/my_facilities/drug_stocks/_drug_stocks_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_stocks_table.html.erb
@@ -1,4 +1,4 @@
-<div class="table-responsive-xl">
+<div class="table-responsive">
   <table class="mt-4 table table-compact table-hover analytics-table">
     <colgroup>
       <col>


### PR DESCRIPTION
**Story card:** [sc-10117](https://app.shortcut.com/simpledotorg/story/10117/drug-display-issue-west-bengal)

## Because

I had assumed the error was at the md breakpoint - as this was broken - but the error was actually also with the xl breakpoint because its too large for the screen to show at mix width

## This addresses

This makes the table able to scroll at all widths.

## Test instructions

Testing - add 5 additional medicines and then view the screen at max width - ensure that the table can scroll