### PR TITLE
Fix overdue patients called count mismatch region and facility level

### DIFF
--- a/app/components/dashboard/hypertension/overdue_patients_called_table_component.rb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_table_component.rb
@@ -7,8 +7,8 @@ class Dashboard::Hypertension::OverduePatientsCalledTableComponent < Application
     @repository = repository
     @period = period
     @current_admin = current_admin
-    @children_data = facility? ? patient_call_count_by_user : patients_call_count_by_region
     @contactable = !with_non_contactable
+    @children_data = facility? ? patient_call_count_by_user : patients_call_count_by_region
   end
 
   def patients_call_count_by_region

--- a/app/queries/overdue_patients_query.rb
+++ b/app/queries/overdue_patients_query.rb
@@ -1,6 +1,6 @@
 class OverduePatientsQuery
-  FILTERS_CONTACTABLE_OVERDUE_PATIENTS_CALLED = {has_called: "yes", removed_from_overdue_list: "no", has_phone: "yes"}
-  FILTERS_PATIENTS_CALLED = {has_called: "yes"}
+  FILTERS_CONTACTABLE_OVERDUE_PATIENTS_CALLED = {has_called: "yes", removed_from_overdue_list: "no", has_phone: "yes", hypertension: "yes", under_care: "yes"}
+  FILTERS_PATIENTS_CALLED = {has_called: "yes", hypertension: "yes", under_care: "yes"}
 
   def count_patients_called(region, period_type, group_by: nil)
     count_patients(region, period_type, group_by: group_by, filters: FILTERS_PATIENTS_CALLED)


### PR DESCRIPTION
**Story card:** [sc-10748](https://app.shortcut.com/simpledotorg/story/10748/bug-sort-on-overdue-patients-called-table-is-broken)

## Because

Overdue patient's called numbers were incorrect at a region and facility level.
- At region level, the toggle was always on
- At the facility level, the query to fetch overdue patients by the user was not excluding non-hypertensive and non-under-care patients

## This addresses

- Fixed the sequence in which `@contactable` is initiated
- Fixed the overdue patients by user query to only include hypertensive and under care patients