### PR TITLE
Cap Overdue Patients Called Table percentage at 100

### DIFF
--- a/app/components/dashboard/hypertension/overdue_patients_called_table_component.rb
+++ b/app/components/dashboard/hypertension/overdue_patients_called_table_component.rb
@@ -60,6 +60,7 @@ class Dashboard::Hypertension::OverduePatientsCalledTableComponent < Application
 
   def percentage(numerator, denominator)
     return 0 if denominator.blank? || denominator.zero?
+    return 100 if numerator > denominator
     numerator * 100 / denominator
   end
 


### PR DESCRIPTION
**Story card:** [sc-10976](https://app.shortcut.com/simpledotorg/story/10976/cap-activity-table-percentages-at-100)

## Because

We want to cap the call percentages at 100% in situations when the calls surpass the overdue patients.

## Test instructions

Use the script to generate call data for a user.
```
c = CallResult.where(user_id: <User ID you want to populate the call data for>)

100.times { 
   CallResult.create!(user_id: c.user_id, appointment_id: Appointment.all.sample.id, result_type: c.result_type, patient_id: Patient.where(assigned_facility_id: c.facility.id).sample.id, facility_id: c.facility_id, device_created_at: 1.months.ago, device_updated_at: 1.month.ago).save 
}
```

## Screenshots
### Before
![Screenshot 2023-08-11 at 16 49 37](https://github.com/simpledotorg/simple-server/assets/13778440/bc996d93-08e6-4c80-80f3-cab7cafabc0c)
![Screenshot 2023-08-11 at 16 49 24](https://github.com/simpledotorg/simple-server/assets/13778440/5c1a63aa-6542-49d8-b372-d51e823f4b9e)

### After
![Screenshot 2023-08-11 at 16 52 18](https://github.com/simpledotorg/simple-server/assets/13778440/1800a039-cdf7-4356-bf11-3a467591374d)
![Screenshot 2023-08-11 at 16 52 06](https://github.com/simpledotorg/simple-server/assets/13778440/24d812f3-4f4a-4918-8222-16c777a1de6a)

