### PR TITLE
Fix some papercuts in the setup script

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -34,9 +34,6 @@ blocks:
           value: "test"
         - name: TB_RSPEC_OPTIONS
           value: "--profile --format RspecJunitFormatter --out junit.xml"
-      secrets:
-        - name: sentry-release-auth-token
-        - name: semaphore-deploy-key
       jobs:
         - name: StandardRB
           commands:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,7 +377,7 @@ GEM
       net-ssh (>= 2.6.5, < 8.0.0)
     net-ssh (7.0.1)
     netrc (0.11.0)
-    nio4r (2.5.8)
+    nio4r (2.5.9)
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,24 @@ $ bin/setup
 
 If you encounter issues with this script, please open [a new issue with details](https://github.com/simpledotorg/simple-server/issues/new?title=Problems+with+bin/setup). Please include the entire log from bin/setup, as well as your computer / OS details.
 
-### Note for Apple Silicon M1 Macs
+### Setup Troubleshooting
+
+#### Setup fails when bundler tries to resolve `nokogiri`
+
+The error message will look like:
+```
+Extracting libxml2-2.9.13.tar.xz into <...>
+========================================================================
+tar (child): xz: Cannot exec: No such file or directory
+tar (child): Error is not recoverable: exiting now
+/bin/tar: Child returned status 2
+/bin/tar: Error is not recoverable: exiting now
+========================================================================
+```
+
+Ensure that you have `xz` installed and *linked* with `brew link xz`.
+
+#### Apple Silicon M1 Macs
 
 With recent gem updates, all of our gems and dependencies now build ARM native on m1 macs. This means you do **not** need to use Rosetta to set up simple-server, and in fact using Rosetta will make things more complicated and confusing in day to day dev experience, and also hurts performance.
 

--- a/bin/setup
+++ b/bin/setup
@@ -11,7 +11,9 @@ init (){
   verify_ruby_version && verify_node_version
   verify_bundled_gems && verify_yarn_packages
   verify_foreman
-  verify_postgres && verify_database_migrations
+  verify_postgres && verify_database_migrations &&
+  cleanup_database
+
   configure_parallel_testing
 }
 
@@ -23,18 +25,15 @@ is_darwin (){
 
 has_homebrew (){
   echo 'Checking for homebrew'
-  [ is_darwin ] && [ hash brew >/dev/null 2>&1 ]
+  is_darwin && hash brew >/dev/null 2>&1
 }
 
 verify_homebrew (){
   echo 'Verifying Homebrew installed'
-  if [ ! has_homebrew ]
+  if ! has_homebrew
   then
     echo 'Homebrew is not installed'
-    if [ is_darwin ]
-    then
-      echo 'Please install homebrew. https://brew.sh'
-    fi
+    is_darwin && echo 'Please install homebrew. https://brew.sh'
     exit 1
   fi
 }
@@ -70,16 +69,13 @@ has_ruby_version (){
 install_ruby_version (){
   verify_homebrew
 
-  if [ ! has_rbenv ]
-  then
+  has_rbenv || {
     echo 'Please install rbenv (https://github.com/rbenv/rbenv) to manage your ruby versions.'
     exit 1
-  fi
-
-  has_rbenv && {
-    update_rbenv
-    rbenv_install_ruby_version
   }
+
+  update_rbenv
+  rbenv_install_ruby_version
 }
 
 verify_postgres (){
@@ -117,8 +113,16 @@ has_node_version (){
 }
 
 install_nodejs (){
+  is_darwin || {
+    echo "Please install node for your platform."
+    exit 1
+  }
+
   echo 'Installing NodeJS...'
   brew install nvm
+
+  # nvm is a bash function and not an executable, so it needs to be sourced
+  source $(brew --prefix nvm)/nvm.sh
   nvm install 18.11.0
   node -v
 }
@@ -144,13 +148,14 @@ migrate_existing_database (){
 }
 
 setup_database (){
-  bundle exec rails db:setup
+  bundle exec rails db:setup ||
+  echo 'Unable to create the databases for you.
+Please ensure your database.yml is configured for your system and try again.'
+}
 
-  if [ $? -ne 0 ]
-  then
-    echo 'Unable to create the databases for you. Please ensure your database.yml is configured for your system and try again.'
-    exit 0
-  fi
+cleanup_database (){
+  echo "Cleaning up previous db setup..."
+  rails db:drop
 }
 
 configure_parallel_testing (){


### PR DESCRIPTION
**Story card:** 🤷 

## Because

I tried to check this codebase out today and run the local setup but faced a few issues while trying to do so. These should hopefully fix them :)

## This addresses

* The bash setup script had several logical errors stemming from incorrect usage of the `[` command, as well as an incorrect invocation of `nvm`. These have been fixed.

* The script also exited with a failure status because the database wasn't cleaned up before the parallel tests ran.

* A dependency of rails, `nio4r` failed to compile on installations having clang 16+. This has been patched upstream, so we bump up the version to make our setup script work.
