### PR TITLE
Fix dates in ltfu graph

### DIFF
--- a/app/components/dashboard/diabetes/lost_to_follow_up_component.html.erb
+++ b/app/components/dashboard/diabetes/lost_to_follow_up_component.html.erb
@@ -11,13 +11,13 @@
           <p class="m-0px c-black">
             <span data-key="ltfuPatients" data-format="numberWithCommas"></span>
             patients with no visit since
-            <span data-key="endDate"></span>
+            <span data-key="startDate"></span>
           </p>
           <p class="m-0px c-grey-dark c-print-black">
             of
             <span data-key="cumulativeAssignedPatients" data-format="numberWithCommas"></span>
             patients registered till
-            <span data-key="registrationDate"></span>
+            <span data-key="endDate"></span>
           </p>
         </div>
       </div>

--- a/app/components/dashboard/diabetes/lost_to_follow_up_component.rb
+++ b/app/components/dashboard/diabetes/lost_to_follow_up_component.rb
@@ -20,13 +20,12 @@ class Dashboard::Diabetes::LostToFollowUpComponent < ApplicationComponent
 
   def period_data
     {
-      startDate: period_info(:bp_control_start_date),
-      endDate: period_info(:bp_control_end_date),
-      registrationDate: period_info(:bp_control_registration_date)
+      startDate: period_info(:ltfu_since_date),
+      endDate: period_info(:ltfu_end_date)
     }
   end
 
   def period_info(key)
-    data[:period_info].map { |k, v| [k, v[key]] }.to_h
+    data[:period_info].transform_values { |v| v[key] }
   end
 end

--- a/app/components/dashboard/hypertension/lost_to_follow_up_component.html.erb
+++ b/app/components/dashboard/hypertension/lost_to_follow_up_component.html.erb
@@ -11,13 +11,13 @@
           <p class="m-0px c-black">
             <span data-key="ltfuPatients" data-format="numberWithCommas"></span>
             patients with no visit since
-            <span data-key="endDate"></span>
+            <span data-key="startDate"></span>
           </p>
           <p class="m-0px c-grey-dark c-print-black">
             of
             <span data-key="cumulativeAssignedPatients" data-format="numberWithCommas"></span>
             patients registered till
-            <span data-key="registrationDate"></span>
+            <span data-key="endDate"></span>
           </p>
         </div>
       </div>

--- a/app/components/dashboard/hypertension/lost_to_follow_up_component.rb
+++ b/app/components/dashboard/hypertension/lost_to_follow_up_component.rb
@@ -20,13 +20,12 @@ class Dashboard::Hypertension::LostToFollowUpComponent < ApplicationComponent
 
   def period_data
     {
-      startDate: period_info(:bp_control_start_date),
-      endDate: period_info(:bp_control_end_date),
-      registrationDate: period_info(:bp_control_registration_date)
+      startDate: period_info(:ltfu_since_date),
+      endDate: period_info(:ltfu_end_date)
     }
   end
 
   def period_info(key)
-    data[:period_info].map { |k, v| [k, v[key]] }.to_h
+    data[:period_info].transform_values { |v| v[key] }
   end
 end

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -94,7 +94,11 @@ class Period
   end
 
   def ltfu_since_date
-    self.begin.advance(months: -12).end_of_month.to_s(:day_mon_year)
+    self.begin.advance(months: -13).end_of_month.to_s(:day_mon_year)
+  end
+
+  def ltfu_end_date
+    self.begin.end_of_month.to_s(:day_mon_year)
   end
 
   def month?
@@ -187,6 +191,7 @@ class Period
     @to_hash ||= {
       name: to_s,
       ltfu_since_date: ltfu_since_date,
+      ltfu_end_date: ltfu_end_date,
       bp_control_start_date: bp_control_range_start_date,
       bp_control_end_date: bp_control_range_end_date,
       bp_control_registration_date: bp_control_registrations_until_date

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -88,7 +88,8 @@ RSpec.describe Reports::RegionsController, type: :controller do
         name: "Dec-2019",
         bp_control_start_date: "1-Oct-2019",
         bp_control_end_date: "31-Dec-2019",
-        ltfu_since_date: "31-Dec-2018",
+        ltfu_end_date: "31-Dec-2019",
+        ltfu_since_date: "30-Nov-2018",
         bp_control_registration_date: "30-Sep-2019"
       }
       expect(data[:period_info][dec_2019_period]).to eq(period_hash)


### PR DESCRIPTION
**Story card:** [sc-11279](https://app.shortcut.com/simpledotorg/story/11279/change-dates-in-ltfu-chart)

## Because

The dates in the LTFU graph is incorrect.

## This addresses

Use the correct LTFU start date and LTFU end date in the graph.
For eg. If current month is OCT-2023, then start date should be "30-SEP-2023" and end date should be "31_OCt-2023"

*After*:
<img width="910" alt="image" src="https://github.com/simpledotorg/simple-server/assets/32141642/c290599a-d537-4a68-8822-00bb076f5efa">

*Before*
<img width="631" alt="image" src="https://github.com/simpledotorg/simple-server/assets/32141642/81512d42-302e-4906-a5f0-3ec48642ac70">

