### PR TITLE
specs: fix bug caused by global mutation of default locale

### DIFF
--- a/spec/services/blood_pressure_export_service_spec.rb
+++ b/spec/services/blood_pressure_export_service_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe BloodPressureExportService, type: :model do
   let(:end_period) { Period.month("May 1st 2021") }
 
   before :each do
-    I18n.default_locale = "en-IN"
     Flipper.enable(:my_facilities_csv)
   end
 
@@ -25,6 +24,8 @@ RSpec.describe BloodPressureExportService, type: :model do
 
         facility_set_1 = [facility_1, facility_2, facility_3]
         facility_set_2 = [facility_1, facility_3, facility_4]
+
+        allow(I18n).to receive(:default_locale).and_return("en-IN")
 
         refresh_views
 


### PR DESCRIPTION
Any spec run after this one will have the `I18n.default_locale` set to "en-IN" which would break the assumption of any other specs that rely on it responding with the library-default of `:en`.

We change this to a mock to contain this mutation within just this example.

**Story card:** [sc-10996](https://app.shortcut.com/simpledotorg/story/10996)

## Because

Cause: This line in the test setup of blood pressures export spec: https://github.com/simpledotorg/simple-server/blob/3d080dd0e2241858378230596087a16ddb15f21b/spec/services/blood_pressure_export_service_spec.rb#L11

Explanation:
The `default_locale` as per the config is always `:en`. But when the sync spec passes in a garbage value in the http Accept-Language header, the [application controller](https://github.com/simpledotorg/simple-server/blob/3d080dd0e2241858378230596087a16ddb15f21b/app/controllers/application_controller.rb#L5-L10) falls back to `"en-IN"` instead of the usual `:en` via the `default_locale` method that’s now overridden by a previous test setup code.

Q: Why did it not fail in any of the earlier workflow runs?
A: Because the failure would only show up if the export service spec ran before the v4 sync spec. I got unlucky with the order that semaphore chose for me and lost the russian roulette.

Q: Why did it fail only in Blood Sugars sync spec?
A: Because it’s the only spec that is running the locale test, via a [shared example](https://github.com/simpledotorg/simple-server/blob/3d080dd0e2241858378230596087a16ddb15f21b/spec/requests/shared_examples/api/v4/shared_spec_for_sync_requests.rb#L162-L183).
