### PR TITLE
Implement authentication for stakeholder resource access

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ gem "webpacker", "6.0.0.rc.6"
 gem "whenever", require: false
 gem "wkhtmltoimage-binary"
 gem "table_print"
+gem "doorkeeper", "~> 5.6"
 
 group :development, :test do
   gem "active_record_query_trace", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,8 @@ GEM
     dogstatsd-ruby (5.5.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    doorkeeper (5.6.6)
+      railties (>= 5)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -729,6 +731,7 @@ DEPENDENCIES
   diffy
   discard (~> 1.2)
   dogstatsd-ruby (~> 5.2)
+  doorkeeper (~> 5.6)
   dotenv-rails
   ed25519 (~> 1.2)
   factory_bot_rails (~> 6.1)

--- a/app/models/machine_user.rb
+++ b/app/models/machine_user.rb
@@ -1,0 +1,13 @@
+class MachineUser < ApplicationRecord
+  belongs_to :organization
+
+  has_many :access_grants,
+    class_name: "Doorkeeper::AccessGrant",
+    foreign_key: :resource_owner_id,
+    dependent: :delete_all
+
+  has_many :access_tokens,
+    class_name: "Doorkeeper::AccessToken",
+    foreign_key: :resource_owner_id,
+    dependent: :delete_all
+end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,0 +1,507 @@
+# frozen_string_literal: true
+
+Doorkeeper.configure do
+  # Change the ORM that doorkeeper will use (requires ORM extensions installed).
+  # Check the list of supported ORMs here: https://github.com/doorkeeper-gem/doorkeeper#orms
+  orm :active_record
+
+  # This block will be called to check whether the resource owner is authenticated or not.
+  resource_owner_authenticator do
+    # Since Authorization Code flow is currently disabled, we will redirect to the admin homepage.
+    redirect_to admins_url
+  end
+
+  # If you didn't skip applications controller from Doorkeeper routes in your application routes.rb
+  # file then you need to declare this block in order to restrict access to the web interface for
+  # adding oauth authorized applications. In other case it will return 403 Forbidden response
+  # every time somebody will try to access the admin web interface.
+  #
+  # admin_authenticator do
+  #   # Put your admin authentication logic here.
+  #   # Example implementation:
+  #
+  #   if current_user
+  #     head :forbidden unless current_user.admin?
+  #   else
+  #     redirect_to sign_in_url
+  #   end
+  # end
+
+  # You can use your own model classes if you need to extend (or even override) default
+  # Doorkeeper models such as `Application`, `AccessToken` and `AccessGrant.
+  #
+  # Be default Doorkeeper ActiveRecord ORM uses it's own classes:
+  #
+  # access_token_class "Doorkeeper::AccessToken"
+  # access_grant_class "Doorkeeper::AccessGrant"
+  # application_class "Doorkeeper::Application"
+  #
+  # Don't forget to include Doorkeeper ORM mixins into your custom models:
+  #
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken - for access token
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant - for access grant
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::Application - for application (OAuth2 clients)
+  #
+  # For example:
+  #
+  # access_token_class "MyAccessToken"
+  #
+  # class MyAccessToken < ApplicationRecord
+  #   include ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken
+  #
+  #   self.table_name = "hey_i_wanna_my_name"
+  #
+  #   def destroy_me!
+  #     destroy
+  #   end
+  # end
+
+  # Enables polymorphic Resource Owner association for Access Tokens and Access Grants.
+  # By default this option is disabled.
+  #
+  # Make sure you properly setup you database and have all the required columns (run
+  # `bundle exec rails generate doorkeeper:enable_polymorphic_resource_owner` and execute Rails
+  # migrations).
+  #
+  # If this option enabled, Doorkeeper will store not only Resource Owner primary key
+  # value, but also it's type (class name). See "Polymorphic Associations" section of
+  # Rails guides: https://guides.rubyonrails.org/association_basics.html#polymorphic-associations
+  #
+  # [NOTE] If you apply this option on already existing project don't forget to manually
+  # update `resource_owner_type` column in the database and fix migration template as it will
+  # set NOT NULL constraint for Access Grants table.
+  #
+  # use_polymorphic_resource_owner
+
+  # If you are planning to use Doorkeeper in Rails 5 API-only application, then you might
+  # want to use API mode that will skip all the views management and change the way how
+  # Doorkeeper responds to a requests.
+  #
+  # api_only
+
+  # Enforce token request content type to application/x-www-form-urlencoded.
+  # It is not enabled by default to not break prior versions of the gem.
+  #
+  # enforce_content_type
+
+  # Authorization Code expiration time (default: 10 minutes).
+  #
+  # authorization_code_expires_in 10.minutes
+
+  # Access token expiration time (default: 2 hours).
+  # If you want to disable expiration, set this to `nil`.
+  #
+  access_token_expires_in 8.hours
+
+  # Assign custom TTL for access tokens. Will be used instead of access_token_expires_in
+  # option if defined. In case the block returns `nil` value Doorkeeper fallbacks to
+  # +access_token_expires_in+ configuration option value. If you really need to issue a
+  # non-expiring access token (which is not recommended) then you need to return
+  # Float::INFINITY from this block.
+  #
+  # `context` has the following properties available:
+  #
+  #   * `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  #   * `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  #   * `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #   * `resource_owner` - authorized resource owner instance (if present)
+  #
+  # custom_access_token_expires_in do |context|
+  #   context.client.additional_settings.implicit_oauth_expiration
+  # end
+
+  # Use a custom class for generating the access token.
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-access-token-generator
+  #
+  # access_token_generator '::Doorkeeper::JWT'
+
+  # The controller +Doorkeeper::ApplicationController+ inherits from.
+  # Defaults to +ActionController::Base+ unless +api_only+ is set, which changes the default to
+  # +ActionController::API+. The return value of this option must be a stringified class name.
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-controllers
+  #
+  # base_controller 'ApplicationController'
+
+  # Reuse access token for the same resource owner within an application (disabled by default).
+  #
+  # This option protects your application from creating new tokens before old **valid** one becomes
+  # expired so your database doesn't bloat. Keep in mind that when this option is enabled Doorkeeper
+  # doesn't update existing token expiration time, it will create a new token instead if no active matching
+  # token found for the application, resources owner and/or set of scopes.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
+  #
+  # You can not enable this option together with +hash_token_secrets+.
+  #
+  # reuse_access_token
+
+  # In case you enabled `reuse_access_token` option Doorkeeper will try to find matching
+  # token using `matching_token_for` Access Token API that searches for valid records
+  # in batches in order not to pollute the memory with all the database records. By default
+  # Doorkeeper uses batch size of 10 000 records. You can increase or decrease this value
+  # depending on your needs and server capabilities.
+  #
+  # token_lookup_batch_size 10_000
+
+  # Set a limit for token_reuse if using reuse_access_token option
+  #
+  # This option limits token_reusability to some extent.
+  # If not set then access_token will be reused unless it expires.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1189
+  #
+  # This option should be a percentage(i.e. (0,100])
+  #
+  # token_reuse_limit 100
+
+  # Only allow one valid access token obtained via client credentials
+  # per client. If a new access token is obtained before the old one
+  # expired, the old one gets revoked (disabled by default)
+  #
+  # When enabling this option, make sure that you do not expect multiple processes
+  # using the same credentials at the same time (e.g. web servers spanning
+  # multiple machines and/or processes).
+  #
+  # revoke_previous_client_credentials_token
+
+  # Hash access and refresh tokens before persisting them.
+  # This will disable the possibility to use +reuse_access_token+
+  # since plain values can no longer be retrieved.
+  #
+  # Note: If you are already a user of doorkeeper and have existing tokens
+  # in your installation, they will be invalid without adding 'fallback: :plain'.
+  #
+  # hash_token_secrets
+  # By default, token secrets will be hashed using the
+  # +Doorkeeper::Hashing::SHA256+ strategy.
+  #
+  # If you wish to use another hashing implementation, you can override
+  # this strategy as follows:
+  #
+  # hash_token_secrets using: '::Doorkeeper::Hashing::MyCustomHashImpl'
+  #
+  # Keep in mind that changing the hashing function will invalidate all existing
+  # secrets, if there are any.
+
+  # Hash application secrets before persisting them.
+  #
+  # hash_application_secrets
+  #
+  # By default, applications will be hashed
+  # with the +Doorkeeper::SecretStoring::SHA256+ strategy.
+  #
+  # If you wish to use bcrypt for application secret hashing, uncomment
+  # this line instead:
+  #
+  # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt'
+
+  # When the above option is enabled, and a hashed token or secret is not found,
+  # you can allow to fall back to another strategy. For users upgrading
+  # doorkeeper and wishing to enable hashing, you will probably want to enable
+  # the fallback to plain tokens.
+  #
+  # This will ensure that old access tokens and secrets
+  # will remain valid even if the hashing above is enabled.
+  #
+  # This can be done by adding 'fallback: plain', e.g. :
+  #
+  # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt', fallback: :plain
+
+  # Issue access tokens with refresh token (disabled by default), you may also
+  # pass a block which accepts `context` to customize when to give a refresh
+  # token or not. Similar to +custom_access_token_expires_in+, `context` has
+  # the following properties:
+  #
+  # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #
+  # use_refresh_token
+
+  # Provide support for an owner to be assigned to each registered application (disabled by default)
+  # Optional parameter confirmation: true (default: false) if you want to enforce ownership of
+  # a registered application
+  # NOTE: you must also run the rails g doorkeeper:application_owner generator
+  # to provide the necessary support
+  #
+  enable_application_owner confirmation: false
+
+  # Define access token scopes for your provider
+  # For more information go to
+  # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
+  #
+  default_scopes :write
+  # optional_scopes :write, :update
+
+  # Allows to restrict only certain scopes for grant_type.
+  # By default, all the scopes will be available for all the grant types.
+  #
+  # Keys to this hash should be the name of grant_type and
+  # values should be the array of scopes for that grant type.
+  # Note: scopes should be from configured_scopes (i.e. default or optional)
+  #
+  # scopes_by_grant_type password: [:write], client_credentials: [:update]
+
+  # Forbids creating/updating applications with arbitrary scopes that are
+  # not in configuration, i.e. +default_scopes+ or +optional_scopes+.
+  # (disabled by default)
+  #
+  enforce_configured_scopes
+
+  # Change the way client credentials are retrieved from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
+  #
+  # client_credentials :from_basic, :from_params
+
+  # Change the way access token is authenticated from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
+  #
+  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+  # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
+  # by default in non-development environments). OAuth2 delegates security in
+  # communication to the HTTPS protocol so it is wise to keep this enabled.
+  #
+  # Callable objects such as proc, lambda, block or any object that responds to
+  # #call can be used in order to allow conditional checks (to allow non-SSL
+  # redirects to localhost for example).
+  #
+  # force_ssl_in_redirect_uri !Rails.env.development?
+  #
+  # force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
+
+  # Specify what redirect URI's you want to block during Application creation.
+  # Any redirect URI is allowed by default.
+  #
+  # You can use this option in order to forbid URI's with 'javascript' scheme
+  # for example.
+  #
+  # forbid_redirect_uri { |uri| uri.scheme.to_s.downcase == 'javascript' }
+
+  # Allows to set blank redirect URIs for Applications in case Doorkeeper configured
+  # to use URI-less OAuth grant flows like Client Credentials or Resource Owner
+  # Password Credentials. The option is on by default and checks configured grant
+  # types, but you **need** to manually drop `NOT NULL` constraint from `redirect_uri`
+  # column for `oauth_applications` database table.
+  #
+  # You can completely disable this feature with:
+  #
+  # allow_blank_redirect_uri false
+  #
+  # Or you can define your custom check:
+  #
+  # allow_blank_redirect_uri do |grant_flows, client|
+  #   client.superapp?
+  # end
+
+  # Specify how authorization errors should be handled.
+  # By default, doorkeeper renders json errors when access token
+  # is invalid, expired, revoked or has invalid scopes.
+  #
+  # If you want to render error response yourself (i.e. rescue exceptions),
+  # set +handle_auth_errors+ to `:raise` and rescue Doorkeeper::Errors::InvalidToken
+  # or following specific errors:
+  #
+  #   Doorkeeper::Errors::TokenForbidden, Doorkeeper::Errors::TokenExpired,
+  #   Doorkeeper::Errors::TokenRevoked, Doorkeeper::Errors::TokenUnknown
+  #
+  # handle_auth_errors :raise
+
+  # Customize token introspection response.
+  # Allows to add your own fields to default one that are required by the OAuth spec
+  # for the introspection response. It could be `sub`, `aud` and so on.
+  # This configuration option can be a proc, lambda or any Ruby object responds
+  # to `.call` method and result of it's invocation must be a Hash.
+  #
+  # custom_introspection_response do |token, context|
+  #   {
+  #     "sub": "Z5O3upPC88QrAjx00dis",
+  #     "aud": "https://protected.example.net/resource",
+  #     "username": User.find(token.resource_owner_id).username
+  #   }
+  # end
+  #
+  # or
+  #
+  # custom_introspection_response CustomIntrospectionResponder
+
+  # Specify what grant flows are enabled in array of Strings. The valid
+  # strings and the flows they enable are:
+  #
+  # "authorization_code" => Authorization Code Grant Flow
+  # "implicit"           => Implicit Grant Flow
+  # "password"           => Resource Owner Password Credentials Grant Flow
+  # "client_credentials" => Client Credentials Grant Flow
+  #
+  # If not specified, Doorkeeper enables authorization_code and
+  # client_credentials.
+  #
+  # implicit and password grant flows have risks that you should understand
+  # before enabling:
+  #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.2
+  #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.3
+  #
+  grant_flows %w[client_credentials]
+
+  # Allows to customize OAuth grant flows that +each+ application support.
+  # You can configure a custom block (or use a class respond to `#call`) that must
+  # return `true` in case Application instance supports requested OAuth grant flow
+  # during the authorization request to the server. This configuration +doesn't+
+  # set flows per application, it only allows to check if application supports
+  # specific grant flow.
+  #
+  # For example you can add an additional database column to `oauth_applications` table,
+  # say `t.array :grant_flows, default: []`, and store allowed grant flows that can
+  # be used with this application there. Then when authorization requested Doorkeeper
+  # will call this block to check if specific Application (passed with client_id and/or
+  # client_secret) is allowed to perform the request for the specific grant type
+  # (authorization, password, client_credentials, etc).
+  #
+  # Example of the block:
+  #
+  #   ->(flow, client) { client.grant_flows.include?(flow) }
+  #
+  # In case this option invocation result is `false`, Doorkeeper server returns
+  # :unauthorized_client error and stops the request.
+  #
+  # @param allow_grant_flow_for_client [Proc] Block or any object respond to #call
+  # @return [Boolean] `true` if allow or `false` if forbid the request
+  #
+  # allow_grant_flow_for_client do |grant_flow, client|
+  #   # `grant_flows` is an Array column with grant
+  #   # flows that application supports
+  #
+  #   client.grant_flows.include?(grant_flow)
+  # end
+
+  # If you need arbitrary Resource Owner-Client authorization you can enable this option
+  # and implement the check your need. Config option must respond to #call and return
+  # true in case resource owner authorized for the specific application or false in other
+  # cases.
+  #
+  # Be default all Resource Owners are authorized to any Client (application).
+  #
+  # authorize_resource_owner_for_client do |client, resource_owner|
+  #   resource_owner.admin? || client.owners_allowlist.include?(resource_owner)
+  # end
+
+  # Allows additional data fields to be sent while granting access to an application,
+  # and for this additional data to be included in subsequently generated access tokens.
+  # The 'authorizations/new' page will need to be overridden to include this additional data
+  # in the request params when granting access. The access grant and access token models
+  # will both need to respond to these additional data fields, and have a database column
+  # to store them in.
+  #
+  # Example:
+  # You have a multi-tenanted platform and want to be able to grant access to a specific
+  # tenant, rather than all the tenants a user has access to. You can use this config
+  # option to specify that a ':tenant_id' will be passed when authorizing. This tenant_id
+  # will be included in the access tokens. When a request is made with one of these access
+  # tokens, you can check that the requested data belongs to the specified tenant.
+  #
+  # Default value is an empty Array: []
+  # custom_access_token_attributes [:tenant_id]
+
+  # Hook into the strategies' request & response life-cycle in case your
+  # application needs advanced customization or logging:
+  #
+  # before_successful_strategy_response do |request|
+  #   puts "BEFORE HOOK FIRED! #{request}"
+  # end
+  #
+  # after_successful_strategy_response do |request, response|
+  #   puts "AFTER HOOK FIRED! #{request}, #{response}"
+  # end
+
+  # Hook into Authorization flow in order to implement Single Sign Out
+  # or add any other functionality. Inside the block you have an access
+  # to `controller` (authorizations controller instance) and `context`
+  # (Doorkeeper::OAuth::Hooks::Context instance) which provides pre auth
+  # or auth objects with issued token based on hook type (before or after).
+  #
+  # before_successful_authorization do |controller, context|
+  #   Rails.logger.info(controller.request.params.inspect)
+  #
+  #   Rails.logger.info(context.pre_auth.inspect)
+  # end
+  #
+  # after_successful_authorization do |controller, context|
+  #   controller.session[:logout_urls] <<
+  #     Doorkeeper::Application
+  #       .find_by(controller.request.params.slice(:redirect_uri))
+  #       .logout_uri
+  #
+  #   Rails.logger.info(context.auth.inspect)
+  #   Rails.logger.info(context.issued_token)
+  # end
+
+  # Under some circumstances you might want to have applications auto-approved,
+  # so that the user skips the authorization step.
+  # For example if dealing with a trusted application.
+  #
+  # skip_authorization do |resource_owner, client|
+  #   client.superapp? or resource_owner.admin?
+  # end
+
+  # Configure custom constraints for the Token Introspection request.
+  # By default this configuration option allows to introspect a token by another
+  # token of the same application, OR to introspect the token that belongs to
+  # authorized client (from authenticated client) OR when token doesn't
+  # belong to any client (public token). Otherwise requester has no access to the
+  # introspection and it will return response as stated in the RFC.
+  #
+  # Block arguments:
+  #
+  # @param token [Doorkeeper::AccessToken]
+  #   token to be introspected
+  #
+  # @param authorized_client [Doorkeeper::Application]
+  #   authorized client (if request is authorized using Basic auth with
+  #   Client Credentials for example)
+  #
+  # @param authorized_token [Doorkeeper::AccessToken]
+  #   Bearer token used to authorize the request
+  #
+  # In case the block returns `nil` or `false` introspection responses with 401 status code
+  # when using authorized token to introspect, or you'll get 200 with { "active": false } body
+  # when using authorized client to introspect as stated in the
+  # RFC 7662 section 2.2. Introspection Response.
+  #
+  # Using with caution:
+  # Keep in mind that these three parameters pass to block can be nil as following case:
+  #  `authorized_client` is nil if and only if `authorized_token` is present, and vice versa.
+  #  `token` will be nil if and only if `authorized_token` is present.
+  # So remember to use `&` or check if it is present before calling method on
+  # them to make sure you doesn't get NoMethodError exception.
+  #
+  # You can define your custom check:
+  #
+  # allow_token_introspection do |token, authorized_client, authorized_token|
+  #   if authorized_token
+  #     # customize: require `introspection` scope
+  #     authorized_token.application == token&.application ||
+  #       authorized_token.scopes.include?("introspection")
+  #   elsif token.application
+  #     # `protected_resource` is a new database boolean column, for example
+  #     authorized_client == token.application || authorized_client.protected_resource?
+  #   else
+  #     # public token (when token.application is nil, token doesn't belong to any application)
+  #     true
+  #   end
+  # end
+  #
+  # Or you can completely disable any token introspection:
+  #
+  # allow_token_introspection false
+  #
+  # If you need to block the request at all, then configure your routes.rb or web-server
+  # like nginx to forbid the request.
+
+  # WWW-Authenticate Realm (default: "Doorkeeper").
+  #
+  # realm "Doorkeeper"
+end

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -1,0 +1,151 @@
+en:
+  activerecord:
+    attributes:
+      doorkeeper/application:
+        name: 'Name'
+        redirect_uri: 'Redirect URI'
+    errors:
+      models:
+        doorkeeper/application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              invalid_uri: 'must be a valid URI.'
+              unspecified_scheme: 'must specify a scheme.'
+              relative_uri: 'must be an absolute URI.'
+              secured_uri: 'must be an HTTPS/SSL URI.'
+              forbidden_uri: 'is forbidden by the server.'
+            scopes:
+              not_match_configured: "doesn't match configured on the server."
+
+  doorkeeper:
+    applications:
+      confirmations:
+        destroy: 'Are you sure?'
+      buttons:
+        edit: 'Edit'
+        destroy: 'Destroy'
+        submit: 'Submit'
+        cancel: 'Cancel'
+        authorize: 'Authorize'
+      form:
+        error: 'Whoops! Check your form for possible errors'
+      help:
+        confidential: 'Application will be used where the client secret can be kept confidential. Native mobile apps and Single Page Apps are considered non-confidential.'
+        redirect_uri: 'Use one line per URI'
+        blank_redirect_uri: "Leave it blank if you configured your provider to use Client Credentials, Resource Owner Password Credentials or any other grant type that doesn't require redirect URI."
+        scopes: 'Separate scopes with spaces. Leave blank to use the default scopes.'
+      edit:
+        title: 'Edit application'
+      index:
+        title: 'Your applications'
+        new: 'New Application'
+        name: 'Name'
+        callback_url: 'Callback URL'
+        confidential: 'Confidential?'
+        actions: 'Actions'
+        confidentiality:
+          'yes': 'Yes'
+          'no': 'No'
+      new:
+        title: 'New Application'
+      show:
+        title: 'Application: %{name}'
+        application_id: 'UID'
+        secret: 'Secret'
+        secret_hashed: 'Secret hashed'
+        scopes: 'Scopes'
+        confidential: 'Confidential'
+        callback_urls: 'Callback urls'
+        actions: 'Actions'
+        not_defined: 'Not defined'
+
+    authorizations:
+      buttons:
+        authorize: 'Authorize'
+        deny: 'Deny'
+      error:
+        title: 'An error has occurred'
+      new:
+        title: 'Authorization required'
+        prompt: 'Authorize %{client_name} to use your account?'
+        able_to: 'This application will be able to'
+      show:
+        title: 'Authorization code'
+      form_post:
+        title: 'Submit this form'
+
+    authorized_applications:
+      confirmations:
+        revoke: 'Are you sure?'
+      buttons:
+        revoke: 'Revoke'
+      index:
+        title: 'Your authorized applications'
+        application: 'Application'
+        created_at: 'Created At'
+        date_format: '%Y-%m-%d %H:%M:%S'
+
+    pre_authorization:
+      status: 'Pre-authorization'
+
+    errors:
+      messages:
+        # Common error messages
+        invalid_request:
+          unknown: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
+          missing_param: 'Missing required parameter: %{value}.'
+          request_not_authorized: 'Request need to be authorized. Required parameter for authorizing request is missing or invalid.'
+        invalid_redirect_uri: "The requested redirect uri is malformed or doesn't match client redirect URI."
+        unauthorized_client: 'The client is not authorized to perform this request using this method.'
+        access_denied: 'The resource owner or authorization server denied the request.'
+        invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
+        invalid_code_challenge_method: 'The code challenge method must be plain or S256.'
+        server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
+        temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
+
+        # Configuration error messages
+        credential_flow_not_configured: 'Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.'
+        resource_owner_authenticator_not_configured: 'Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfigured.'
+        admin_authenticator_not_configured: 'Access to admin panel is forbidden due to Doorkeeper.configure.admin_authenticator being unconfigured.'
+
+        # Access grant errors
+        unsupported_response_type: 'The authorization server does not support this response type.'
+        unsupported_response_mode: 'The authorization server does not support this response mode.'
+
+        # Access token errors
+        invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
+        invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
+        unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
+
+        invalid_token:
+          revoked: "The access token was revoked"
+          expired: "The access token expired"
+          unknown: "The access token is invalid"
+        revoke:
+          unauthorized: "You are not authorized to revoke this token"
+
+        forbidden_token:
+          missing_scope: 'Access to this resource requires scope "%{oauth_scopes}".'
+
+    flash:
+      applications:
+        create:
+          notice: 'Application created.'
+        destroy:
+          notice: 'Application deleted.'
+        update:
+          notice: 'Application updated.'
+      authorized_applications:
+        destroy:
+          notice: 'Application revoked.'
+
+    layouts:
+      admin:
+        title: 'Doorkeeper'
+        nav:
+          oauth2_provider: 'OAuth2 Provider'
+          applications: 'Applications'
+          home: 'Home'
+      application:
+        title: 'OAuth authorization required'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
     end
   end
 
+  use_doorkeeper
+
   mount Rswag::Ui::Engine => "/api-docs"
   mount Rswag::Api::Engine => "/api-docs"
 

--- a/db/migrate/20230713065237_create_machine_users.rb
+++ b/db/migrate/20230713065237_create_machine_users.rb
@@ -1,0 +1,12 @@
+class CreateMachineUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :machine_users, id: :uuid do |t|
+      t.string :name
+      t.references :organization, null: false, type: :uuid
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+    add_index :machine_users, :name
+  end
+end

--- a/db/migrate/20230713065420_create_doorkeeper_tables.rb
+++ b/db/migrate/20230713065420_create_doorkeeper_tables.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class CreateDoorkeeperTables < ActiveRecord::Migration[6.1]
+  def change
+    create_table :oauth_applications, id: :uuid do |t|
+      t.string :name, null: false
+      t.string :uid, null: false
+      t.string :secret, null: false
+
+      # Remove `null: false` if you are planning to use grant flows
+      # that doesn't require redirect URI to be used during authorization
+      # like Client Credentials flow or Resource Owner Password.
+      t.text :redirect_uri
+      t.string :scopes, null: false, default: ""
+      t.boolean :confidential, null: false, default: true
+      t.timestamps null: false
+    end
+
+    add_index :oauth_applications, :uid, unique: true
+
+    create_table :oauth_access_grants, id: :uuid do |t|
+      t.references :resource_owner, null: false, type: :uuid
+      t.references :application, null: false, type: :uuid
+      t.string :token, null: false
+      t.integer :expires_in, null: false
+      t.text :redirect_uri, null: false
+      t.string :scopes, null: false, default: ""
+      t.datetime :created_at, null: false
+      t.datetime :revoked_at
+    end
+
+    add_index :oauth_access_grants, :token, unique: true
+    add_foreign_key(
+      :oauth_access_grants,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    create_table :oauth_access_tokens, id: :uuid do |t|
+      t.references :resource_owner, index: true, type: :uuid
+
+      # Remove `null: false` if you are planning to use Password
+      # Credentials Grant flow that doesn't require an application.
+      t.references :application, null: false, type: :uuid
+
+      # If you use a custom token generator you may need to change this column
+      # from string to text, so that it accepts tokens larger than 255
+      # characters. More info on custom token generators in:
+      # https://github.com/doorkeeper-gem/doorkeeper/tree/v3.0.0.rc1#custom-access-token-generator
+      #
+      # t.text :token, null: false
+      t.string :token, null: false
+
+      t.string :refresh_token
+      t.integer :expires_in
+      t.string :scopes
+      t.datetime :created_at, null: false
+      t.datetime :revoked_at
+
+      # The authorization server MAY issue a new refresh token, in which case
+      # *the client MUST discard the old refresh token* and replace it with the
+      # new refresh token. The authorization server MAY revoke the old
+      # refresh token after issuing a new refresh token to the client.
+      # @see https://datatracker.ietf.org/doc/html/rfc6749#section-6
+      #
+      # Doorkeeper implementation: if there is a `previous_refresh_token` column,
+      # refresh tokens will be revoked after a related access token is used.
+      # If there is no `previous_refresh_token` column, previous tokens are
+      # revoked as soon as a new access token is created.
+      #
+      # Comment out this line if you want refresh tokens to be instantly
+      # revoked after use.
+      t.string :previous_refresh_token, null: false, default: ""
+    end
+
+    add_index :oauth_access_tokens, :token, unique: true
+
+    # See https://github.com/doorkeeper-gem/doorkeeper/issues/1592
+    if ActiveRecord::Base.connection.adapter_name == "SQLServer"
+      execute <<~SQL.squish
+        CREATE UNIQUE NONCLUSTERED INDEX index_oauth_access_tokens_on_refresh_token ON oauth_access_tokens(refresh_token)
+        WHERE refresh_token IS NOT NULL
+      SQL
+    else
+      add_index :oauth_access_tokens, :refresh_token, unique: true
+    end
+
+    add_foreign_key(
+      :oauth_access_tokens,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    # Uncomment below to ensure a valid reference to the resource owner's table
+    add_foreign_key :oauth_access_grants, :machine_users, column: :resource_owner_id
+    add_foreign_key :oauth_access_tokens, :machine_users, column: :resource_owner_id
+  end
+end

--- a/db/migrate/20230713135154_add_owner_to_application.rb
+++ b/db/migrate/20230713135154_add_owner_to_application.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOwnerToApplication < ActiveRecord::Migration[6.1]
+  def change
+    add_column :oauth_applications, :owner_id, :uuid, default: "gen_random_uuid()", null: true
+    add_column :oauth_applications, :owner_type, :string, null: true
+    add_index :oauth_applications, [:owner_id, :owner_type]
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -968,6 +968,20 @@ CREATE MATERIALIZED VIEW public.latest_blood_pressures_per_patients AS
 
 
 --
+-- Name: machine_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.machine_users (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying,
+    organization_id uuid NOT NULL,
+    deleted_at timestamp without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: patient_business_identifiers; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1514,6 +1528,60 @@ CREATE TABLE public.notifications (
     subject_type character varying,
     subject_id uuid,
     purpose character varying NOT NULL
+);
+
+
+--
+-- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.oauth_access_grants (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    resource_owner_id uuid NOT NULL,
+    application_id uuid NOT NULL,
+    token character varying NOT NULL,
+    expires_in integer NOT NULL,
+    redirect_uri text NOT NULL,
+    scopes character varying DEFAULT ''::character varying NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    revoked_at timestamp without time zone
+);
+
+
+--
+-- Name: oauth_access_tokens; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.oauth_access_tokens (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    resource_owner_id uuid,
+    application_id uuid NOT NULL,
+    token character varying NOT NULL,
+    refresh_token character varying,
+    expires_in integer,
+    scopes character varying,
+    created_at timestamp without time zone NOT NULL,
+    revoked_at timestamp without time zone,
+    previous_refresh_token character varying DEFAULT ''::character varying NOT NULL
+);
+
+
+--
+-- Name: oauth_applications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.oauth_applications (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying NOT NULL,
+    uid character varying NOT NULL,
+    secret character varying NOT NULL,
+    redirect_uri text,
+    scopes character varying DEFAULT ''::character varying NOT NULL,
+    confidential boolean DEFAULT true NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    owner_id uuid DEFAULT gen_random_uuid(),
+    owner_type character varying
 );
 
 
@@ -5548,6 +5616,14 @@ ALTER TABLE ONLY public.flipper_gates
 
 
 --
+-- Name: machine_users machine_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.machine_users
+    ADD CONSTRAINT machine_users_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: medical_histories medical_histories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5561,6 +5637,30 @@ ALTER TABLE ONLY public.medical_histories
 
 ALTER TABLE ONLY public.notifications
     ADD CONSTRAINT notifications_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oauth_access_grants oauth_access_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_access_grants
+    ADD CONSTRAINT oauth_access_grants_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oauth_access_tokens oauth_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_access_tokens
+    ADD CONSTRAINT oauth_access_tokens_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oauth_applications oauth_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_applications
+    ADD CONSTRAINT oauth_applications_pkey PRIMARY KEY (id);
 
 
 --
@@ -6404,6 +6504,20 @@ CREATE INDEX index_latest_bp_per_patient_per_quarters_patient_id ON public.lates
 
 
 --
+-- Name: index_machine_users_on_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_machine_users_on_name ON public.machine_users USING btree (name);
+
+
+--
+-- Name: index_machine_users_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_machine_users_on_organization_id ON public.machine_users USING btree (organization_id);
+
+
+--
 -- Name: index_materialized_patient_summaries_on_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6450,6 +6564,69 @@ CREATE INDEX index_notifications_on_reminder_template_id ON public.notifications
 --
 
 CREATE INDEX index_notifications_on_subject_type_and_subject_id ON public.notifications USING btree (subject_type, subject_id);
+
+
+--
+-- Name: index_oauth_access_grants_on_application_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_oauth_access_grants_on_application_id ON public.oauth_access_grants USING btree (application_id);
+
+
+--
+-- Name: index_oauth_access_grants_on_resource_owner_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_oauth_access_grants_on_resource_owner_id ON public.oauth_access_grants USING btree (resource_owner_id);
+
+
+--
+-- Name: index_oauth_access_grants_on_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_oauth_access_grants_on_token ON public.oauth_access_grants USING btree (token);
+
+
+--
+-- Name: index_oauth_access_tokens_on_application_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_oauth_access_tokens_on_application_id ON public.oauth_access_tokens USING btree (application_id);
+
+
+--
+-- Name: index_oauth_access_tokens_on_refresh_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_oauth_access_tokens_on_refresh_token ON public.oauth_access_tokens USING btree (refresh_token);
+
+
+--
+-- Name: index_oauth_access_tokens_on_resource_owner_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_oauth_access_tokens_on_resource_owner_id ON public.oauth_access_tokens USING btree (resource_owner_id);
+
+
+--
+-- Name: index_oauth_access_tokens_on_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_oauth_access_tokens_on_token ON public.oauth_access_tokens USING btree (token);
+
+
+--
+-- Name: index_oauth_applications_on_owner_id_and_owner_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_oauth_applications_on_owner_id_and_owner_type ON public.oauth_applications USING btree (owner_id, owner_type);
+
+
+--
+-- Name: index_oauth_applications_on_uid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_oauth_applications_on_uid ON public.oauth_applications USING btree (uid);
 
 
 --
@@ -7068,6 +7245,14 @@ ALTER TABLE ONLY public.patients
 
 
 --
+-- Name: oauth_access_grants fk_rails_330c32d8d9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_access_grants
+    ADD CONSTRAINT fk_rails_330c32d8d9 FOREIGN KEY (resource_owner_id) REFERENCES public.machine_users(id);
+
+
+--
 -- Name: patients fk_rails_39783febcc; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7137,6 +7322,14 @@ ALTER TABLE ONLY public.observations
 
 ALTER TABLE ONLY public.patients
     ADD CONSTRAINT fk_rails_66733b5dc0 FOREIGN KEY (assigned_facility_id) REFERENCES public.facilities(id);
+
+
+--
+-- Name: oauth_access_tokens fk_rails_732cb83ab7; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_access_tokens
+    ADD CONSTRAINT fk_rails_732cb83ab7 FOREIGN KEY (application_id) REFERENCES public.oauth_applications(id);
 
 
 --
@@ -7220,6 +7413,14 @@ ALTER TABLE ONLY public.notifications
 
 
 --
+-- Name: oauth_access_grants fk_rails_b4b53e07b8; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_access_grants
+    ADD CONSTRAINT fk_rails_b4b53e07b8 FOREIGN KEY (application_id) REFERENCES public.oauth_applications(id);
+
+
+--
 -- Name: exotel_phone_number_details fk_rails_b7da75c721; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7289,6 +7490,14 @@ ALTER TABLE ONLY public.accesses
 
 ALTER TABLE ONLY public.notifications
     ADD CONSTRAINT fk_rails_e966d86b08 FOREIGN KEY (patient_id) REFERENCES public.patients(id);
+
+
+--
+-- Name: oauth_access_tokens fk_rails_ee63f25419; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_access_tokens
+    ADD CONSTRAINT fk_rails_ee63f25419 FOREIGN KEY (resource_owner_id) REFERENCES public.machine_users(id);
 
 
 --
@@ -7432,6 +7641,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230522081701'),
 ('20230523084623'),
 ('20230613090949'),
-('20230614171507');
+('20230614171507'),
+('20230713065237'),
+('20230713065420'),
+('20230713135154');
 
 

--- a/doc/howto/setup_new_oauth_applications.md
+++ b/doc/howto/setup_new_oauth_applications.md
@@ -1,0 +1,15 @@
+# How to setup a new OAuth Application for integrating with Simple
+
+Currently, we need to create OAuth Applications for users that want to send us data through the `/import` API.
+
+Since our partner organizations are trusted machine clients in this case, we create and send them a client ID and secret
+that is used for the client credential flow needed for the import API. We also create a machine user associated with these
+organizations.
+
+To create a machine user and an OAuth application, run the following:
+
+```shell
+bundle exec cap <env> deploy:rake task='setup_oauth_application[<name>,<org_id>,<client_id>,<client_secret (optional)>]'
+```
+
+Note the client ID and client secret of the OAuth application in the output. This should be shared with the partner organizations.

--- a/lib/tasks/scripts/create_machine_user.rb
+++ b/lib/tasks/scripts/create_machine_user.rb
@@ -1,0 +1,6 @@
+module CreateMachineUser
+  def self.create(name, organization_id)
+    organization = Organization.find_by(id: organization_id)
+    MachineUser.create!(name: name, organization: organization)
+  end
+end

--- a/lib/tasks/scripts/create_oauth_application.rb
+++ b/lib/tasks/scripts/create_oauth_application.rb
@@ -1,0 +1,5 @@
+module CreateOAuthApplication
+  def self.create(name, machine_user, client_id, client_secret)
+    Doorkeeper::Application.create!(name: name, owner: machine_user, uid: client_id, secret: client_secret, scopes: "write")
+  end
+end

--- a/lib/tasks/setup_oauth_application.rake
+++ b/lib/tasks/setup_oauth_application.rake
@@ -1,0 +1,26 @@
+desc "Create a machine user and an OAuth Application"
+task :setup_oauth_application, [:name, :organization_id, :client_id, :client_secret] => :environment do |_t, args|
+  require "tasks/scripts/create_machine_user"
+  require "tasks/scripts/create_oauth_application"
+
+  abort "Requires <name>" unless args[:name].present?
+  abort "Requires <client_id>" unless args[:client_id].present?
+  abort "Requires <organization_id>" unless args[:client_id].present?
+  puts "No client secret given, generating a secret" unless args[:client_secret].present?
+
+  name = args[:name]
+  client_id = args[:client_id]
+  organization_id = args[:organization_id]
+  client_secret = args[:client_secret] || SecureRandom.hex(8)
+
+  begin
+    machine_user = CreateMachineUser.create(name, organization_id)
+    oauth_application = CreateOAuthApplication.create(name, machine_user, client_id, client_secret)
+    puts "#### OAuth Application ####"
+    puts JSON.pretty_generate(oauth_application.attributes)
+    puts "#### Machine User ####"
+    puts JSON.pretty_generate(machine_user.attributes)
+  rescue => e
+    puts "Failed to create #{name}: #{e.message}"
+  end
+end

--- a/spec/api/v4/imports/imports_spec.rb
+++ b/spec/api/v4/imports/imports_spec.rb
@@ -3,25 +3,35 @@ require "swagger_helper"
 describe "Import v4 API", swagger_doc: "v4/import.json" do
   before { Flipper.enable(:imports_api) }
   path "/import" do
+    let(:organization) { FactoryBot.create(:organization) }
+    let(:resource) { build_patient_import_resource }
+    let(:machine_user) { FactoryBot.create(:machine_user, organization: organization) }
+    let(:application) { FactoryBot.create(:oauth_application, owner: machine_user) }
+    let(:token) {
+      FactoryBot.create(:oauth_access_token,
+        application: application,
+        scopes: "write",
+        resource_owner_id: machine_user.id)
+    }
     put "Send bulk resources to Simple" do
       tags "import"
       security [access_token: [], import_auth: ["write"]]
-      parameter name: :organization_header,
+      parameter name: :HTTP_X_ORGANIZATION_ID,
         in: :header,
         type: :uuid,
-        description: "UUID of organization"
+        description: "UUID of organization. The header key should be passed as 'X-Organization-ID'."
       parameter name: :import_request, in: :body, schema: Api::V4::Imports.import_request_payload
 
       response "202", "Accepted" do
-        let(:organization_header) { SecureRandom.uuid }
-        let(:Authorization) { "Bearer #{::Base64.strict_encode64("bogusbogus")}" }
+        let(:HTTP_X_ORGANIZATION_ID) { organization.id }
+        let(:Authorization) { "Bearer #{token.token}" }
         let(:import_request) { {"resources" => [build_patient_import_resource]} }
         run_test!
       end
 
       response "400", "Bad Request" do
-        let(:organization_header) { SecureRandom.uuid }
-        let(:Authorization) { "Bearer #{::Base64.strict_encode64("bogusbogus")}" }
+        let(:HTTP_X_ORGANIZATION_ID) { organization.id }
+        let(:Authorization) { "Bearer #{token.token}" }
         let(:import_request) { {"resources" => [{"invalid" => "invalid"}]} }
         run_test!
       end

--- a/spec/factories/machine_users.rb
+++ b/spec/factories/machine_users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :machine_user do
+    name { Faker::App.name }
+    organization
+  end
+end

--- a/spec/factories/oauth_access_token.rb
+++ b/spec/factories/oauth_access_token.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :oauth_access_token, class: "Doorkeeper::AccessToken" do
+    application { oauth_application }
+  end
+end

--- a/spec/factories/oauth_application.rb
+++ b/spec/factories/oauth_application.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :oauth_application, class: "Doorkeeper::Application" do
+    sequence(:name) { |n| "Project #{n}" }
+  end
+end

--- a/spec/requests/oauth_spec.rb
+++ b/spec/requests/oauth_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe "OAuth Credentials", type: :request do
+  context "import API" do
+    before { Flipper.enable(:imports_api) }
+    context "when unauthorized" do
+      let(:resource) { build_patient_import_resource }
+      it "fails with HTTP 401" do
+        put "/api/v4/import",
+          headers: {"Content-Type": "application/json",
+                    HTTP_X_ORGANIZATION_ID: SecureRandom.uuid},
+          params: {resources: [resource]}.to_json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when authorization header present" do
+      let(:organization) { FactoryBot.create(:organization) }
+      let(:resource) { build_patient_import_resource }
+      let(:machine_user) { FactoryBot.create(:machine_user, organization: organization) }
+      let(:application) { FactoryBot.create(:oauth_application, owner: machine_user) }
+      let(:token_write_scope) {
+        FactoryBot.create(:oauth_access_token,
+          application: application,
+          scopes: "write",
+          resource_owner_id: machine_user.id)
+      }
+      let(:token_invalid_scope) {
+        FactoryBot.create(:oauth_access_token,
+          application: application,
+          scopes: "read",
+          resource_owner_id: machine_user.id)
+      }
+
+      it "succeeds with HTTP 202 for valid token" do
+        put "/api/v4/import",
+          headers: {"Content-Type": "application/json",
+                    Authorization: "Bearer " + token_write_scope.token,
+                    HTTP_X_ORGANIZATION_ID: organization.id},
+          params: {resources: [resource]}.to_json
+
+        expect(response).to have_http_status(:accepted)
+      end
+
+      it "fails with HTTP 401 with an invalid token" do
+        put "/api/v4/import",
+          headers: {"Content-Type": "application/json",
+                    Authorization: "Bearer invalidtoken",
+                    HTTP_X_ORGANIZATION_ID: organization.id},
+          params: {resources: [resource]}.to_json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "fails with HTTP 403 with an invalid scope" do
+        put "/api/v4/import",
+          headers: {"Content-Type": "application/json",
+                    Authorization: "Bearer " + token_invalid_scope.token,
+                    HTTP_X_ORGANIZATION_ID: organization.id},
+          params: {resources: [resource]}.to_json
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "fails with HTTP 403 with an invalid organization" do
+        put "/api/v4/import",
+          headers: {"Content-Type": "application/json",
+                    Authorization: "Bearer " + token_write_scope.token,
+                    HTTP_X_ORGANIZATION_ID: SecureRandom.uuid},
+          params: {resources: [resource]}.to_json
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/swagger/v4/import.json
+++ b/swagger/v4/import.json
@@ -45,10 +45,10 @@
         ],
         "parameters": [
           {
-            "name": "organization_header",
+            "name": "HTTP_X_ORGANIZATION_ID",
             "in": "header",
             "type": "uuid",
-            "description": "UUID of organization"
+            "description": "UUID of organization. The header key should be passed as 'X-Organization-ID'."
           },
           {
             "name": "import_request",


### PR DESCRIPTION
**Story card:** [sc-10740](https://app.shortcut.com/simpledotorg/story/10740)

## Context

[Link to relevant section of the PRD](https://github.com/doorkeeper-gem/doorkeeper/wiki)

Currently, we need to create OAuth Applications for users that want to send us data through the `/import` API.

Since our partner organizations are trusted machine clients in this case, we create and send them a client ID and secret that is used for the [client credential flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-credentials-flow) needed for the import API. We also create a machine user associated with these organizations.

We introduce a new dependency, [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper/wiki) to implement our OAuth provider.

The expiry token is set to 8 hours by default.

## This addresses

* Adds an OAuth provider, which involves migrations to hold OAuth-related details, all mostly generated by doorkeeper.
* Adds a machine user model, which currently only holds a name and organization.
* Secure the `/import` endpoint to only those who provide an OAuth token with the `write` scope.
* Adds a rake task to register and set up an OAuth application, whose details we will hand over to the partner orgs so they can integrate with us.

## Test instructions

Run the rake task (refer to the howto doc added in the PR).

Run the following HTTP request to obtain a token:
```
POST http://localhost:3000/oauth/token
Authorization: Basic <base64(client_id:client_secret)>
Content-Type: application/x-www-form-urlencoded;charset=UTF-8

grant_type=client_credentials
```

Copy the token ID, and call the API with it:
```
PUT http://localhost:3000/api/v4/import
Content-Type: application/json; charset=UTF-8
X-Organization-ID: <use the org ID passed into the rake task>
Authorization: Bearer <token>

{"resources": []} # use a valid resource if you want a 202 response instead of a 400
```

Any status code that's not 401 or 403 means the authorization worked. Conversely, an invalid token should return a 403 and no token at all should return a 401.