### PR TITLE
Update india matview and cache refresh time

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -36,8 +36,9 @@ FOLLOW_UP_TIMES = [
   "07:00 pm"
 ].map { |t| local(t) }
 
-REPORTS_REFRESH_FREQUENCY = CountryConfig.current_country?("India") ? :sunday : :day
-REPORTS_CACHE_REFRESH_TIME = CountryConfig.current_country?("India") ? "12:00 pm" : "04:30 am"
+REPORTS_REFRESH_FREQUENCY = CountryConfig.current_country?("India") ? :saturday : :day
+REPORTS_REFRESH_TIME = CountryConfig.current_country?("India") ? "05:00 pm" : "12:30 am"
+REPORTS_CACHE_REFRESH_TIME = CountryConfig.current_country?("India") ? "11:55 pm" : "04:30 am"
 
 every :day, at: FOLLOW_UP_TIMES, roles: [:cron] do
   rake "db:refresh_daily_follow_ups_and_registrations"
@@ -73,7 +74,7 @@ every :day, at: local("12:00 am"), roles: [:whitelist_phone_numbers] do
   rake "exotel_tasks:whitelist_patient_phone_numbers"
 end
 
-every REPORTS_REFRESH_FREQUENCY, at: local("12:30 am"), roles: [:cron] do
+every REPORTS_REFRESH_FREQUENCY, at: local(REPORTS_REFRESH_TIME), roles: [:cron] do
   rake "db:refresh_reporting_views"
 end
 


### PR DESCRIPTION
**Story card:** [sc-11220](https://app.shortcut.com/simpledotorg/story/11220)

## Because

Due to the infra scale-down, the mat view refresh is taking 26 hours. Therefore, we've moved the refresh start time to Saturday evening at 5 PM and adjusted the cache warming to 11:44 PM

## This addresses

Reporting data issues in the dashboard and progress tab