### PR TITLE
Dashboard htn indicators column design improvement

### DIFF
--- a/app/assets/stylesheets/partials/_dashboard.scss
+++ b/app/assets/stylesheets/partials/_dashboard.scss
@@ -176,15 +176,34 @@ th sup {
       color: #fff;
     }
 
+    th[role="columnheader"]:not(.no-sort)::before,
     th[role="columnheader"]:not(.no-sort)::after {
-      content: "⇣";
       border: none;
       background: none;
       font-weight: bold;
     }
 
+    th[role="columnheader"]:not(.no-sort).align-right::before,
+    th[role="columnheader"]:not(.no-sort)::after {
+      content: "⇣";
+    }
+
+    th[aria-sort="ascending"]:not(.no-sort).align-right::before,
     th[aria-sort="ascending"]:not(.no-sort)::after {
+        content: "⇡";
+    }
+
+    th[role="columnheader"].reverse:not(.no-sort)::after {
       content: "⇡";
+    }
+
+    th[aria-sort="ascending"].reverse:not(.no-sort)::after {
+      content: "⇣";
+    }
+
+    th[role="columnheader"]:not(.no-sort).align-right::after,
+    th[role="ascending"]:not(.no-sort).align-right::after {
+      content: "";
     }
 
     th.sort-label {

--- a/app/assets/stylesheets/partials/_dashboard.scss
+++ b/app/assets/stylesheets/partials/_dashboard.scss
@@ -219,6 +219,10 @@ th sup {
       min-width: 40px;
     }
 
+    th.align-right {
+      text-align: right;
+    }
+
     .row-medicine {
       overflow: hidden;
       text-overflow: ellipsis;
@@ -710,7 +714,8 @@ th {
 //
 // Table sorting styles (override tablesort.css)
 //
-th[role="columnheader"]:not(.no-sort):after {
+th[role="columnheader"]:not(.no-sort)::before,
+th[role="columnheader"]:not(.no-sort)::after {
   border-color: $blue transparent;
   display: inline-block;
   float: none;
@@ -718,21 +723,32 @@ th[role="columnheader"]:not(.no-sort):after {
   vertical-align: middle;
 }
 
+th[role="columnheader"]:not(.no-sort)::before {
+  opacity: 0,
+}
+
+
+th[role="columnheader"]:not(.no-sort):hover::before,
 th[role="columnheader"]:not(.no-sort):hover:after {
   opacity: 0.5;
 }
 
+th[aria-sort]:not(.no-sort)::before,
 th[aria-sort]:not(.no-sort)::after,
-th[aria-sort]:not(.no-sort):hover:after {
-  opacity: 1;
+th[aria-sort]:not(.no-sort):hover::before,
+th[aria-sort]:not(.no-sort):hover::after {
+    opacity: 1;
 }
 
 // Reverse the arrows since we default to descending
+th[role="columnheader"]:not(.no-sort)::before,
+th[aria-sort="descending"]:not(.no-sort)::before,
 th[role="columnheader"]:not(.no-sort):after,
 th[aria-sort="descending"]:not(.no-sort):after {
   border-width: 4px 4px 0;
 }
 
+th[aria-sort="ascending"]:not(.no-sort)::before,
 th[aria-sort="ascending"]:not(.no-sort):after {
   border-bottom: 4px solid;
   border-width: 0 4px 4px;

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -10,6 +10,7 @@
         <col>
         <% if @region.state_region? %>
           <col class="table-divider">
+          <col>
         <% end %>
         <col class="table-divider">
         <col>

--- a/app/views/reports/regions/_child_data_tables.html.erb
+++ b/app/views/reports/regions/_child_data_tables.html.erb
@@ -71,40 +71,40 @@
         </th>
       </tr>
       <tr class="sorts" data-sort-method="thead">
-        <th class="row-label sort-label sort-label-small" data-sort-default>
+        <th class="row-label sort-label sort-label-small reverse" data-sort-default>
           <%= localized_region_type.capitalize %>
         </th>
-        <th class="row-label sort-label sort-label-small" data-sort-method="number">
-          <%= @period.to_s %>
-        </th>
-        <th class="row-label sort-label sort-label-small" data-sort-method="number">
+        <th class="row-label sort-label sort-label-small align-right" data-sort-method="number">
           Total
         </th>
+        <th class="row-label sort-label sort-label-small align-right" data-sort-method="number">
+          <%= @period.to_s %>
+        </th>
         <% if @region.state_region? %>
+          <th class="row-label sort-label sort-label-small align-right" data-sort-method="number">
+            Total
+          </th>
           <th class="row-label sort-label sort-label-small" data-sort-method="number">
             Percent
           </th>
-            <th class="row-label sort-label sort-label-small" data-sort-method="number">
-              Total
-            </th>
         <% end %>
-        <th class="row-label sort-label sort-label-small" data-sort-method="number">
-          Percent
-        </th>
-        <th class="row-label sort-label sort-label-small" data-sort-method="number">
+        <th class="row-label sort-label sort-label-small align-right" data-sort-method="number">
           Total
         </th>
         <th class="row-label sort-label sort-label-small" data-sort-method="number">
           Percent
         </th>
-        <th class="row-label sort-label sort-label-small" data-sort-method="number">
+        <th class="row-label sort-label sort-label-small align-right" data-sort-method="number">
           Total
         </th>
         <th class="row-label sort-label sort-label-small" data-sort-method="number">
           Percent
         </th>
-        <th class="row-label sort-label sort-label-small" data-sort-method="number">
+        <th class="row-label sort-label sort-label-small align-right" data-sort-method="number">
           Total
+        </th>
+        <th class="row-label sort-label sort-label-small" data-sort-method="number">
+          Percent
         </th>
       </tr>
       </thead>
@@ -114,11 +114,26 @@
           <%= @region.name %>
         </td>
         <td class="ta-right">
-          <%= number_with_delimiter(@data.dig(:registrations, @period)) %>
-        </td>
-        <td class="ta-right">
           <%= number_with_delimiter(@data.dig(:cumulative_registrations, @period)) %>
         </td>
+        <td class="ta-right">
+          <%= number_with_delimiter(@data.dig(:registrations, @period)) %>
+        </td>
+        <% if @region.state_region? %>
+          <% if @region.estimated_population && @region.estimated_population.population_available_for_all_districts? %>
+            <% estimated_population = number_with_delimiter(@region.estimated_population.population) %>
+            <td class="ta-right">
+              <%= estimated_population %>
+            </td>
+          <% else %>
+            <td class="ta-right"
+            data-sort-column-key="estimated_population"
+            data-sort="<%= estimated_population %>"
+            data-toggle="tooltip"
+            title="<%= t("population_coverage.add_missing_child_estimate.accessible_region", diagnosis: :hypertension, child_type: @region.child_region_type.pluralize) %>">-
+            </td>
+          <% end %>
+        <% end %>
         <% if @region.state_region? %>
             <% if @region.estimated_population && @region.estimated_population.population_available_for_all_districts? && @region.estimated_population.population > 0 %>
             <% coverage_rate = number_to_percentage(@region.estimated_population.patient_coverage_rate(@data.dig(:cumulative_registrations, @period)), precision: 0) %>
@@ -139,21 +154,9 @@
             </td>
           <% end %>
         <% end %>
-          <% if @region.state_region? %>
-            <% if @region.estimated_population && @region.estimated_population.population_available_for_all_districts? %>
-              <% estimated_population = number_with_delimiter(@region.estimated_population.population) %>
-              <td class="ta-right">
-                <%= estimated_population %>
-              </td>
-            <% else %>
-              <td class="ta-right"
-              data-sort-column-key="estimated_population"
-              data-sort="<%= estimated_population %>"
-              data-toggle="tooltip"
-              title="<%= t("population_coverage.add_missing_child_estimate.accessible_region", diagnosis: :hypertension, child_type: @region.child_region_type.pluralize) %>">-
-              </td>
-            <% end %>
-          <% end %>
+        <td class="ta-right">
+          <%= number_with_delimiter(@data.dig(:controlled_patients, @period), precision: 0) %>
+        </td>
         <td
           class="type-percent"
           data-sort-column-key="total-patients-<%= @period %>"
@@ -166,7 +169,7 @@
           </em>
         </td>
         <td class="ta-right">
-          <%= number_with_delimiter(@data.dig(:controlled_patients, @period), precision: 0) %>
+          <%= number_with_delimiter(@data.dig(:uncontrolled_patients, @period)) %>
         </td>
         <td
           class="type-percent"
@@ -180,7 +183,7 @@
           </em>
         </td>
         <td class="ta-right">
-          <%= number_with_delimiter(@data.dig(:uncontrolled_patients, @period)) %>
+          <%= number_with_delimiter(@data.dig(:missed_visits, @period)) %>
         </td>
         <td
           class="type-percent"
@@ -193,9 +196,6 @@
             <%= number_to_percentage(@data.dig(:missed_visits_rate, @period) || 0, precision: 0) %>
           </em>
         </td>
-        <td class="ta-right">
-          <%= number_with_delimiter(@data.dig(:missed_visits, @period)) %>
-        </td>
       </tr>
       <% data.each do |result| %>
         <% child = result[:region] %>
@@ -207,11 +207,29 @@
             <% end %>
           </td>
           <td class="ta-right">
-            <%= number_with_delimiter(result.dig(:registrations, @period)) %>
-          </td>
-          <td class="ta-right">
             <%= number_with_delimiter(result.dig(:cumulative_registrations, @period)) %>
           </td>
+          <td class="ta-right">
+            <%= number_with_delimiter(result.dig(:registrations, @period)) %>
+          </td>
+          <% if @region.state_region? %>
+            <% if child.estimated_population.present? %>
+              <% estimated_population = number_with_delimiter(child.estimated_population.population) %>
+              <td class="ta-right">
+                <%= estimated_population %>
+              </td>
+            <% else %>
+              <td
+              class="ta-right"
+              data-sort-column-key="population-coverage"
+              data-sort="0"
+              data-toggle="tooltip"
+              title="<%= accessible_region?(child, :manage) ?
+                            t("population_coverage.add_missing_estimate.accessible_region_with_region_name", diagnosis: :hypertension, region_name: child.name) :
+                            t("population_coverage.add_missing_estimate.inaccessible_region", diagnosis: :hypertension, region_name: @region.name) %>">-
+              </td>
+            <% end %>
+          <% end %>
           <% if @region.state_region? %>
               <% if child.estimated_population.present? && child.estimated_population.population > 0 %>
               <% coverage_rate = number_to_percentage(child.estimated_population.patient_coverage_rate(result.dig(:cumulative_registrations, @period)), precision: 0) %>
@@ -234,24 +252,9 @@
               </td>
             <% end %>
           <% end %>
-            <% if @region.state_region? %>
-              <% if child.estimated_population.present? %>
-                <% estimated_population = number_with_delimiter(child.estimated_population.population) %>
-                <td class="ta-right">
-                  <%= estimated_population %>
-                </td>
-              <% else %>
-                <td
-                class="ta-right"
-                data-sort-column-key="population-coverage"
-                data-sort="0"
-                data-toggle="tooltip"
-                title="<%= accessible_region?(child, :manage) ?
-                             t("population_coverage.add_missing_estimate.accessible_region_with_region_name", diagnosis: :hypertension, region_name: child.name) :
-                             t("population_coverage.add_missing_estimate.inaccessible_region", diagnosis: :hypertension, region_name: @region.name) %>">-
-                </td>
-              <% end %>
-            <% end %>
+          <td class="ta-right">
+            <%= number_with_delimiter(result.dig(:controlled_patients, @period)) %>
+          </td>
           <td
             class="type-percent"
             data-sort-column-key="total-patients-<%= @period %>"
@@ -264,7 +267,7 @@
             </em>
           </td>
           <td class="ta-right">
-            <%= number_with_delimiter(result.dig(:controlled_patients, @period)) %>
+            <%= number_with_delimiter(result.dig(:uncontrolled_patients, @period)) %>
           </td>
           <td
             class="type-percent"
@@ -278,7 +281,7 @@
             </em>
           </td>
           <td class="ta-right">
-            <%= number_with_delimiter(result.dig(:uncontrolled_patients, @period)) %>
+            <%= number_with_delimiter(result.dig(:missed_visits, @period)) %>
           </td>
           <td
             class="type-percent"
@@ -290,9 +293,6 @@
             <em data-rate="<%= result.dig(:missed_visits_rate, @period) %>" class="low-is-good">
               <%= number_to_percentage(result.dig(:missed_visits_rate, @period) || 0, precision: 0) %>
             </em>
-          </td>
-          <td class="ta-right">
-            <%= number_with_delimiter(result.dig(:missed_visits, @period)) %>
           </td>
         </tr>
       <% end %>


### PR DESCRIPTION
**Story card:** [sc-10405](https://app.shortcut.com/simpledotorg/story/10405/htn-indicators-design-change-request-from-dr-subhasis-via-praveen)

## Because

Can this percentage be made closer to their counts. Currently the % is close to "n" of other indicator. 

Example screenshot (Not real data)
![Screenshot 2023-04-20 at 18 33 31](https://user-images.githubusercontent.com/9541902/233443955-ad6311b3-cad2-4c4f-850a-4975dfe317ae.png)

## This addresses

Design alterations to make readability of the tables easier.

(Not real data)
![Screenshot 2023-04-20 at 18 21 43](https://user-images.githubusercontent.com/9541902/233444181-ac4dccd7-fbf6-4f71-abd9-9ea4181d3695.png)

## Test instructions

Load the branch 
```
dashboard-htn-indicators-percent-improvement
```
Go to reports -> district -> HTN -> 'HTN indicators'
Test the columns resort as expected.
Test the arrows display on hover of the cells
Test the arrows when pressing the cells to sort.