### PR TITLE
Add english translation for NHF one off message

### DIFF
--- a/config/locales/notifications/en.yml
+++ b/config/locales/notifications/en.yml
@@ -1,5 +1,6 @@
 en:
   notifications:
+    one_off_medications_reminder: "{%patient_name%}, BP medications are available at Upazila. Please come pick it up."
     set01:
       basic: "%{patient_name}, please visit %{facility_name} on %{appointment_date} for a BP measure and medicines."
       gratitude: "Thank you for taking regular medicines for High BP. %{patient_name}, please visit %{facility_name} on %{appointment_date} for a BP measure and medicines."


### PR DESCRIPTION
**Story card:** [sc-9146](https://app.shortcut.com/simpledotorg/story/9146/setup-bangladesh-feb-experiment)

## Because

We added a one off message string for bangladesh in https://github.com/simpledotorg/simple-server/pull/4835. Rails does not pickup this string until the key is also present in the default locale (`en.yml`)

## This addresses

Adds the one notification string to `en.yml` also.
