### PR TITLE
Fix Barishal spelling in canonical_states.yml

### DIFF
--- a/config/data/canonical_states.yml
+++ b/config/data/canonical_states.yml
@@ -36,7 +36,7 @@ India:
   - Uttarakhand
   - West Bengal
 Bangladesh:
-  - Barisal
+  - Barishal
   - Bogura
   - Chattogram
   - Comilla


### PR DESCRIPTION
**Story card:** -

## Because
Barisal was renamed to Barishal in https://github.com/simpledotorg/simple-server/pull/3026. However the canonical_states list wasn't updated which means it's possible to create new districts under `Barisal`. 

## This addresses

This will be accompanied by a small data cleanup to merge `Barisal` and `Barishal` states on BD production.

Reported on this [slack thread](https://simpledotorg.slack.com/archives/C03URFX2LUT/p1677585608560569).
