### PR TITLE
Dashboard overdue: fix toggle styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -734,16 +734,16 @@ span.inactive {
 }
 .jc-space-between { justify-content: space-between; }
 
-.checkbox-outside-card.custom-control-input:not(:checked) ~ .custom-control-label::before {
+.checkbox-outside-card .custom-control-input:not(:checked) ~ .custom-control-label::before {
   background-color: #ADB2B8;
   border-color: #ADB2B8;
 }
 
-.checkbox-outside-card.custom-control-input:not(:checked) ~ .custom-control-label::after {
+.checkbox-outside-card .custom-control-input:not(:checked) ~ .custom-control-label::after {
   background-color: #fff;
 }
 
-.checkbox-outside-card.custom-control-label {
+.checkbox-outside-card .custom-control-label {
   color: #2f363d;
 }
 


### PR DESCRIPTION
- inlined css was not correctly styling.

**Story card:** [sc-XXXX](URL)

Styling for the toggle which was previously working not longer showing - lost in translation

Enter the reason for raising this PR...

## This addresses

This fixes the styling.

## Test instructions

Before fix:
![Screenshot 2023-06-08 at 16 43 38](https://github.com/simpledotorg/simple-server/assets/9541902/ae73b585-1962-4cca-a91e-72f7cb8c407c)

After fix:
![Screenshot 2023-06-08 at 16 43 23](https://github.com/simpledotorg/simple-server/assets/9541902/3143393d-8e20-4547-b7f4-93631cd34dcb)
