### PR TITLE
Fix typo in translated strings

### DIFF
--- a/config/locales/api/am_ET.yml
+++ b/config/locales/api/am_ET.yml
@@ -418,7 +418,7 @@ am-ET:
         controlled_card:
           subtitle: "ከ 3 ወራት በፊት የተመዘገቡ በ%{facility_name}የ %{diagnosis} ታካሚዎች ባለፉት 3 ወራት ውስጥ%{controlled_threshold} ለመጨረሻ ጊዜ ጉብኝታቸው"
           help_tooltip:
-            numerator: "ባለፉት 3 ወራት ውስጥ%{uncontrolled_threshold} በመጨረሻ ጉብኝታቸው ላይ ያሉ ታካሚዎች።"
+            numerator: "ባለፉት 3 ወራት ውስጥ%{controlled_threshold} በመጨረሻ ጉብኝታቸው ላይ ያሉ ታካሚዎች።"
             denominator: "ወደ %{facility_name} ተመደቡት የ  %{diagnosis} ታካሚዎች፣ ካለፉት 3 ወራት በፊት የተመዘገቡ። ለክትትል ታካሚዎች የሞቱ እና የጠፉ አይካተቱም"
         uncontrolled_card:
           subtitle: "ከ 3 ወራት በፊት የተመዘገቡ በ%{facility_name}የ %{diagnosis} ታካሚዎች ባለፉት 3 ወራት ውስጥ%{controlled_threshold} ለመጨረሻ ጊዜ ጉብኝታቸው"

--- a/config/locales/api/om_ET.yml
+++ b/config/locales/api/om_ET.yml
@@ -423,7 +423,7 @@ om-ET:
         uncontrolled_card:
           subtitle: "Dhukkubsatoota %{diagnosis} kan %{facility_name} tti ji'oota  >3 galmaa'anii %{controlled_threshold}yoo xiqqaate ji'oota 3 darbaniif qabaatan."
           help_tooltip:
-            numerator: "Dhukkubsatoota %{controlled_threshold} daawwannaa isaanii ji'oota 3 wajjiin."
+            numerator: "Dhukkubsatoota %{uncontrolled_threshold} daawwannaa isaanii ji'oota 3 wajjiin."
             denominator: "Dhukkubsatootni %{diagnosis} bakka kanatti qajeelfamu, kan ji'oota 3n darban keessa %{facility_name}tti galmaa'an. Dhukkubsatootni du'anii fi hordoffii hin qabne keessaa baafamanii jiru."
         very_uncontrolled_card:
           subtitle: "Dhukkubsatoota Sukkaaraa kan %{facility_name} tti ji'oota  >3 galmaa'anii %{very_uncontrolled_threshold}yoo xiqqaate ji'oota 3 darbaniif qabaatan."


### PR DESCRIPTION
**Story card:** [sc-11033](https://app.shortcut.com/simpledotorg/story/11033/missing-interpolation-argument)

## Because

Some of the translated strings had typos in the argument. 

## This addresses

Fixed the typo in the translated string 