### PR TITLE
Show link to org reports only if admin has access

### DIFF
--- a/app/views/reports/regions/index.html.erb
+++ b/app/views/reports/regions/index.html.erb
@@ -9,7 +9,8 @@
   <% @accessible_regions.each do |org, children| %>
     <div class="organization card show">
       <div class="access-tree__section-header">
-        <% if current_admin.feature_enabled?(:organization_reports) %>
+        <% if current_admin.feature_enabled?(:organization_reports) &&
+          current_admin.accessible_organizations(:view_reports).find_by_id(org.source) %>
           <h3><%= link_to(org.name, reports_region_path(org.source.slug, report_scope: org.region_type)) %></h3>
         <% else %>
           <h3><%= org.name %></h3>


### PR DESCRIPTION
**Story card:** [sc-10248](https://app.shortcut.com/simpledotorg/story/10248/dashboard-permission-issue)

## Because

All admins can see a link to the org's reports on the reports index page. If an admin doesn't have access to the org, clicking on it returns a `You are not authorized to perform this action.`. This link shouldn't be visible in the first place to a user who doesn't have access.

## This addresses

Doesn't render the link to org report if the admin doesn't have access. 

For an STS user:
**Before**
<img width="250" alt="image" src="https://user-images.githubusercontent.com/16774200/234587803-0e57939d-ffd3-4acb-b9f1-83ebe3671ab5.png">

**After**
<img width="250" alt="image" src="https://user-images.githubusercontent.com/16774200/234587638-45de649f-b76a-48ce-b409-afdd630aa00f.png">

