### PR TITLE
Seed questionnaire & questionnaire_responses

### DIFF
--- a/app/schema/api/v4/models/questionnaires/monthly_screening_report.rb
+++ b/app/schema/api/v4/models/questionnaires/monthly_screening_report.rb
@@ -78,11 +78,6 @@ class Api::V4::Models::Questionnaires::MonthlyScreeningReport
           },
           {
             type: "display",
-            id: "234700ac-645b-47e8-8d17-457ab3c0f53f",
-            view_type: "separator"
-          },
-          {
-            type: "display",
             id: "c0777808-7098-4a93-a40c-9860c716d9d3",
             view_type: "line_separator"
           }

--- a/lib/seed/questionnaire_seeder.rb
+++ b/lib/seed/questionnaire_seeder.rb
@@ -1,0 +1,15 @@
+require_dependency "seed/config"
+require "tasks/scripts/pre_fill_monthly_screening_reports"
+
+module Seed
+  class QuestionnaireSeeder
+    def self.call
+      FactoryBot.create(:questionnaire,
+        questionnaire_type: "monthly_screening_reports",
+        is_active: true,
+        layout: Api::V4::Models::Questionnaires::MonthlyScreeningReport.layout)
+
+      (1..3).map { |n| PreFillMonthlyScreeningReports.call(n.month.ago) }
+    end
+  end
+end

--- a/lib/seed/runner.rb
+++ b/lib/seed/runner.rb
@@ -55,6 +55,12 @@ module Seed
       total_counts.merge!(hsh)
 
       print_summary
+
+      ENV["REFRESH_MATVIEWS_CONCURRENTLY"] = "false"
+      RefreshReportingViews.call
+      puts "Reporting views have been refreshed"
+      QuestionnaireSeeder.call
+
       [counts, total_counts]
     end
 
@@ -72,6 +78,7 @@ module Seed
       [
         :dashboard_progress_reports,
         :drug_stocks,
+        :monthly_screening_reports,
         :follow_ups_v2_progress_tab,
         :notifications,
         (:auto_approve_users if SimpleServer.env.android_review?),

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -45,8 +45,3 @@ end
 Rake::Task["db:structure:dump"].enhance do
   Rake::Task["db:structure:clean"].invoke
 end
-
-Rake::Task["db:seed"].enhance do
-  ENV["REFRESH_MATVIEWS_CONCURRENTLY"] = "false"
-  Rake::Task["db:refresh_reporting_views"].invoke
-end


### PR DESCRIPTION
**Story card:** [sc-10142](https://app.shortcut.com/simpledotorg/story/10142/seed-monthly-screening-reports-data-in-simple-server-repository)

## Because

Mobile can run integration tests against data in review server & developers can seed Questionnaire data locally.

## This addresses

Seeding of monthly screening forms

## Test instructions

Run rake task `db:seed` & check Database for Questionnaire & QuestionnaireResponse entries.