### PR TITLE
Fix contactable toggle not working for Overdue Patients Returned

### DIFF
--- a/app/components/dashboard/hypertension/overdue_patients_return_to_care_component.rb
+++ b/app/components/dashboard/hypertension/overdue_patients_return_to_care_component.rb
@@ -1,11 +1,11 @@
 class Dashboard::Hypertension::OverduePatientsReturnToCareComponent < ApplicationComponent
   attr_reader :data, :contactable, :period
 
-  def initialize(region:, data:, period:, with_removed_from_overdue_list:)
+  def initialize(region:, data:, period:, with_non_contactable:)
     @region = region
     @data = data
     @period = period
-    @contactable = !with_removed_from_overdue_list
+    @contactable = !with_non_contactable
   end
 
   def graph_data

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -279,7 +279,7 @@
         region: @region,
         data: @data,
         period: @period,
-        with_removed_from_overdue_list: @with_removed_from_overdue_list)) %>
+        with_non_contactable: @with_non_contactable)) %>
       <div class="d-lg-flex w-lg-50 pl-lg-2 hidden" style="margin-bottom: 16px;">
         <div class="" style="display: flex; justify-content: center; align-items: center; border: dashed 2px #CECECE; width: 50%; border-radius: 4px; width: 100%;">
           <p style="color: #A0A0A0;">


### PR DESCRIPTION
**Story card:** [sc-10784](https://app.shortcut.com/simpledotorg/story/10784/integrate-data-with-return-to-care-graph)

## Because

The contactable toggle for Overdue Patients Returned Chart was not working.

## This addresses

The graph was using the wrong key to fetch the toggle info
