### PR TITLE
Pre-fill Screening reports for Ethiopia

### DIFF
--- a/lib/tasks/scripts/pre_fill_monthly_screening_reports.rb
+++ b/lib/tasks/scripts/pre_fill_monthly_screening_reports.rb
@@ -34,8 +34,10 @@ class PreFillMonthlyScreeningReports
       month_date: month_date_str
     ).select(
       "facility_id",
+      "monthly_follow_ups_htn_all",
       "monthly_follow_ups_htn_male",
       "monthly_follow_ups_htn_female",
+      "monthly_follow_ups_dm_all",
       "monthly_follow_ups_dm_male",
       "monthly_follow_ups_dm_female",
       "monthly_follow_ups_htn_and_dm_male",
@@ -53,15 +55,32 @@ class PreFillMonthlyScreeningReports
   end
 
   def self.prefilled_responses(month_date_str, facility_report)
-    {
+    content = {
       "month_date" => month_date_str,
-      "submitted" => false,
-      "monthly_screening_report.diagnosed_cases_on_follow_up_htn.male" => facility_report.monthly_follow_ups_htn_male,
-      "monthly_screening_report.diagnosed_cases_on_follow_up_htn.female" => facility_report.monthly_follow_ups_htn_female,
-      "monthly_screening_report.diagnosed_cases_on_follow_up_dm.male" => facility_report.monthly_follow_ups_dm_male,
-      "monthly_screening_report.diagnosed_cases_on_follow_up_dm.female" => facility_report.monthly_follow_ups_dm_female,
-      "monthly_screening_report.diagnosed_cases_on_follow_up_htn_and_dm.male" => facility_report.monthly_follow_ups_htn_and_dm_male,
-      "monthly_screening_report.diagnosed_cases_on_follow_up_htn_and_dm.female" => facility_report.monthly_follow_ups_htn_and_dm_female
+      "submitted" => false
     }
+    case Rails.application.config.country[:name]
+    when CountryConfig::CONFIGS[:IN]["name"]
+      content.merge(
+        {
+          "monthly_screening_report.diagnosed_cases_on_follow_up_htn.male" => facility_report.monthly_follow_ups_htn_male,
+          "monthly_screening_report.diagnosed_cases_on_follow_up_htn.female" => facility_report.monthly_follow_ups_htn_female,
+          "monthly_screening_report.diagnosed_cases_on_follow_up_dm.male" => facility_report.monthly_follow_ups_dm_male,
+          "monthly_screening_report.diagnosed_cases_on_follow_up_dm.female" => facility_report.monthly_follow_ups_dm_female,
+          "monthly_screening_report.diagnosed_cases_on_follow_up_htn_and_dm.male" => facility_report.monthly_follow_ups_htn_and_dm_male,
+          "monthly_screening_report.diagnosed_cases_on_follow_up_htn_and_dm.female" => facility_report.monthly_follow_ups_htn_and_dm_female
+        }
+      )
+
+    when CountryConfig::CONFIGS[:ET]["name"]
+      content.merge(
+        {
+          "monthly_screening_report.total_htn_diagnosed" => facility_report.monthly_follow_ups_htn_all,
+          "monthly_screening_report.total_dm_diagnosed" => facility_report.monthly_follow_ups_dm_all
+        }
+      )
+    else
+      content
+    end
   end
 end

--- a/spec/tasks/scripts/pre_fill_monthly_screening_reports_spec.rb
+++ b/spec/tasks/scripts/pre_fill_monthly_screening_reports_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PreFillMonthlyScreeningReports do
   end
 
   describe "#call" do
-    it "pre-fills monthly screening reports for previous month" do
+    it "[India] pre-fills monthly screening reports for previous month" do
       PreFillMonthlyScreeningReports.call
 
       date = 1.month.ago.beginning_of_month
@@ -39,6 +39,27 @@ RSpec.describe PreFillMonthlyScreeningReports do
       )
       expect(questionnaire_response.device_created_at).to eq(date)
       expect(questionnaire_response.device_updated_at).to eq(date)
+    end
+
+    it "[Ethiopia] pre-fills monthly screening reports for previous month" do
+      current_country = Rails.application.config.country
+      Rails.application.config.country = CountryConfig.for("ET")
+      PreFillMonthlyScreeningReports.call
+
+      date = 1.month.ago.beginning_of_month
+      questionnaire_response = QuestionnaireResponse.find_by_facility_id(facility)
+      expect(questionnaire_response.content).to eq(
+        {
+          "month_date" => date.strftime("%Y-%m-%d"),
+          "submitted" => false,
+          "monthly_screening_report.total_htn_diagnosed" => 1,
+          "monthly_screening_report.total_dm_diagnosed" => 0
+        }
+      )
+      expect(questionnaire_response.device_created_at).to eq(date)
+      expect(questionnaire_response.device_updated_at).to eq(date)
+
+      Rails.application.config.country = current_country
     end
 
     it "ignores existing monthly screening reports" do


### PR DESCRIPTION
**Story card:** [sc-10435](https://app.shortcut.com/simpledotorg/story/10435/pre-fill-ethiopia-screening-reports)

## Test instructions

![image](https://user-images.githubusercontent.com/9414539/234250539-a2623f18-55d0-4746-bfb5-aaac3408c9eb.png)
Questionnaire Responses in Ethiopia should have pre-populated fields that go by above field names.