### PR TITLE
Setup one off medication reminders in bangladesh

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -26,6 +26,7 @@ class Notification < ApplicationRecord
   }, _prefix: true
   enum purpose: {
     covid_medication_reminder: "covid_medication_reminder",
+    one_off_medication_reminder: "one_off_medication_reminder",
     experimental_appointment_reminder: "experimental_appointment_reminder",
     missed_visit_reminder: "missed_visit_reminder",
     test_message: "test_message"

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -26,7 +26,7 @@ class Notification < ApplicationRecord
   }, _prefix: true
   enum purpose: {
     covid_medication_reminder: "covid_medication_reminder",
-    one_off_medication_reminder: "one_off_medication_reminder",
+    one_off_medications_reminder: "one_off_medications_reminder",
     experimental_appointment_reminder: "experimental_appointment_reminder",
     missed_visit_reminder: "missed_visit_reminder",
     test_message: "test_message"

--- a/config/locales/notifications/bn_BD.yml
+++ b/config/locales/notifications/bn_BD.yml
@@ -1,5 +1,6 @@
 bn_BD:
   notifications:
+    one_off_medications_reminder: "{%patient_name%}, উপজেলা স্বাস্হ্য কমপ্লেক্সে উচ্চ রক্তচাপের ঔষধ এসেছে। অনুগ্রহ করে নিতে আসুন।"
     set01:
       basic: "%{patient_name}, রক্তচাপের পরিমাপ এবং ওষুধের জন্য অনুগ্রহ করে %{appointment_date}-এ %{facility_name}-এ যান।"
       gratitude: "উচ্চরক্তচাপের ঔষধ নিয়মিত সেবন করার জন্য আপনাকে ধন্যবাদ। %{patient_name}, রক্তচাপের পরিমাপ এবং ওষুধের জন্য অনুগ্রহ করে %{appointment_date}-এ %{facility_name}-এ যান।"

--- a/db/data/20230306143819_setup_one_off_medication_reminders_bangladesh.rb
+++ b/db/data/20230306143819_setup_one_off_medication_reminders_bangladesh.rb
@@ -25,7 +25,7 @@ class SetupOneOffMedicationRemindersBangladesh < ActiveRecord::Migration[6.1]
         Notification.create!(
           patient_id: patient.id,
           remind_on: Date.current + batch_number.days + 1,
-          status: "scheduled",
+          status: "pending",
           message: "notifications.one_off_medications_reminder",
           purpose: "one_off_medications_reminder"
         )
@@ -36,7 +36,7 @@ class SetupOneOffMedicationRemindersBangladesh < ActiveRecord::Migration[6.1]
   def down
     Notification
       .where(purpose: :one_off_medications_reminder)
-      .status_scheduled
+      .where(status: [:pending, :scheduled])
       .update_all(status: :cancelled, deleted_at: Time.now)
   end
 end

--- a/db/data/20230306143819_setup_one_off_medication_reminders_bangladesh.rb
+++ b/db/data/20230306143819_setup_one_off_medication_reminders_bangladesh.rb
@@ -1,0 +1,34 @@
+class SetupOneOffMedicationRemindersBangladesh < ActiveRecord::Migration[6.1]
+  PATIENTS_PER_DAY = 8000
+
+  def up
+    return unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
+
+    excluded_facilities = %w[2e7a4917-be56-4d2e-aee6-4c9738ab8a9b edaf3ebd-3dbd-48c3-9911-875ad1356f5d daff41a3-4922-41b0-a822-6fef2db07e68 cc98c651-ce8b-4019-be6b-012f52d0cb21]
+    patients = PatientSummary.where(id: Patient
+                                          .with_hypertension
+                                          .contactable
+                                          .where_current_age(">=", 18))
+      .where("days_overdue < ?", 365)
+      .where.not(assigned_facility_id: excluded_facilities)
+
+    patients.find_in_batches(batch_size: PATIENTS_PER_DAY).with_index do |batch, batch_number|
+      batch.each do |patient|
+        Notification.create!(
+          patient_id: patient.id,
+          remind_on: Date.current + batch_number.days + 1,
+          status: "scheduled",
+          message: "notifications.one_off_medication_reminder",
+          purpose: "one_off_medication_reminder"
+        )
+      end
+    end
+  end
+
+  def down
+    Notification
+      .where(purpose: :one_off_medication_reminder)
+      .status_scheduled
+      .discard_all
+  end
+end

--- a/db/data/20230306143819_setup_one_off_medication_reminders_bangladesh.rb
+++ b/db/data/20230306143819_setup_one_off_medication_reminders_bangladesh.rb
@@ -1,16 +1,22 @@
 class SetupOneOffMedicationRemindersBangladesh < ActiveRecord::Migration[6.1]
   PATIENTS_PER_DAY = 8000
+  EXCLUDED_FACILITIES = %w[
+    2e7a4917-be56-4d2e-aee6-4c9738ab8a9b
+    edaf3ebd-3dbd-48c3-9911-875ad1356f5d
+    daff41a3-4922-41b0-a822-6fef2db07e68
+    cc98c651-ce8b-4019-be6b-012f52d0cb21
+  ]
 
   def up
     return unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
 
-    excluded_facilities = %w[2e7a4917-be56-4d2e-aee6-4c9738ab8a9b edaf3ebd-3dbd-48c3-9911-875ad1356f5d daff41a3-4922-41b0-a822-6fef2db07e68 cc98c651-ce8b-4019-be6b-012f52d0cb21]
-    patients = PatientSummary.where(id: Patient
-                                          .with_hypertension
-                                          .contactable
-                                          .where_current_age(">=", 18))
-      .where("days_overdue < ?", 365)
-      .where.not(assigned_facility_id: excluded_facilities)
+    patients =
+      PatientSummary
+        .joins(:patient)
+        .merge(Patient.contactable)
+        .where("current_age >= ?", 18)
+        .where("days_overdue < ?", 365)
+        .where.not(assigned_facility_id: EXCLUDED_FACILITIES)
 
     patients.find_in_batches(batch_size: PATIENTS_PER_DAY).with_index do |batch, batch_number|
       batch.each do |patient|
@@ -29,6 +35,6 @@ class SetupOneOffMedicationRemindersBangladesh < ActiveRecord::Migration[6.1]
     Notification
       .where(purpose: :one_off_medications_reminder)
       .status_scheduled
-      .discard_all
+      .update_all(status: :cancelled, deleted_at: Time.now)
   end
 end

--- a/db/data/20230306143819_setup_one_off_medication_reminders_bangladesh.rb
+++ b/db/data/20230306143819_setup_one_off_medication_reminders_bangladesh.rb
@@ -16,6 +16,8 @@ class SetupOneOffMedicationRemindersBangladesh < ActiveRecord::Migration[6.1]
         .merge(Patient.contactable)
         .where("current_age >= ?", 18)
         .where("days_overdue < ?", 365)
+        .where(next_appointment_status: :scheduled)
+        .where("next_appointment_scheduled_date < ?", Date.today)
         .where.not(assigned_facility_id: EXCLUDED_FACILITIES)
 
     patients.find_in_batches(batch_size: PATIENTS_PER_DAY).with_index do |batch, batch_number|

--- a/db/data/20230306143819_setup_one_off_medication_reminders_bangladesh.rb
+++ b/db/data/20230306143819_setup_one_off_medication_reminders_bangladesh.rb
@@ -18,8 +18,8 @@ class SetupOneOffMedicationRemindersBangladesh < ActiveRecord::Migration[6.1]
           patient_id: patient.id,
           remind_on: Date.current + batch_number.days + 1,
           status: "scheduled",
-          message: "notifications.one_off_medication_reminder",
-          purpose: "one_off_medication_reminder"
+          message: "notifications.one_off_medications_reminder",
+          purpose: "one_off_medications_reminder"
         )
       end
     end
@@ -27,7 +27,7 @@ class SetupOneOffMedicationRemindersBangladesh < ActiveRecord::Migration[6.1]
 
   def down
     Notification
-      .where(purpose: :one_off_medication_reminder)
+      .where(purpose: :one_off_medications_reminder)
       .status_scheduled
       .discard_all
   end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,1 @@
-# encoding: UTF-8
-DataMigrate::Data.define(version: 20220902131201)
+DataMigrate::Data.define(version: 20230306143819)

--- a/spec/data/setup_one_off_medication_reminders_bangladesh_spec.rb
+++ b/spec/data/setup_one_off_medication_reminders_bangladesh_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SetupOneOffMedicationRemindersBangladesh do
     described_class.new.up
 
     expect(Notification.count).to eq(5)
-    expect(Notification.pluck(:status)).to all eq("scheduled")
+    expect(Notification.pluck(:status)).to all eq("pending")
     expect(Notification.pluck(:message)).to all eq("notifications.one_off_medications_reminder")
     expect(Notification.pluck(:purpose)).to all eq("one_off_medications_reminder")
     expect(Notification.order(:remind_on).pluck(:remind_on)).to eq [

--- a/spec/data/setup_one_off_medication_reminders_bangladesh_spec.rb
+++ b/spec/data/setup_one_off_medication_reminders_bangladesh_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe SetupOneOffMedicationRemindersBangladesh do
     allow(CountryConfig).to receive(:current_country?).with("Bangladesh").and_return true
     stub_const("SIMPLE_SERVER_ENV", "production")
     stub_const("SetupOneOffMedicationRemindersBangladesh::PATIENTS_PER_DAY", 2)
-    create_list(:patient, 5)
-    create_list(:patient, 2, facility_id: "2e7a4917-be56-4d2e-aee6-4c9738ab8a9b")
+    create_list(:patient, 5, :with_overdue_appointments)
+    excluded_facility = create(:facility, id: SetupOneOffMedicationRemindersBangladesh::EXCLUDED_FACILITIES.first)
+    _excluded_patients = create_list(:patient, 2, registration_facility_id: excluded_facility)
 
     described_class.new.up
 

--- a/spec/data/setup_one_off_medication_reminders_bangladesh_spec.rb
+++ b/spec/data/setup_one_off_medication_reminders_bangladesh_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+require Rails.root.join("db", "data", "20230306143819_setup_one_off_medication_reminders_bangladesh")
+
+RSpec.describe SetupOneOffMedicationRemindersBangladesh do
+  it "sets up the current notifications" do
+    allow(CountryConfig).to receive(:current_country?).with("Bangladesh").and_return true
+    stub_const("SIMPLE_SERVER_ENV", "production")
+    stub_const("SetupOneOffMedicationRemindersBangladesh::PATIENTS_PER_DAY", 2)
+    create_list(:patient, 5)
+    create_list(:patient, 2, facility_id: "2e7a4917-be56-4d2e-aee6-4c9738ab8a9b")
+
+    described_class.new.up
+
+    expect(Notification.count).to eq(5)
+    expect(Notification.pluck(:status)).to all eq("scheduled")
+    expect(Notification.pluck(:message)).to all eq("notifications.one_off_medications_reminder")
+    expect(Notification.pluck(:purpose)).to all eq("one_off_medications_reminder")
+    expect(Notification.order(:remind_on).pluck(:remind_on)).to eq [
+      1.days.from_now.to_date,
+      1.days.from_now.to_date,
+      2.days.from_now.to_date,
+      2.days.from_now.to_date,
+      3.days.from_now.to_date
+    ]
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-9146](https://app.shortcut.com/simpledotorg/story/9146/setup-bangladesh-feb-experiment)

## Because

Since NHF has medicines back in stock, we want to send a one-off reminder in Bangladesh to all patients to come get their medicines.

## This addresses

This adds a data migration to setup the notifications. There's roughly 100k eligible patients in Bangladesh. We'll send 8k messages everyday over the next two weeks.

