### PR TITLE
Counts call made to overdue patient in prev month

### DIFF
--- a/spec/models/reports/region_summary_spec.rb
+++ b/spec/models/reports/region_summary_spec.rb
@@ -1500,13 +1500,13 @@ RSpec.describe Reports::RegionSummary, {type: :model, reporting_spec: true} do
       region_results = described_class.call(region)[region.slug]
 
       expect(facility_1_results[this_month.to_period]["contactable_patients_returned_with_result_removed_from_list"]).to eq 1
-      expect(facility_1_results[one_month_ago.to_period]["contactable_patients_returned_with_result_removed_from_list"]).to eq 0
+      expect(facility_1_results[one_month_ago.to_period]["contactable_patients_returned_with_result_removed_from_list"]).to eq 1 # Call made to facility_1_patient_removed_from_list with result type 'removed from list' before 'this_month'
       expect(facility_1_results[two_months_ago.to_period]["contactable_patients_returned_with_result_removed_from_list"]).to eq 1
       expect(facility_2_results[this_month.to_period]["contactable_patients_returned_with_result_removed_from_list"]).to eq 1
       expect(facility_2_results[one_month_ago.to_period]["contactable_patients_returned_with_result_removed_from_list"]).to eq 1
       expect(facility_2_results[two_months_ago.to_period]["contactable_patients_returned_with_result_removed_from_list"]).to eq 0
       expect(region_results[this_month.to_period]["contactable_patients_returned_with_result_removed_from_list"]).to eq 2
-      expect(region_results[one_month_ago.to_period]["contactable_patients_returned_with_result_removed_from_list"]).to eq 1
+      expect(region_results[one_month_ago.to_period]["contactable_patients_returned_with_result_removed_from_list"]).to eq 2
       expect(region_results[two_months_ago.to_period]["contactable_patients_returned_with_result_removed_from_list"]).to eq 1
 
       periods_before_three_months = five_months_ago.to_period..three_months_ago.to_period


### PR DESCRIPTION
## Because

Calls with result type 'removed from overdue list' in the previous month were not counted before

## This addresses

Fix the count in the test case

