### PR TITLE
Ensure order is maintained when patient business identifier is missing

### DIFF
--- a/app/exporters/patients_with_history_exporter.rb
+++ b/app/exporters/patients_with_history_exporter.rb
@@ -112,7 +112,10 @@ class PatientsWithHistoryExporter
       patient_summary.current_age.to_i,
       patient_summary.gender.capitalize,
       status(patient_summary),
-      patient_summary.latest_phone_number,
+      patient_summary.latest_phone_number
+    ]
+
+    patient_address_details = [
       patient_summary.street_address,
       patient_summary.village_or_colony,
       patient_summary.district,
@@ -148,6 +151,7 @@ class PatientsWithHistoryExporter
     end
 
     [patient_details,
+      patient_address_details,
       facility_details,
       treatment_history,
       blood_pressures,

--- a/spec/exporters/patients_with_history_exporter_spec.rb
+++ b/spec/exporters/patients_with_history_exporter_spec.rb
@@ -368,5 +368,15 @@ RSpec.describe PatientsWithHistoryExporter, type: :model do
         expect { subject.csv(Patient.all) }.not_to raise_error
       end
     end
+
+    it "maintains the order when patient doesn't have a BP passport assigned" do
+      patient.business_identifiers.destroy_all
+      Timecop.freeze do
+        timestamp = ["Report generated at:", Time.current]
+
+        expect(fields[3]).to be_nil
+        expect(subject.csv(Patient.all).to_s.strip).to eq((timestamp.to_csv + measurement_headers.to_csv + headers.to_csv + fields.to_csv).to_s.strip)
+      end
+    end
   end
 end


### PR DESCRIPTION
**Story card:** -

## Because

If a patient doesn't have a patient business identifier, the order of line lists gets messed up

## This addresses

Adds an empty cell if the business identifier is missing. This prevents the order from being messed up.

## Test instructions

Create a patient without a patient business identifier. There should be an empty cell in the corresponding column for that patient in the line list download. 