### PR TITLE
Fix alpha sms detail class

### DIFF
--- a/app/models/alpha_sms_delivery_detail.rb
+++ b/app/models/alpha_sms_delivery_detail.rb
@@ -17,6 +17,10 @@ class AlphaSmsDeliveryDetail < DeliveryDetail
     request_status.blank?
   end
 
+  def result
+    request_status
+  end
+
   def self.create_with_communication!(request_id:, recipient_number:, message:)
     ActiveRecord::Base.transaction do
       delivery_detail = create!(

--- a/app/models/delivery_detail.rb
+++ b/app/models/delivery_detail.rb
@@ -14,6 +14,10 @@ class DeliveryDetail < ApplicationRecord
     raise NotImplementedError
   end
 
+  def result
+    raise NotImplementedError
+  end
+
   # This should create the delivery detail, create an
   # associated communication and return the communication object.
   def self.create_with_communication!

--- a/app/models/delivery_detail.rb
+++ b/app/models/delivery_detail.rb
@@ -14,10 +14,6 @@ class DeliveryDetail < ApplicationRecord
     raise NotImplementedError
   end
 
-  def result
-    raise NotImplementedError
-  end
-
   # This should create the delivery detail, create an
   # associated communication and return the communication object.
   def self.create_with_communication!

--- a/db/data/20230628132154_setup_july_v2_experiments_bangladesh.rb
+++ b/db/data/20230628132154_setup_july_v2_experiments_bangladesh.rb
@@ -1,0 +1,85 @@
+class SetupJulyV2ExperimentsBangladesh < ActiveRecord::Migration[6.1]
+  START_TIME = DateTime.new(2023, 7, 1).beginning_of_day
+  END_TIME = DateTime.new(2023, 8, 1).beginning_of_day
+  CURRENT_PATIENTS_EXPERIMENT = "Current Patient July V2 2023"
+  STALE_PATIENTS_EXPERIMENT = "Stale Patient July V2 2023"
+  PATIENTS_PER_DAY = 5000
+  FILTERS = {
+    "states" => {"include" => ["Sylhet"]},
+    "facilities" => {"exclude" => ["edaf3ebd-3dbd-48c3-9911-875ad1356f5d", "fe48375c-7826-41dd-9110-d716a9181e8f", "032b5549-eb26-4784-b3c2-162011297df6", "4d1e7df5-edcd-439c-a6c0-86078c9b7c50", "68603a37-175d-4f11-bd30-85fc6c4c3a38", "00db147c-5289-40b4-bd3c-090cac07c9ea", "0fad3822-9f5a-46ea-b02f-90501a184252", "130be963-f38e-4c58-b671-69b71949dfbd", "3d9e19a2-8a57-4248-98fe-e90967806f27", "8bf07061-0681-4224-af29-f265baaf6437"]}
+  }
+
+  def up
+    return unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
+
+    buggy_current_experiment = Experimentation::Experiment.find_by_name("Current Patient July 2023")
+    buggy_current_experiment.cancel
+    buggy_current_experiment.treatment_group_memberships.each { |tgm| tgm.evict(reason: "Patients were in buggy experiment") }
+
+    buggy_stale_experiment = Experimentation::Experiment.find_by_name("Stale Patient July 2023")
+    buggy_stale_experiment.cancel
+    buggy_stale_experiment.treatment_group_memberships.each { |tgm| tgm.evict(reason: "Patients were in buggy experiment") }
+
+    transaction do
+      Experimentation::Experiment.current_patients.create!(
+        name: CURRENT_PATIENTS_EXPERIMENT,
+        start_time: START_TIME,
+        end_time: END_TIME,
+        max_patients_per_day: PATIENTS_PER_DAY,
+        filters: FILTERS
+      ).tap do |experiment|
+        _control_group = experiment.treatment_groups.create!(description: "control")
+
+        single_group = experiment.treatment_groups.create!(description: "single_notification")
+        single_group.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 3)
+
+        cascade1 = experiment.treatment_groups.create!(description: "cascade1")
+        cascade1.reminder_templates.create!(message: "notifications.set01.official_short", remind_on_in_days: -1)
+        cascade1.reminder_templates.create!(message: "notifications.set02.official_short", remind_on_in_days: 0)
+        cascade1.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 3)
+
+        cascade2 = experiment.treatment_groups.create!(description: "cascade2")
+        cascade2.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 1)
+        cascade2.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 3)
+
+        cascade3 = experiment.treatment_groups.create!(description: "cascade3")
+        cascade3.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 3)
+        cascade3.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 7)
+      end
+    end
+
+    transaction do
+      Experimentation::Experiment.stale_patients.create!(
+        name: STALE_PATIENTS_EXPERIMENT,
+        start_time: START_TIME,
+        end_time: END_TIME,
+        max_patients_per_day: PATIENTS_PER_DAY,
+        filters: FILTERS
+      ).tap do |experiment|
+        _control_group = experiment.treatment_groups.create!(description: "control")
+
+        single_group = experiment.treatment_groups.create!(description: "single_notification")
+        single_group.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 0)
+
+        cascade1 = experiment.treatment_groups.create!(description: "cascade1")
+        cascade1.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 0)
+        cascade1.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 3)
+        # Stale (5 buckets): control, 0,  0/3, 0/7, and 0/3/7
+
+        cascade2 = experiment.treatment_groups.create!(description: "cascade2")
+        cascade2.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 0)
+        cascade2.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 7)
+
+        cascade3 = experiment.treatment_groups.create!(description: "cascade3")
+        cascade3.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 0)
+        cascade3.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 3)
+        cascade3.reminder_templates.create!(message: "notifications.set03.basic", remind_on_in_days: 7)
+      end
+    end
+  end
+
+  def down
+    Experimentation::Experiment.current_patients.find_by_name(CURRENT_PATIENTS_EXPERIMENT).cancel
+    Experimentation::Experiment.stale_patients.find_by_name(STALE_PATIENTS_EXPERIMENT).cancel
+  end
+end

--- a/db/data/20230628132154_setup_july_v2_experiments_bangladesh.rb
+++ b/db/data/20230628132154_setup_july_v2_experiments_bangladesh.rb
@@ -14,11 +14,11 @@ class SetupJulyV2ExperimentsBangladesh < ActiveRecord::Migration[6.1]
 
     buggy_current_experiment = Experimentation::Experiment.find_by_name("Current Patient July 2023")
     buggy_current_experiment.cancel
-    buggy_current_experiment.treatment_group_memberships.each { |tgm| tgm.evict(reason: "Patients were in buggy experiment") }
+    buggy_current_experiment.evict_patients
 
     buggy_stale_experiment = Experimentation::Experiment.find_by_name("Stale Patient July 2023")
     buggy_stale_experiment.cancel
-    buggy_stale_experiment.treatment_group_memberships.each { |tgm| tgm.evict(reason: "Patients were in buggy experiment") }
+    buggy_stale_experiment.evict_patients
 
     transaction do
       Experimentation::Experiment.current_patients.create!(

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20230620114230)
+DataMigrate::Data.define(version: 20230628132154)

--- a/spec/models/alpha_sms_delivery_detail_spec.rb
+++ b/spec/models/alpha_sms_delivery_detail_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe AlphaSmsDeliveryDetail, type: :model do
           recipient_number: phone_number,
           message: message
         ).tap do |c|
-          c.detailable.result = "Sent"
+          c.detailable.request_status = "Sent"
         end
 
       expect(communication.detailable.recipient_number).to eq phone_number

--- a/spec/models/alpha_sms_delivery_detail_spec.rb
+++ b/spec/models/alpha_sms_delivery_detail_spec.rb
@@ -54,11 +54,14 @@ RSpec.describe AlphaSmsDeliveryDetail, type: :model do
           request_id: request_id,
           recipient_number: phone_number,
           message: message
-        )
+        ).tap do |communication|
+          communication.detailable.request_status = "Sent"
+        end
 
       expect(communication.detailable.recipient_number).to eq phone_number
       expect(communication.detailable.message).to eq message
       expect(communication.detailable.request_id).to eq request_id
+      expect(communication.detailable.result).to eq "Sent"
     end
   end
 end

--- a/spec/models/alpha_sms_delivery_detail_spec.rb
+++ b/spec/models/alpha_sms_delivery_detail_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe AlphaSmsDeliveryDetail, type: :model do
           request_id: request_id,
           recipient_number: phone_number,
           message: message
-        ).tap do |communication|
-          communication.detailable.request_status = "Sent"
+        ).tap do |c|
+          c.detailable.result = "Sent"
         end
 
       expect(communication.detailable.recipient_number).to eq phone_number

--- a/spec/models/bsnl_delivery_detail_spec.rb
+++ b/spec/models/bsnl_delivery_detail_spec.rb
@@ -34,9 +34,12 @@ RSpec.describe BsnlDeliveryDetail, type: :model do
           message_id: "1000123",
           recipient_number: phone_number,
           dlt_template_id: "12398127312492"
-        )
+        ).tap do |c|
+          c.detailable.result = "Sent"
+        end
 
       expect(communication.detailable.recipient_number).to eq phone_number
+      expect(communication.detailable.result).to eq "Sent"
     end
   end
 

--- a/spec/models/twilio_sms_delivery_detail_spec.rb
+++ b/spec/models/twilio_sms_delivery_detail_spec.rb
@@ -19,6 +19,7 @@ describe TwilioSmsDeliveryDetail, type: :model do
         )
 
       expect(communication.detailable.callee_phone_number).to eq phone_number
+      expect(communication.detailable.result).to eq("sent")
     end
   end
 end


### PR DESCRIPTION
**Story card:** bug

## Because
Notifications aren't being sent out in Bangladesh environment because of a `NoMethodError` error in the "monitoring" step. Details:
1. Everyday at 5.45 AM BD time,  `Experimentation::Runner.call` rake task runs
1. `conduct_daily` performs enrolling, monitoring & notifying steps sequentially
1. Enrolling step is working fine as there are treatment group memberships created until today
1. In the monitoring step, `successful_delivery.detailable.result` is failing with NoMethodError
1. Hence, the rake task never gets to Notifying step.

**Solution**: `BsnlDeliveryDetail` does have a `.result` attribute, but `AlphaSmsDeliveryDetail` has `.request_status` instead. We have added a `result` method to AlphaSms class which returns value of `request_status`
