### PR TITLE
Handle exeption when user's reg facility is nil

### DIFF
--- a/app/components/dashboard/hypertension/overdue_patients_called_table_component.rb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_table_component.rb
@@ -95,7 +95,7 @@ class Dashboard::Hypertension::OverduePatientsCalledTableComponent < Application
   end
 
   def registered_in_current_facility(user)
-    user.registration_facility_id == @region.facilities.first.id
+    user.registration_facility&.id == @region.facilities.first.id
   end
 
   def atleast_one_call?(call_count_by_period)


### PR DESCRIPTION
**Story card:** [sc-10763](https://app.shortcut.com/simpledotorg/story/10763/handle-execption-when-user-s-reg-facility-is-nil)

## Because

When the registration facility of some users doesn't exist, it [throws an exception](https://resolve-to-save-lives.sentry.io/issues/4252099910/?project=1217715&referrer=slack) while rendering the overdue patients called by the user table

## This addresses

Adds a safe navigation operator(`&.`) before accessing the registration facility id of a user
