### PR TITLE
Fix Bangla locale file

### DIFF
--- a/config/locales/notifications/bn_BD.yml
+++ b/config/locales/notifications/bn_BD.yml
@@ -1,6 +1,6 @@
 bn-BD:
   notifications:
-    one_off_medications_reminder: "{%patient_name%}, উপজেলা স্বাস্হ্য কমপ্লেক্সে উচ্চ রক্তচাপের ঔষধ এসেছে। অনুগ্রহ করে নিতে আসুন।"
+    one_off_medications_reminder: "%{patient_name}, উপজেলা স্বাস্হ্য কমপ্লেক্সে উচ্চ রক্তচাপের ঔষধ এসেছে। অনুগ্রহ করে নিতে আসুন।"
     set01:
       basic: "%{patient_name}, রক্তচাপের পরিমাপ এবং ওষুধের জন্য অনুগ্রহ করে %{appointment_date}-এ %{facility_name}-এ যান।"
       gratitude: "উচ্চরক্তচাপের ঔষধ নিয়মিত সেবন করার জন্য আপনাকে ধন্যবাদ। %{patient_name}, রক্তচাপের পরিমাপ এবং ওষুধের জন্য অনুগ্রহ করে %{appointment_date}-এ %{facility_name}-এ যান।"

--- a/config/locales/notifications/bn_BD.yml
+++ b/config/locales/notifications/bn_BD.yml
@@ -1,4 +1,4 @@
-bn_BD:
+bn-BD:
   notifications:
     one_off_medications_reminder: "{%patient_name%}, উপজেলা স্বাস্হ্য কমপ্লেক্সে উচ্চ রক্তচাপের ঔষধ এসেছে। অনুগ্রহ করে নিতে আসুন।"
     set01:

--- a/config/locales/notifications/en.yml
+++ b/config/locales/notifications/en.yml
@@ -1,6 +1,5 @@
 en:
   notifications:
-    one_off_medications_reminder: "{%patient_name%}, BP medications are available at Upazila. Please come pick it up."
     set01:
       basic: "%{patient_name}, please visit %{facility_name} on %{appointment_date} for a BP measure and medicines."
       gratitude: "Thank you for taking regular medicines for High BP. %{patient_name}, please visit %{facility_name} on %{appointment_date} for a BP measure and medicines."


### PR DESCRIPTION
**Story card:** -

## Because

The `bn_BD` locale file has an underscore in the name instead of an hyphen.

## This addresses

Reverts https://github.com/simpledotorg/simple-server/pull/4837 since it was unnecessary and fixes the locale key in `notifications/bn_BD.yml`