### PR TITLE
Raise error when bsnl jwt referesh fails

### DIFF
--- a/lib/tasks/scripts/refresh_bsnl_sms_jwt.rb
+++ b/lib/tasks/scripts/refresh_bsnl_sms_jwt.rb
@@ -24,6 +24,8 @@ class RefreshBsnlSmsJwt
       jwt = response.body.delete_prefix('"').delete_suffix('"')
       config = Configuration.find_or_create_by(name: "bsnl_sms_jwt")
       config.update!(value: jwt)
+    else
+      response.error!
     end
   end
 end

--- a/spec/lib/tasks/scripts/refresh_bsnl_sms_jwt_spec.rb
+++ b/spec/lib/tasks/scripts/refresh_bsnl_sms_jwt_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe RefreshBsnlSmsJwt do
         expect(request).to have_been_made
         expect(Configuration.fetch("bsnl_sms_jwt")).to eq("new_jwt")
       end
+
+      it "raises an error if the HTTP call fails" do
+        stub_request(:post, "https://bulksms.bsnl.in:5010/api/Create_New_API_Token").to_return(status: 401)
+        expect { described_class.new("1", "invalid username", "invalid password", "X").call }.to raise_error
+
+        stub_request(:post, "https://bulksms.bsnl.in:5010/api/Create_New_API_Token").to_return(status: 500)
+        expect { described_class.new("1", "username", "password", "X").call }.to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
Related story card: [sc-11112](https://app.shortcut.com/simpledotorg/story/11112/p1-bsnl-smses-failing-with-401)

The task to refresh bsnl token would fail silently when we were arbitrarily blacklisted. We want to an add alert to catch these issues with the api earlier on.