### PR TITLE
Allow empty string for 'text' in questionnaire layout

### DIFF
--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -71,6 +71,7 @@ class Questionnaire < ApplicationRecord
   def localize_layout(sub_layout)
     text = sub_layout["text"]
     return sub_layout unless text
+    return sub_layout if text.empty?
 
     sub_layout.merge({"text" => I18n.t!(text)})
   end

--- a/config/locales/api/am_ET.yml
+++ b/config/locales/api/am_ET.yml
@@ -446,7 +446,6 @@ am-ET:
         cohort_subtitle: "%{number_of_patients} %{patient_or_patients} በ %{registration_period} የተመዘገቡ"
         cohort_bar_tooltip: "%{total_patients} %{patient_or_patients} የ %{threshold}"
   questionnaire_layout:
-    empty: ""
     male: "ወንድ"
     female: "ሴት"
     transgender: "ወንዳገረድ"

--- a/config/locales/api/bn_BD.yml
+++ b/config/locales/api/bn_BD.yml
@@ -446,7 +446,6 @@ bn-BD:
         cohort_subtitle: "%{registration_period}-এ নিবন্ধিত %{number_of_patients} %{patient_or_patients}"
         cohort_bar_tooltip: "%{threshold} সহ %{total_patients} %{patient_or_patients}"
   questionnaire_layout:
-    empty: ""
     male: "পুরুষ"
     female: "মহিলা"
     transgender: "ট্রান্সজেন্ডার"

--- a/config/locales/api/bn_IN.yml
+++ b/config/locales/api/bn_IN.yml
@@ -446,7 +446,6 @@ bn-IN:
         cohort_subtitle: "%{registration_period}-এ রেজিস্টার করা %{number_of_patients} %{patient_or_patients}"
         cohort_bar_tooltip: "%{threshold} থাকা %{total_patients} %{patient_or_patients}"
   questionnaire_layout:
-    empty: ""
     male: "পুরুষ"
     female: "মহিলা"
     transgender: "ট্রান্সজেন্ডার"

--- a/config/locales/api/en.yml
+++ b/config/locales/api/en.yml
@@ -446,7 +446,6 @@ en:
         cohort_subtitle: "%{number_of_patients} %{patient_or_patients} registered in %{registration_period}"
         cohort_bar_tooltip: "%{total_patients} %{patient_or_patients} with %{threshold}"
   questionnaire_layout:
-    empty: ""
     male: "Male"
     female: "Female"
     transgender: "Transgender"

--- a/config/locales/api/es.yml
+++ b/config/locales/api/es.yml
@@ -450,7 +450,6 @@ es:
         cohort_subtitle: "%{number_of_patients}%{patient_or_patients} registrados en %{registration_period}"
         cohort_bar_tooltip: "%{total_patients}%{patient_or_patients} con %{threshold}"
   questionnaire_layout:
-    empty: ""
     male: "Másculino"
     female: "Femenino"
     transgender: "Transgénero"

--- a/config/locales/api/hi_IN.yml
+++ b/config/locales/api/hi_IN.yml
@@ -446,7 +446,6 @@ hi-IN:
         cohort_subtitle: "%{registration_period} में %{number_of_patients} %{patient_or_patients} रजिस्टर किए गए"
         cohort_bar_tooltip: "%{threshold} वाले %{total_patients} %{patient_or_patients}"
   questionnaire_layout:
-    empty: ""
     male: "पुरूष"
     female: "महिला"
     transgender: "ट्रांसजेंडर"

--- a/config/locales/api/kn_IN.yml
+++ b/config/locales/api/kn_IN.yml
@@ -446,7 +446,6 @@ kn-IN:
         cohort_subtitle: "%{registration_period} ನಲ್ಲಿ ನೋಂದಾಯಿಸಿಕೊಂಡಿರುವ %{number_of_patients} %{patient_or_patients}"
         cohort_bar_tooltip: "%{threshold} ಹೊಂದಿರುವ %{total_patients} %{patient_or_patients}"
   questionnaire_layout:
-    empty: ""
     male: "ಪುರುಷ"
     female: "ಮಹಿಳೆ"
     transgender: "ತೃತೀಯ ಲಿಂಗಿ"

--- a/config/locales/api/mr_IN.yml
+++ b/config/locales/api/mr_IN.yml
@@ -446,7 +446,6 @@ mr-IN:
         cohort_subtitle: "%{number_of_patients} %{patient_or_patients} %{registration_period} मध्ये नोंदणीकृत आहेत"
         cohort_bar_tooltip: "%{threshold} सह %{total_patients} %{patient_or_patients}"
   questionnaire_layout:
-    empty: ""
     male: "पुरुष"
     female: "स्त्री"
     transgender: "किन्नर"

--- a/config/locales/api/om_ET.yml
+++ b/config/locales/api/om_ET.yml
@@ -446,7 +446,6 @@ om-ET:
         cohort_subtitle: "%{number_of_patients} %{patient_or_patients} kan %{registration_period} keessatti galmaa'an"
         cohort_bar_tooltip: "%{total_patients} %{patient_or_patients} kan %{threshold}"
   questionnaire_layout:
-    empty: ""
     male: "Dhiira"
     female: "Dubara"
     transgender: "Saaldarbaa"

--- a/config/locales/api/pa_Guru_IN.yml
+++ b/config/locales/api/pa_Guru_IN.yml
@@ -446,7 +446,6 @@ pa-Guru-IN:
         cohort_subtitle: "%{number_of_patients} %{patient_or_patients} %{registration_period} ਵਿੱਚ ਰਜਿਸਟਰ ਕੀਤਾ ਗਿਆ"
         cohort_bar_tooltip: "%{threshold} ਦੇ ਨਾਲ %{total_patients} %{patient_or_patients}"
   questionnaire_layout:
-    empty: ""
     male: "ਮਰਦ"
     female: "ਔਰਤ"
     transgender: "ਦੁਲਿੰਗੀ"

--- a/config/locales/api/si_LK.yml
+++ b/config/locales/api/si_LK.yml
@@ -446,7 +446,6 @@ si-LK:
         cohort_subtitle: "%{number_of_patients} %{patient_or_patients} %{registration_period} හි ලියාපදිංචි වී ඇත"
         cohort_bar_tooltip: "%{threshold} සමඟ %{total_patients} %{patient_or_patients}"
   questionnaire_layout:
-    empty: ""
     male: "පුරුෂ"
     female: "ස්ත්‍රී"
     transgender: "සංක්‍රාන්ති"

--- a/config/locales/api/sid_ET.yml
+++ b/config/locales/api/sid_ET.yml
@@ -446,7 +446,6 @@ sid-ET:
         cohort_subtitle: "%{number_of_patients} \n%{patient_or_patients} borreessantinori \n%{registration_period}"
         cohort_bar_tooltip: "%{total_patients} \n%{patient_or_patients} ledo \n%{threshold}"
   questionnaire_layout:
-    empty: ""
     male: "Labbaaha"
     female: "Meyaa beeetto"
     transgender: "lamenka koo/te "

--- a/config/locales/api/so_ET.yml
+++ b/config/locales/api/so_ET.yml
@@ -446,7 +446,6 @@ so-ET:
         cohort_subtitle: "%{number_of_patients} %{patient_or_patients} ka duwaan gashan %{registration_period}"
         cohort_bar_tooltip: "%{total_patients} %{patient_or_patients} leh %{threshold}"
   questionnaire_layout:
-    empty: ""
     male: "Lab"
     female: "Dhedig"
     transgender: "Jinsiga Badalay"

--- a/config/locales/api/ta_IN.yml
+++ b/config/locales/api/ta_IN.yml
@@ -446,7 +446,6 @@ ta-IN:
         cohort_subtitle: "%{registration_period}-இல் %{number_of_patients} %{patient_or_patients} பதிவுசெய்துள்ளனர்"
         cohort_bar_tooltip: "%{threshold} உடனான %{total_patients} %{patient_or_patients}"
   questionnaire_layout:
-    empty: ""
     male: "ஆண்"
     female: "பெண்"
     transgender: "திருநங்கை"

--- a/config/locales/api/ta_LK.yml
+++ b/config/locales/api/ta_LK.yml
@@ -446,7 +446,6 @@ ta-LK:
         cohort_subtitle: "%{number_of_patients} %{patient_or_patients}, %{registration_period} இல் பதிவுசெய்தனர்"
         cohort_bar_tooltip: "%{threshold} உடன்%{total_patients} %{patient_or_patients}"
   questionnaire_layout:
-    empty: ""
     male: "ஆண்"
     female: "பெண்"
     transgender: "திருநங்கைகள்"

--- a/config/locales/api/te_IN.yml
+++ b/config/locales/api/te_IN.yml
@@ -446,7 +446,6 @@ te-IN:
         cohort_subtitle: "%{number_of_patients} %{patient_or_patients} %{registration_period}లో రిజిస్టర్ అయినవారు"
         cohort_bar_tooltip: "%{threshold} తో %{total_patients} %{patient_or_patients}"
   questionnaire_layout:
-    empty: ""
     male: "పురుషుడు"
     female: "మహిళ"
     transgender: "ట్రాన్స్‌జండర్"

--- a/config/locales/api/ti_ET.yml
+++ b/config/locales/api/ti_ET.yml
@@ -446,7 +446,6 @@ ti-ET:
         cohort_subtitle: "%{number_of_patients} %{patient_or_patients} ዝተመዝገቡ ኣብ %{registration_period}"
         cohort_bar_tooltip: "%{total_patients} %{patient_or_patients} ምስ%{threshold}"
   questionnaire_layout:
-    empty: ""
     male: "ወዲ-ተባዕታይ"
     female: "ጓል-አነስተይቲ"
     transgender: "ፆታ-ዝቐየረ"

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -97,7 +97,8 @@ RSpec.describe Questionnaire, type: :model do
            {"text" => "test_translations.test_string"},
            {"text" => "test_translations.test_string"}
          ]},
-        {"text" => "test_translations.test_string"}
+        {"text" => "test_translations.test_string"},
+        {"text" => ""}
       ]}
 
       localized_layout = {"item" => [
@@ -106,7 +107,8 @@ RSpec.describe Questionnaire, type: :model do
            {"text" => "Test"},
            {"text" => "Test"}
          ]},
-        {"text" => "Test"}
+        {"text" => "Test"},
+        {"text" => ""}
       ]}
 
       questionnaire = build(:questionnaire, layout: layout)


### PR DESCRIPTION
**Story card:** [sc-10991](https://app.shortcut.com/simpledotorg/story/10991)

## Because

Launch the supplies report questionnaire in Srilanka.

## This addresses

- When 'text' is empty, bypass translation