### PR TITLE
Ensure a `deleted_reason` for deduplicated patients

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -16,6 +16,8 @@ class Patient < ApplicationRecord
 
   enum status: STATUSES.zip(STATUSES).to_h, _prefix: true
 
+  enum deleted_reason: DELETED_REASONS.zip(DELETED_REASONS).to_h, _prefix: true
+
   enum reminder_consent: {
     granted: "granted",
     denied: "denied"
@@ -224,9 +226,9 @@ class Patient < ApplicationRecord
      gender: gender}
   end
 
-  def discard_data(deleted_reason: "unknown")
+  def discard_data(reason:)
     ActiveRecord::Base.transaction do
-      update(deleted_reason: deleted_reason)
+      update(deleted_reason: reason)
       address&.discard
       appointments.discard_all
       blood_pressures.discard_all

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -224,8 +224,9 @@ class Patient < ApplicationRecord
      gender: gender}
   end
 
-  def discard_data
+  def discard_data(deleted_reason: "unknown")
     ActiveRecord::Base.transaction do
+      update(deleted_reason: deleted_reason)
       address&.discard
       appointments.discard_all
       blood_pressures.discard_all
@@ -239,5 +240,7 @@ class Patient < ApplicationRecord
       teleconsultations.discard_all
       discard
     end
+
+    self
   end
 end

--- a/app/services/merge_patient_service.rb
+++ b/app/services/merge_patient_service.rb
@@ -5,7 +5,6 @@ class MergePatientService
   end
 
   def merge
-    patient_before_merge = existing_patient
     merged_address = Address.merge(payload[:address]) if payload[:address].present?
 
     patient_attributes =
@@ -22,15 +21,20 @@ class MergePatientService
 
     touch_patient(merged_patient) if associations_updated?(merged_address, merged_phone_numbers, merged_business_ids)
 
-    # Patient has been soft-deleted by the client, server should soft-delete the patient and their associated data.
-    if discarded_in_this_merge?(merged_patient, patient_before_merge)
-      discard_patient_data(merged_patient, deleted_reason: merged_patient.deleted_reason)
+    if should_discard_patient_data?(merged_patient, patient_attributes)
+      discard_patient_data(merged_patient)
     end
 
     merged_patient
   end
 
   private
+
+  def should_discard_patient_data?(merged_patient, merged_attributes)
+    merged_patient.merge_status == :updated &&
+      merged_attributes[:deleted_at].present? &&
+      merged_patient.discarded?
+  end
 
   attr_reader :payload, :request_metadata
 
@@ -75,13 +79,9 @@ class MergePatientService
     end
   end
 
-  def discarded_in_this_merge?(patient, existing_patient)
-    patient.deleted_at.present? && existing_patient&.deleted_at.nil?
-  end
-
-  def discard_patient_data(patient, deleted_reason: "unknown")
+  def discard_patient_data(patient)
     patient.update(deleted_by_user_id: request_metadata[:request_user_id])
-    patient.discard_data(deleted_reason: deleted_reason)
+    patient.discard_data(reason: patient.deleted_reason)
   end
 
   def associations_updated?(address, phone_numbers, business_ids)

--- a/app/services/merge_patient_service.rb
+++ b/app/services/merge_patient_service.rb
@@ -23,7 +23,9 @@ class MergePatientService
     touch_patient(merged_patient) if associations_updated?(merged_address, merged_phone_numbers, merged_business_ids)
 
     # Patient has been soft-deleted by the client, server should soft-delete the patient and their associated data.
-    discard_patient_data(merged_patient) if discarded_in_this_merge?(merged_patient, patient_before_merge)
+    if discarded_in_this_merge?(merged_patient, patient_before_merge)
+      discard_patient_data(merged_patient, deleted_reason: merged_patient.deleted_reason)
+    end
 
     merged_patient
   end
@@ -77,9 +79,9 @@ class MergePatientService
     patient.deleted_at.present? && existing_patient&.deleted_at.nil?
   end
 
-  def discard_patient_data(patient)
+  def discard_patient_data(patient, deleted_reason: "unknown")
     patient.update(deleted_by_user_id: request_metadata[:request_user_id])
-    patient.discard_data
+    patient.discard_data(deleted_reason: deleted_reason)
   end
 
   def associations_updated?(address, phone_numbers, business_ids)

--- a/app/services/patient_deduplication/deduplicator.rb
+++ b/app/services/patient_deduplication/deduplicator.rb
@@ -54,8 +54,8 @@ module PatientDeduplication
       @patients.each do |patient|
         track(Patient, patient, new_patient)
       end
-      @patients.map do |p|
-        p.discard_data(deleted_reason: "duplicate")
+      @patients.map do |patient|
+        patient.discard_data(reason: :duplicate)
       end
     end
 

--- a/app/services/patient_deduplication/deduplicator.rb
+++ b/app/services/patient_deduplication/deduplicator.rb
@@ -54,7 +54,9 @@ module PatientDeduplication
       @patients.each do |patient|
         track(Patient, patient, new_patient)
       end
-      @patients.map(&:discard_data)
+      @patients.map do |p|
+        p.discard_data(deleted_reason: "duplicate")
+      end
     end
 
     def create_patient

--- a/lib/tasks/scripts/soft_delete_duplicate_patients.rb
+++ b/lib/tasks/scripts/soft_delete_duplicate_patients.rb
@@ -21,6 +21,8 @@ module SoftDeleteDuplicatePatients
   end
 
   def self.discard_patients(patient_ids)
-    Patient.where(id: patient_ids).map { |p| p.discard_data(deleted_reason: "duplicate") }
+    Patient.where(id: patient_ids).map do |patient|
+      patient.discard_data(reason: :duplicate)
+    end
   end
 end

--- a/lib/tasks/scripts/soft_delete_duplicate_patients.rb
+++ b/lib/tasks/scripts/soft_delete_duplicate_patients.rb
@@ -21,6 +21,6 @@ module SoftDeleteDuplicatePatients
   end
 
   def self.discard_patients(patient_ids)
-    Patient.where(id: patient_ids).map(&:discard_data)
+    Patient.where(id: patient_ids).map { |p| p.discard_data(deleted_reason: "duplicate") }
   end
 end

--- a/spec/controllers/api/v3/patients_controller_spec.rb
+++ b/spec/controllers/api/v3/patients_controller_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Api::V3::PatientsController, type: :controller do
       it "doesn't update soft deleted patient's attributes" do
         existing_patient_name = existing_patient.full_name
 
-        existing_patient.discard_data
+        existing_patient.discard_data(reason: :unknown)
 
         update_payload_for_discarded_patient =
           build_payload.call(existing_patient).merge(full_name: "Test Patient Name Xcad7asd")

--- a/spec/controllers/api/v4/patients_controller_spec.rb
+++ b/spec/controllers/api/v4/patients_controller_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Api::V4::PatientsController, type: :controller do
       )
 
       set_headers(patient_1.registration_user, patient_1.registration_facility)
-      patient_1.discard_data
+      patient_1.discard_data(reason: :unknown)
       business_identifier.reload.undiscard
 
       post :lookup, params: {identifier: patient_1.business_identifiers.first.identifier}, as: :json

--- a/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
+++ b/spec/controllers/shared_examples/shared_spec_for_sync_controller.rb
@@ -15,7 +15,7 @@ def parse_process_token(response_body)
 end
 
 def discard_patient(record)
-  record.instance_of?(Patient) ? record.discard_data : record.patient.discard_data
+  record.instance_of?(Patient) ? record.discard_data(reason: nil) : record.patient.discard_data(reason: nil)
 end
 
 RSpec.shared_examples "a sync controller that authenticates user requests: sync_from_user" do

--- a/spec/lib/tasks/scripts/soft_delete_duplicate_patients_spec.rb
+++ b/spec/lib/tasks/scripts/soft_delete_duplicate_patients_spec.rb
@@ -31,11 +31,20 @@ RSpec.describe SoftDeleteDuplicatePatients do
         .map { |patient| patient["Simple Patient ID"] }
     end
     let!(:patient_ids_to_delete) { described_class.parse(file_path) }
-    let!(:patients) { patient_ids.map { |id| create(:patient, id: id) } }
 
-    it "should discard all patients given their ids" do
+    it "discards all patients given their IDs" do
+      patient_ids.map { |id| create(:patient, id: id) }
+
       expect { described_class.discard_patients(patient_ids_to_delete) }.to change { Patient.count }.from(5).to(3)
       expect(Patient.unscoped.count).to eq(5)
+    end
+
+    it "sets the discard reason for all deleted IDs to 'duplicate'" do
+      patient_ids_to_delete.map { |id| create(:patient, id: id) }
+
+      discarded_patients = described_class.discard_patients(patient_ids_to_delete)
+
+      expect(discarded_patients.pluck(:deleted_reason)).to all eq("duplicate")
     end
   end
 end

--- a/spec/lib/tasks/scripts/soft_delete_duplicate_patients_spec.rb
+++ b/spec/lib/tasks/scripts/soft_delete_duplicate_patients_spec.rb
@@ -34,16 +34,13 @@ RSpec.describe SoftDeleteDuplicatePatients do
 
     it "discards all patients given their IDs" do
       patient_ids.map { |id| create(:patient, id: id) }
-
       expect { described_class.discard_patients(patient_ids_to_delete) }.to change { Patient.count }.from(5).to(3)
       expect(Patient.unscoped.count).to eq(5)
     end
 
     it "sets the discard reason for all deleted IDs to 'duplicate'" do
       patient_ids_to_delete.map { |id| create(:patient, id: id) }
-
       discarded_patients = described_class.discard_patients(patient_ids_to_delete)
-
       expect(discarded_patients.pluck(:deleted_reason)).to all eq("duplicate")
     end
   end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -206,7 +206,7 @@ describe Appointment, type: :model do
     let!(:discarded_overdue_appointment) { create(:appointment, :overdue, patient: discard_patient) }
 
     it "shouldn't include discarded patients' appointments " do
-      discard_patient.discard_data
+      discard_patient.discard_data(reason: :unknown)
 
       expect(Appointment.overdue).to include(overdue_appointment)
       expect(Appointment.overdue).not_to include(discarded_overdue_appointment)

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -495,7 +495,7 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
         subject: nil)
       membership = create(:treatment_group_membership, treatment_group: treatment_group, status: :evicted, patient: patient)
       membership.record_notification(reminder_template.id, notification)
-      patient.discard_data
+      patient.discard_data(reason: :duplicate)
 
       experiment.record_notification_results
     end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -107,6 +107,17 @@ describe Patient, type: :model do
     end
 
     it { should validate_presence_of(:status) }
+
+    it "validates deleted reason" do
+      patient = Patient.new
+
+      # valid deleted reasons should not cause problems
+      Patient::DELETED_REASONS.each { |reason| patient.deleted_reason = reason }
+      # nil is also a valid reason
+      patient.deleted_reason = nil
+
+      expect { patient.deleted_reason = "something else" }.to raise_error(ArgumentError)
+    end
   end
 
   describe "Behavior" do
@@ -666,15 +677,9 @@ describe Patient, type: :model do
   end
 
   context ".discard_data" do
-    it "adds a default deleted reason of 'unknown'" do
-      patient = create(:patient)
-      patient.discard_data
-      expect(patient.deleted_reason).to eq "unknown"
-    end
-
     it "adds a deleted reason" do
       patient = create(:patient)
-      patient.discard_data(deleted_reason: "accidental_registration")
+      patient.discard_data(reason: :accidental_registration)
       expect(patient.deleted_reason).to eq "accidental_registration"
     end
 
@@ -682,7 +687,7 @@ describe Patient, type: :model do
       patient = create(:patient)
       create_list(:blood_pressure, 2, :with_encounter, patient: patient, user: patient.registration_user, facility: patient.registration_facility)
 
-      patient.discard_data
+      patient.discard_data(reason: :duplicate)
       expect(Encounter.where(patient: patient)).to be_empty
     end
 
@@ -690,7 +695,7 @@ describe Patient, type: :model do
       patient = create(:patient)
       create_list(:blood_pressure, 2, :with_encounter, patient: patient, user: patient.registration_user, facility: patient.registration_facility)
 
-      patient.discard_data
+      patient.discard_data(reason: :duplicate)
       encounter_ids = Encounter.with_discarded.where(patient: patient).pluck(:id)
       expect(Observation.where(encounter_id: encounter_ids)).to be_empty
     end
@@ -699,7 +704,7 @@ describe Patient, type: :model do
       patient = create(:patient)
       create_list(:blood_pressure, 2, :with_encounter, patient: patient, user: patient.registration_user, facility: patient.registration_facility)
 
-      patient.discard_data
+      patient.discard_data(reason: :duplicate)
       expect(BloodPressure.where(patient: patient)).to be_empty
     end
 
@@ -707,7 +712,7 @@ describe Patient, type: :model do
       patient = create(:patient)
       create_list(:blood_sugar, 2, :with_encounter, patient: patient, user: patient.registration_user, facility: patient.registration_facility)
 
-      patient.discard_data
+      patient.discard_data(reason: :duplicate)
       expect(BloodSugar.where(patient: patient)).to be_empty
     end
 
@@ -715,7 +720,7 @@ describe Patient, type: :model do
       patient = create(:patient)
       create_list(:appointment, 2, patient: patient, user: patient.registration_user, facility: patient.registration_facility)
 
-      patient.discard_data
+      patient.discard_data(reason: :duplicate)
       expect(Appointment.where(patient: patient)).to be_empty
     end
 
@@ -723,31 +728,31 @@ describe Patient, type: :model do
       patient = create(:patient)
       create_list(:prescription_drug, 2, patient: patient, user: patient.registration_user, facility: patient.registration_facility)
 
-      patient.discard_data
+      patient.discard_data(reason: :duplicate)
       expect(PrescriptionDrug.where(patient: patient)).to be_empty
     end
 
     it "soft deletes the patient's business identifiers" do
       patient = create(:patient)
-      patient.discard_data
+      patient.discard_data(reason: :duplicate)
       expect(PatientBusinessIdentifier.where(patient: patient)).to be_empty
     end
 
     it "soft deletes the patient's phone numbers" do
       patient = create(:patient)
-      patient.discard_data
+      patient.discard_data(reason: :duplicate)
       expect(PatientPhoneNumber.where(patient: patient)).to be_empty
     end
 
     it "soft deletes the patient's medical history" do
       patient = create(:patient)
-      patient.discard_data
+      patient.discard_data(reason: :duplicate)
       expect(MedicalHistory.where(patient: patient)).to be_empty
     end
 
     it "soft deletes the patient's address" do
       patient = create(:patient)
-      patient.discard_data
+      patient.discard_data(reason: :duplicate)
       expect(Address.where(id: patient.address_id)).to be_empty
     end
 
@@ -755,16 +760,14 @@ describe Patient, type: :model do
       patient = create(:patient)
       user = patient.registration_user
       create_list(:teleconsultation, 2, patient: patient, requester: user, medical_officer: user, requested_medical_officer: user)
-      patient.discard_data
+      patient.discard_data(reason: :duplicate)
 
       expect(Teleconsultation.where(patient: patient)).to be_empty
     end
 
     it "soft deletes the patient itself" do
       patient = create(:patient)
-
-      patient.discard_data
-
+      patient.discard_data(reason: :duplicate)
       expect(patient.deleted_at).not_to be_nil
     end
   end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -666,6 +666,18 @@ describe Patient, type: :model do
   end
 
   context ".discard_data" do
+    it "adds a default deleted reason of 'unknown'" do
+      patient = create(:patient)
+      patient.discard_data
+      expect(patient.deleted_reason).to eq "unknown"
+    end
+
+    it "adds a deleted reason" do
+      patient = create(:patient)
+      patient.discard_data(deleted_reason: "accidental_registration")
+      expect(patient.deleted_reason).to eq "accidental_registration"
+    end
+
     it "soft deletes the patient's encounters" do
       patient = create(:patient)
       create_list(:blood_pressure, 2, :with_encounter, patient: patient, user: patient.registration_user, facility: patient.registration_facility)
@@ -739,13 +751,21 @@ describe Patient, type: :model do
       expect(Address.where(id: patient.address_id)).to be_empty
     end
 
-    it "soft deleted the patient's teleconsultations" do
+    it "soft deletes the patient's teleconsultations" do
       patient = create(:patient)
       user = patient.registration_user
       create_list(:teleconsultation, 2, patient: patient, requester: user, medical_officer: user, requested_medical_officer: user)
       patient.discard_data
 
       expect(Teleconsultation.where(patient: patient)).to be_empty
+    end
+
+    it "soft deletes the patient itself" do
+      patient = create(:patient)
+
+      patient.discard_data
+
+      expect(patient.deleted_at).not_to be_nil
     end
   end
 end

--- a/spec/queries/cohort_analytics_query_spec.rb
+++ b/spec/queries/cohort_analytics_query_spec.rb
@@ -186,7 +186,9 @@ RSpec.describe CohortAnalyticsQuery do
       end
 
       it "does not count discarded patients" do
-        jan_patients_1[0..2].each(&:discard_data)
+        jan_patients_1[0..2].each do |p|
+          p.discard_data(reason: nil)
+        end
         analytics = CohortAnalyticsQuery.new(facility_group, period: :month, prev_periods: 3, from_time: report_end)
         counts = analytics.patient_counts(cohort_start, cohort_end, report_start, report_end).deep_symbolize_keys
         expect(counts[:cohort_patients][:total]).to eq(14)

--- a/spec/queries/district_analytics_query_spec.rb
+++ b/spec/queries/district_analytics_query_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe DistrictAnalyticsQuery do
         create(:bp_with_encounter, patient: patients.second, facility: facility_2, user: user)
       end
 
-      patients.first.discard_data
+      patients.first.discard_data(reason: nil)
       refresh_views
     end
 

--- a/spec/queries/facility_analytics_query_spec.rb
+++ b/spec/queries/facility_analytics_query_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe FacilityAnalyticsQuery do
         create(:blood_pressure, patient: patients.first, facility: facility, user: users.first)
         create(:blood_pressure, patient: patients.second, facility: facility, user: users.first)
       end
-      patients.first.discard_data
+      patients.first.discard_data(reason: nil)
     end
 
     describe "#registered_patients_by_period" do

--- a/spec/rachets/lets_not_spec.rb
+++ b/spec/rachets/lets_not_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe "Rachet down usage of let!" do
-  expected_usages = 434
+  expected_usages = 433
 
   it "prevents new usages" do
     command = %{grep -rn "\slet\!(:" spec}


### PR DESCRIPTION
**Story card:** [sc-8392](https://app.shortcut.com/simpledotorg/story/8392/set-deleted-reason-for-deduplicated-patients)

## Because

The `deleted_reason` is currently left empty for patients who are de-duplicated and merged automatically. It should be set to `duplicate`. We also ensure that the `deleted_reason` is preserved across patient sync merges.

## This addresses

When we delete a patient during a merge, we must provide a valid deletion reason. This change ensures that the reason is:
- "duplicate" whenever we de-duplicate a patient 
    - occurrences: `SoftDeleteDuplicatePatients` and `PatientDeduplicator` module
- the already-present `deleted_reason` when a sync merge happens
    - occurrences: `MergePatientService`

## Test instructions

* Unit tests, etc.
* Mark a patient as duplicate from the deduplication page in the dashboard and verify if the deletion reason is set to "duplicate" in the database.