### PR TITLE
CPHC fixes: update create user request API

### DIFF
--- a/app/services/one_off/cphc_enrollment/create_user_request.rb
+++ b/app/services/one_off/cphc_enrollment/create_user_request.rb
@@ -41,7 +41,7 @@ class OneOff::CphcEnrollment::CreateUserRequest
   end
 
   def headers
-    {"stateCode" => state_code, "txnUser" => CPHC_TXN_USER, "Host" => CPHC_HOST}
+    {"stateCode" => state_code, "txnUser" => CPHC_TXN_USER, "Host" => CPHC_HOST, "facilityType" => "STATE"}
   end
 
   def payload


### PR DESCRIPTION
**Story card:** -

## Because

CPHC added a new required header in the user creation API.

## This addresses

Adds the new header to the user creation script.