### PR TITLE
add additional note to table tooltip

### DIFF
--- a/app/components/dashboard/hypertension/overdue_patients_called_table_component.html.erb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_table_component.html.erb
@@ -6,6 +6,7 @@
     <%= c.tooltip({ "Patients called" => t("overdue_patients_call_activity.patients_called"),
                     "Percent called" => "",
                     "Numerator" => t("overdue_patients_call_activity.percent_called_numerator"),
+                    "note" => t("overdue_patients_called.numerator_note"),
                     "divider" => "",
                     "Denominator" => t("overdue_patients_call_activity.percent_called_denominator", region_name: @region.name)
                   }) %>


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

## Because

Add the 'note' text from the patients called chart tooltip to the patients called table tooltip

## This addresses

A mismatch in the explanation
The figures shown are identical in calculation so this should read the same in the tooltip

## Test instructions

Hover the tooltip ? in the overdue table element
You should see this:
![Screenshot 2023-06-15 at 13 23 23](https://github.com/simpledotorg/simple-server/assets/9541902/74704eb6-ec17-48cd-a6ea-8004550f3b37)
