### PR TITLE
Remove check for old app version to display progress tab

### DIFF
--- a/app/controllers/api/v3/analytics/user_analytics_controller.rb
+++ b/app/controllers/api/v3/analytics/user_analytics_controller.rb
@@ -4,8 +4,6 @@ class Api::V3::Analytics::UserAnalyticsController < Api::V3::AnalyticsController
   before_action :set_for_end_of_month
   before_action :set_bust_cache
 
-  NEW_PROGRESS_TAB_MIN_APP_VERSION = "2022-07-04-8318"
-
   layout false
 
   def show
@@ -25,7 +23,7 @@ class Api::V3::Analytics::UserAnalyticsController < Api::V3::AnalyticsController
     end
 
     respond_to do |format|
-      format.html { render :progress_update_required if less_than_min_app_version? }
+      format.html
       format.json { render json: @user_analytics.statistics }
     end
   end
@@ -36,15 +34,5 @@ class Api::V3::Analytics::UserAnalyticsController < Api::V3::AnalyticsController
 
   def set_bust_cache
     RequestStore.store[:bust_cache] = true if params[:bust_cache].present?
-  end
-
-  def less_than_min_app_version?
-    # Bypass check for all environments except production
-    env = ENV.fetch("SIMPLE_SERVER_ENV").to_sym
-    return false unless env == :production
-
-    app_version = request.headers["HTTP_X_APP_VERSION"]
-    return true unless app_version.present?
-    app_version < NEW_PROGRESS_TAB_MIN_APP_VERSION
   end
 end

--- a/app/controllers/api/v3/analytics/user_analytics_controller.rb
+++ b/app/controllers/api/v3/analytics/user_analytics_controller.rb
@@ -41,7 +41,7 @@ class Api::V3::Analytics::UserAnalyticsController < Api::V3::AnalyticsController
   def less_than_min_app_version?
     app_version = request.headers["HTTP_X_APP_VERSION"]
     return true unless app_version.present?
-    return false if !!app_version.match(/-qa$/) # QA apps follows semver versioning scheme followed by a suffix "-qa". For eg. "0.1-qa"
-    app_version < NEW_PROGRESS_TAB_MIN_APP_VERSION
+    # QA apps follows semver versioning scheme followed by a suffix "-qa". For eg. "0.1-qa"
+    !app_version.match(/-qa$/) && (app_version < NEW_PROGRESS_TAB_MIN_APP_VERSION)
   end
 end

--- a/app/controllers/api/v3/analytics/user_analytics_controller.rb
+++ b/app/controllers/api/v3/analytics/user_analytics_controller.rb
@@ -41,6 +41,7 @@ class Api::V3::Analytics::UserAnalyticsController < Api::V3::AnalyticsController
   def less_than_min_app_version?
     app_version = request.headers["HTTP_X_APP_VERSION"]
     return true unless app_version.present?
+    return false if !!app_version.match(/-qa$/) # QA apps follows semver versioning scheme followed by a suffix "-qa". For eg. "0.1-qa"
     app_version < NEW_PROGRESS_TAB_MIN_APP_VERSION
   end
 end

--- a/app/controllers/api/v3/analytics/user_analytics_controller.rb
+++ b/app/controllers/api/v3/analytics/user_analytics_controller.rb
@@ -39,9 +39,12 @@ class Api::V3::Analytics::UserAnalyticsController < Api::V3::AnalyticsController
   end
 
   def less_than_min_app_version?
+    # Bypass check for all environments except production
+    env = ENV.fetch("SIMPLE_SERVER_ENV").to_sym
+    return false unless env == :production
+
     app_version = request.headers["HTTP_X_APP_VERSION"]
     return true unless app_version.present?
-    # QA apps follows semver versioning scheme followed by a suffix "-qa". For eg. "0.1-qa"
-    !app_version.match(/-qa$/) && (app_version < NEW_PROGRESS_TAB_MIN_APP_VERSION)
+    app_version < NEW_PROGRESS_TAB_MIN_APP_VERSION
   end
 end


### PR DESCRIPTION
**Story card:** [sc-10919](https://app.shortcut.com/simpledotorg/story/10919)

## Because

The server didn't support the semver version format of QA app build(`0.1-qa`). 
The server always returns `true` for the `less_than_min_app_version?` check and responds with `Update required card` instead of the Progress tab.

## This addresses

- Removes the `less_than_min_app_version?` check to display the progress tab
- App users with old versions will have to update their app to see the new progress tab
- See the [slack conversation for more details](https://simpledotorg.slack.com/archives/C03URFX2LUT/p1690357087359759?thread_ts=1690168637.286639&cid=C03URFX2LUT)

## Test instructions

- Goto to the `progress tab` in app or `http://0.0.0.0:3000/api/v3/analytics/user_analytics.html` (Add `X-USER-ID`, `X-Facility-ID` and `Authorization` headers)
- Ensure the progress tab is visible