### PR TITLE
Add facility & facility-group slugs

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5830,6 +5830,13 @@ CREATE INDEX index_facilities_on_facility_group_id ON public.facilities USING bt
 
 
 --
+-- Name: index_facilities_on_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_facilities_on_slug ON public.facilities USING btree (slug);
+
+
+--
 -- Name: index_facilities_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5876,6 +5883,13 @@ CREATE INDEX index_facility_groups_on_organization_id ON public.facility_groups 
 --
 
 CREATE INDEX index_facility_groups_on_protocol_id ON public.facility_groups USING btree (protocol_id);
+
+
+--
+-- Name: index_facility_groups_on_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_facility_groups_on_slug ON public.facility_groups USING btree (slug);
 
 
 --

--- a/lib/seed/facility_seeder.rb
+++ b/lib/seed/facility_seeder.rb
@@ -169,8 +169,8 @@ module Seed
         }
       end
 
-      announce "Importing #{facility_attrs.count} Facilities"
       Facility.import(facility_attrs, returning: [:id, :name, :zone], on_duplicate_key_ignore: true)
+        .tap { |results| announce "Imported #{results.count} Facilities" }
     end
 
     def create_facility_regions(facility_results)
@@ -188,8 +188,9 @@ module Seed
         }
         FactoryBot.build(:region, attrs)
       }
-      logger.info { "Importing #{facility_regions.count} Facility regions" }
-      Region.import(facility_regions, on_duplicate_key_ignore: true)
+      Region
+        .import(facility_regions, on_duplicate_key_ignore: true)
+        .tap { |results| logger.info "Imported #{results.count} Facility regions" }
     end
   end
 end


### PR DESCRIPTION
**Story card:** bug

## Because

The 2 indexes got accidentally deleted as part of this commit: 74f84e1e7e16fc07c0c86fe5f62de26e1030ace4

## This addresses

Android specs would not fail randomly because `db:seed` would error out. This fixes it because `Facility.import(facility_attrs, returning: [:id, :name, :zone], on_duplicate_key_ignore: true)` will ignore duplicate keys due to uniqueness index, hence not causing an error in Region creation which does have uniqueness index in the DB.

## Test instructions

-