### PR TITLE
Disable users in migrated facilities

### DIFF
--- a/db/data/20230907045337_disable_users_in_migrated_facilities.rb
+++ b/db/data/20230907045337_disable_users_in_migrated_facilities.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class DisableUsersInMigratedFacilities < ActiveRecord::Migration[6.1]
+  REGIONS_WITH_ONGOING_ACCESS = [
+    {region_type: :state, slug: "west-bengal"},
+    {region_type: :state, slug: "nagaland"},
+    {region_type: :district, slug: "chennai"},
+    {region_type: :district, slug: "pimpri-chinchwad-municipal-corporation"},
+    {region_type: :district, slug: "pune-municipal-corporation"}
+  ]
+  def up
+    users_with_remaining_access = REGIONS_WITH_ONGOING_ACCESS.flat_map do |region_details|
+      region = Region.find_by(region_details)
+      next unless region
+
+      if region.district_region?
+        region.source.users.sync_approval_status_allowed
+      elsif region.state_region?
+        region.children.flat_map { |district| district.source.users.sync_approval_status_allowed }
+      end
+    end
+
+    all_allowed_users = User.all.sync_approval_status_allowed.pluck(:id)
+    disabled_users = all_allowed_users - users_with_remaining_access.map(&:id)
+
+    User.where(id: disabled_users).update_all(
+      sync_approval_status: :denied,
+      sync_approval_status_reason: "Instructions to disable users"
+    )
+  end
+
+  def down
+    print "DisableUsersInMigratedFacilities cannot be reversed."
+  end
+end

--- a/db/data/20230907045337_disable_users_in_migrated_facilities.rb
+++ b/db/data/20230907045337_disable_users_in_migrated_facilities.rb
@@ -9,6 +9,10 @@ class DisableUsersInMigratedFacilities < ActiveRecord::Migration[6.1]
     {region_type: :district, slug: "pune-municipal-corporation"}
   ]
   def up
+    unless CountryConfig.current_country?("India") && ENV["SIMPLE_SERVER_ENV"] == "production"
+      return print "DisableUsersInMigratedFacilities is only for production India"
+    end
+
     users_with_remaining_access = REGIONS_WITH_ONGOING_ACCESS.flat_map do |region_details|
       region = Region.find_by(region_details)
       next unless region

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20230831064255)
+DataMigrate::Data.define(version: 20230907045337)


### PR DESCRIPTION
## Because

We have received instructions to disable users in all regions other than: 

- Chennai district
- West Bengal (all districts)
- Nagaland districts
- Pimpri Chinchwad Municipal Corporation
- Pune municipal corporation in Maharashtra

## This addresses

Adds a data migration that disables these users

## Test instructions

1. Copy the following tables locally: 
- Organizations
- Facility Groups
- Facilities
- Regions
- Users
- User authentications
- Phone number authentications

2. Very the number of users to be present before and after the migration. In a rails console, run: 
```
require './db/data/20230907045337_disable_users_in_migrated_facilities.rb'
regions = DisableUsersInMigratedFacilities::REGIONS_WITH_ONGOING_ACCESS.map { |detail| Region.find_by(detail) }
all_users_with_access = User.all.sync_approval_status_allowed
users_on_going_access = regions.map { |region| region.state_region? ? region.children.flat_map { |d| d.source.users.sync_approval_status_allowed } : region.source.users.sync_approval_status_allowed }.flatten

all_users_with_access.count
users_on_going_access.count
```

3. Run the migration using `rake data:migrate`

4. Verify that `all_users_with_access = users_on_going_access` and that users with on going access only belong to the above mentioned regions. 
