### PR TITLE
Re-enable experiments in India

### DIFF
--- a/lib/tasks/experiments.rake
+++ b/lib/tasks/experiments.rake
@@ -1,11 +1,9 @@
 namespace :experiments do
   desc "Conduct an experiment for the day and send out notifications"
   task conduct_daily: :environment do
-    unless CountryConfig.current_country?("India")
-      Time.use_zone(CountryConfig.current[:time_zone]) do
-        Experimentation::Runner.call
-        AppointmentNotification::ScheduleExperimentReminders.call
-      end
+    Time.use_zone(CountryConfig.current[:time_zone]) do
+      Experimentation::Runner.call
+      AppointmentNotification::ScheduleExperimentReminders.call
     end
   end
 end


### PR DESCRIPTION
**Story card:** [sc-11112](https://app.shortcut.com/simpledotorg/story/11112/p1-bsnl-smses-failing-with-401)

We temporarily disabled sms experiments in India due to a bug where smses were failing with HTTP 401. Now that the BSNL blacklist is lifted, we're enabling them again. Details on long term fixes are captred in the card.