### PR TITLE
Update DHIS2 data element IDs for ET

### DIFF
--- a/config/initializers/country_config.rb
+++ b/config/initializers/country_config.rb
@@ -60,7 +60,7 @@ class CountryConfig
       patient_line_list_show_zone: false,
       dhis2_data_elements: {
         cumulative_assigned: "nrK3Yj6ELl0",
-        cumulative_assigned_adjusted: "YKsRrnjBiVE",
+        cumulative_assigned_adjusted: "DxHkdQjTpXC",
         controlled: "ZCkeHFQETzb",
         uncontrolled: "z4mVPviB8OH",
         missed_visits: "tNRBsYt0ZOK",


### PR DESCRIPTION
**Story card:** [sc-10138](https://app.shortcut.com/simpledotorg/story/10138)

Updates ET DHIS2 data element IDs to match current production configuration.

The ET DHIS2 data export has been disabled through Flipper, so we can ship this seamlessly, and test before reactivating.