### PR TITLE
Add manifest.json file in manifest pages for android compatibility

### DIFF
--- a/.github/workflows/deploy-manifest.yml
+++ b/.github/workflows/deploy-manifest.yml
@@ -4,7 +4,7 @@ name: Deploy public/manifest content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master", "update-manifest-pages"]
+    branches: ["master"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/deploy-manifest.yml
+++ b/.github/workflows/deploy-manifest.yml
@@ -4,7 +4,7 @@ name: Deploy public/manifest content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
+    branches: ["master", "update-manifest-pages"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Create manifest.json file from production.json
+        run: cp public/manifest/production.json public/manifest/manifest.json
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact


### PR DESCRIPTION
**Story card:** [10621](https://app.shortcut.com/simpledotorg/story/10621)

## Because

Android client uses https://manifest.simple.org/manifest.json URL format

## This addresses

Add manifest.json file in manifest pages

## Test instructions

curl https://manifest.simple.org/manifest.json