### PR TITLE
Dashboard overdue: fix missing column divider in table

### DIFF
--- a/app/components/dashboard/hypertension/overdue_patients_called_table_component.html.erb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_table_component.html.erb
@@ -19,6 +19,7 @@
           <col class="table-divider">
           <col>
           <col class="table-divider">
+        <col>
         </colgroup>
       <% end %>
       <% periods.each do |period| %>


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

## Because

There is a missing column divider in the table.
![image](https://github.com/simpledotorg/simple-server/assets/9541902/953a06d2-7943-4850-a353-3a20a9c27106)

## This addresses

This fixes the issue by adding a missing <col> element to the table header

## Test instructions

Please check the column divider appears at both the facility level AND any level above facility.
![Screenshot 2023-06-08 at 16 56 30](https://github.com/simpledotorg/simple-server/assets/9541902/70fb9bfc-ce93-46ad-96d6-11b4d2547240)

Images are fake data from dev