### PR TITLE
Fix: Some users not visible on the Overdue Patients Called Table

### DIFF
--- a/app/components/dashboard/hypertension/overdue_patients_called_table_component.rb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_table_component.rb
@@ -20,7 +20,6 @@ class Dashboard::Hypertension::OverduePatientsCalledTableComponent < Application
   def patient_call_count_by_user
     @current_admin.accessible_users(:view_reports)
       .order(:full_name)
-      .filter { |accessible_user| accessible_user.registration_facility_id == @region.facilities.first.id }
       .map { |user| calls_made_by_user(user) }
       .reduce(:merge)
   end


### PR DESCRIPTION
**Story card:** [sc-10747](https://app.shortcut.com/simpledotorg/story/10747/bug-overdue-patients-called-table-on-the-dashboard-at-a-facility-level-does-not-show-all-the-users)

## Because

At a facility level, users who called overdue patients from a facility they were not registered to were not showing up.

## This addresses

An additional filter was used to remove non-facility registered users. The filter has been removed
