### PR TITLE
UX fix drug stock scrolling

### DIFF
--- a/app/views/my_facilities/drug_stocks/_drug_consumption_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_consumption_table.html.erb
@@ -1,4 +1,4 @@
-<div class="table-responsive-md">
+<div class="table-responsive">
   <table class="mt-4 table table-compact table-hover analytics-table">
   <colgroup>
     <col>

--- a/app/views/my_facilities/drug_stocks/drug_consumption.html.erb
+++ b/app/views/my_facilities/drug_stocks/drug_consumption.html.erb
@@ -1,7 +1,6 @@
 <%= render "drug_stock_nav" %>
-
 <div class="row">
-  <div class="col-lg-12">
+  <div>
     <div class="card card-responsive">
       <div>
         <div class="d-flex align-baseline jc-between">
@@ -9,7 +8,6 @@
             Drug consumption during <%= @for_end_of_month_display %>
           </h3>
         </div>
-
         <p class="mb-4">
           Consumption is calculated by:
           <span class="badge badge-light text-muted">CLOSING BALANCE OF PREVIOUS MONTH</span>
@@ -21,7 +19,6 @@
           <span class="badge badge-light text-muted">STOCK ISSUED TO OTHER FACILITIES THIS MONTH</span>
         </p>
         <p>
-
         </p>
       </div>
       <div class="d-flex fw-wrap mb-16px">

--- a/app/views/my_facilities/drug_stocks/drug_consumption.html.erb
+++ b/app/views/my_facilities/drug_stocks/drug_consumption.html.erb
@@ -1,7 +1,7 @@
 <%= render "drug_stock_nav" %>
 <div class="row">
   <div>
-    <div class="card card-responsive">
+    <div class="card">
       <div>
         <div class="d-flex align-baseline jc-between">
           <h3>

--- a/app/views/my_facilities/drug_stocks/drug_stocks.html.erb
+++ b/app/views/my_facilities/drug_stocks/drug_stocks.html.erb
@@ -1,7 +1,6 @@
 <%= render "drug_stock_nav" %>
-
 <div class="row">
-  <div class="col-lg-12">
+  <div>
     <div class="card">
       <div>
         <div class="d-flex align-baseline jc-between">
@@ -9,7 +8,6 @@
             Stock on hand: end of <%= @for_end_of_month_display %>
           </h3>
         </div>
-
         <p class="mb-4">
           <!--a href="#" type="button" class="float-right ml-4 btn btn-sm btn-primary" data-toggle="modal" data-target="#DrugReportModal"><i class="fas fa-plus-circle mr-2"></i> Drug stock report</a-->
           Patient days is calculated by comparing assigned patients against current stock on hand, normalized by

--- a/app/views/my_facilities/drug_stocks/drug_stocks.html.erb
+++ b/app/views/my_facilities/drug_stocks/drug_stocks.html.erb
@@ -1,7 +1,7 @@
 <%= render "drug_stock_nav" %>
 <div class="row">
   <div>
-    <div class="card card-responsive">
+    <div class="card">
       <div>
         <div class="d-flex align-baseline jc-between">
           <h3>

--- a/app/views/my_facilities/drug_stocks/drug_stocks.html.erb
+++ b/app/views/my_facilities/drug_stocks/drug_stocks.html.erb
@@ -1,7 +1,7 @@
 <%= render "drug_stock_nav" %>
 <div class="row">
   <div>
-    <div class="card">
+    <div class="card card-responsive">
       <div>
         <div class="d-flex align-baseline jc-between">
           <h3>


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)
No story 

## Because

Quick and dirty fix to implement browser level horizontal scroll on the drug stock and drug consumption pages

## This addresses

Praveen mentioned that it is hard to scroll horizontally on the drug stock pages because the 

## Test instructions

Add some extra medicines and ensure the whole screen becomes the scrollable object.

Things broken:
- on mobile the nav bar does not extend over the 100% screen size: most likely not visible when scrolling down and across the drug tables.
- the card wont extend to 100% width when only a few medicines present.