### PR TITLE
Use under_care instead of cumulative_assigned_patients as the denominator

### DIFF
--- a/app/models/reports/region_summary_schema.rb
+++ b/app/models/reports/region_summary_schema.rb
@@ -268,7 +268,7 @@ module Reports
     memoize def overdue_patients_rates
       region_period_cached_query(__method__) do |entry|
         slug, period = entry.slug, entry.period
-        percentage(overdue_patients[slug][period], cumulative_assigned_patients[slug][period])
+        percentage(overdue_patients[slug][period], under_care[slug][period])
       end
     end
 
@@ -282,7 +282,7 @@ module Reports
     memoize def contactable_overdue_patients_rates
       region_period_cached_query(__method__) do |entry|
         slug, period = entry.slug, entry.period
-        percentage(contactable_overdue_patients[slug][period], cumulative_assigned_patients[slug][period])
+        percentage(contactable_overdue_patients[slug][period], under_care[slug][period])
       end
     end
 


### PR DESCRIPTION
**Story card:** [sc-10749](https://app.shortcut.com/simpledotorg/story/10749/fix-overdue-patient-percentage-in-the-overdue-patient-card)

## Because

The overdue patient percentage is calculated using cumulative_assigned_patient in the denominator instead of under_care

## This addresses

Use `under_care` as the denominator for calculating `overdue_patients_rate`

## Test instructions

##### Before
<img width="687" alt="Screenshot 2023-06-14 at 10 20 51 AM" src="https://github.com/simpledotorg/simple-server/assets/32141642/80ec5505-f835-4ca1-b664-16bd96905608">

##### After
<img width="687" alt="Screenshot 2023-06-14 at 10 22 25 AM" src="https://github.com/simpledotorg/simple-server/assets/32141642/102f1704-188d-4a86-9ba8-d5de949c4051">
