### PR TITLE
Account for region suffix when setting locale

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   around_action :switch_locale
 
   def switch_locale(&action)
-    locale = http_accept_language.compatible_language_from(I18n.available_locales) || I18n.default_locale
+    locale = http_accept_language.language_region_compatible_from(I18n.available_locales) || I18n.default_locale
     I18n.with_locale(locale, &action)
   end
 


### PR DESCRIPTION
**Story card:** bug

## Because

- We were using `compatible_language_from` method to find locale based on the header `Accept-Language`
  - According to documentation of `http_accept_language` gem, this method ignores region part of the locale and defaults the first locale it can find in the available locales
  - As a result, both `bn-IN` & `bn-BD` got resolved to `bn-BD`, which was defined first in `config.i18n.available_locales`.
- We've switched to using `language_region_compatible_from` method to find locale now. This method does not ignore the region part of the locale, and defaults to primary language only if it cannot find the region specified by the user.
- Documentation for reference: https://github.com/iain/http_accept_language#available-methods