### PR TITLE
bulk facility upload: fix incorrect duplicate check

### DIFF
--- a/app/validators/csv/facilities_validator.rb
+++ b/app/validators/csv/facilities_validator.rb
@@ -59,7 +59,7 @@ class Csv::FacilitiesValidator
 
   def duplicate_business_identifiers
     business_identifiers = facilities.flat_map { |facility| facility[:business_identifiers] }
-    identifiers = business_identifiers.pluck(:identifiers)
+    identifiers = business_identifiers.pluck(:identifier)
     errors << "Uploaded file has duplicate business identifiers" if identifiers.count != identifiers.uniq.count
   end
 

--- a/spec/validators/csv/facilities_validator_spec.rb
+++ b/spec/validators/csv/facilities_validator_spec.rb
@@ -39,6 +39,23 @@ RSpec.describe Csv::FacilitiesValidator do
       end
     end
 
+    context "when there are no duplicate identifiers" do
+      it "does not return an error message about duplicate facilities" do
+        organization = create(:organization, name: "O")
+        create(:facility_group, name: "FG", organization_id: organization.id)
+        facility = FactoryBot.create(:facility, organization_name: "O", facility_group_name: "FG", name: "F")
+        business_identifier_1 = build_stubbed(:facility_business_identifier, identifier: "abc", facility_id: facility.id)
+        business_identifier_2 = build_stubbed(:facility_business_identifier, identifier: "xyz", identifier_type: :external_org_facility_id, facility_id: facility.id)
+        validator = described_class.new([
+          {facility: facility, business_identifiers: [business_identifier_1, business_identifier_2]}
+        ])
+
+        validator.validate
+
+        expect(validator.errors).to be_empty
+      end
+    end
+
     context "per-facility validations" do
       let(:organization) { create(:organization, name: "O") }
       let(:facility_group) { create(:facility_group, name: "FG", organization: organization) }


### PR DESCRIPTION
The bulk facility upload tool always reported that the business identifiers were duplicated. This is because of a one-letter typo in our code. We fix this and add a test case to avoid this in the future.

Explanation: we are plucking `identifiers` from `FacilityBusinessIdentifiers`, but the attribute name is a singular `identifier`. This incorrect pluck creates a map of `nil`s and causes the uniqueness check to always fail.