### PR TITLE
Change month_string to month_date in questionnaire responses

### DIFF
--- a/lib/tasks/scripts/pre_fill_monthly_screening_reports.rb
+++ b/lib/tasks/scripts/pre_fill_monthly_screening_reports.rb
@@ -3,19 +3,19 @@ class PreFillMonthlyScreeningReports
     return unless Flipper.enabled?(:monthly_screening_reports)
 
     month_date = date.beginning_of_month
-    month_string = month_date.strftime("%Y-%m")
+    month_date_str = month_date.strftime("%Y-%m-%d")
     facility_reports = monthly_followup_and_registration(month_date)
 
     reports_exist = false
     questionnaire = Questionnaire.monthly_screening_reports.active.order(:dsl_version).last
     facility_reports.each do |facility_report|
-      if monthly_screening_report_exists?(facility_report.facility_id, month_string)
+      if monthly_screening_report_exists?(facility_report.facility_id, month_date_str)
         reports_exist = true
       else
         QuestionnaireResponse.create!(
           questionnaire_id: questionnaire.id,
           facility_id: facility_report.facility_id,
-          content: prefilled_responses(month_string, facility_report),
+          content: prefilled_responses(month_date_str, facility_report),
           device_created_at: Time.now,
           device_updated_at: Time.now
         )
@@ -23,7 +23,7 @@ class PreFillMonthlyScreeningReports
     end
 
     if reports_exist
-      Rails.logger.error("Some/all monthly screening reports already existed during pre-fill task for month: %s" % month_string)
+      Rails.logger.error("Some/all monthly screening reports already existed during pre-fill task for month: %s" % month_date_str)
     end
   end
 
@@ -43,18 +43,18 @@ class PreFillMonthlyScreeningReports
     ).load
   end
 
-  def self.monthly_screening_report_exists?(facility_id, month_string)
+  def self.monthly_screening_report_exists?(facility_id, month_date)
     QuestionnaireResponse
       .where(facility_id: facility_id)
       .merge(Questionnaire.monthly_screening_reports)
       .joins(:questionnaire)
-      .where("content->>'month_string' = ?", month_string)
+      .where("content->>'month_date' = ?", month_date)
       .any?
   end
 
-  def self.prefilled_responses(month_string, facility_report)
+  def self.prefilled_responses(month_date, facility_report)
     {
-      "month_string" => month_string,
+      "month_date" => month_date,
       "submitted" => false,
       "monthly_screening_reports.diagnosed_cases_on_follow_up_htn.male" => facility_report.monthly_follow_ups_htn_male,
       "monthly_screening_reports.diagnosed_cases_on_follow_up_htn.female" => facility_report.monthly_follow_ups_htn_female,

--- a/lib/tasks/scripts/pre_fill_monthly_screening_reports.rb
+++ b/lib/tasks/scripts/pre_fill_monthly_screening_reports.rb
@@ -3,19 +3,19 @@ class PreFillMonthlyScreeningReports
     return unless Flipper.enabled?(:monthly_screening_reports)
 
     month_date = date.beginning_of_month
-    month_date_str = month_date.strftime("%Y-%m-%d")
+    month_date = month_date.strftime("%Y-%m-%d")
     facility_reports = monthly_followup_and_registration(month_date)
 
     reports_exist = false
     questionnaire = Questionnaire.monthly_screening_reports.active.order(:dsl_version).last
     facility_reports.each do |facility_report|
-      if monthly_screening_report_exists?(facility_report.facility_id, month_date_str)
+      if monthly_screening_report_exists?(facility_report.facility_id, month_date)
         reports_exist = true
       else
         QuestionnaireResponse.create!(
           questionnaire_id: questionnaire.id,
           facility_id: facility_report.facility_id,
-          content: prefilled_responses(month_date_str, facility_report),
+          content: prefilled_responses(month_date, facility_report),
           device_created_at: Time.now,
           device_updated_at: Time.now
         )
@@ -23,7 +23,7 @@ class PreFillMonthlyScreeningReports
     end
 
     if reports_exist
-      Rails.logger.error("Some/all monthly screening reports already existed during pre-fill task for month: %s" % month_date_str)
+      Rails.logger.error("Some/all monthly screening reports already existed during pre-fill task for month: %s" % month_date)
     end
   end
 

--- a/spec/tasks/scripts/pre_fill_monthly_screening_reports_spec.rb
+++ b/spec/tasks/scripts/pre_fill_monthly_screening_reports_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe PreFillMonthlyScreeningReports do
     it "pre-fills monthly screening reports for previous month" do
       PreFillMonthlyScreeningReports.call
 
-      date = 1.month.ago
+      date = 1.month.ago.beginning_of_month
       expect(QuestionnaireResponse.find_by_facility_id(facility).content).to eq(
         {
-          "month_string" => date.strftime("%Y-%m"),
+          "month_date" => date.strftime("%Y-%m-%d"),
           "submitted" => false,
           "monthly_screening_reports.diagnosed_cases_on_follow_up_htn.male" => 0,
           "monthly_screening_reports.diagnosed_cases_on_follow_up_htn.female" => 1,
@@ -39,7 +39,7 @@ RSpec.describe PreFillMonthlyScreeningReports do
     end
 
     it "ignores existing monthly screening reports" do
-      existing_content = {"month_string" => month_date.strftime("%Y-%m")}
+      existing_content = {"month_date" => month_date.strftime("%Y-%m-%d")}
       existing_monthly_screening_report = create(:questionnaire_response, facility: facility, content: existing_content)
 
       PreFillMonthlyScreeningReports.call
@@ -59,7 +59,7 @@ RSpec.describe PreFillMonthlyScreeningReports do
 
     it "ignores non-monthly screening reports for idempotency check" do
       questionnaire = create(:questionnaire, questionnaire_type: @questionnaire_types[1])
-      existing_content = {"month_string" => month_date.strftime("%Y-%m")}
+      existing_content = {"month_date" => month_date.strftime("%Y-%m-%d")}
       create(:questionnaire_response, questionnaire: questionnaire, facility: facility, content: existing_content)
       expect(QuestionnaireResponse.where(facility: facility).count).to eq(1)
 
@@ -76,12 +76,12 @@ RSpec.describe PreFillMonthlyScreeningReports do
       create(:appointment, patient: patient_1, user: user, facility: facility, recorded_at: three_months_ago)
       refresh_views
 
-      date = three_months_ago
+      date = three_months_ago.beginning_of_month
       PreFillMonthlyScreeningReports.call(date)
 
       expect(QuestionnaireResponse.find_by_facility_id(facility).content).to eq(
         {
-          "month_string" => date.strftime("%Y-%m"),
+          "month_date" => date.strftime("%Y-%m-%d"),
           "submitted" => false,
           "monthly_screening_reports.diagnosed_cases_on_follow_up_htn.male" => 1,
           "monthly_screening_reports.diagnosed_cases_on_follow_up_htn.female" => 0,


### PR DESCRIPTION
**Story card:** no-story

## Because

In questionnaire response content, we send `month_string` in the format `YYYY-MM` to represent the month that form is being filled in. However an ISO format `YYYY-MM-DD` is more convenient for the client to parse and work with.

## This addresses

Sends a `month_date` in the questionnaire response (example `2023-03-01`). Android won't have to append every `month_date` with `-01` now.