### PR TITLE
Add docker entry point script for sidekiq worker

### DIFF
--- a/bin/docker-worker
+++ b/bin/docker-worker
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+/usr/sbin/cron -f &
+
+bundle exec sidekiq  -C config/sidekiq.yml -e production


### PR DESCRIPTION
**Story card:** [11157](https://app.shortcut.com/simpledotorg/story/11157)

## Because

Logrotae is not working on the worker pods

## This addresses

Start cron service during docker startup