### PR TITLE
Fix Argocd silent deployment failure

### DIFF
--- a/script/argocd_deployment.sh
+++ b/script/argocd_deployment.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 if [ "$#" -ne 4 ]; then
   echo "Usage: $0 <argocd-endpoint> <argocd-user> <argocd-password> <image-tag>" >&2
   exit 1


### PR DESCRIPTION
**Story card:** [sc-10676](https://app.shortcut.com/simpledotorg/story/10676)

## Because

Argocd deployment was failing silently without any error

## This addresses

Configured bash option to exit immediately on failure
