### PR TITLE
import api: add error message for missing parameters

### DIFF
--- a/app/controllers/api/v4/imports_controller.rb
+++ b/app/controllers/api/v4/imports_controller.rb
@@ -3,6 +3,10 @@ class Api::V4::ImportsController < ApplicationController
   before_action :doorkeeper_authorize!
   before_action :validate_token_organization
 
+  rescue_from ActionController::ParameterMissing do |error|
+    render json: {error: "Unable to find key in payload: \"#{error.param}\""}, status: :bad_request
+  end
+
   def import
     return head :not_found unless Flipper.enabled?(:imports_api)
 


### PR DESCRIPTION
**Story card:** 😶‍🌫️ 

## This addresses

We return a more descriptive error that pinpoints to the missing top-level parameter rather than return a generic 404.
