### PR TITLE
Fix user enumeration API rate limit logging

### DIFF
--- a/config/initializers/rate_limiter.rb
+++ b/config/initializers/rate_limiter.rb
@@ -65,7 +65,9 @@ module RateLimit
   end
 
   ActiveSupport::Notifications.subscribe(/throttle.rack_attack/) do |name, start, finish, request_id, payload|
+    next unless payload[:request].path == "/api/v4/users/activate"
+
     request = ActionDispatch::Request.new(payload[:request].env)
-    RateLimit.logger.info "Too many login attempts for user #{request.params.dig(:user, :id)}"
+    RateLimit.logger.info "Too many login attempts for user #{request.params.dig(:user, :id)} from IP: #{request.ip}"
   end
 end


### PR DESCRIPTION
**Story card:** [sc-9976](https://app.shortcut.com/simpledotorg/story/9976/user-enumeration-through-api-endpoints)

## Because

We added logging to flag brute force attempts to `api/v4/user/activate` in #4872. Although, we are accidentally logging all rate limited requests. 

## This addresses

Fixes the rate limit logging to only work on the users activate route.
