### PR TITLE
Initialize ET dynamic forms 1 month in advance

### DIFF
--- a/app/services/questionnaire_responses/monthly_screening_reports.rb
+++ b/app/services/questionnaire_responses/monthly_screening_reports.rb
@@ -3,17 +3,17 @@ class QuestionnaireResponses::MonthlyScreeningReports
 
   def initialize(date = 1.month.ago)
     @month_date = date.beginning_of_month
-    @facility_reports = monthly_followup_and_registration
+    @facility_ids = Facility.select("id").pluck(:id)
     @questionnaire_id = latest_active_questionnaire_id(Questionnaire.questionnaire_types[:monthly_screening_reports])
   end
 
-  def pre_fill
-    @facility_reports.each do |facility_report|
-      unless monthly_screening_report_exists?(facility_report.facility_id)
+  def seed
+    @facility_ids.each do |facility_id|
+      unless monthly_screening_report_exists?(facility_id)
         QuestionnaireResponse.create!(
           questionnaire_id: @questionnaire_id,
-          facility_id: facility_report.facility_id,
-          content: prefilled_responses(month_date_str, facility_report),
+          facility_id: facility_id,
+          content: monthly_reports_base_content,
           device_created_at: @month_date,
           device_updated_at: @month_date
         )
@@ -23,22 +23,6 @@ class QuestionnaireResponses::MonthlyScreeningReports
 
   private
 
-  def monthly_followup_and_registration
-    Reports::FacilityMonthlyFollowUpAndRegistration.where(
-      month_date: month_date_str
-    ).select(
-      "facility_id",
-      "monthly_follow_ups_htn_all",
-      "monthly_follow_ups_htn_male",
-      "monthly_follow_ups_htn_female",
-      "monthly_follow_ups_dm_all",
-      "monthly_follow_ups_dm_male",
-      "monthly_follow_ups_dm_female",
-      "monthly_follow_ups_htn_and_dm_male",
-      "monthly_follow_ups_htn_and_dm_female"
-    ).load
-  end
-
   def monthly_screening_report_exists?(facility_id)
     QuestionnaireResponse
       .where(facility_id: facility_id)
@@ -46,29 +30,5 @@ class QuestionnaireResponses::MonthlyScreeningReports
       .merge(Questionnaire.monthly_screening_reports)
       .where("content->>'month_date' = ?", month_date_str)
       .any?
-  end
-
-  def prefilled_responses(month_date_str, facility_report)
-    case Rails.application.config.country[:name]
-    when CountryConfig::CONFIGS[:IN]["name"]
-      {
-        **monthly_reports_base_content,
-        "monthly_screening_report.diagnosed_cases_on_follow_up_htn.male" => facility_report.monthly_follow_ups_htn_male,
-        "monthly_screening_report.diagnosed_cases_on_follow_up_htn.female" => facility_report.monthly_follow_ups_htn_female,
-        "monthly_screening_report.diagnosed_cases_on_follow_up_dm.male" => facility_report.monthly_follow_ups_dm_male,
-        "monthly_screening_report.diagnosed_cases_on_follow_up_dm.female" => facility_report.monthly_follow_ups_dm_female,
-        "monthly_screening_report.diagnosed_cases_on_follow_up_htn_and_dm.male" => facility_report.monthly_follow_ups_htn_and_dm_male,
-        "monthly_screening_report.diagnosed_cases_on_follow_up_htn_and_dm.female" => facility_report.monthly_follow_ups_htn_and_dm_female
-      }
-
-    when CountryConfig::CONFIGS[:ET]["name"]
-      {
-        **monthly_reports_base_content,
-        "monthly_screening_report.total_htn_diagnosed" => facility_report.monthly_follow_ups_htn_all,
-        "monthly_screening_report.total_dm_diagnosed" => facility_report.monthly_follow_ups_dm_all
-      }
-    else
-      monthly_reports_base_content
-    end
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -130,15 +130,7 @@ every :day, at: local("05:45 am"), roles: [:cron] do
 end
 
 every 1.month, at: local("06:00 am"), roles: [:cron] do
-  if Flipper.enabled?(:monthly_screening_reports)
-    runner "QuestionnaireResponses::MonthlyScreeningReports.new.pre_fill"
-  end
-  if Flipper.enabled?(:monthly_supplies_reports)
-    runner "QuestionnaireResponses::MonthlySuppliesReports.new.seed"
-  end
-  if Flipper.enabled?(:drug_stock_questionnaires)
-    runner "QuestionnaireResponses::DrugStockReports.new.seed"
-  end
+  rake "questionnaires:initialize"
 end
 
 every 1.month, at: local("07:00 am"), roles: [:cron] do

--- a/lib/seed/questionnaire_seeder.rb
+++ b/lib/seed/questionnaire_seeder.rb
@@ -25,7 +25,7 @@ module Seed
         layout: drug_stock_reports_seed_layout)
 
       (1..3).map do |n|
-        QuestionnaireResponses::MonthlyScreeningReports.new(n.month.ago).pre_fill
+        QuestionnaireResponses::MonthlyScreeningReports.new(n.month.ago).seed
         QuestionnaireResponses::MonthlySuppliesReports.new(n.month.ago).seed
         QuestionnaireResponses::DrugStockReports.new(n.month.ago).seed
       end

--- a/lib/tasks/questionnaires.rake
+++ b/lib/tasks/questionnaires.rake
@@ -1,7 +1,7 @@
 namespace :questionnaires do
   desc "Initialize questionnaire responses"
   task initialize: :environment do
-    date = CountryConfig.current_country?("Ethiopia") ? Date.current : 1.month.ago
+    date = CountryConfig.current_country?("Ethiopia") ? 1.month.from_now : -1.month.from_now
 
     if Flipper.enabled?(:monthly_screening_reports)
       QuestionnaireResponses::MonthlyScreeningReports.new(date).pre_fill

--- a/lib/tasks/questionnaires.rake
+++ b/lib/tasks/questionnaires.rake
@@ -1,0 +1,16 @@
+namespace :questionnaires do
+  desc "Initialize questionnaire responses"
+  task initialize: :environment do
+    date = CountryConfig.current_country?("Ethiopia") ? Date.current : 1.month.ago
+
+    if Flipper.enabled?(:monthly_screening_reports)
+      QuestionnaireResponses::MonthlyScreeningReports.new(date).pre_fill
+    end
+    if Flipper.enabled?(:monthly_supplies_reports)
+      QuestionnaireResponses::MonthlySuppliesReports.new(date).seed
+    end
+    if Flipper.enabled?(:drug_stock_questionnaires)
+      QuestionnaireResponses::DrugStockReports.new(date).seed
+    end
+  end
+end

--- a/lib/tasks/questionnaires.rake
+++ b/lib/tasks/questionnaires.rake
@@ -1,6 +1,9 @@
 namespace :questionnaires do
   desc "Initialize questionnaire responses"
   task initialize: :environment do
+    # Due to mismatch in Gregorian<>Ethiopian calendars,
+    # Dynamic forms initialization had a delay of 20+ days in Ethiopia.
+    # To avoid this delay, we initialize dynamic forms 2 months in advance in Ethiopia.
     date = CountryConfig.current_country?("Ethiopia") ? 1.month.from_now : -1.month.from_now
 
     if Flipper.enabled?(:monthly_screening_reports)

--- a/lib/tasks/questionnaires.rake
+++ b/lib/tasks/questionnaires.rake
@@ -3,11 +3,11 @@ namespace :questionnaires do
   task initialize: :environment do
     # Due to mismatch in Gregorian<>Ethiopian calendars,
     # Dynamic forms initialization had a delay of 20+ days in Ethiopia.
-    # To avoid this delay, we initialize dynamic forms 2 months in advance in Ethiopia.
-    date = CountryConfig.current_country?("Ethiopia") ? 1.month.from_now : -1.month.from_now
+    # To avoid this delay, we initialize dynamic forms 1 month in advance in Ethiopia.
+    date = CountryConfig.current_country?("Ethiopia") ? Date.current : 1.month.ago
 
     if Flipper.enabled?(:monthly_screening_reports)
-      QuestionnaireResponses::MonthlyScreeningReports.new(date).pre_fill
+      QuestionnaireResponses::MonthlyScreeningReports.new(date).seed
     end
     if Flipper.enabled?(:monthly_supplies_reports)
       QuestionnaireResponses::MonthlySuppliesReports.new(date).seed

--- a/spec/services/questionnaire_responses/monthly_screening_reports_spec.rb
+++ b/spec/services/questionnaire_responses/monthly_screening_reports_spec.rb
@@ -19,46 +19,15 @@ RSpec.describe QuestionnaireResponses::MonthlyScreeningReports do
   end
 
   describe "#pre_fill" do
-    it "[India] pre-fills monthly screening reports for previous month" do
-      QuestionnaireResponses::MonthlyScreeningReports.new.pre_fill
-
+    it "should initialize monthly screening reports for previous month" do
+      QuestionnaireResponses::MonthlyScreeningReports.new.seed
       date = 1.month.ago.beginning_of_month
       questionnaire_response = QuestionnaireResponse.find_by_facility_id(facility)
       expect(questionnaire_response.content).to eq(
-        {
-          "month_date" => date.strftime("%Y-%m-%d"),
-          "submitted" => false,
-          "monthly_screening_report.diagnosed_cases_on_follow_up_htn.male" => 0,
-          "monthly_screening_report.diagnosed_cases_on_follow_up_htn.female" => 1,
-          "monthly_screening_report.diagnosed_cases_on_follow_up_dm.male" => 0,
-          "monthly_screening_report.diagnosed_cases_on_follow_up_dm.female" => 0,
-          "monthly_screening_report.diagnosed_cases_on_follow_up_htn_and_dm.male" => 0,
-          "monthly_screening_report.diagnosed_cases_on_follow_up_htn_and_dm.female" => 0
-        }
+        {"month_date" => date.strftime("%Y-%m-%d"), "submitted" => false}
       )
       expect(questionnaire_response.device_created_at).to eq(date)
       expect(questionnaire_response.device_updated_at).to eq(date)
-    end
-
-    it "[Ethiopia] pre-fills monthly screening reports for previous month" do
-      current_country = Rails.application.config.country
-      Rails.application.config.country = CountryConfig.for("ET")
-      QuestionnaireResponses::MonthlyScreeningReports.new.pre_fill
-
-      date = 1.month.ago.beginning_of_month
-      questionnaire_response = QuestionnaireResponse.find_by_facility_id(facility)
-      expect(questionnaire_response.content).to eq(
-        {
-          "month_date" => date.strftime("%Y-%m-%d"),
-          "submitted" => false,
-          "monthly_screening_report.total_htn_diagnosed" => 1,
-          "monthly_screening_report.total_dm_diagnosed" => 0
-        }
-      )
-      expect(questionnaire_response.device_created_at).to eq(date)
-      expect(questionnaire_response.device_updated_at).to eq(date)
-
-      Rails.application.config.country = current_country
     end
 
     it "ignores existing monthly screening reports" do
@@ -66,7 +35,7 @@ RSpec.describe QuestionnaireResponses::MonthlyScreeningReports do
       random_questionnaire = create(:questionnaire, questionnaire_type: "monthly_screening_reports")
       existing_monthly_screening_report = create(:questionnaire_response, facility: facility, content: existing_content, questionnaire: random_questionnaire)
 
-      QuestionnaireResponses::MonthlyScreeningReports.new.pre_fill
+      QuestionnaireResponses::MonthlyScreeningReports.new.seed
 
       expect(QuestionnaireResponse.where(facility: facility).count).to eq(1)
       expect(QuestionnaireResponse.find_by_facility_id(facility)).to eq(existing_monthly_screening_report)
@@ -76,7 +45,7 @@ RSpec.describe QuestionnaireResponses::MonthlyScreeningReports do
       create(:questionnaire, :active, dsl_version: "1", questionnaire_type: "monthly_screening_reports")
       latest_questionnaire = Questionnaire.find_by_dsl_version("1.2")
 
-      QuestionnaireResponses::MonthlyScreeningReports.new.pre_fill
+      QuestionnaireResponses::MonthlyScreeningReports.new.seed
 
       expect(QuestionnaireResponse.find_by_facility_id(facility).questionnaire).to eq(latest_questionnaire)
     end
@@ -87,7 +56,7 @@ RSpec.describe QuestionnaireResponses::MonthlyScreeningReports do
       create(:questionnaire_response, questionnaire: questionnaire, facility: facility, content: existing_content)
       expect(QuestionnaireResponse.where(facility: facility).count).to eq(1)
 
-      QuestionnaireResponses::MonthlyScreeningReports.new.pre_fill
+      QuestionnaireResponses::MonthlyScreeningReports.new.seed
 
       expect(QuestionnaireResponse.where(facility: facility).count).to eq(2)
       expect(QuestionnaireResponse.where(facility: facility).merge(Questionnaire.monthly_screening_reports).joins(:questionnaire).count).to eq(1)
@@ -101,18 +70,12 @@ RSpec.describe QuestionnaireResponses::MonthlyScreeningReports do
       refresh_views
 
       date = three_months_ago.beginning_of_month
-      QuestionnaireResponses::MonthlyScreeningReports.new(date).pre_fill
+      QuestionnaireResponses::MonthlyScreeningReports.new(date).seed
 
       expect(QuestionnaireResponse.find_by_facility_id(facility).content).to eq(
         {
           "month_date" => date.strftime("%Y-%m-%d"),
-          "submitted" => false,
-          "monthly_screening_report.diagnosed_cases_on_follow_up_htn.male" => 1,
-          "monthly_screening_report.diagnosed_cases_on_follow_up_htn.female" => 0,
-          "monthly_screening_report.diagnosed_cases_on_follow_up_dm.male" => 0,
-          "monthly_screening_report.diagnosed_cases_on_follow_up_dm.female" => 0,
-          "monthly_screening_report.diagnosed_cases_on_follow_up_htn_and_dm.male" => 0,
-          "monthly_screening_report.diagnosed_cases_on_follow_up_htn_and_dm.female" => 0
+          "submitted" => false
         }
       )
     end


### PR DESCRIPTION
**Story card:** [sc-11191](https://app.shortcut.com/simpledotorg/story/11191/initialize-all-dynamic-form-months-for-et)

## Because

All the dynamic forms are initialised on first of every month. In Ethiopia, due to the difference in calendar, these forms appear around 20th of a month. 

## This addresses

Disclaimer: We are going for a hack to fix this because accommodating Ethiopian calendar in Simple will take up more than 2-3 months of work.

- We have decided to initialise the `current month` form in Ethiopia instead of `previous month` form from next month onwards. That is, On 1st Nov, we will be initialising the form for `Nov-2023` in Ethiopia and `Oct-2023` in other countries. 
- We will have to manually initialise `Oct-2023` form for Ethiopia to catch up with other countries.
---
- We have moved the initialisation code to a rake task
  - We had to pass in a different `date` argument to initialise forms in different countries. 
  - With `runner` taking a `string` was not practical in our case
## Test instructions

- Run the rake task locally and verify if the forms are being created
    - `bundle exec rake questionnaires:initiliaze` 