### PR TITLE
Goal-lines - Minimum 6 months period data [bug correction]

### DIFF
--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -452,7 +452,8 @@ Reports = function ({ withLtfu, showGoalLines }) {
   }
 
   function lessThan6MonthsSinceFirstPatientRegistered(periodValues) {
-    if (periodValues.length < 6) {
+    const periodKeysArray = Object.keys(periodValues)
+    if (periodKeysArray.length < 6) {
       return true;
     }
     return false;


### PR DESCRIPTION
I was checking the length of an object instead of an array.
- Convert object to array of key names
- Check length to ensure minimum of 6 months before calculating goal

**Story card:** [sc-XXXX](URL)

## This addresses

Dashboard throws and error on facilities with less than 6 months data present

## Test instructions

Requires 'goal_lines' flipper flag
View facility with less than 6 months of data.