### PR TITLE
Goal lines - change region visibility option

### DIFF
--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -474,17 +474,15 @@ Reports = function ({
   }
 
   function disabledForRegionLevel() {
-    const enabledRegions = [
-      "organization",
-      "region",
-      "division",
-      "districtBD",
-    ];
-    // region types present in multiple countries
-    if (regionType === "district" || regionType === "facility") {
-      return enabledRegions.indexOf(regionType + countryAbbreviation) === -1;
-    }
-    return enabledRegions.indexOf(regionType) === -1;
+    console.log(regionType);
+    // region names top to bottom: 'organization' > 'state' > 'district' > 'block' > 'facility' (all countries)
+    const enabledRegions = {
+      IN: [],
+      BD: ["organization", "state", "district"],
+      ET: ["organization", "state"],
+      LK: ["organization"],
+    };
+    return enabledRegions[countryAbbreviation].indexOf(regionType) === -1;
   }
   function calculateGoal(periodValues, goalDownwards) {
     const { goalMonthValue, goalMonthIndex } = goalPeriodValue(periodValues);

--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -474,7 +474,6 @@ Reports = function ({
   }
 
   function disabledForRegionLevel() {
-    console.log(regionType);
     // region names top to bottom: 'organization' > 'state' > 'district' > 'block' > 'facility' (all countries)
     const enabledRegions = {
       IN: [],

--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -609,7 +609,6 @@ Reports = function ({
     ctx.fillStyle = fillColor || "rgba(0, 0, 0, 0.1)";
     ctx.fill();
     ctx.restore();
-
   }
 
   function canvasDrawRoundRect(

--- a/app/assets/javascripts/common/reports.js
+++ b/app/assets/javascripts/common/reports.js
@@ -483,6 +483,7 @@ Reports = function ({
     };
     return enabledRegions[countryAbbreviation].indexOf(regionType) === -1;
   }
+  
   function calculateGoal(periodValues, goalDownwards) {
     const { goalMonthValue, goalMonthIndex } = goalPeriodValue(periodValues);
     const improvementRatio = relativeImprovementRatio(goalMonthIndex);


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

## Because

I assumed that the name 'region type' was relative to the table [listed in the docs](https://docs.simple.org/reports/what-we-report#region-reports). This is not the case and all region types follow the pattern for india when naming.

## This addresses

Changes to the way it checks if this region can view the goal lines.
Now organised by country.

## Test instructions

Dev environment is based on IN setup.
Head to the dashboard and go to any region level then add the region type name of the level you are viewing. When refreshing the goal line should appear.

Reports.js file
```
const enabledRegions = {
      IN: [],
      BD: ["organization", "state", "district"],
      ET: ["organization", "state"],
      LK: ["organization"],
    };
```
Options to add to IN
`organization` `state` `district` `block` `facility`