### PR TITLE
Deploy manifest files to github pages

### DIFF
--- a/.github/workflows/deploy-manifest.yml
+++ b/.github/workflows/deploy-manifest.yml
@@ -1,0 +1,41 @@
+# Workflow for deploying public/manifest content to GitHub Pages
+name: Deploy public/manifest content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'public/manifest'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
**Story card:** [10334](https://app.shortcut.com/simpledotorg/story/10334)

## Because

We have a Rails application deployed for multiple countries, each with its own instance. The application relies on a manifest.json file to display a list of countries. Currently, this file is served from the India deployment, creating a dependency on that specific instance. In order to improve reliability and maintainability, we need to decouple the manifest.json file from the India deployment and host it on a separate deployment.

## This addresses

Deploy manifest to GitHub pages