### PR TITLE
Overdue dashboard: CSS corrections

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -748,6 +748,12 @@ span.inactive {
 }
 
 .o-65 { opacity: 0.65; }
+.card-chip-container {
+  white-space: nowrap;
+  display: flex;
+  flex-direction: row;
+  grid-gap: 8px;
+}
 
 .card-chip {
   width: 33%;
@@ -789,5 +795,5 @@ span.inactive {
 }
 
 .no-card-gap-filler p {
-  color: #A0A0A0;
+  color: #a0a0a0;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -772,3 +772,22 @@ span.inactive {
   background: rgba(232, 144, 80, 0.15);
   color: rgb(143, 17, 12);
 }
+.no-card-gap-filler {
+  display: none;
+  justify-content: center;
+  align-items: center;
+  border: dashed 2px #cecece;
+  width: 50%;
+  border-radius: 4px;
+  width: 100%;
+}
+
+@media screen and (min-width: 992px) {
+  .no-card-gap-filler {
+    display: flex;
+  }
+}
+
+.no-card-gap-filler p {
+  color: #A0A0A0;
+}

--- a/app/components/dashboard/hypertension/overdue_patients_called_component.html.erb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_component.html.erb
@@ -27,7 +27,7 @@
           <p class="fw-bold mb-4px">
             Call results <span data-key="endDate"></span>
           </p>
-          <div style="white-space: nowrap; display: flex; flex-direction: row; grid-gap: 8px;">
+        <div class="card-chip-container">
             <p data-title="chartProportionalPercentageCalledWithResultAgreedToVisit"
                 style="border-radius: 30px; text-align: center; width: 33%; margin: 0; padding: 2px 8px; overflow: hidden; color: rgba(44, 115, 0, 1); background: rgba(78, 206, 0, 0.15);">
               <span data-key="chartProportionalPercentageCalledWithResultAgreedToVisit"></span>%

--- a/app/components/dashboard/hypertension/overdue_patients_called_component.html.erb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_component.html.erb
@@ -26,22 +26,22 @@
         <div class="pb-8px">
           <p class="fw-bold mb-4px">
             Call results <span data-key="endDate"></span>
-          </p>
+        </p>
         <div class="card-chip-container">
-            <p data-title="chartProportionalPercentageCalledWithResultAgreedToVisit"
-                style="border-radius: 30px; text-align: center; width: 33%; margin: 0; padding: 2px 8px; overflow: hidden; color: rgba(44, 115, 0, 1); background: rgba(78, 206, 0, 0.15);">
-              <span data-key="chartProportionalPercentageCalledWithResultAgreedToVisit"></span>%
-              'Agreed to visit'
-            </p>
-            <p data-title="chartProportionalPercentageCalledWithResultRemindToCallLater"
-              style="border-radius: 30px; text-align: center; background: rgba(252, 247, 193, 0.8); color:rgb(118, 93, 3); margin: 0; white-space: nowrap;  width: 33%; margin: 0; padding: 2px 8px; overflow: hidden;">
-              <span data-key="chartProportionalPercentageCalledWithResultRemindToCallLater"></span>% 'Remind to call'
-            </p>
-            <p data-title="chartProportionalPercentageCalledWithResultRemoveFromOverdueList"
-               style="background: rgba(232, 144, 80, 0.15); color:rgb(143,17,12 ); border-radius: 30px; margin: 0; text-align: center; white-space: nowrap; overflow: hidden; width: 33%; margin: 0; padding: 2px 16px; overflow: hidden;">
-              <span data-key="chartProportionalPercentageCalledWithResultRemoveFromOverdueList"></span>% 'Remove from...'
-            </p>
-          </div>
+          <p data-title="chartProportionalPercentageCalledWithResultAgreedToVisit"
+          class="card-chip card-chip-green">
+            <span data-key="chartProportionalPercentageCalledWithResultAgreedToVisit"></span>%
+            'Agreed to visit'
+          </p>
+          <p data-title="chartProportionalPercentageCalledWithResultRemindToCallLater"
+          class="card-chip card-chip-amber">
+            <span data-key="chartProportionalPercentageCalledWithResultRemindToCallLater"></span>% 'Remind to call'
+          </p>
+          <p data-title="chartProportionalPercentageCalledWithResultRemoveFromOverdueList"
+          class="card-chip card-chip-red">
+            <span data-key="chartProportionalPercentageCalledWithResultRemoveFromOverdueList"></span>% 'Remove from...'
+          </p>
+        </div>
         </div>
       <%end%>
     <% end %>

--- a/app/components/dashboard/hypertension/overdue_patients_return_to_care_component.html.erb
+++ b/app/components/dashboard/hypertension/overdue_patients_return_to_care_component.html.erb
@@ -25,7 +25,7 @@
         <p class="fw-bold mb-4px">
           Returned to care by call result <span data-key="endDate"></span>
         </p>
-        <div style="white-space: nowrap; display: flex; flex-direction: row; grid-gap: 8px;">
+        <div class="card-chip-container">
           <p data-title="patientsReturnedAgreedToVisitRates" title="'Agreed to visit'"
                 class="card-chip card-chip-green">
             <span data-key="patientsReturnedAgreedToVisitRates"></span>%

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -281,8 +281,8 @@
         period: @period,
         with_removed_from_overdue_list: @with_removed_from_overdue_list)) %>
       <div class="d-lg-flex w-lg-50 pl-lg-2 hidden" style="margin-bottom: 16px;">
-        <div class="" style="display: flex; justify-content: center; align-items: center; border: dashed 2px #CECECE; width: 50%; border-radius: 4px; width: 100%;">
-          <p style="color: #A0A0A0;">
+        <div class="no-card-gap-filler">
+          <p>
             Intentionally blank
           </p>
         </div>


### PR DESCRIPTION
**Story card:** [sc-10836](https://app.shortcut.com/simpledotorg/story/10836/refactor-move-all-the-inline-css-to-classes)

## Because

Some styles left in the HTML code rather than CSS classes

## This addresses

Fixes to change to CSS classes

## Test instructions

1. Intentionally blank card (next to 'returned to care' chart card)
This should be hidden when looking at the site on a mobile device - when the number of cards in a row drops to 1. (View with a skinny screen width).
2. Check the chips (the colored bubbles with the % call outcomes and return to care).
Ensure that they work at all screen widths, they should not have more than a single line of text and where the bubble is too small to display the text then ... appears.
The 'Remove from overdue list' is cropped initially to improve reading - hovering the chip shows the full text.
![Screenshot 2023-06-28 at 14 22 06](https://github.com/simpledotorg/simple-server/assets/9541902/2b1b6ae1-5573-4899-ae3d-403016bb6485)
