### PR TITLE
fix incorrect drug stock instruction source

### DIFF
--- a/app/schema/api/v4/models/questionnaires/specimen_layout.rb
+++ b/app/schema/api/v4/models/questionnaires/specimen_layout.rb
@@ -217,7 +217,7 @@ module Api::V4::Models::Questionnaires::SpecimenLayout
         id: "7c660864-b50a-4b3c-b019-c37a3fba3b8e",
         type: "display",
         view_type: "paragraph",
-        text: "If you have more than 3 batches then add any additional batch stocks to batch 3 using the same date"
+        text: "Enter the supplies left in stock at the end of every month"
       },
       {
         id: "5f98dcc1-504b-473a-bff8-2f1576a85bca",

--- a/swagger/v4/import.json
+++ b/swagger/v4/import.json
@@ -454,6 +454,7 @@
         "resourceType",
         "meta",
         "identifier",
+        "start",
         "participant",
         "status",
         "appointmentOrganization"


### PR DESCRIPTION
Context: https://github.com/simpledotorg/simple-server/pull/5236#discussion_r1302552677

tldr;
The source which rswag used to generate the swagger json was out of sync with what we want. This fixes that.