### PR TITLE
Disable experiments in India temporarily

### DIFF
--- a/lib/tasks/experiments.rake
+++ b/lib/tasks/experiments.rake
@@ -1,9 +1,11 @@
 namespace :experiments do
   desc "Conduct an experiment for the day and send out notifications"
   task conduct_daily: :environment do
-    Time.use_zone(CountryConfig.current[:time_zone]) do
-      Experimentation::Runner.call
-      AppointmentNotification::ScheduleExperimentReminders.call
+    unless CountryConfig.current_country?("India")
+      Time.use_zone(CountryConfig.current[:time_zone]) do
+        Experimentation::Runner.call
+        AppointmentNotification::ScheduleExperimentReminders.call
+      end
     end
   end
 end


### PR DESCRIPTION
**Story card:** [sc-11112](https://app.shortcut.com/simpledotorg/story/11112/p1-bsnl-smses-failing-with-401)

## Because

Smses in India are failing with 401: Unauthorized since 2nd Sep. Disabling experiments till the bug is fixed so we're not bombarding BSNL.