### PR TITLE
[Epic] Overdue Patients on the Dashboard

### DIFF
--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -354,6 +354,22 @@ DashboardReports = () => {
         }
       };
       return withBaseLineConfig(config)
+    },
+    overduePatientsCalledTrend: function (data) {
+      const config = {
+        data: {
+          labels: Object.keys(data.overduePatientsCalledRates),
+          datasets: [
+            {
+              label: "Overdue Patients Called",
+              data: Object.values(data.overduePatientsCalledRates),
+              backgroundColor: colors.lightPurple,
+              borderColor: colors.darkPurple,
+            }
+          ]
+        }
+      };
+      return withBaseLineConfig(config)
     }
   };
 

--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -339,6 +339,22 @@ DashboardReports = () => {
       };
       return withBaseLineConfig(config);
     },
+    overdueTrend: function (data) {
+      const config = {
+        data: {
+          labels: Object.keys(data.overduePatientsRates),
+          datasets: [
+            {
+              label: "Overdue Patients",
+              data: Object.values(data.overduePatientsRates),
+              backgroundColor: colors.lightRed,
+              borderColor: colors.darkRed,
+            }
+          ]
+        }
+      };
+      return withBaseLineConfig(config)
+    }
   };
 
   return {

--- a/app/components/dashboard/hypertension/overdue_patients_called_by_user_component.html.erb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_by_user_component.html.erb
@@ -1,8 +1,9 @@
-<!--Implementation Pending - Overdue Patients Graph-->
-<div id="" class="d-lg-flex w-lg-50 pr-lg-2">
-  <%= render Dashboard::Card::GraphComponent.new(id: "", data: graph_data, period: @period) do |c| %>
-    <%= c.title(title: "Overdue Patients Called By User Table".html_safe)%>
+<div class="card mb-16px">
+  <%= render Dashboard::Card::TitleComponent.new(
+    title: "Overdue Patients Called",
+    subtitle: "Subtitle here" 
+  ) do |c| %>
+    <%= c.tooltip({ "Types of blood sugars measured" => t("bs_measurement_details_copy.numerator", region_name: @region.name) }) %>
   <% end %>
+
 </div>
-
-

--- a/app/components/dashboard/hypertension/overdue_patients_called_by_user_component.html.erb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_by_user_component.html.erb
@@ -1,6 +1,6 @@
 <div class="card mb-16px">
   <%= render Dashboard::Card::TitleComponent.new(
-    title: "Overdue Patients Called",
+    title: "Overdue Patients Called By User",
     subtitle: "Subtitle here" 
   ) do |c| %>
     <%= c.tooltip({ "Types of blood sugars measured" => t("bs_measurement_details_copy.numerator", region_name: @region.name) }) %>

--- a/app/components/dashboard/hypertension/overdue_patients_called_by_user_component.html.erb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_by_user_component.html.erb
@@ -1,0 +1,8 @@
+<!--Implementation Pending - Overdue Patients Graph-->
+<div id="" class="d-lg-flex w-lg-50 pr-lg-2">
+  <%= render Dashboard::Card::GraphComponent.new(id: "", data: graph_data, period: @period) do |c| %>
+    <%= c.title(title: "Overdue Patients Called By User Table".html_safe)%>
+  <% end %>
+</div>
+
+

--- a/app/components/dashboard/hypertension/overdue_patients_called_by_user_component.html.erb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_by_user_component.html.erb
@@ -1,9 +1,8 @@
-<div class="card mb-16px">
+<div class="card mb-16px mt-0 w-full">
   <%= render Dashboard::Card::TitleComponent.new(
     title: "Overdue Patients Called By User",
     subtitle: "Subtitle here" 
   ) do |c| %>
     <%= c.tooltip({ "Types of blood sugars measured" => t("bs_measurement_details_copy.numerator", region_name: @region.name) }) %>
   <% end %>
-
 </div>

--- a/app/components/dashboard/hypertension/overdue_patients_called_by_user_component.rb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_by_user_component.rb
@@ -9,19 +9,20 @@ class Dashboard::Hypertension::OverduePatientsCalledByUserComponent < Applicatio
     @with_removed_from_overdue_list = with_removed_from_overdue_list
   end
 
-  def graph_data; end
+  def graph_data
+  end
 
   def gen_children_data
     user = {
       user: User.first,
-      patients_called: periods.map { |p| { p => rand(0..200) } }.reduce(:merge),
-      total_patients: periods.map { |p| { p => rand(0..200) } }.reduce(:merge)
+      patients_called: periods.map { |p| {p => rand(0..200)} }.reduce(:merge),
+      total_patients: periods.map { |p| {p => rand(0..200)} }.reduce(:merge)
     }
     [user, user]
   end
 
   def table_headers
-    [{ title: 'RBS &lt;200'.html_safe }]
+    [{title: "RBS &lt;200".html_safe}]
   end
 
   def periods

--- a/app/components/dashboard/hypertension/overdue_patients_called_by_user_component.rb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_by_user_component.rb
@@ -1,11 +1,31 @@
 class Dashboard::Hypertension::OverduePatientsCalledByUserComponent < ApplicationComponent
+  attr_reader :region, :period, :data, :children_data, :localized_region_type
+
   def initialize(region:, data:, period:, with_removed_from_overdue_list:)
     @region = region
     @data = data
     @period = period
+    @children_data = gen_children_data
     @with_removed_from_overdue_list = with_removed_from_overdue_list
   end
 
-  def graph_data
+  def graph_data; end
+
+  def gen_children_data
+    user = {
+      user: User.first,
+      patients_called: periods.map { |p| { p => rand(0..200) } }.reduce(:merge),
+      total_patients: periods.map { |p| { p => rand(0..200) } }.reduce(:merge)
+    }
+    [user, user]
+  end
+
+  def table_headers
+    [{ title: 'RBS &lt;200'.html_safe }]
+  end
+
+  def periods
+    start_period = @period.advance(months: -3)
+    Range.new(start_period, @period)
   end
 end

--- a/app/components/dashboard/hypertension/overdue_patients_called_by_user_component.rb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_by_user_component.rb
@@ -1,0 +1,11 @@
+class Dashboard::Hypertension::OverduePatientsCalledByUserComponent < ApplicationComponent
+  def initialize(region:, data:, period:, with_removed_from_overdue_list:)
+    @region = region
+    @data = data
+    @period = period
+    @with_removed_from_overdue_list = with_removed_from_overdue_list
+  end
+
+  def graph_data
+  end
+end

--- a/app/components/dashboard/hypertension/overdue_patients_called_component.html.erb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_component.html.erb
@@ -1,6 +1,24 @@
 <!--Implementation Pending - Overdue Patients Graph-->
-<div id="" class="d-lg-flex w-lg-50 pr-lg-2">
-  <%= render Dashboard::Card::GraphComponent.new(id: "", data: graph_data, period: @period) do |c| %>
-    <%= c.title(title: "Overdue Patients Called".html_safe)%>
+<div id="overdue-patients-called-trend" class="d-lg-flex w-lg-50 pr-lg-2">
+  <%= render Dashboard::Card::GraphComponent.new(id: "overduePatientsCalledTrend", data: graph_data, period: @period) do |c| %>
+    <%= c.title(title: "Overdue Patients Called".html_safe)do |title| %>
+
+    <%end%>
+    <%= c.summary do %>
+      <div class="mb-12px d-lg-flex align-lg-center">
+        <p class="c-print-black graph-percent fs-28px" data-key="overduePatientsCalledRates" data-format="percentage"></p>
+        <div>
+          <p class="m-0px c-black">
+            <span data-key="overduePatientsCalled" data-format="numberWithCommas"></span>
+            patients overdue
+          </p>
+          <p class="m-0px c-grey-dark c-print-black">
+            of
+            <span data-key="overduePatients" data-format="numberWithCommas"></span>
+            overdue patients
+          </p>
+        </div>
+      </div>
+    <%end%>
   <% end %>
 </div>

--- a/app/components/dashboard/hypertension/overdue_patients_called_component.html.erb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_component.html.erb
@@ -1,8 +1,7 @@
 <!--Implementation Pending - Overdue Patients Graph-->
-<div id="overdue-patients-called-trend" class="d-lg-flex w-lg-50 pr-lg-2">
+<div id="overdue-patients-called-trend" class="d-lg-flex w-lg-50 pl-lg-2">
   <%= render Dashboard::Card::GraphComponent.new(id: "overduePatientsCalledTrend", data: graph_data, period: @period) do |c| %>
     <%= c.title(title: "Overdue Patients Called".html_safe)do |title| %>
-
     <%end%>
     <%= c.summary do %>
       <div class="mb-12px d-lg-flex align-lg-center">

--- a/app/components/dashboard/hypertension/overdue_patients_called_component.html.erb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_component.html.erb
@@ -1,0 +1,6 @@
+<!--Implementation Pending - Overdue Patients Graph-->
+<div id="" class="d-lg-flex w-lg-50 pr-lg-2">
+  <%= render Dashboard::Card::GraphComponent.new(id: "", data: graph_data, period: @period) do |c| %>
+    <%= c.title(title: "Overdue Patients Called".html_safe)%>
+  <% end %>
+</div>

--- a/app/components/dashboard/hypertension/overdue_patients_called_component.rb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_component.rb
@@ -4,8 +4,37 @@ class Dashboard::Hypertension::OverduePatientsCalledComponent < ApplicationCompo
     @data = data
     @period = period
     @with_removed_from_overdue_list = with_removed_from_overdue_list
+    @with_removed_from_overdue_list = with_removed_from_overdue_list
+    @rates = gen_rates
   end
 
   def graph_data
+    # TODO: Implement toggle logic. We can reuse the keys in the graph_data but inject the
+    # filtered / non filtered data based on the toggle
+    {
+      overduePatients: @rates.map { |k, v| {k => v[:overduePatients]} }.reduce(:merge),
+      overduePatientsCalled: @rates.map { |k, v| {k => v[:overduePatientsCalled]} }.reduce(:merge),
+      overduePatientsCalledRates: @rates.map { |k, v| {k => v[:overduePatientsCalledRates]} }.reduce(:merge),
+      startDate: @period.advance(months: -12),
+      endDate: @periods
+    }
+  end
+
+  def gen_rates
+    periods
+      .reduce({}) { |merged_values, val| merged_values.merge({val => rand(1..10_000)}) }
+      .map do |period, value|
+      overdue_count = rand(0..value)
+      rate = overdue_count * 100 / value
+      {period => {overduePatients: value,
+                  overduePatientsCalled: overdue_count,
+                  overduePatientsCalledRates: rate}}
+    end
+      .reduce(:merge)
+  end
+
+  def periods
+    start_period = @period.advance(months: -12)
+    Range.new(start_period, @period)
   end
 end

--- a/app/components/dashboard/hypertension/overdue_patients_called_component.rb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_component.rb
@@ -1,0 +1,11 @@
+class Dashboard::Hypertension::OverduePatientsCalledComponent < ApplicationComponent
+  def initialize(region:, data:, period:, with_removed_from_overdue_list:)
+    @region = region
+    @data = data
+    @period = period
+    @with_removed_from_overdue_list = with_removed_from_overdue_list
+  end
+
+  def graph_data
+  end
+end

--- a/app/components/dashboard/hypertension/overdue_patients_component.html.erb
+++ b/app/components/dashboard/hypertension/overdue_patients_component.html.erb
@@ -1,6 +1,25 @@
 <!--Implementation Pending - Overdue Patients Graph-->
-<div id="" class="d-lg-flex w-lg-50 pr-lg-2">
-  <%= render Dashboard::Card::GraphComponent.new(id: "", data: graph_data, period: @period) do |c| %>
-    <%= c.title(title: "Overdue Patients".html_safe)%>
-  <% end %>
+<div id="overdue-trend" class="d-lg-flex w-lg-50 pr-lg-2">
+
+   <%= render Dashboard::Card::GraphComponent.new(id: "overdueTrend", data: graph_data, period: @period) do |c| %>
+      <%= c.title(title: "Overdue Patients") do |title| %>
+        
+      <%end%>
+    <%= c.summary do %>
+      <div class="mb-12px d-lg-flex align-lg-center">
+        <p class="c-print-black graph-percent fs-28px" data-key="overduePatientsRates" data-format="percentage"></p>
+        <div>
+          <p class="m-0px c-black">
+            <span data-key="overduePatients" data-format="numberWithCommas"></span>
+            patients overdue
+          </p>
+          <p class="m-0px c-grey-dark c-print-black">
+            of
+            <span data-key="assignedPatients" data-format="numberWithCommas"></span>
+            patients
+          </p>
+        </div>
+      </div>
+      <%end%>
+  <%end%>
 </div>

--- a/app/components/dashboard/hypertension/overdue_patients_component.html.erb
+++ b/app/components/dashboard/hypertension/overdue_patients_component.html.erb
@@ -1,0 +1,6 @@
+<!--Implementation Pending - Overdue Patients Graph-->
+<div id="" class="d-lg-flex w-lg-50 pr-lg-2">
+  <%= render Dashboard::Card::GraphComponent.new(id: "", data: graph_data, period: @period) do |c| %>
+    <%= c.title(title: "Overdue Patients".html_safe)%>
+  <% end %>
+</div>

--- a/app/components/dashboard/hypertension/overdue_patients_component.rb
+++ b/app/components/dashboard/hypertension/overdue_patients_component.rb
@@ -11,23 +11,23 @@ class Dashboard::Hypertension::OverduePatientsComponent < ApplicationComponent
     # TODO: Implement toggle logic. We can reuse the keys in the graph_data but inject the
     # filtered / non filtered data based on the toggle
     {
-      assignedPatients: @rates.map { |k, v| { k => v[:assignedPatients] } }.reduce(:merge),
-      overduePatients: @rates.map { |k, v| { k => v[:overduePatients] } }.reduce(:merge),
-      overduePatientsRates: @rates.map { |k, v| { k => v[:overduePatientsRates] } }.reduce(:merge),
+      assignedPatients: @rates.map { |k, v| {k => v[:assignedPatients]} }.reduce(:merge),
+      overduePatients: @rates.map { |k, v| {k => v[:overduePatients]} }.reduce(:merge),
+      overduePatientsRates: @rates.map { |k, v| {k => v[:overduePatientsRates]} }.reduce(:merge),
       startDate: @period.advance(months: -12),
-      endDate: @periods
+      endDate: @period
     }
   end
 
   def gen_rates
     periods
-      .reduce({}) { |merged_values, val| merged_values.merge({ val => rand(1..10_000) }) }
+      .reduce({}) { |merged_values, val| merged_values.merge({val => rand(1..10_000)}) }
       .map do |period, value|
         overdue_count = rand(0..value)
         rate = overdue_count * 100 / value
-        { period => { assignedPatients: value,
-                      overduePatients: overdue_count,
-                      overduePatientsRates: rate } }
+        {period => {assignedPatients: value,
+                    overduePatients: overdue_count,
+                    overduePatientsRates: rate}}
       end
       .reduce(:merge)
   end

--- a/app/components/dashboard/hypertension/overdue_patients_component.rb
+++ b/app/components/dashboard/hypertension/overdue_patients_component.rb
@@ -1,0 +1,24 @@
+class Dashboard::Hypertension::OverduePatientsComponent < ApplicationComponent
+  def initialize(region:, data:, period:, with_removed_from_overdue_list:)
+    @region = region
+    @data = data
+    @period = period
+    @with_removed_from_overdue_list = with_removed_from_overdue_list
+  end
+
+  def graph_data
+    {
+      assigned_patients: periods.reduce({}) { |merged_values, p| merged_values.merge({p => rand(0..500)}) },
+      filter_assigned_patients: {},
+      overdue_patients: {},
+      filter_overdue_patients: {},
+      overdue_patients_rates: {},
+      filter_overdue_patients_rates: {}
+    }
+  end
+
+  def periods
+    start_period = @period.advance(months: -12)
+    Range.new(start_period, @period)
+  end
+end

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -57,6 +57,7 @@ class Reports::RegionsController < AdminController
     @overview_data = @presenter.call(@region)
     @latest_period = Period.current
     @with_ltfu = with_ltfu?
+    @with_removed_from_overdue_list = with_removed_from_overdue_list? # TODO: Better name
 
     @child_regions = @region.reportable_children
     repo = Reports::Repository.new(@child_regions, periods: @period)
@@ -456,6 +457,10 @@ class Reports::RegionsController < AdminController
 
   def with_ltfu?
     params[:with_ltfu].present?
+  end
+
+  def with_removed_from_overdue_list? # TODO: Better name
+    params[:with_removed_from_overdue_list].present?
   end
 
   def log_cache_metrics

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -231,6 +231,26 @@
   <%= render(Dashboard::Hypertension::LostToFollowUpComponent.new(data: @data, region: @region, period: @period)) %>
 </div>
 
+<h4 class="mt-5 mb-32px">Overdue</h4>
+
+<div class="d-lg-flex flex-lg-wrap">
+  <%= render(Dashboard::Hypertension::OverduePatientsComponent.new(
+    region: @region,
+    data: @data,
+    period: @period,
+    with_removed_from_overdue_list: @with_removed_from_overdue_list)) %>
+  <%= render(Dashboard::Hypertension::OverduePatientsCalledComponent.new(
+    region: @region,
+    data: @data,
+    period: @period,
+    with_removed_from_overdue_list: @with_removed_from_overdue_list)) %>
+  <%= render(Dashboard::Hypertension::OverduePatientsCalledByUserComponent.new(
+    region: @region,
+    data: @data,
+    period: @period,
+    with_removed_from_overdue_list: @with_removed_from_overdue_list)) %>
+</div>
+
   <% if current_admin.feature_enabled?(:medications_dispensation) %>
     <h4 class="mt-5 mb-32px">Medications</h4>
     <%= render Dashboard::MedicationDispensationComponent.new(data: @data, region: @region, period: @period) %>


### PR DESCRIPTION
**Story card:** [sc-10335](https://app.shortcut.com/simpledotorg/story/10335/setup-a-common-interface-for-the-overdue-patients-dashboard)

## Because

Backend and frontend developers had to agree on a standard `data interface` to work on the feature independently.

## This addresses

- Create a `data interface`. 
- Provide dummy data for the graphs and table. 
- Setup a basic UI to test the data structure of dummy data

## Note

- This branch will stay as a source of truth for the `data interface`.  
  - Any changes to the data structure should be pushed to this branch. 
  - Please notify your team members if you are making any changes to the data structure in the `#overdue-patients` channel
- All the branches related to the epic should branch off from this branch

- Data is randomly generated and cross-data validation among the graphs and table would be possible.