### PR TITLE
Add new header required by CPHC user creation API

### DIFF
--- a/app/services/one_off/cphc_enrollment/create_subcenter_user_request.rb
+++ b/app/services/one_off/cphc_enrollment/create_subcenter_user_request.rb
@@ -42,7 +42,10 @@ class OneOff::CphcEnrollment::CreateSubcenterUserRequest
   end
 
   def headers
-    {"stateCode" => state_code, "txnUser" => CPHC_TXN_USER, "Host" => CPHC_HOST}
+    {"stateCode" => state_code,
+     "txnUser" => CPHC_TXN_USER,
+     "Host" => CPHC_HOST,
+     "facilityType" => "STATE"}
   end
 
   def payload


### PR DESCRIPTION
The CPHC user creation API has changed recently and requires us to send an additional header value `facilityType` set to `STATE`. 