### PR TITLE
Introduce a materialized view for Overdue Patients v2

### DIFF
--- a/app/models/reports/overdue_patient.rb
+++ b/app/models/reports/overdue_patient.rb
@@ -1,0 +1,10 @@
+module Reports
+  class OverduePatient < Reports::View
+    self.table_name = "reporting_overdue_patients"
+    belongs_to :patient
+
+    def self.materialized?
+      true
+    end
+  end
+end

--- a/app/services/refresh_reporting_views.rb
+++ b/app/services/refresh_reporting_views.rb
@@ -24,6 +24,7 @@ class RefreshReportingViews
     Reports::PatientFollowUp
     Reports::PatientState
     Reports::FacilityAppointmentScheduledDays
+    Reports::OverduePatient
     Reports::FacilityState
     Reports::QuarterlyFacilityState
     Reports::FacilityDailyFollowUpAndRegistration

--- a/db/migrate/20230522081701_create_reporting_overdue_patients.rb
+++ b/db/migrate/20230522081701_create_reporting_overdue_patients.rb
@@ -1,0 +1,10 @@
+class CreateReportingOverduePatients < ActiveRecord::Migration[6.1]
+  def change
+    create_view :reporting_overdue_patients, materialized: true
+    add_index :reporting_overdue_patients, [:month_date, :patient_id],
+      unique: true,
+      name: "overdue_patients_month_date_patient_id"
+    add_index :reporting_overdue_patients, [:month_date, :assigned_facility_region_id],
+      name: "overdue_patients_month_date_assigned_facility_region_id"
+  end
+end

--- a/db/migrate/20230522081701_create_reporting_overdue_patients.rb
+++ b/db/migrate/20230522081701_create_reporting_overdue_patients.rb
@@ -4,7 +4,7 @@ class CreateReportingOverduePatients < ActiveRecord::Migration[6.1]
     add_index :reporting_overdue_patients, [:month_date, :patient_id],
       unique: true,
       name: "overdue_patients_month_date_patient_id"
-    add_index :reporting_overdue_patients, [:month_date, :assigned_facility_region_id],
-      name: "overdue_patients_month_date_assigned_facility_region_id"
+    add_index :reporting_overdue_patients, [:assigned_facility_region_id],
+      name: "overdue_patients_assigned_facility_region_id"
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4557,101 +4557,231 @@ COMMENT ON COLUMN public.reporting_facility_states.diabetes_appts_scheduled_more
 --
 
 CREATE MATERIALIZED VIEW public.reporting_overdue_patients AS
- SELECT DISTINCT ON (reporting_patient_states.month_date, reporting_patient_states.patient_id) reporting_patient_states.month_date,
-    reporting_patient_states.month,
-    reporting_patient_states.quarter,
-    reporting_patient_states.year,
-    reporting_patient_states.month_string,
-    reporting_patient_states.quarter_string,
-    reporting_patient_states.patient_id,
-    reporting_patient_states.assigned_facility_id,
-    reporting_patient_states.assigned_facility_slug,
-    reporting_patient_states.assigned_facility_region_id,
-    reporting_patient_states.assigned_block_slug,
-    reporting_patient_states.assigned_block_region_id,
-    reporting_patient_states.assigned_district_slug,
-    reporting_patient_states.assigned_district_region_id,
-    reporting_patient_states.assigned_state_slug,
-    reporting_patient_states.assigned_state_region_id,
-    reporting_patient_states.assigned_organization_slug,
-    reporting_patient_states.assigned_organization_region_id,
-    next_call_results.user_id AS called_by_user_id,
-    appointments.id AS previous_appointment_id,
-    ((appointments.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE 'UTC'::text) AS previous_appointment_date,
-    ((appointments.scheduled_date AT TIME ZONE 'UTC'::text) AT TIME ZONE 'UTC'::text) AS previous_appointment_scheduled_date,
-    ((visits.visited_at_after_appointment AT TIME ZONE 'UTC'::text) AT TIME ZONE 'UTC'::text) AS visited_at_after_appointment,
-    ((next_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE 'UTC'::text) AS next_called_at,
-    ((previous_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE 'UTC'::text) AS previous_called_at,
-    reporting_patient_states.hypertension,
-    reporting_patient_states.diabetes,
-    next_call_results.result_type AS next_call_result_type,
-    next_call_results.remove_reason AS next_call_remove_from_overdue_list_reason,
-    previous_call_results.result_type AS previous_call_result_type,
-    previous_call_results.remove_reason AS previous_call_remove_from_overdue_list_reason,
+ WITH patients_with_appointments AS (
+         SELECT DISTINCT ON (rps.patient_id, rps.month_date) rps.month_date,
+            rps.patient_id,
+            rps.hypertension,
+            rps.diabetes,
+            rps.htn_care_state,
+            rps.month,
+            rps.quarter,
+            rps.year,
+            rps.month_string,
+            rps.quarter_string,
+            rps.assigned_facility_id,
+            rps.assigned_facility_slug,
+            rps.assigned_facility_region_id,
+            rps.assigned_block_slug,
+            rps.assigned_block_region_id,
+            rps.assigned_district_slug,
+            rps.assigned_district_region_id,
+            rps.assigned_state_slug,
+            rps.assigned_state_region_id,
+            rps.assigned_organization_slug,
+            rps.assigned_organization_region_id,
+            appointments.id AS previous_appointment_id,
+            appointments.device_created_at AS previous_appointment_date,
+            appointments.scheduled_date AS previous_appointment_schedule_date
+           FROM (public.reporting_patient_states rps
+             LEFT JOIN public.appointments ON (((appointments.patient_id = rps.patient_id) AND (appointments.device_created_at < rps.month_date))))
+          WHERE ((rps.status)::text <> 'dead'::text)
+          ORDER BY rps.patient_id, rps.month_date, appointments.device_created_at DESC
+        ), patients_with_appointments_and_visits AS (
+         SELECT DISTINCT ON (patients_with_appointments.patient_id, patients_with_appointments.month_date) patients_with_appointments.month_date,
+            patients_with_appointments.patient_id,
+            patients_with_appointments.hypertension,
+            patients_with_appointments.diabetes,
+            patients_with_appointments.htn_care_state,
+            patients_with_appointments.month,
+            patients_with_appointments.quarter,
+            patients_with_appointments.year,
+            patients_with_appointments.month_string,
+            patients_with_appointments.quarter_string,
+            patients_with_appointments.assigned_facility_id,
+            patients_with_appointments.assigned_facility_slug,
+            patients_with_appointments.assigned_facility_region_id,
+            patients_with_appointments.assigned_block_slug,
+            patients_with_appointments.assigned_block_region_id,
+            patients_with_appointments.assigned_district_slug,
+            patients_with_appointments.assigned_district_region_id,
+            patients_with_appointments.assigned_state_slug,
+            patients_with_appointments.assigned_state_region_id,
+            patients_with_appointments.assigned_organization_slug,
+            patients_with_appointments.assigned_organization_region_id,
+            patients_with_appointments.previous_appointment_id,
+            patients_with_appointments.previous_appointment_date,
+            patients_with_appointments.previous_appointment_schedule_date,
+            visits.visit_id,
+            visits.visited_at_after_appointment
+           FROM (patients_with_appointments
+             LEFT JOIN LATERAL ( SELECT blood_sugars.id AS visit_id,
+                    blood_sugars.patient_id,
+                    blood_sugars.recorded_at AS visited_at_after_appointment
+                   FROM public.blood_sugars
+                  WHERE ((blood_sugars.deleted_at IS NULL) AND (blood_sugars.patient_id = patients_with_appointments.patient_id) AND (patients_with_appointments.previous_appointment_date < blood_sugars.recorded_at) AND (blood_sugars.recorded_at < ((patients_with_appointments.month_date + '1 mon'::interval) + '15 days'::interval)))
+                UNION
+                 SELECT blood_pressures.id AS visit_id,
+                    blood_pressures.patient_id,
+                    blood_pressures.recorded_at AS visited_at_after_appointment
+                   FROM public.blood_pressures
+                  WHERE ((blood_pressures.deleted_at IS NULL) AND (blood_pressures.patient_id = patients_with_appointments.patient_id) AND (patients_with_appointments.previous_appointment_date < blood_pressures.recorded_at) AND (blood_pressures.recorded_at < ((patients_with_appointments.month_date + '1 mon'::interval) + '15 days'::interval)))
+                UNION
+                 SELECT patients_with_appointments_visit.id AS visit_id,
+                    patients_with_appointments_visit.patient_id,
+                    patients_with_appointments_visit.device_created_at AS visited_at_after_appointment
+                   FROM public.appointments patients_with_appointments_visit
+                  WHERE ((patients_with_appointments_visit.deleted_at IS NULL) AND (patients_with_appointments_visit.patient_id = patients_with_appointments.patient_id) AND (patients_with_appointments.previous_appointment_date < patients_with_appointments_visit.device_created_at) AND (patients_with_appointments_visit.device_created_at < ((patients_with_appointments.month_date + '1 mon'::interval) + '15 days'::interval)))
+                UNION
+                 SELECT prescription_drugs.id AS visit_id,
+                    prescription_drugs.patient_id,
+                    prescription_drugs.device_created_at AS visited_at_after_appointment
+                   FROM public.prescription_drugs
+                  WHERE ((prescription_drugs.deleted_at IS NULL) AND (prescription_drugs.patient_id = patients_with_appointments.patient_id) AND (patients_with_appointments.previous_appointment_date < prescription_drugs.device_created_at) AND (prescription_drugs.device_created_at < ((patients_with_appointments.month_date + '1 mon'::interval) + '15 days'::interval)))) visits ON ((patients_with_appointments.patient_id = visits.patient_id)))
+          ORDER BY patients_with_appointments.patient_id, patients_with_appointments.month_date, patients_with_appointments.previous_appointment_date DESC, visits.visited_at_after_appointment
+        ), patient_with_call_results AS (
+         SELECT DISTINCT ON (patients_with_appointments_and_visits.patient_id, patients_with_appointments_and_visits.month_date) patients_with_appointments_and_visits.month_date,
+            patients_with_appointments_and_visits.patient_id,
+            patients_with_appointments_and_visits.hypertension,
+            patients_with_appointments_and_visits.diabetes,
+            patients_with_appointments_and_visits.htn_care_state,
+            patients_with_appointments_and_visits.month,
+            patients_with_appointments_and_visits.quarter,
+            patients_with_appointments_and_visits.year,
+            patients_with_appointments_and_visits.month_string,
+            patients_with_appointments_and_visits.quarter_string,
+            patients_with_appointments_and_visits.assigned_facility_id,
+            patients_with_appointments_and_visits.assigned_facility_slug,
+            patients_with_appointments_and_visits.assigned_facility_region_id,
+            patients_with_appointments_and_visits.assigned_block_slug,
+            patients_with_appointments_and_visits.assigned_block_region_id,
+            patients_with_appointments_and_visits.assigned_district_slug,
+            patients_with_appointments_and_visits.assigned_district_region_id,
+            patients_with_appointments_and_visits.assigned_state_slug,
+            patients_with_appointments_and_visits.assigned_state_region_id,
+            patients_with_appointments_and_visits.assigned_organization_slug,
+            patients_with_appointments_and_visits.assigned_organization_region_id,
+            patients_with_appointments_and_visits.previous_appointment_id,
+            patients_with_appointments_and_visits.previous_appointment_date,
+            patients_with_appointments_and_visits.previous_appointment_schedule_date,
+            patients_with_appointments_and_visits.visit_id,
+            patients_with_appointments_and_visits.visited_at_after_appointment,
+            ((previous_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE 'UTC'::text) AS previous_called_at,
+            previous_call_results.result_type AS previous_call_result_type,
+            previous_call_results.remove_reason AS previous_call_removed_from_overdue_list_reason,
+            ((next_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE 'UTC'::text) AS next_called_at,
+            next_call_results.result_type AS next_call_result_type,
+            next_call_results.remove_reason AS next_call_removed_from_overdue_list_reason,
+            next_call_results.user_id AS called_by_user_id
+           FROM ((patients_with_appointments_and_visits
+             LEFT JOIN public.call_results previous_call_results ON (((patients_with_appointments_and_visits.patient_id = previous_call_results.patient_id) AND (((previous_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)) < patients_with_appointments_and_visits.month_date) AND (previous_call_results.device_created_at > patients_with_appointments_and_visits.previous_appointment_schedule_date))))
+             LEFT JOIN public.call_results next_call_results ON (((patients_with_appointments_and_visits.patient_id = next_call_results.patient_id) AND (((next_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)) >= patients_with_appointments_and_visits.month_date) AND (((next_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)) < (patients_with_appointments_and_visits.month_date + '1 mon'::interval)))))
+          ORDER BY patients_with_appointments_and_visits.patient_id, patients_with_appointments_and_visits.month_date, next_call_results.device_created_at, previous_call_results.device_created_at DESC
+        ), patient_with_call_results_and_phone AS (
+         SELECT DISTINCT ON (patient_with_call_results.patient_id, patient_with_call_results.month_date) patient_with_call_results.month_date,
+            patient_with_call_results.patient_id,
+            patient_with_call_results.hypertension,
+            patient_with_call_results.diabetes,
+            patient_with_call_results.htn_care_state,
+            patient_with_call_results.month,
+            patient_with_call_results.quarter,
+            patient_with_call_results.year,
+            patient_with_call_results.month_string,
+            patient_with_call_results.quarter_string,
+            patient_with_call_results.assigned_facility_id,
+            patient_with_call_results.assigned_facility_slug,
+            patient_with_call_results.assigned_facility_region_id,
+            patient_with_call_results.assigned_block_slug,
+            patient_with_call_results.assigned_block_region_id,
+            patient_with_call_results.assigned_district_slug,
+            patient_with_call_results.assigned_district_region_id,
+            patient_with_call_results.assigned_state_slug,
+            patient_with_call_results.assigned_state_region_id,
+            patient_with_call_results.assigned_organization_slug,
+            patient_with_call_results.assigned_organization_region_id,
+            patient_with_call_results.previous_appointment_id,
+            patient_with_call_results.previous_appointment_date,
+            patient_with_call_results.previous_appointment_schedule_date,
+            patient_with_call_results.visit_id,
+            patient_with_call_results.visited_at_after_appointment,
+            patient_with_call_results.previous_called_at,
+            patient_with_call_results.previous_call_result_type,
+            patient_with_call_results.previous_call_removed_from_overdue_list_reason,
+            patient_with_call_results.next_called_at,
+            patient_with_call_results.next_call_result_type,
+            patient_with_call_results.next_call_removed_from_overdue_list_reason,
+            patient_with_call_results.called_by_user_id,
+            patient_phone_numbers.number AS patient_phone_number
+           FROM (patient_with_call_results
+             LEFT JOIN public.patient_phone_numbers ON ((patient_phone_numbers.patient_id = patient_with_call_results.patient_id)))
+          ORDER BY patient_with_call_results.patient_id, patient_with_call_results.month_date
+        )
+ SELECT patient_with_call_results_and_phone.month_date,
+    patient_with_call_results_and_phone.patient_id,
+    patient_with_call_results_and_phone.hypertension,
+    patient_with_call_results_and_phone.diabetes,
+    patient_with_call_results_and_phone.htn_care_state,
+    patient_with_call_results_and_phone.month,
+    patient_with_call_results_and_phone.quarter,
+    patient_with_call_results_and_phone.year,
+    patient_with_call_results_and_phone.month_string,
+    patient_with_call_results_and_phone.quarter_string,
+    patient_with_call_results_and_phone.assigned_facility_id,
+    patient_with_call_results_and_phone.assigned_facility_slug,
+    patient_with_call_results_and_phone.assigned_facility_region_id,
+    patient_with_call_results_and_phone.assigned_block_slug,
+    patient_with_call_results_and_phone.assigned_block_region_id,
+    patient_with_call_results_and_phone.assigned_district_slug,
+    patient_with_call_results_and_phone.assigned_district_region_id,
+    patient_with_call_results_and_phone.assigned_state_slug,
+    patient_with_call_results_and_phone.assigned_state_region_id,
+    patient_with_call_results_and_phone.assigned_organization_slug,
+    patient_with_call_results_and_phone.assigned_organization_region_id,
+    patient_with_call_results_and_phone.previous_appointment_id,
+    patient_with_call_results_and_phone.previous_appointment_date,
+    patient_with_call_results_and_phone.previous_appointment_schedule_date,
+    patient_with_call_results_and_phone.visited_at_after_appointment,
+    patient_with_call_results_and_phone.called_by_user_id,
+    patient_with_call_results_and_phone.next_called_at,
+    patient_with_call_results_and_phone.previous_called_at,
+    patient_with_call_results_and_phone.next_call_result_type,
+    patient_with_call_results_and_phone.next_call_removed_from_overdue_list_reason,
+    patient_with_call_results_and_phone.previous_call_result_type,
+    patient_with_call_results_and_phone.previous_call_removed_from_overdue_list_reason,
         CASE
-            WHEN (appointments.scheduled_date >= reporting_patient_states.month_date) THEN 'no'::text
-            WHEN ((appointments.scheduled_date < reporting_patient_states.month_date) AND (visits.visited_at_after_appointment < reporting_patient_states.month_date)) THEN 'no'::text
+            WHEN (patient_with_call_results_and_phone.previous_appointment_schedule_date >= patient_with_call_results_and_phone.month_date) THEN 'no'::text
+            WHEN ((patient_with_call_results_and_phone.previous_appointment_schedule_date < patient_with_call_results_and_phone.month_date) AND (patient_with_call_results_and_phone.visited_at_after_appointment < patient_with_call_results_and_phone.month_date)) THEN 'no'::text
             ELSE 'yes'::text
         END AS is_overdue,
         CASE
-            WHEN (next_call_results.device_created_at IS NULL) THEN 'no'::text
+            WHEN (patient_with_call_results_and_phone.next_called_at IS NULL) THEN 'no'::text
             ELSE 'yes'::text
         END AS has_called,
         CASE
-            WHEN ((visits.visited_at_after_appointment IS NULL) OR (next_call_results.device_created_at IS NULL)) THEN 'no'::text
-            WHEN (visits.visited_at_after_appointment > (next_call_results.device_created_at + '15 days'::interval)) THEN 'no'::text
+            WHEN ((patient_with_call_results_and_phone.visited_at_after_appointment IS NULL) OR (patient_with_call_results_and_phone.next_called_at IS NULL)) THEN 'no'::text
+            WHEN (patient_with_call_results_and_phone.visited_at_after_appointment > (patient_with_call_results_and_phone.next_called_at + '15 days'::interval)) THEN 'no'::text
             ELSE 'yes'::text
         END AS has_visited_following_call,
         CASE
-            WHEN (reporting_patient_states.htn_care_state = 'lost_to_follow_up'::text) THEN 'yes'::text
+            WHEN (patient_with_call_results_and_phone.htn_care_state = 'lost_to_follow_up'::text) THEN 'yes'::text
             ELSE 'no'::text
         END AS ltfu,
         CASE
-            WHEN (reporting_patient_states.htn_care_state = 'under_care'::text) THEN 'yes'::text
+            WHEN (patient_with_call_results_and_phone.htn_care_state = 'under_care'::text) THEN 'yes'::text
             ELSE 'no'::text
         END AS under_care,
         CASE
-            WHEN (patient_phone_numbers.number IS NULL) THEN 'no'::text
+            WHEN (patient_with_call_results_and_phone.patient_phone_number IS NULL) THEN 'no'::text
             ELSE 'yes'::text
         END AS has_phone,
         CASE
-            WHEN ((previous_call_results.result_type)::text = 'removed_from_overdue_list'::text) THEN 'yes'::text
+            WHEN ((patient_with_call_results_and_phone.previous_call_result_type)::text = 'removed_from_overdue_list'::text) THEN 'yes'::text
             ELSE 'no'::text
-        END AS removed_from_overdue_list
-   FROM (((((public.reporting_patient_states
-     LEFT JOIN public.appointments ON (((reporting_patient_states.patient_id = appointments.patient_id) AND (((appointments.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)) < reporting_patient_states.month_date))))
-     LEFT JOIN public.patient_phone_numbers ON ((patient_phone_numbers.patient_id = reporting_patient_states.patient_id)))
-     LEFT JOIN LATERAL ( SELECT blood_sugars.id AS visit_id,
-            blood_sugars.patient_id,
-            blood_sugars.recorded_at AS visited_at_after_appointment,
-            'Blood Sugar'::text AS visit_type
-           FROM public.blood_sugars
-          WHERE ((blood_sugars.deleted_at IS NULL) AND (blood_sugars.patient_id = reporting_patient_states.patient_id) AND (appointments.device_created_at < blood_sugars.recorded_at))
-        UNION
-         SELECT blood_pressures.id AS visit_id,
-            blood_pressures.patient_id,
-            blood_pressures.recorded_at AS visited_at_after_appointment,
-            'Blood Pressure'::text AS visit_type
-           FROM public.blood_pressures
-          WHERE ((blood_pressures.deleted_at IS NULL) AND (blood_pressures.patient_id = reporting_patient_states.patient_id) AND (appointments.device_created_at < blood_pressures.recorded_at))
-        UNION
-         SELECT appointments_visit.id AS visit_id,
-            appointments_visit.patient_id,
-            appointments_visit.device_created_at AS visited_at_after_appointment,
-            'Appointments'::text AS visit_type
-           FROM public.appointments appointments_visit
-          WHERE ((appointments_visit.deleted_at IS NULL) AND (appointments_visit.patient_id = reporting_patient_states.patient_id) AND (appointments.device_created_at < appointments_visit.device_created_at))
-        UNION
-         SELECT prescription_drugs.id AS visit_id,
-            prescription_drugs.patient_id,
-            prescription_drugs.device_created_at AS visited_at_after_appointment,
-            'Prescription Drugs'::text AS visit_type
-           FROM public.prescription_drugs
-          WHERE ((prescription_drugs.deleted_at IS NULL) AND (prescription_drugs.patient_id = reporting_patient_states.patient_id) AND (appointments.device_created_at < prescription_drugs.device_created_at))) visits ON ((reporting_patient_states.patient_id = visits.patient_id)))
-     LEFT JOIN public.call_results previous_call_results ON (((reporting_patient_states.patient_id = previous_call_results.patient_id) AND (((previous_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)) < reporting_patient_states.month_date) AND (previous_call_results.device_created_at > appointments.scheduled_date))))
-     FULL JOIN public.call_results next_call_results ON (((reporting_patient_states.patient_id = next_call_results.patient_id) AND (((next_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)) >= reporting_patient_states.month_date) AND (((next_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)) < (reporting_patient_states.month_date + '1 mon'::interval)))))
-  WHERE ((reporting_patient_states.status)::text <> 'dead'::text)
-  ORDER BY reporting_patient_states.month_date, reporting_patient_states.patient_id, appointments.device_created_at DESC, visits.visited_at_after_appointment, next_call_results.device_created_at, previous_call_results.device_created_at DESC
+        END AS removed_from_overdue_list,
+        CASE
+            WHEN ((patient_with_call_results_and_phone.next_call_result_type)::text = 'removed_from_overdue_list'::text) THEN 'yes'::text
+            ELSE 'no'::text
+        END AS removed_from_overdue_list_during_the_month
+   FROM patient_with_call_results_and_phone
   WITH NO DATA;
 
 
@@ -6600,10 +6730,10 @@ CREATE UNIQUE INDEX overdue_calls_month_date_patient_id ON public.reporting_over
 
 
 --
--- Name: overdue_patients_month_date_assigned_facility_region_id; Type: INDEX; Schema: public; Owner: -
+-- Name: overdue_patients_assigned_facility_region_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX overdue_patients_month_date_assigned_facility_region_id ON public.reporting_overdue_patients USING btree (month_date, assigned_facility_region_id);
+CREATE INDEX overdue_patients_assigned_facility_region_id ON public.reporting_overdue_patients USING btree (assigned_facility_region_id);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4584,7 +4584,7 @@ CREATE MATERIALIZED VIEW public.reporting_overdue_patients AS
             appointments.scheduled_date AS previous_appointment_schedule_date
            FROM (public.reporting_patient_states rps
              LEFT JOIN public.appointments ON (((appointments.patient_id = rps.patient_id) AND (appointments.device_created_at < rps.month_date))))
-          WHERE ((rps.status)::text <> 'dead'::text)
+          WHERE (((rps.status)::text <> 'dead'::text) AND (rps.month_date > (now() - '2 years'::interval)))
           ORDER BY rps.patient_id, rps.month_date, appointments.device_created_at DESC
         ), patients_with_appointments_and_visits AS (
          SELECT DISTINCT ON (patients_with_appointments.patient_id, patients_with_appointments.month_date) patients_with_appointments.month_date,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4553,6 +4553,109 @@ COMMENT ON COLUMN public.reporting_facility_states.diabetes_appts_scheduled_more
 
 
 --
+-- Name: reporting_overdue_patients; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.reporting_overdue_patients AS
+ SELECT DISTINCT ON (reporting_patient_states.month_date, reporting_patient_states.patient_id) reporting_patient_states.month_date,
+    reporting_patient_states.month,
+    reporting_patient_states.quarter,
+    reporting_patient_states.year,
+    reporting_patient_states.month_string,
+    reporting_patient_states.quarter_string,
+    reporting_patient_states.patient_id,
+    reporting_patient_states.assigned_facility_id,
+    reporting_patient_states.assigned_facility_slug,
+    reporting_patient_states.assigned_facility_region_id,
+    reporting_patient_states.assigned_block_slug,
+    reporting_patient_states.assigned_block_region_id,
+    reporting_patient_states.assigned_district_slug,
+    reporting_patient_states.assigned_district_region_id,
+    reporting_patient_states.assigned_state_slug,
+    reporting_patient_states.assigned_state_region_id,
+    reporting_patient_states.assigned_organization_slug,
+    reporting_patient_states.assigned_organization_region_id,
+    next_call_results.user_id AS called_by_user_id,
+    appointments.id AS previous_appointment_id,
+    ((appointments.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE 'UTC'::text) AS previous_appointment_date,
+    ((appointments.scheduled_date AT TIME ZONE 'UTC'::text) AT TIME ZONE 'UTC'::text) AS previous_appointment_scheduled_date,
+    ((visits.visited_at_after_appointment AT TIME ZONE 'UTC'::text) AT TIME ZONE 'UTC'::text) AS visited_at_after_appointment,
+    ((next_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE 'UTC'::text) AS next_called_at,
+    ((previous_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE 'UTC'::text) AS previous_called_at,
+    reporting_patient_states.hypertension,
+    reporting_patient_states.diabetes,
+    next_call_results.result_type AS next_call_result_type,
+    next_call_results.remove_reason AS next_call_remove_from_overdue_list_reason,
+    previous_call_results.result_type AS previous_call_result_type,
+    previous_call_results.remove_reason AS previous_call_remove_from_overdue_list_reason,
+        CASE
+            WHEN (appointments.scheduled_date >= reporting_patient_states.month_date) THEN 'no'::text
+            WHEN ((appointments.scheduled_date < reporting_patient_states.month_date) AND (visits.visited_at_after_appointment < reporting_patient_states.month_date)) THEN 'no'::text
+            ELSE 'yes'::text
+        END AS is_overdue,
+        CASE
+            WHEN (next_call_results.device_created_at IS NULL) THEN 'no'::text
+            ELSE 'yes'::text
+        END AS has_called,
+        CASE
+            WHEN ((visits.visited_at_after_appointment IS NULL) OR (next_call_results.device_created_at IS NULL)) THEN 'no'::text
+            WHEN (visits.visited_at_after_appointment > (next_call_results.device_created_at + '15 days'::interval)) THEN 'no'::text
+            ELSE 'yes'::text
+        END AS has_visited_following_call,
+        CASE
+            WHEN (reporting_patient_states.htn_care_state = 'lost_to_follow_up'::text) THEN 'yes'::text
+            ELSE 'no'::text
+        END AS ltfu,
+        CASE
+            WHEN (reporting_patient_states.htn_care_state = 'under_care'::text) THEN 'yes'::text
+            ELSE 'no'::text
+        END AS under_care,
+        CASE
+            WHEN (patient_phone_numbers.number IS NULL) THEN 'no'::text
+            ELSE 'yes'::text
+        END AS has_phone,
+        CASE
+            WHEN ((previous_call_results.result_type)::text = 'removed_from_overdue_list'::text) THEN 'yes'::text
+            ELSE 'no'::text
+        END AS removed_from_overdue_list
+   FROM (((((public.reporting_patient_states
+     LEFT JOIN public.appointments ON (((reporting_patient_states.patient_id = appointments.patient_id) AND (((appointments.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)) < reporting_patient_states.month_date))))
+     LEFT JOIN public.patient_phone_numbers ON ((patient_phone_numbers.patient_id = reporting_patient_states.patient_id)))
+     LEFT JOIN LATERAL ( SELECT blood_sugars.id AS visit_id,
+            blood_sugars.patient_id,
+            blood_sugars.recorded_at AS visited_at_after_appointment,
+            'Blood Sugar'::text AS visit_type
+           FROM public.blood_sugars
+          WHERE ((blood_sugars.deleted_at IS NULL) AND (blood_sugars.patient_id = reporting_patient_states.patient_id) AND (appointments.device_created_at < blood_sugars.recorded_at))
+        UNION
+         SELECT blood_pressures.id AS visit_id,
+            blood_pressures.patient_id,
+            blood_pressures.recorded_at AS visited_at_after_appointment,
+            'Blood Pressure'::text AS visit_type
+           FROM public.blood_pressures
+          WHERE ((blood_pressures.deleted_at IS NULL) AND (blood_pressures.patient_id = reporting_patient_states.patient_id) AND (appointments.device_created_at < blood_pressures.recorded_at))
+        UNION
+         SELECT appointments_visit.id AS visit_id,
+            appointments_visit.patient_id,
+            appointments_visit.device_created_at AS visited_at_after_appointment,
+            'Appointments'::text AS visit_type
+           FROM public.appointments appointments_visit
+          WHERE ((appointments_visit.deleted_at IS NULL) AND (appointments_visit.patient_id = reporting_patient_states.patient_id) AND (appointments.device_created_at < appointments_visit.device_created_at))
+        UNION
+         SELECT prescription_drugs.id AS visit_id,
+            prescription_drugs.patient_id,
+            prescription_drugs.device_created_at AS visited_at_after_appointment,
+            'Prescription Drugs'::text AS visit_type
+           FROM public.prescription_drugs
+          WHERE ((prescription_drugs.deleted_at IS NULL) AND (prescription_drugs.patient_id = reporting_patient_states.patient_id) AND (appointments.device_created_at < prescription_drugs.device_created_at))) visits ON ((reporting_patient_states.patient_id = visits.patient_id)))
+     LEFT JOIN public.call_results previous_call_results ON (((reporting_patient_states.patient_id = previous_call_results.patient_id) AND (((previous_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)) < reporting_patient_states.month_date) AND (previous_call_results.device_created_at > appointments.scheduled_date))))
+     FULL JOIN public.call_results next_call_results ON (((reporting_patient_states.patient_id = next_call_results.patient_id) AND (((next_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)) >= reporting_patient_states.month_date) AND (((next_call_results.device_created_at AT TIME ZONE 'UTC'::text) AT TIME ZONE ( SELECT current_setting('TIMEZONE'::text) AS current_setting)) < (reporting_patient_states.month_date + '1 mon'::interval)))))
+  WHERE ((reporting_patient_states.status)::text <> 'dead'::text)
+  ORDER BY reporting_patient_states.month_date, reporting_patient_states.patient_id, appointments.device_created_at DESC, visits.visited_at_after_appointment, next_call_results.device_created_at, previous_call_results.device_created_at DESC
+  WITH NO DATA;
+
+
+--
 -- Name: reporting_quarterly_facility_states; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
@@ -6497,6 +6600,20 @@ CREATE UNIQUE INDEX overdue_calls_month_date_patient_id ON public.reporting_over
 
 
 --
+-- Name: overdue_patients_month_date_assigned_facility_region_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX overdue_patients_month_date_assigned_facility_region_id ON public.reporting_overdue_patients USING btree (month_date, assigned_facility_region_id);
+
+
+--
+-- Name: overdue_patients_month_date_patient_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX overdue_patients_month_date_patient_id ON public.reporting_overdue_patients USING btree (month_date, patient_id);
+
+
+--
 -- Name: patient_blood_pressures_patient_id_month_date; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7010,6 +7127,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230124063249'),
 ('20230130161639'),
 ('20230512070306'),
-('20230512070357');
+('20230512070357'),
+('20230522081701');
 
 

--- a/db/views/reporting_overdue_patients_v01.sql
+++ b/db/views/reporting_overdue_patients_v01.sql
@@ -29,6 +29,7 @@ WITH patients_with_appointments AS (
     LEFT JOIN appointments ON appointments.patient_id = rps.patient_id
         AND appointments.device_created_at < rps.month_date
     WHERE rps.status <> 'dead'
+	AND rps.month_date > NOW() - INTERVAL '24 months'
     ORDER BY
         rps.patient_id,
         rps.month_date,

--- a/db/views/reporting_overdue_patients_v01.sql
+++ b/db/views/reporting_overdue_patients_v01.sql
@@ -26,7 +26,7 @@ WITH patients_with_appointments AS (
         appointments.device_created_at AS previous_appointment_date,
         appointments.scheduled_date AS previous_appointment_schedule_date
     FROM reporting_patient_states rps
-             LEFT JOIN appointments ON appointments.patient_id = rps.patient_id
+    LEFT JOIN appointments ON appointments.patient_id = rps.patient_id
         AND appointments.device_created_at < rps.month_date
     WHERE rps.status <> 'dead'
     ORDER BY
@@ -35,91 +35,91 @@ WITH patients_with_appointments AS (
         appointments.device_created_at DESC
 ),
 
-     patients_with_appointments_and_visits AS (
-         SELECT
-             DISTINCT ON ( patients_with_appointments.patient_id, patients_with_appointments.month_date)
-             patients_with_appointments.*,
-             visit_id,
-             visited_at_after_appointment
-         FROM patients_with_appointments
-                  LEFT JOIN lateral (
-             SELECT id AS visit_id, patient_id, recorded_at AS visited_at_after_appointment
-             FROM blood_sugars
-             WHERE deleted_at IS NULL
-               AND patient_id = patients_with_appointments.patient_id
-               AND patients_with_appointments.previous_appointment_date < blood_sugars.recorded_at
-               AND blood_sugars.recorded_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
-             UNION
-             (
-                 SELECT id AS visit_id, patient_id, recorded_at AS visited_at_after_appointment
-                 FROM blood_pressures
-                 WHERE deleted_at IS NULL
-                   AND patient_id = patients_with_appointments.patient_id
-                   AND patients_with_appointments.previous_appointment_date < blood_pressures.recorded_at
-                   AND blood_pressures.recorded_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
-             )
-             UNION
-             (
-                 SELECT id AS visit_id, patient_id, device_created_at AS visited_at_after_appointment
-                 FROM appointments AS patients_with_appointments_visit
-                 WHERE deleted_at IS NULL
-                   AND patient_id = patients_with_appointments.patient_id
-                   AND patients_with_appointments.previous_appointment_date < patients_with_appointments_visit.device_created_at
-                   AND patients_with_appointments_visit.device_created_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
-             )
-             UNION
-             (
-                 SELECT id AS visit_id, patient_id, device_created_at AS visited_at_after_appointment
-                 FROM prescription_drugs
-                 WHERE deleted_at IS NULL
-                   AND patient_id = patients_with_appointments.patient_id
-                   AND patients_with_appointments.previous_appointment_date < prescription_drugs.device_created_at
-                   AND prescription_drugs.device_created_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
-             )
-             ) AS visits ON patients_with_appointments.patient_id = visits.patient_id
-         ORDER BY
-             patients_with_appointments.patient_id,
-             patients_with_appointments.month_date,
-             patients_with_appointments.previous_appointment_date DESC,
-             visited_at_after_appointment
-     ),
+patients_with_appointments_and_visits AS (
+    SELECT
+        DISTINCT ON ( patients_with_appointments.patient_id, patients_with_appointments.month_date)
+        patients_with_appointments.*,
+        visit_id,
+        visited_at_after_appointment
+    FROM patients_with_appointments
+    LEFT JOIN lateral (
+        SELECT id AS visit_id, patient_id, recorded_at AS visited_at_after_appointment
+        FROM blood_sugars
+        WHERE deleted_at IS NULL
+          AND patient_id = patients_with_appointments.patient_id
+          AND patients_with_appointments.previous_appointment_date < blood_sugars.recorded_at
+          AND blood_sugars.recorded_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+        UNION
+        (
+            SELECT id AS visit_id, patient_id, recorded_at AS visited_at_after_appointment
+            FROM blood_pressures
+            WHERE deleted_at IS NULL
+              AND patient_id = patients_with_appointments.patient_id
+              AND patients_with_appointments.previous_appointment_date < blood_pressures.recorded_at
+              AND blood_pressures.recorded_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+        )
+        UNION
+        (
+            SELECT id AS visit_id, patient_id, device_created_at AS visited_at_after_appointment
+            FROM appointments AS patients_with_appointments_visit
+            WHERE deleted_at IS NULL
+              AND patient_id = patients_with_appointments.patient_id
+              AND patients_with_appointments.previous_appointment_date < patients_with_appointments_visit.device_created_at
+              AND patients_with_appointments_visit.device_created_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+        )
+        UNION
+        (
+            SELECT id AS visit_id, patient_id, device_created_at AS visited_at_after_appointment
+            FROM prescription_drugs
+            WHERE deleted_at IS NULL
+              AND patient_id = patients_with_appointments.patient_id
+              AND patients_with_appointments.previous_appointment_date < prescription_drugs.device_created_at
+              AND prescription_drugs.device_created_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+        )
+    ) AS visits ON patients_with_appointments.patient_id = visits.patient_id
+    ORDER BY
+        patients_with_appointments.patient_id,
+        patients_with_appointments.month_date,
+        patients_with_appointments.previous_appointment_date DESC,
+        visited_at_after_appointment
+),
 
-     patient_with_call_results AS (
-         SELECT
-             DISTINCT ON ( patients_with_appointments_and_visits.patient_id, patients_with_appointments_and_visits.month_date)
-             patients_with_appointments_and_visits.*,
-             previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS previous_called_at,
-             previous_call_results.result_type AS previous_call_result_type,
-             previous_call_results.remove_reason AS previous_call_removed_from_overdue_list_reason,
-             next_call_results.device_created_at AT TIME ZONE 'UTC'  AT TIME ZONE 'UTC'  AS next_called_at,
-             next_call_results.result_type AS next_call_result_type,
-             next_call_results.remove_reason as next_call_removed_from_overdue_list_reason,
-             next_call_results.user_id AS called_by_user_id
-         FROM patients_with_appointments_and_visits
-                  LEFT JOIN call_results previous_call_results ON patients_with_appointments_and_visits.patient_id = previous_call_results.patient_id
-             AND previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < patients_with_appointments_and_visits.month_date
-             AND previous_call_results.device_created_at > previous_appointment_schedule_date
-                  LEFT JOIN call_results next_call_results ON patients_with_appointments_and_visits.patient_id = next_call_results.patient_id
-             AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) >= patients_with_appointments_and_visits.month_date
-             AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < patients_with_appointments_and_visits.month_date + INTERVAL '1 month'
-         ORDER BY
-             patients_with_appointments_and_visits.patient_id,
-             patients_with_appointments_and_visits.month_date,
-             next_call_results.device_created_at,
-             previous_call_results.device_created_at DESC
-     ),
+patient_with_call_results AS (
+    SELECT
+        DISTINCT ON ( patients_with_appointments_and_visits.patient_id, patients_with_appointments_and_visits.month_date)
+        patients_with_appointments_and_visits.*,
+        previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS previous_called_at,
+        previous_call_results.result_type AS previous_call_result_type,
+        previous_call_results.remove_reason AS previous_call_removed_from_overdue_list_reason,
+        next_call_results.device_created_at AT TIME ZONE 'UTC'  AT TIME ZONE 'UTC'  AS next_called_at,
+        next_call_results.result_type AS next_call_result_type,
+        next_call_results.remove_reason as next_call_removed_from_overdue_list_reason,
+        next_call_results.user_id AS called_by_user_id
+    FROM patients_with_appointments_and_visits
+    LEFT JOIN call_results previous_call_results ON patients_with_appointments_and_visits.patient_id = previous_call_results.patient_id
+        AND previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < patients_with_appointments_and_visits.month_date
+        AND previous_call_results.device_created_at > previous_appointment_schedule_date
+    LEFT JOIN call_results next_call_results ON patients_with_appointments_and_visits.patient_id = next_call_results.patient_id
+        AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) >= patients_with_appointments_and_visits.month_date
+        AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < patients_with_appointments_and_visits.month_date + INTERVAL '1 month'
+    ORDER BY
+        patients_with_appointments_and_visits.patient_id,
+        patients_with_appointments_and_visits.month_date,
+        next_call_results.device_created_at,
+        previous_call_results.device_created_at DESC
+),
 
-     patient_with_call_results_and_phone AS (
-         SELECT
-             DISTINCT ON ( patient_with_call_results.patient_id, patient_with_call_results.month_date)
-             patient_with_call_results.*,
-             patient_phone_numbers.number AS patient_phone_number
-         FROM patient_with_call_results
-                  LEFT JOIN patient_phone_numbers ON patient_phone_numbers.patient_id = patient_with_call_results.patient_id
-         ORDER BY
-             patient_with_call_results.patient_id,
-             patient_with_call_results.month_date
-     )
+patient_with_call_results_and_phone AS (
+    SELECT
+        DISTINCT ON ( patient_with_call_results.patient_id, patient_with_call_results.month_date)
+        patient_with_call_results.*,
+        patient_phone_numbers.number AS patient_phone_number
+    FROM patient_with_call_results
+    LEFT JOIN patient_phone_numbers ON patient_phone_numbers.patient_id = patient_with_call_results.patient_id
+    ORDER BY
+        patient_with_call_results.patient_id,
+        patient_with_call_results.month_date
+)
 
 SELECT
     month_date,
@@ -189,5 +189,5 @@ SELECT
        WHEN next_call_result_type = 'removed_from_overdue_list' THEN 'yes'
        ELSE 'no'
        END AS removed_from_overdue_list_during_the_month
-
 FROM patient_with_call_results_and_phone;
+

--- a/db/views/reporting_overdue_patients_v01.sql
+++ b/db/views/reporting_overdue_patients_v01.sql
@@ -1,6 +1,6 @@
 WITH patients_with_appointments AS (
     SELECT
-        DISTINCT ON (rps.patient_id, rps.month_date)
+        DISTINCT ON (rps.patient_id, rps.month_date) 
         rps.month_date,
         rps.patient_id,
         rps.hypertension AS hypertension,
@@ -25,11 +25,13 @@ WITH patients_with_appointments AS (
         appointments.id AS previous_appointment_id,
         appointments.device_created_at AS previous_appointment_date,
         appointments.scheduled_date AS previous_appointment_schedule_date
-    FROM reporting_patient_states rps
-    LEFT JOIN appointments ON appointments.patient_id = rps.patient_id
+    FROM
+        reporting_patient_states rps
+        LEFT JOIN appointments ON appointments.patient_id = rps.patient_id
         AND appointments.device_created_at < rps.month_date
-    WHERE rps.status <> 'dead'
-	AND rps.month_date > NOW() - INTERVAL '24 months'
+    WHERE
+        rps.status <> 'dead'
+        AND rps.month_date > NOW() - INTERVAL '24 months'
     ORDER BY
         rps.patient_id,
         rps.month_date,
@@ -38,46 +40,69 @@ WITH patients_with_appointments AS (
 
 patients_with_appointments_and_visits AS (
     SELECT
-        DISTINCT ON ( patients_with_appointments.patient_id, patients_with_appointments.month_date)
-        patients_with_appointments.*,
+        DISTINCT ON (
+            patients_with_appointments.patient_id,
+            patients_with_appointments.month_date
+        ) patients_with_appointments.*,
         visit_id,
         visited_at_after_appointment
-    FROM patients_with_appointments
-    LEFT JOIN lateral (
-        SELECT id AS visit_id, patient_id, recorded_at AS visited_at_after_appointment
-        FROM blood_sugars
-        WHERE deleted_at IS NULL
-          AND patient_id = patients_with_appointments.patient_id
-          AND patients_with_appointments.previous_appointment_date < blood_sugars.recorded_at
-          AND blood_sugars.recorded_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
-        UNION
-        (
-            SELECT id AS visit_id, patient_id, recorded_at AS visited_at_after_appointment
-            FROM blood_pressures
-            WHERE deleted_at IS NULL
-              AND patient_id = patients_with_appointments.patient_id
-              AND patients_with_appointments.previous_appointment_date < blood_pressures.recorded_at
-              AND blood_pressures.recorded_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
-        )
-        UNION
-        (
-            SELECT id AS visit_id, patient_id, device_created_at AS visited_at_after_appointment
-            FROM appointments AS patients_with_appointments_visit
-            WHERE deleted_at IS NULL
-              AND patient_id = patients_with_appointments.patient_id
-              AND patients_with_appointments.previous_appointment_date < patients_with_appointments_visit.device_created_at
-              AND patients_with_appointments_visit.device_created_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
-        )
-        UNION
-        (
-            SELECT id AS visit_id, patient_id, device_created_at AS visited_at_after_appointment
-            FROM prescription_drugs
-            WHERE deleted_at IS NULL
-              AND patient_id = patients_with_appointments.patient_id
-              AND patients_with_appointments.previous_appointment_date < prescription_drugs.device_created_at
-              AND prescription_drugs.device_created_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
-        )
-    ) AS visits ON patients_with_appointments.patient_id = visits.patient_id
+    FROM
+        patients_with_appointments
+        LEFT JOIN lateral (
+            SELECT
+                id AS visit_id,
+                patient_id,
+                recorded_at AS visited_at_after_appointment
+            FROM
+                blood_sugars
+            WHERE
+                deleted_at IS NULL
+                AND patient_id = patients_with_appointments.patient_id
+                AND patients_with_appointments.previous_appointment_date < blood_sugars.recorded_at
+                AND blood_sugars.recorded_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+            UNION
+            (
+                SELECT
+                    id AS visit_id,
+                    patient_id,
+                    recorded_at AS visited_at_after_appointment
+                FROM
+                    blood_pressures
+                WHERE
+                    deleted_at IS NULL
+                    AND patient_id = patients_with_appointments.patient_id
+                    AND patients_with_appointments.previous_appointment_date < blood_pressures.recorded_at
+                    AND blood_pressures.recorded_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+            )
+            UNION
+            (
+                SELECT
+                    id AS visit_id,
+                    patient_id,
+                    device_created_at AS visited_at_after_appointment
+                FROM
+                    appointments AS patients_with_appointments_visit
+                WHERE
+                    deleted_at IS NULL
+                    AND patient_id = patients_with_appointments.patient_id
+                    AND patients_with_appointments.previous_appointment_date < patients_with_appointments_visit.device_created_at
+                    AND patients_with_appointments_visit.device_created_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+            )
+            UNION
+            (
+                SELECT
+                    id AS visit_id,
+                    patient_id,
+                    device_created_at AS visited_at_after_appointment
+                FROM
+                    prescription_drugs
+                WHERE
+                    deleted_at IS NULL
+                    AND patient_id = patients_with_appointments.patient_id
+                    AND patients_with_appointments.previous_appointment_date < prescription_drugs.device_created_at
+                    AND prescription_drugs.device_created_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+            )
+        ) AS visits ON patients_with_appointments.patient_id = visits.patient_id
     ORDER BY
         patients_with_appointments.patient_id,
         patients_with_appointments.month_date,
@@ -87,36 +112,50 @@ patients_with_appointments_and_visits AS (
 
 patient_with_call_results AS (
     SELECT
-        DISTINCT ON ( patients_with_appointments_and_visits.patient_id, patients_with_appointments_and_visits.month_date)
-        patients_with_appointments_and_visits.*,
+        DISTINCT ON (
+            patients_with_appointments_and_visits.patient_id,
+            patients_with_appointments_and_visits.month_date
+        ) patients_with_appointments_and_visits.*,
         previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS previous_called_at,
         previous_call_results.result_type AS previous_call_result_type,
         previous_call_results.remove_reason AS previous_call_removed_from_overdue_list_reason,
-        next_call_results.device_created_at AT TIME ZONE 'UTC'  AT TIME ZONE 'UTC'  AS next_called_at,
+        next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS next_called_at,
         next_call_results.result_type AS next_call_result_type,
         next_call_results.remove_reason as next_call_removed_from_overdue_list_reason,
         next_call_results.user_id AS called_by_user_id
-    FROM patients_with_appointments_and_visits
-    LEFT JOIN call_results previous_call_results ON patients_with_appointments_and_visits.patient_id = previous_call_results.patient_id
-        AND previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < patients_with_appointments_and_visits.month_date
+    FROM
+        patients_with_appointments_and_visits
+        LEFT JOIN call_results previous_call_results ON patients_with_appointments_and_visits.patient_id = previous_call_results.patient_id
+        AND previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (
+            SELECT
+                current_setting('TIMEZONE')
+        ) < patients_with_appointments_and_visits.month_date
         AND previous_call_results.device_created_at > previous_appointment_schedule_date
-    LEFT JOIN call_results next_call_results ON patients_with_appointments_and_visits.patient_id = next_call_results.patient_id
-        AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) >= patients_with_appointments_and_visits.month_date
-        AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < patients_with_appointments_and_visits.month_date + INTERVAL '1 month'
+        LEFT JOIN call_results next_call_results ON patients_with_appointments_and_visits.patient_id = next_call_results.patient_id
+        AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (
+            SELECT
+                current_setting('TIMEZONE')
+        ) >= patients_with_appointments_and_visits.month_date
+        AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (
+            SELECT
+                current_setting('TIMEZONE')
+        ) < patients_with_appointments_and_visits.month_date + INTERVAL '1 month'
     ORDER BY
         patients_with_appointments_and_visits.patient_id,
         patients_with_appointments_and_visits.month_date,
         next_call_results.device_created_at,
         previous_call_results.device_created_at DESC
 ),
-
 patient_with_call_results_and_phone AS (
     SELECT
-        DISTINCT ON ( patient_with_call_results.patient_id, patient_with_call_results.month_date)
-        patient_with_call_results.*,
+        DISTINCT ON (
+            patient_with_call_results.patient_id,
+            patient_with_call_results.month_date
+        ) patient_with_call_results.*,
         patient_phone_numbers.number AS patient_phone_number
-    FROM patient_with_call_results
-    LEFT JOIN patient_phone_numbers ON patient_phone_numbers.patient_id = patient_with_call_results.patient_id
+    FROM
+        patient_with_call_results
+        LEFT JOIN patient_phone_numbers ON patient_phone_numbers.patient_id = patient_with_call_results.patient_id
     ORDER BY
         patient_with_call_results.patient_id,
         patient_with_call_results.month_date
@@ -156,39 +195,42 @@ SELECT
     previous_call_result_type,
     previous_call_removed_from_overdue_list_reason,
     CASE
-       WHEN (previous_appointment_schedule_date >= month_date) THEN 'no'
-       WHEN (previous_appointment_schedule_date < month_date
-           and visited_at_after_appointment < month_date) THEN 'no'
-       ELSE 'yes'
-       END AS is_overdue,
-   CASE
-       WHEN next_called_at IS NULL THEN 'no'
-       ELSE 'yes'
-       END AS has_called,
-   CASE
-       WHEN visited_at_after_appointment IS NULL OR next_called_at IS NULL THEN 'no'
-       WHEN visited_at_after_appointment > next_called_at + INTERVAL '15 days' THEN 'no'
-       ELSE 'yes'
-       END AS has_visited_following_call,
-   CASE
-       WHEN htn_care_state = 'lost_to_follow_up' THEN 'yes'
-       ELSE 'no'
-       END AS ltfu,
-   CASE
-       WHEN htn_care_state = 'under_care' THEN 'yes'
-       ELSE 'no'
-       END AS under_care,
-   CASE
-       WHEN patient_phone_number IS NULL THEN 'no'
-       ELSE 'yes'
-       END AS has_phone,
-   CASE
-       WHEN previous_call_result_type = 'removed_from_overdue_list' THEN 'yes'
-       ELSE 'no'
-       END AS removed_from_overdue_list,
-   CASE
-       WHEN next_call_result_type = 'removed_from_overdue_list' THEN 'yes'
-       ELSE 'no'
-       END AS removed_from_overdue_list_during_the_month
-FROM patient_with_call_results_and_phone;
-
+        WHEN (previous_appointment_schedule_date >= month_date) THEN 'no'
+        WHEN (
+            previous_appointment_schedule_date < month_date
+            and visited_at_after_appointment < month_date
+        ) THEN 'no'
+        ELSE 'yes'
+    END AS is_overdue,
+    CASE
+        WHEN next_called_at IS NULL THEN 'no'
+        ELSE 'yes'
+    END AS has_called,
+    CASE
+        WHEN visited_at_after_appointment IS NULL
+        OR next_called_at IS NULL THEN 'no'
+        WHEN visited_at_after_appointment > next_called_at + INTERVAL '15 days' THEN 'no'
+        ELSE 'yes'
+    END AS has_visited_following_call,
+    CASE
+        WHEN htn_care_state = 'lost_to_follow_up' THEN 'yes'
+        ELSE 'no'
+    END AS ltfu,
+    CASE
+        WHEN htn_care_state = 'under_care' THEN 'yes'
+        ELSE 'no'
+    END AS under_care,
+    CASE
+        WHEN patient_phone_number IS NULL THEN 'no'
+        ELSE 'yes'
+    END AS has_phone,
+    CASE
+        WHEN previous_call_result_type = 'removed_from_overdue_list' THEN 'yes'
+        ELSE 'no'
+    END AS removed_from_overdue_list,
+    CASE
+        WHEN next_call_result_type = 'removed_from_overdue_list' THEN 'yes'
+        ELSE 'no'
+    END AS removed_from_overdue_list_during_the_month
+FROM
+    patient_with_call_results_and_phone;

--- a/db/views/reporting_overdue_patients_v01.sql
+++ b/db/views/reporting_overdue_patients_v01.sql
@@ -1,104 +1,193 @@
-SELECT DISTINCT ON (reporting_patient_states.month_date, reporting_patient_states.patient_id)
-  reporting_patient_states.month_date AS month_date,
-  reporting_patient_states.month AS month,
-  reporting_patient_states.quarter AS quarter,
-  reporting_patient_states.year AS year,
-  reporting_patient_states.month_string AS month_string,
-  reporting_patient_states.quarter_string AS quarter_string,
-  reporting_patient_states.patient_id AS patient_id,
-  reporting_patient_states.assigned_facility_id AS assigned_facility_id,
-  reporting_patient_states.assigned_facility_slug AS assigned_facility_slug,
-  reporting_patient_states.assigned_facility_region_id AS assigned_facility_region_id,
-  reporting_patient_states.assigned_block_slug AS assigned_block_slug,
-  reporting_patient_states.assigned_block_region_id AS assigned_block_region_id,
-  reporting_patient_states.assigned_district_slug AS assigned_district_slug,
-  reporting_patient_states.assigned_district_region_id AS assigned_district_region_id,
-  reporting_patient_states.assigned_state_slug AS assigned_state_slug,
-  reporting_patient_states.assigned_state_region_id AS assigned_state_region_id,
-  reporting_patient_states.assigned_organization_slug AS assigned_organization_slug,
-  reporting_patient_states.assigned_organization_region_id AS assigned_organization_region_id,
-  next_call_results.user_id AS called_by_user_id,
-  appointments.id AS previous_appointment_id,
-  appointments.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS previous_appointment_date,
-  appointments.scheduled_date AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS previous_appointment_scheduled_date,
-  visits.visited_at_after_appointment AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS visited_at_after_appointment,
-  next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS next_called_at,
-  previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS previous_called_at,
-  reporting_patient_states.hypertension AS hypertension,
-  reporting_patient_states.diabetes AS diabetes,
-  next_call_results.result_type AS next_call_result_type,
-  next_call_results.remove_reason AS next_call_remove_from_overdue_list_reason,
-  previous_call_results.result_type AS previous_call_result_type,
-  previous_call_results.remove_reason AS previous_call_remove_from_overdue_list_reason,
-  CASE
-    WHEN (appointments.scheduled_date >= reporting_patient_states.month_date) THEN 'no'
-    WHEN (appointments.scheduled_date < reporting_patient_states.month_date
-	AND visits.visited_at_after_appointment < reporting_patient_states.month_date) THEN 'no'
-    ELSE 'yes'
-  END AS is_overdue,
-  CASE
-    WHEN next_call_results.device_created_at IS NULL THEN 'no'
-    ELSE 'yes'
-  END AS has_called,
-  CASE
-    WHEN visited_at_after_appointment IS NULL OR next_call_results.device_created_at IS NULL THEN 'no'
-    WHEN visited_at_after_appointment > next_call_results.device_created_at + interval '15 days' THEN 'no'
-    ELSE 'yes'
-  END AS has_visited_following_call,
-  CASE
-    WHEN reporting_patient_states.htn_care_state = 'lost_to_follow_up' THEN 'yes'
-    ELSE 'no'
-  END AS ltfu,
-  CASE
-    WHEN reporting_patient_states.htn_care_state = 'under_care' THEN 'yes'
-    ELSE 'no'
-  END AS under_care,
-  CASE
-    WHEN patient_phone_numbers.number IS NULL THEN 'no'
-    ELSE 'yes'
-  END AS has_phone,
-  CASE
-    WHEN previous_call_results.result_type = 'removed_from_overdue_list' THEN 'yes'
-    ELSE 'no'
-  END AS removed_from_overdue_list
-FROM reporting_patient_states
-  LEFT JOIN appointments ON reporting_patient_states.patient_id = appointments.patient_id
-  AND appointments.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < reporting_patient_states.month_date
-  LEFT JOIN patient_phone_numbers ON patient_phone_numbers.patient_id = reporting_patient_states.patient_id
-  LEFT JOIN lateral (
-    -- Merging BS, BP, Appointments & PD
-    SELECT id AS visit_id, patient_id, recorded_at AS visited_at_after_appointment, 'Blood Sugar' AS visit_type
-    FROM blood_sugars
-    WHERE deleted_at IS NULL AND patient_id = reporting_patient_states.patient_id AND appointments.device_created_at < blood_sugars.recorded_at
-    UNION
-      (SELECT id AS visit_id, patient_id, recorded_at AS visited_at_after_appointment, 'Blood Pressure' AS visit_type
-        FROM blood_pressures
-        WHERE deleted_at IS NULL AND patient_id = reporting_patient_states.patient_id AND appointments.device_created_at < blood_pressures.recorded_at)
-    UNION
-      (SELECT id AS visit_id, patient_id, device_created_at AS visited_at_after_appointment, 'Appointments' AS visit_type
-        FROM appointments AS appointments_visit
-        WHERE deleted_at IS NULL AND patient_id = reporting_patient_states.patient_id AND appointments.device_created_at < appointments_visit.device_created_at)
-    UNION
-      (SELECT id AS visit_id, patient_id, device_created_at AS visited_at_after_appointment, 'Prescription Drugs' AS visit_type
-        FROM prescription_drugs
-        WHERE deleted_at IS NULL AND patient_id = reporting_patient_states.patient_id AND appointments.device_created_at < prescription_drugs.device_created_at)
-  ) visits ON reporting_patient_states.patient_id = visits.patient_id
-  -- Used to determine if the patient was removed from overdue list at the beginning of the month
-  LEFT JOIN call_results AS previous_call_results
-    ON reporting_patient_states.patient_id = previous_call_results.patient_id
-      AND previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < reporting_patient_states.month_date
-      AND previous_call_results.device_created_at > appointments.scheduled_date
-  -- Used to determine the outcome of a call and how it affects the rate of patients returing to care
-  FULL JOIN call_results AS next_call_results
-    ON reporting_patient_states.patient_id = next_call_results.patient_id
-      AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) >= reporting_patient_states.month_date
-      AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < reporting_patient_states.month_date + interval '1 month'
-WHERE
-  reporting_patient_states.status <> 'dead'
-ORDER BY
-  reporting_patient_states.month_date,
-  reporting_patient_states.patient_id,
-  appointments.device_created_at DESC,
-  visits.visited_at_after_appointment,
-  next_call_results.device_created_at,
-  previous_call_results.device_created_at DESC
+WITH patients_with_appointments AS (
+    SELECT
+        DISTINCT ON (rps.patient_id, rps.month_date)
+        rps.month_date,
+        rps.patient_id,
+        rps.hypertension AS hypertension,
+        rps.diabetes AS diabetes,
+        rps.htn_care_state,
+        rps.month,
+        rps.quarter,
+        rps.year,
+        rps.month_string,
+        rps.quarter_string,
+        rps.assigned_facility_id,
+        rps.assigned_facility_slug,
+        rps.assigned_facility_region_id,
+        rps.assigned_block_slug,
+        rps.assigned_block_region_id,
+        rps.assigned_district_slug,
+        rps.assigned_district_region_id,
+        rps.assigned_state_slug,
+        rps.assigned_state_region_id,
+        rps.assigned_organization_slug,
+        rps.assigned_organization_region_id,
+        appointments.id AS previous_appointment_id,
+        appointments.device_created_at AS previous_appointment_date,
+        appointments.scheduled_date AS previous_appointment_schedule_date
+    FROM reporting_patient_states rps
+             LEFT JOIN appointments ON appointments.patient_id = rps.patient_id
+        AND appointments.device_created_at < rps.month_date
+    WHERE rps.status <> 'dead'
+    ORDER BY
+        rps.patient_id,
+        rps.month_date,
+        appointments.device_created_at DESC
+),
+
+     patients_with_appointments_and_visits AS (
+         SELECT
+             DISTINCT ON ( patients_with_appointments.patient_id, patients_with_appointments.month_date)
+             patients_with_appointments.*,
+             visit_id,
+             visited_at_after_appointment
+         FROM patients_with_appointments
+                  LEFT JOIN lateral (
+             SELECT id AS visit_id, patient_id, recorded_at AS visited_at_after_appointment
+             FROM blood_sugars
+             WHERE deleted_at IS NULL
+               AND patient_id = patients_with_appointments.patient_id
+               AND patients_with_appointments.previous_appointment_date < blood_sugars.recorded_at
+               AND blood_sugars.recorded_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+             UNION
+             (
+                 SELECT id AS visit_id, patient_id, recorded_at AS visited_at_after_appointment
+                 FROM blood_pressures
+                 WHERE deleted_at IS NULL
+                   AND patient_id = patients_with_appointments.patient_id
+                   AND patients_with_appointments.previous_appointment_date < blood_pressures.recorded_at
+                   AND blood_pressures.recorded_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+             )
+             UNION
+             (
+                 SELECT id AS visit_id, patient_id, device_created_at AS visited_at_after_appointment
+                 FROM appointments AS patients_with_appointments_visit
+                 WHERE deleted_at IS NULL
+                   AND patient_id = patients_with_appointments.patient_id
+                   AND patients_with_appointments.previous_appointment_date < patients_with_appointments_visit.device_created_at
+                   AND patients_with_appointments_visit.device_created_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+             )
+             UNION
+             (
+                 SELECT id AS visit_id, patient_id, device_created_at AS visited_at_after_appointment
+                 FROM prescription_drugs
+                 WHERE deleted_at IS NULL
+                   AND patient_id = patients_with_appointments.patient_id
+                   AND patients_with_appointments.previous_appointment_date < prescription_drugs.device_created_at
+                   AND prescription_drugs.device_created_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+             )
+             ) AS visits ON patients_with_appointments.patient_id = visits.patient_id
+         ORDER BY
+             patients_with_appointments.patient_id,
+             patients_with_appointments.month_date,
+             patients_with_appointments.previous_appointment_date DESC,
+             visited_at_after_appointment
+     ),
+
+     patient_with_call_results AS (
+         SELECT
+             DISTINCT ON ( patients_with_appointments_and_visits.patient_id, patients_with_appointments_and_visits.month_date)
+             patients_with_appointments_and_visits.*,
+             previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS previous_called_at,
+             previous_call_results.result_type AS previous_call_result_type,
+             previous_call_results.remove_reason AS previous_call_removed_from_overdue_list_reason,
+             next_call_results.device_created_at AT TIME ZONE 'UTC'  AT TIME ZONE 'UTC'  AS next_called_at,
+             next_call_results.result_type AS next_call_result_type,
+             next_call_results.remove_reason as next_call_removed_from_overdue_list_reason,
+             next_call_results.user_id AS called_by_user_id
+         FROM patients_with_appointments_and_visits
+                  LEFT JOIN call_results previous_call_results ON patients_with_appointments_and_visits.patient_id = previous_call_results.patient_id
+             AND previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < patients_with_appointments_and_visits.month_date
+             AND previous_call_results.device_created_at > previous_appointment_schedule_date
+                  LEFT JOIN call_results next_call_results ON patients_with_appointments_and_visits.patient_id = next_call_results.patient_id
+             AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) >= patients_with_appointments_and_visits.month_date
+             AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < patients_with_appointments_and_visits.month_date + INTERVAL '1 month'
+         ORDER BY
+             patients_with_appointments_and_visits.patient_id,
+             patients_with_appointments_and_visits.month_date,
+             next_call_results.device_created_at,
+             previous_call_results.device_created_at DESC
+     ),
+
+     patient_with_call_results_and_phone AS (
+         SELECT
+             DISTINCT ON ( patient_with_call_results.patient_id, patient_with_call_results.month_date)
+             patient_with_call_results.*,
+             patient_phone_numbers.number AS patient_phone_number
+         FROM patient_with_call_results
+                  LEFT JOIN patient_phone_numbers ON patient_phone_numbers.patient_id = patient_with_call_results.patient_id
+         ORDER BY
+             patient_with_call_results.patient_id,
+             patient_with_call_results.month_date
+     )
+
+SELECT
+    month_date,
+    patient_id,
+    hypertension,
+    diabetes,
+    htn_care_state,
+    month,
+    quarter,
+    year,
+    month_string,
+    quarter_string,
+    assigned_facility_id,
+    assigned_facility_slug,
+    assigned_facility_region_id,
+    assigned_block_slug,
+    assigned_block_region_id,
+    assigned_district_slug,
+    assigned_district_region_id,
+    assigned_state_slug,
+    assigned_state_region_id,
+    assigned_organization_slug,
+    assigned_organization_region_id,
+    previous_appointment_id,
+    previous_appointment_date,
+    previous_appointment_schedule_date,
+    visited_at_after_appointment,
+    called_by_user_id,
+    next_called_at,
+    previous_called_at,
+    next_call_result_type,
+    next_call_removed_from_overdue_list_reason,
+    previous_call_result_type,
+    previous_call_removed_from_overdue_list_reason,
+    CASE
+       WHEN (previous_appointment_schedule_date >= month_date) THEN 'no'
+       WHEN (previous_appointment_schedule_date < month_date
+           and visited_at_after_appointment < month_date) THEN 'no'
+       ELSE 'yes'
+       END AS is_overdue,
+   CASE
+       WHEN next_called_at IS NULL THEN 'no'
+       ELSE 'yes'
+       END AS has_called,
+   CASE
+       WHEN visited_at_after_appointment IS NULL OR next_called_at IS NULL THEN 'no'
+       WHEN visited_at_after_appointment > next_called_at + INTERVAL '15 days' THEN 'no'
+       ELSE 'yes'
+       END AS has_visited_following_call,
+   CASE
+       WHEN htn_care_state = 'lost_to_follow_up' THEN 'yes'
+       ELSE 'no'
+       END AS ltfu,
+   CASE
+       WHEN htn_care_state = 'under_care' THEN 'yes'
+       ELSE 'no'
+       END AS under_care,
+   CASE
+       WHEN patient_phone_number IS NULL THEN 'no'
+       ELSE 'yes'
+       END AS has_phone,
+   CASE
+       WHEN previous_call_result_type = 'removed_from_overdue_list' THEN 'yes'
+       ELSE 'no'
+       END AS removed_from_overdue_list,
+   CASE
+       WHEN next_call_result_type = 'removed_from_overdue_list' THEN 'yes'
+       ELSE 'no'
+       END AS removed_from_overdue_list_during_the_month
+
+FROM patient_with_call_results_and_phone;

--- a/db/views/reporting_overdue_patients_v01.sql
+++ b/db/views/reporting_overdue_patients_v01.sql
@@ -1,0 +1,104 @@
+SELECT DISTINCT ON (reporting_patient_states.month_date, reporting_patient_states.patient_id)
+  reporting_patient_states.month_date AS month_date,
+  reporting_patient_states.month AS month,
+  reporting_patient_states.quarter AS quarter,
+  reporting_patient_states.year AS year,
+  reporting_patient_states.month_string AS month_string,
+  reporting_patient_states.quarter_string AS quarter_string,
+  reporting_patient_states.patient_id AS patient_id,
+  reporting_patient_states.assigned_facility_id AS assigned_facility_id,
+  reporting_patient_states.assigned_facility_slug AS assigned_facility_slug,
+  reporting_patient_states.assigned_facility_region_id AS assigned_facility_region_id,
+  reporting_patient_states.assigned_block_slug AS assigned_block_slug,
+  reporting_patient_states.assigned_block_region_id AS assigned_block_region_id,
+  reporting_patient_states.assigned_district_slug AS assigned_district_slug,
+  reporting_patient_states.assigned_district_region_id AS assigned_district_region_id,
+  reporting_patient_states.assigned_state_slug AS assigned_state_slug,
+  reporting_patient_states.assigned_state_region_id AS assigned_state_region_id,
+  reporting_patient_states.assigned_organization_slug AS assigned_organization_slug,
+  reporting_patient_states.assigned_organization_region_id AS assigned_organization_region_id,
+  next_call_results.user_id AS called_by_user_id,
+  appointments.id AS previous_appointment_id,
+  appointments.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS previous_appointment_date,
+  appointments.scheduled_date AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS previous_appointment_scheduled_date,
+  visits.visited_at_after_appointment AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS visited_at_after_appointment,
+  next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS next_called_at,
+  previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS previous_called_at,
+  reporting_patient_states.hypertension AS hypertension,
+  reporting_patient_states.diabetes AS diabetes,
+  next_call_results.result_type AS next_call_result_type,
+  next_call_results.remove_reason AS next_call_remove_from_overdue_list_reason,
+  previous_call_results.result_type AS previous_call_result_type,
+  previous_call_results.remove_reason AS previous_call_remove_from_overdue_list_reason,
+  CASE
+    WHEN (appointments.scheduled_date >= reporting_patient_states.month_date) THEN 'no'
+    WHEN (appointments.scheduled_date < reporting_patient_states.month_date
+	AND visits.visited_at_after_appointment < reporting_patient_states.month_date) THEN 'no'
+    ELSE 'yes'
+  END AS is_overdue,
+  CASE
+    WHEN next_call_results.device_created_at IS NULL THEN 'no'
+    ELSE 'yes'
+  END AS has_called,
+  CASE
+    WHEN visited_at_after_appointment IS NULL OR next_call_results.device_created_at IS NULL THEN 'no'
+    WHEN visited_at_after_appointment > next_call_results.device_created_at + interval '15 days' THEN 'no'
+    ELSE 'yes'
+  END AS has_visited_following_call,
+  CASE
+    WHEN reporting_patient_states.htn_care_state = 'lost_to_follow_up' THEN 'yes'
+    ELSE 'no'
+  END AS ltfu,
+  CASE
+    WHEN reporting_patient_states.htn_care_state = 'under_care' THEN 'yes'
+    ELSE 'no'
+  END AS under_care,
+  CASE
+    WHEN patient_phone_numbers.number IS NULL THEN 'no'
+    ELSE 'yes'
+  END AS has_phone,
+  CASE
+    WHEN previous_call_results.result_type = 'removed_from_overdue_list' THEN 'yes'
+    ELSE 'no'
+  END AS removed_from_overdue_list
+FROM reporting_patient_states
+  LEFT JOIN appointments ON reporting_patient_states.patient_id = appointments.patient_id
+  AND appointments.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < reporting_patient_states.month_date
+  LEFT JOIN patient_phone_numbers ON patient_phone_numbers.patient_id = reporting_patient_states.patient_id
+  LEFT JOIN lateral (
+    -- Merging BS, BP, Appointments & PD
+    SELECT id AS visit_id, patient_id, recorded_at AS visited_at_after_appointment, 'Blood Sugar' AS visit_type
+    FROM blood_sugars
+    WHERE deleted_at IS NULL AND patient_id = reporting_patient_states.patient_id AND appointments.device_created_at < blood_sugars.recorded_at
+    UNION
+      (SELECT id AS visit_id, patient_id, recorded_at AS visited_at_after_appointment, 'Blood Pressure' AS visit_type
+        FROM blood_pressures
+        WHERE deleted_at IS NULL AND patient_id = reporting_patient_states.patient_id AND appointments.device_created_at < blood_pressures.recorded_at)
+    UNION
+      (SELECT id AS visit_id, patient_id, device_created_at AS visited_at_after_appointment, 'Appointments' AS visit_type
+        FROM appointments AS appointments_visit
+        WHERE deleted_at IS NULL AND patient_id = reporting_patient_states.patient_id AND appointments.device_created_at < appointments_visit.device_created_at)
+    UNION
+      (SELECT id AS visit_id, patient_id, device_created_at AS visited_at_after_appointment, 'Prescription Drugs' AS visit_type
+        FROM prescription_drugs
+        WHERE deleted_at IS NULL AND patient_id = reporting_patient_states.patient_id AND appointments.device_created_at < prescription_drugs.device_created_at)
+  ) visits ON reporting_patient_states.patient_id = visits.patient_id
+  -- Used to determine if the patient was removed from overdue list at the beginning of the month
+  LEFT JOIN call_results AS previous_call_results
+    ON reporting_patient_states.patient_id = previous_call_results.patient_id
+      AND previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < reporting_patient_states.month_date
+      AND previous_call_results.device_created_at > appointments.scheduled_date
+  -- Used to determine the outcome of a call and how it affects the rate of patients returing to care
+  FULL JOIN call_results AS next_call_results
+    ON reporting_patient_states.patient_id = next_call_results.patient_id
+      AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) >= reporting_patient_states.month_date
+      AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < reporting_patient_states.month_date + interval '1 month'
+WHERE
+  reporting_patient_states.status <> 'dead'
+ORDER BY
+  reporting_patient_states.month_date,
+  reporting_patient_states.patient_id,
+  appointments.device_created_at DESC,
+  visits.visited_at_after_appointment,
+  next_call_results.device_created_at,
+  previous_call_results.device_created_at DESC

--- a/spec/models/reports/overdue_patient_spec.rb
+++ b/spec/models/reports/overdue_patient_spec.rb
@@ -1,0 +1,303 @@
+require "rails_helper"
+
+RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
+  around do |example|
+    freeze_time_for_reporting_specs(example)
+  end
+
+  describe "Associations" do
+    it { should belong_to(:patient) }
+  end
+
+  describe "Model" do
+    it "should not include dead patients" do
+      create(:patient)
+      dead_patient = create(:patient, status: "dead")
+      Reports::PatientState.refresh
+      described_class.refresh
+
+      with_reporting_time_zone do
+        expect(described_class.count).not_to eq 0
+        expect(described_class.where(patient_id: dead_patient.id)).to be_empty
+      end
+    end
+  end
+
+  context "indicators" do
+    describe "next_called_at" do
+      it "should only select the first call that took place during the month" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        call_result_1 = create(:call_result, patient: patient, device_created_at: month_date + 2.days)
+        _call_result_2 = create(:call_result, patient: patient, device_created_at: month_date + 3.days)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).next_called_at).to eq(call_result_1.device_created_at)
+        end
+      end
+
+      it "should not select the call that took place after the month" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        _call_result_1 = create(:call_result, patient: patient, device_created_at: month_date + 1.month)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).next_called_at).to be_nil
+        end
+      end
+
+      it "should not select the call that took place before the month" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        _call_result_1 = create(:call_result, patient: patient, device_created_at: month_date - 1.hour)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).next_called_at).to be_nil
+        end
+      end
+    end
+
+    describe "previous_called_at" do
+      it "should only select the latest call in the previous month" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        appointment = create(:appointment, patient: patient, device_created_at: june_2021[:two_months_ago], scheduled_date: month_date - 15.days)
+        _call_result_1 = create(:call_result, patient: patient, appointment: appointment, device_created_at: month_date - 15.days + 1.day)
+        call_result_2 = create(:call_result, patient: patient, appointment: appointment, device_created_at: month_date - 15.days + 2.days)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).previous_called_at).to eq(call_result_2.device_created_at)
+        end
+      end
+
+      it "should only select the call that was made after the scheduled date of latest appointment" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        appointment = create(:appointment, patient: patient, device_created_at: june_2021[:two_months_ago], scheduled_date: month_date - 15.days)
+        _call_result_1 = create(:call_result, patient: patient, appointment: appointment, device_created_at: month_date - 15.days - 1.day)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).previous_called_at).to be_nil
+        end
+      end
+    end
+
+    describe "previous_appointment_id" do
+      it "should only select the latest appointment in the previous month" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        _appointment_1 = create(:appointment, patient: patient, device_created_at: june_2021[:two_months_ago])
+        appointment_2 = create(:appointment, patient: patient, device_created_at: june_2021[:two_months_ago] + 15.days)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).previous_appointment_id).to eq(appointment_2.id)
+        end
+      end
+
+      it "should pick cancelled appointments also" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        _appointment_1 = create(:appointment, patient: patient, device_created_at: month_date - 30.days)
+        appointment_2 = create(:appointment, patient: patient, device_created_at: month_date - 15.days, status: :cancelled)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).previous_appointment_id).to eq(appointment_2.id)
+        end
+      end
+    end
+
+    describe "is_overdue" do
+      it "should be no when the previous appointments scheduled date is during the month" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        create(:appointment, patient: patient, device_created_at: month_date - 1.month, scheduled_date: month_date)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).is_overdue).to eq("no")
+        end
+      end
+
+      it "should be yes when the previous appointments scheduled date is in the previous month and the visit date is during the month" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        create(:blood_pressure, patient: patient, recorded_at: month_date + 1.day)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).is_overdue).to eq("yes")
+        end
+      end
+
+      it "should be no when the previous appointments scheduled date and visited date is in the previous month and the visit took place after the scheduled date" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        create(:blood_pressure, patient: patient, recorded_at: month_date - 30.days + 16.days)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).is_overdue).to eq("no")
+        end
+      end
+    end
+
+    describe "has_phone" do
+      it "should be yes if the patient has atleast one phone number linked" do
+        patient = create(:patient)
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id).has_phone).to eq("yes")
+        end
+      end
+
+      it "should be no if the patient has no phone number linked" do
+        patient_without_phone_numbers = create(:patient, :with_overdue_appointments, phone_numbers: [])
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient_without_phone_numbers.id).has_phone).to eq("no")
+        end
+      end
+    end
+
+    describe "has_visited_following_call" do
+      it "should be no when there was no visit" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        create(:call_result, patient: patient, device_created_at: month_date - 14.days, appointment: appointment)
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).has_visited_following_call).to eq("no")
+        end
+      end
+
+      it "should be no when a call was not made" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        create(:blood_pressure, patient: patient, recorded_at: month_date - 14.days)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).has_visited_following_call).to eq("no")
+        end
+      end
+
+      it "should be yes when a call was made and the patient visited within 15 days" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        create(:call_result, patient: patient, device_created_at: month_date, appointment: appointment)
+        create(:blood_pressure, patient: patient, recorded_at: month_date + 4.days)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).has_visited_following_call).to eq("yes")
+        end
+      end
+
+      it "should be no when a call was made but the patient visited after 15 days of first call" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        create(:call_result, patient: patient, device_created_at: month_date, appointment: appointment)
+        create(:blood_pressure, patient: patient, recorded_at: month_date + 16.days)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).has_visited_following_call).to eq("no")
+        end
+      end
+    end
+
+    describe "removed_from_overdue_list" do
+      it "should be yes when the call result corresponding to the previous appointment is removed_from_overdue_list" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        create(:call_result, patient: patient, device_created_at: month_date - 14.days, appointment: appointment,
+          result_type: :removed_from_overdue_list, remove_reason: :invalid_phone_number)
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).removed_from_overdue_list).to eq("yes")
+        end
+      end
+
+      it "should be no when the call result corresponding to the previous appointment is not removed_from_overdue_list" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        create(:call_result, patient: patient, device_created_at: month_date - 14.days, appointment: appointment, result_type: :agreed_to_visit)
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).removed_from_overdue_list).to eq("no")
+        end
+      end
+
+      it "should be no when a call was not made after the previous appointment" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).removed_from_overdue_list).to eq("no")
+        end
+      end
+    end
+
+    describe "has_called" do
+      it "should be yes when a call was made during the month after the previous appointment" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        create(:call_result, patient: patient, device_created_at: month_date, appointment: appointment)
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).has_called).to eq("yes")
+        end
+      end
+
+      it "should be no when a call was not made during the month after the previous appointment" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).has_called).to eq("no")
+        end
+      end
+    end
+  end
+end

--- a/spec/models/reports/overdue_patient_spec.rb
+++ b/spec/models/reports/overdue_patient_spec.rb
@@ -1,8 +1,16 @@
 require "rails_helper"
 
 RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
+  timezone = Time.find_zone(Period::REPORTING_TIME_ZONE)
+  this_month = timezone.local(Date.today.year, Date.today.month, 1, 0, 0, 0)
+
   around do |example|
-    freeze_time_for_reporting_specs(example)
+    # This is in the style of ReportingHelpers::freeze_time_for_reporting_specs.
+    # Since this view only keeps the last 6 months of data, the date cannot be a
+    # fixed point in time like the spec helper.
+    Timecop.freeze("#{Date.today.end_of_month} 23:00 IST") do
+      example.run
+    end
   end
 
   describe "Associations" do
@@ -27,7 +35,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
     describe "next_called_at" do
       it "should only select the first call that took place during the month" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         call_result_1 = create(:call_result, patient: patient, device_created_at: month_date + 2.days)
         _call_result_2 = create(:call_result, patient: patient, device_created_at: month_date + 3.days)
 
@@ -41,7 +49,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should not select the call that took place after the month" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         _call_result_1 = create(:call_result, patient: patient, device_created_at: month_date + 1.month)
 
         RefreshReportingViews.refresh_v2
@@ -53,7 +61,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should not select the call that took place before the month" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         _call_result_1 = create(:call_result, patient: patient, device_created_at: month_date - 1.hour)
 
         RefreshReportingViews.refresh_v2
@@ -67,7 +75,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
     describe "previous_called_at" do
       it "should only select the latest call in the previous month" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         appointment = create(:appointment, patient: patient, device_created_at: june_2021[:two_months_ago],
                                            scheduled_date: month_date - 15.days)
         _call_result_1 = create(:call_result, patient: patient, appointment: appointment,
@@ -85,7 +93,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should only select the call that was made after the scheduled date of latest appointment" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         appointment = create(:appointment, patient: patient, device_created_at: june_2021[:two_months_ago],
                                            scheduled_date: month_date - 15.days)
         _call_result_1 = create(:call_result, patient: patient, appointment: appointment,
@@ -94,7 +102,8 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
         RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
-          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).previous_called_at).to be_nil
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).previous_called_at).to be_nil
         end
       end
     end
@@ -102,12 +111,12 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
     describe "visited_at_after_appointment" do
       it "should only select the first visit that took place after the appointment" do
         patient = create(:patient)
-        month_date = june_2021[:now]
-        _appointment = create(:appointment, patient: patient, device_created_at: june_2021[:now] - 7.days)
+        month_date = this_month
+        _appointment = create(:appointment, patient: patient, device_created_at: this_month - 7.days)
 
-        _blood_pressure_visit = create(:blood_pressure, patient: patient, recorded_at: june_2021[:now] + 5.days)
-        _appointment_visit = create(:appointment, patient: patient, device_created_at: june_2021[:now] + 3.days)
-        blood_sugar_visit = create(:blood_sugar, patient: patient, recorded_at: june_2021[:now] - 2.days)
+        _blood_pressure_visit = create(:blood_pressure, patient: patient, recorded_at: this_month + 5.days)
+        _appointment_visit = create(:appointment, patient: patient, device_created_at: this_month + 3.days)
+        blood_sugar_visit = create(:blood_sugar, patient: patient, recorded_at: this_month - 2.days)
 
         RefreshReportingViews.refresh_v2
 
@@ -119,12 +128,12 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should not select visits that took place before the appointment or after 15 days of the next month" do
         patient = create(:patient)
-        month_date = june_2021[:now]
-        _appointment = create(:appointment, patient: patient, device_created_at: june_2021[:now] - 7.days)
+        month_date = this_month
+        _appointment = create(:appointment, patient: patient, device_created_at: this_month - 7.days)
 
-        _blood_pressure_visit = create(:blood_pressure, patient: patient, recorded_at: june_2021[:now] - 8.days)
+        _blood_pressure_visit = create(:blood_pressure, patient: patient, recorded_at: this_month - 8.days)
         _appointment_visit = create(:appointment, patient: patient,
-                                                 device_created_at: june_2021[:now] + 1.month + 16.days)
+                                                  device_created_at: this_month + 1.month + 16.days)
 
         RefreshReportingViews.refresh_v2
 
@@ -136,12 +145,12 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should only select visits that took place in the current month or within the first 15 days of the next month" do
         patient = create(:patient)
-        month_date = june_2021[:now]
-        _appointment = create(:appointment, patient: patient, device_created_at: june_2021[:now] - 7.days)
+        month_date = this_month
+        _appointment = create(:appointment, patient: patient, device_created_at: this_month - 7.days)
 
-        _appointment_visit = create(:appointment, patient: patient, device_created_at: june_2021[:now] + 3.days)
-        blood_sugar_visit = create(:blood_sugar, patient: patient, recorded_at: june_2021[:now] - 2.days)
-        _blood_pressure_visit = create(:blood_pressure, patient: patient, recorded_at: june_2021[:now] - 8.days)
+        _appointment_visit = create(:appointment, patient: patient, device_created_at: this_month + 3.days)
+        blood_sugar_visit = create(:blood_sugar, patient: patient, recorded_at: this_month - 2.days)
+        _blood_pressure_visit = create(:blood_pressure, patient: patient, recorded_at: this_month - 8.days)
 
         RefreshReportingViews.refresh_v2
 
@@ -153,10 +162,11 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should select visits that take place in the first 15 days of the next month" do
         patient = create(:patient)
-        month_date = june_2021[:now]
-        _appointment = create(:appointment, patient: patient, device_created_at: june_2021[:now] - 7.days)
+        month_date = this_month
+        _appointment = create(:appointment, patient: patient, device_created_at: this_month - 7.days)
 
-        blood_pressure_visit = create(:blood_pressure, patient: patient, device_created_at: june_2021[:now] + 1.month + 15.days)
+        blood_pressure_visit = create(:blood_pressure, patient: patient,
+                                                       device_created_at: this_month + 1.month + 15.days)
 
         RefreshReportingViews.refresh_v2
 
@@ -170,9 +180,10 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
     describe "previous_appointment_id" do
       it "should only select the latest appointment in the previous month" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         _appointment_1 = create(:appointment, patient: patient, device_created_at: june_2021[:two_months_ago])
-        appointment_2 = create(:appointment, patient: patient, device_created_at: june_2021[:two_months_ago] + 15.days)
+        appointment_2 = create(:appointment, patient: patient,
+                                             device_created_at: june_2021[:two_months_ago] + 15.days)
 
         RefreshReportingViews.refresh_v2
 
@@ -184,7 +195,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should pick cancelled appointments also" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         _appointment_1 = create(:appointment, patient: patient, device_created_at: month_date - 30.days)
         appointment_2 = create(:appointment, patient: patient, device_created_at: month_date - 15.days,
                                              status: :cancelled)
@@ -201,7 +212,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
     describe "is_overdue" do
       it "should be no when the previous appointments scheduled date is during the month" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         create(:appointment, patient: patient, device_created_at: month_date - 1.month, scheduled_date: month_date)
 
         RefreshReportingViews.refresh_v2
@@ -213,7 +224,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should be yes when the previous appointments scheduled date is in the previous month and the visit date is during the month" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         create(:appointment, patient: patient, device_created_at: month_date - 30.days,
                              scheduled_date: month_date - 15.days)
         create(:blood_pressure, patient: patient, recorded_at: month_date + 1.day)
@@ -227,7 +238,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should be no when the previous appointments scheduled date and visited date is in the previous month and the visit took place after the scheduled date" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         create(:appointment, patient: patient, device_created_at: month_date - 30.days,
                              scheduled_date: month_date - 15.days)
         create(:blood_pressure, patient: patient, recorded_at: month_date - 30.days + 16.days)
@@ -263,7 +274,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
     describe "has_visited_following_call" do
       it "should be no when there was no visit" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days,
                                            scheduled_date: month_date - 15.days)
         create(:call_result, patient: patient, device_created_at: month_date - 14.days, appointment: appointment)
@@ -277,7 +288,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should be no when a call was not made" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         create(:appointment, patient: patient, device_created_at: month_date - 30.days,
                              scheduled_date: month_date - 15.days)
         create(:blood_pressure, patient: patient, recorded_at: month_date - 14.days)
@@ -292,7 +303,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should be yes when a call was made and the patient visited within 15 days" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days,
                                            scheduled_date: month_date - 15.days)
         create(:call_result, patient: patient, device_created_at: month_date, appointment: appointment)
@@ -308,7 +319,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should be no when a call was made but the patient visited after 15 days of first call" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days,
                                            scheduled_date: month_date - 15.days)
         create(:call_result, patient: patient, device_created_at: month_date, appointment: appointment)
@@ -326,7 +337,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
     describe "removed_from_overdue_list" do
       it "should be yes when the call result corresponding to the previous appointment is removed_from_overdue_list" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days,
                                            scheduled_date: month_date - 15.days)
         create(:call_result, patient: patient, device_created_at: month_date - 14.days, appointment: appointment,
@@ -341,7 +352,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should be no when the call result corresponding to the previous appointment is not removed_from_overdue_list" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days,
                                            scheduled_date: month_date - 15.days)
         create(:call_result, patient: patient, device_created_at: month_date - 14.days, appointment: appointment,
@@ -356,7 +367,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should be no when a call was not made after the previous appointment" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         create(:appointment, patient: patient, device_created_at: month_date - 30.days,
                              scheduled_date: month_date - 15.days)
 
@@ -372,7 +383,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
     describe "has_called" do
       it "should be yes when a call was made during the month after the previous appointment" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days,
                                            scheduled_date: month_date - 15.days)
         create(:call_result, patient: patient, device_created_at: month_date, appointment: appointment)
@@ -385,7 +396,7 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
 
       it "should be no when a call was not made during the month after the previous appointment" do
         patient = create(:patient)
-        month_date = june_2021[:now]
+        month_date = this_month
         create(:appointment, patient: patient, device_created_at: month_date - 30.days,
                              scheduled_date: month_date - 15.days)
 

--- a/spec/models/reports/overdue_patient_spec.rb
+++ b/spec/models/reports/overdue_patient_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
         RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
-          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).next_called_at).to eq(call_result_1.device_created_at)
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).next_called_at).to eq(call_result_1.device_created_at)
         end
       end
 
@@ -67,27 +68,101 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
       it "should only select the latest call in the previous month" do
         patient = create(:patient)
         month_date = june_2021[:now]
-        appointment = create(:appointment, patient: patient, device_created_at: june_2021[:two_months_ago], scheduled_date: month_date - 15.days)
-        _call_result_1 = create(:call_result, patient: patient, appointment: appointment, device_created_at: month_date - 15.days + 1.day)
-        call_result_2 = create(:call_result, patient: patient, appointment: appointment, device_created_at: month_date - 15.days + 2.days)
+        appointment = create(:appointment, patient: patient, device_created_at: june_2021[:two_months_ago],
+                                           scheduled_date: month_date - 15.days)
+        _call_result_1 = create(:call_result, patient: patient, appointment: appointment,
+                                              device_created_at: month_date - 15.days + 1.day)
+        call_result_2 = create(:call_result, patient: patient, appointment: appointment,
+                                             device_created_at: month_date - 15.days + 2.days)
 
         RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
-          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).previous_called_at).to eq(call_result_2.device_created_at)
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).previous_called_at).to eq(call_result_2.device_created_at)
         end
       end
 
       it "should only select the call that was made after the scheduled date of latest appointment" do
         patient = create(:patient)
         month_date = june_2021[:now]
-        appointment = create(:appointment, patient: patient, device_created_at: june_2021[:two_months_ago], scheduled_date: month_date - 15.days)
-        _call_result_1 = create(:call_result, patient: patient, appointment: appointment, device_created_at: month_date - 15.days - 1.day)
+        appointment = create(:appointment, patient: patient, device_created_at: june_2021[:two_months_ago],
+                                           scheduled_date: month_date - 15.days)
+        _call_result_1 = create(:call_result, patient: patient, appointment: appointment,
+                                              device_created_at: month_date - 15.days - 1.day)
 
         RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
           expect(described_class.find_by(patient_id: patient.id, month_date: month_date).previous_called_at).to be_nil
+        end
+      end
+    end
+
+    describe "visited_at_after_appointment" do
+      it "should only select the first visit that took place after the appointment" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        _appointment = create(:appointment, patient: patient, device_created_at: june_2021[:now] - 7.days)
+
+        _blood_pressure_visit = create(:blood_pressure, patient: patient, recorded_at: june_2021[:now] + 5.days)
+        _appointment_visit = create(:appointment, patient: patient, device_created_at: june_2021[:now] + 3.days)
+        blood_sugar_visit = create(:blood_sugar, patient: patient, recorded_at: june_2021[:now] - 2.days)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).visited_at_after_appointment).to eq(blood_sugar_visit.recorded_at)
+        end
+      end
+
+      it "should not select visits that took place before the appointment or after 15 days of the next month" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        _appointment = create(:appointment, patient: patient, device_created_at: june_2021[:now] - 7.days)
+
+        _blood_pressure_visit = create(:blood_pressure, patient: patient, recorded_at: june_2021[:now] - 8.days)
+        _appointment_visit = create(:appointment, patient: patient,
+                                                 device_created_at: june_2021[:now] + 1.month + 16.days)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).visited_at_after_appointment).to be_nil
+        end
+      end
+
+      it "should only select visits that took place in the current month or within the first 15 days of the next month" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        _appointment = create(:appointment, patient: patient, device_created_at: june_2021[:now] - 7.days)
+
+        _appointment_visit = create(:appointment, patient: patient, device_created_at: june_2021[:now] + 3.days)
+        blood_sugar_visit = create(:blood_sugar, patient: patient, recorded_at: june_2021[:now] - 2.days)
+        _blood_pressure_visit = create(:blood_pressure, patient: patient, recorded_at: june_2021[:now] - 8.days)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).visited_at_after_appointment).to eq(blood_sugar_visit.recorded_at)
+        end
+      end
+
+      it "should select visits that take place in the first 15 days of the next month" do
+        patient = create(:patient)
+        month_date = june_2021[:now]
+        _appointment = create(:appointment, patient: patient, device_created_at: june_2021[:now] - 7.days)
+
+        blood_pressure_visit = create(:blood_pressure, patient: patient, device_created_at: june_2021[:now] + 1.month + 15.days)
+
+        RefreshReportingViews.refresh_v2
+
+        with_reporting_time_zone do
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).visited_at_after_appointment).to eq(blood_pressure_visit.recorded_at)
         end
       end
     end
@@ -102,7 +177,8 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
         RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
-          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).previous_appointment_id).to eq(appointment_2.id)
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).previous_appointment_id).to eq(appointment_2.id)
         end
       end
 
@@ -110,12 +186,14 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
         patient = create(:patient)
         month_date = june_2021[:now]
         _appointment_1 = create(:appointment, patient: patient, device_created_at: month_date - 30.days)
-        appointment_2 = create(:appointment, patient: patient, device_created_at: month_date - 15.days, status: :cancelled)
+        appointment_2 = create(:appointment, patient: patient, device_created_at: month_date - 15.days,
+                                             status: :cancelled)
 
         RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
-          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).previous_appointment_id).to eq(appointment_2.id)
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).previous_appointment_id).to eq(appointment_2.id)
         end
       end
     end
@@ -136,7 +214,8 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
       it "should be yes when the previous appointments scheduled date is in the previous month and the visit date is during the month" do
         patient = create(:patient)
         month_date = june_2021[:now]
-        create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        create(:appointment, patient: patient, device_created_at: month_date - 30.days,
+                             scheduled_date: month_date - 15.days)
         create(:blood_pressure, patient: patient, recorded_at: month_date + 1.day)
 
         RefreshReportingViews.refresh_v2
@@ -149,7 +228,8 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
       it "should be no when the previous appointments scheduled date and visited date is in the previous month and the visit took place after the scheduled date" do
         patient = create(:patient)
         month_date = june_2021[:now]
-        create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        create(:appointment, patient: patient, device_created_at: month_date - 30.days,
+                             scheduled_date: month_date - 15.days)
         create(:blood_pressure, patient: patient, recorded_at: month_date - 30.days + 16.days)
 
         RefreshReportingViews.refresh_v2
@@ -184,53 +264,61 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
       it "should be no when there was no visit" do
         patient = create(:patient)
         month_date = june_2021[:now]
-        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days,
+                                           scheduled_date: month_date - 15.days)
         create(:call_result, patient: patient, device_created_at: month_date - 14.days, appointment: appointment)
         RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
-          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).has_visited_following_call).to eq("no")
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).has_visited_following_call).to eq("no")
         end
       end
 
       it "should be no when a call was not made" do
         patient = create(:patient)
         month_date = june_2021[:now]
-        create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        create(:appointment, patient: patient, device_created_at: month_date - 30.days,
+                             scheduled_date: month_date - 15.days)
         create(:blood_pressure, patient: patient, recorded_at: month_date - 14.days)
 
         RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
-          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).has_visited_following_call).to eq("no")
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).has_visited_following_call).to eq("no")
         end
       end
 
       it "should be yes when a call was made and the patient visited within 15 days" do
         patient = create(:patient)
         month_date = june_2021[:now]
-        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days,
+                                           scheduled_date: month_date - 15.days)
         create(:call_result, patient: patient, device_created_at: month_date, appointment: appointment)
         create(:blood_pressure, patient: patient, recorded_at: month_date + 4.days)
 
         RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
-          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).has_visited_following_call).to eq("yes")
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).has_visited_following_call).to eq("yes")
         end
       end
 
       it "should be no when a call was made but the patient visited after 15 days of first call" do
         patient = create(:patient)
         month_date = june_2021[:now]
-        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days,
+                                           scheduled_date: month_date - 15.days)
         create(:call_result, patient: patient, device_created_at: month_date, appointment: appointment)
         create(:blood_pressure, patient: patient, recorded_at: month_date + 16.days)
 
         RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
-          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).has_visited_following_call).to eq("no")
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).has_visited_following_call).to eq("no")
         end
       end
     end
@@ -239,37 +327,44 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
       it "should be yes when the call result corresponding to the previous appointment is removed_from_overdue_list" do
         patient = create(:patient)
         month_date = june_2021[:now]
-        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days,
+                                           scheduled_date: month_date - 15.days)
         create(:call_result, patient: patient, device_created_at: month_date - 14.days, appointment: appointment,
-          result_type: :removed_from_overdue_list, remove_reason: :invalid_phone_number)
+                             result_type: :removed_from_overdue_list, remove_reason: :invalid_phone_number)
         RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
-          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).removed_from_overdue_list).to eq("yes")
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).removed_from_overdue_list).to eq("yes")
         end
       end
 
       it "should be no when the call result corresponding to the previous appointment is not removed_from_overdue_list" do
         patient = create(:patient)
         month_date = june_2021[:now]
-        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
-        create(:call_result, patient: patient, device_created_at: month_date - 14.days, appointment: appointment, result_type: :agreed_to_visit)
+        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days,
+                                           scheduled_date: month_date - 15.days)
+        create(:call_result, patient: patient, device_created_at: month_date - 14.days, appointment: appointment,
+                             result_type: :agreed_to_visit)
         RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
-          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).removed_from_overdue_list).to eq("no")
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).removed_from_overdue_list).to eq("no")
         end
       end
 
       it "should be no when a call was not made after the previous appointment" do
         patient = create(:patient)
         month_date = june_2021[:now]
-        create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        create(:appointment, patient: patient, device_created_at: month_date - 30.days,
+                             scheduled_date: month_date - 15.days)
 
         RefreshReportingViews.refresh_v2
 
         with_reporting_time_zone do
-          expect(described_class.find_by(patient_id: patient.id, month_date: month_date).removed_from_overdue_list).to eq("no")
+          expect(described_class.find_by(patient_id: patient.id,
+            month_date: month_date).removed_from_overdue_list).to eq("no")
         end
       end
     end
@@ -278,7 +373,8 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
       it "should be yes when a call was made during the month after the previous appointment" do
         patient = create(:patient)
         month_date = june_2021[:now]
-        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        appointment = create(:appointment, patient: patient, device_created_at: month_date - 30.days,
+                                           scheduled_date: month_date - 15.days)
         create(:call_result, patient: patient, device_created_at: month_date, appointment: appointment)
         RefreshReportingViews.refresh_v2
 
@@ -290,7 +386,8 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
       it "should be no when a call was not made during the month after the previous appointment" do
         patient = create(:patient)
         month_date = june_2021[:now]
-        create(:appointment, patient: patient, device_created_at: month_date - 30.days, scheduled_date: month_date - 15.days)
+        create(:appointment, patient: patient, device_created_at: month_date - 30.days,
+                             scheduled_date: month_date - 15.days)
 
         RefreshReportingViews.refresh_v2
 

--- a/spec/services/refresh_reporting_views_spec.rb
+++ b/spec/services/refresh_reporting_views_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe RefreshReportingViews do
     }.to change { Reports::PatientBloodPressure.count }.by(4)
       .and change { Reports::PatientBloodSugar.count }.by(4)
       .and change { Reports::PatientState.count }.by(4)
+      .and change { Reports::OverduePatient.count }.by(4)
       .and change { Reports::PatientVisit.count }.by(4)
       .and change { Reports::PatientFollowUp.count }.by(1)
   end


### PR DESCRIPTION
**Story card:** 
[sc-10498](https://app.shortcut.com/simpledotorg/story/10498/failing-deployments-in-india-and-bangladesh-production-servers) 

[sc-10149](https://app.shortcut.com/simpledotorg/story/10149/add-a-mat-view-for-creating-a-line-list-of-overdue-patients)


## Because

We want to show a line list of overdue patients and report the aggregate data on the dashboard. The current reporting pipeline doesn't allow us to efficiently fetch and display this data.

Note: This is a v2 of the query. The initial query ([v1](https://github.com/simpledotorg/simple-server/pull/5073)) was failing in production and had to be reworked. 

## This addresses

The new materialised view enables Simple to report Overdue Patient's information at the start of each reporting month.

### Profiling
We used the production replica dataset to test the new materialised view. It shows acceptable performance.

Prevoius Query Plan: https://explain.depesz.com/s/6S5V
Current Query Plan: https://explain.depesz.com/s/3Kkh
