### PR TITLE
fix foreman Procfile `clock` for non-GNU developers

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
 web: bundle exec rails server -p 3000
 worker: bundle exec sidekiq
-clock: bundle exec whenever && sleep infinity
+clock: bundle exec whenever && while true; do sleep 16777216; done


### PR DESCRIPTION
`sleep infinity` is a GNU extension to `sleep`; so this command breaks for MacOS users, which in turn causes all the processes started by foreman to exit. We change this to a POSIX compliant version that loops once every 2^24 seconds, ie, 5ish years (this is much below the POSIX-required maximum of 2147483647 seconds [~68 years], but I found this number less intimidating).