### PR TITLE
import api: relax unit requirements for medication

### DIFF
--- a/app/schema/api/v4/imports.rb
+++ b/app/schema/api/v4/imports.rb
@@ -483,11 +483,19 @@ class Api::V4::Imports
                doseAndRate: {type: [:array, :null],
                              items: {type: [:object, :null],
                                      properties: {
-                                       doseQuantity: value_quantity(
-                                         system: "http://unitsofmeasure.org",
-                                         unit: "mg",
-                                         code: "mg"
-                                       )
+                                       doseQuantity: {
+                                         type: :object,
+                                         properties: {
+                                           value: {type: "number", nullable: false},
+                                           unit: {type: :string, nullable: false,
+                                                  description: "Can be mg, ml or your unit of choice"},
+                                           system: {type: :string, enum: ["http://unitsofmeasure.org"], nullable: false},
+                                           code: {type: :string, nullable: false,
+                                                  description: "Can be mg, ml or your unit of choice"}
+                                         },
+                                         nullable: false,
+                                         required: %w[value unit system code]
+                                       }
                                      }},
                              maxItems: 1,
                              minItems: 0,

--- a/spec/factories/import_resources/medication_requests.rb
+++ b/spec/factories/import_resources/medication_requests.rb
@@ -11,6 +11,7 @@ def build_medication_request_import_resource
     }
   }
 
+  medication_unit = %w[mg ml g].sample
   {
     contained: [contained_medication],
     resourceType: "MedicationRequest",
@@ -30,9 +31,9 @@ def build_medication_request_import_resource
     dosageInstruction: [{
       timing: {code: %w[QD BID TID QID].sample},
       doseAndRate: [{doseQuantity: {value: Faker::Number.between(from: 1, to: 10),
-                                    unit: "mg",
+                                    unit: medication_unit,
                                     system: "http://unitsofmeasure.org",
-                                    code: "mg"}}],
+                                    code: medication_unit}}],
       text: Faker::Quote.yoda
     }]
   }

--- a/swagger/v4/import.json
+++ b/swagger/v4/import.json
@@ -1323,11 +1323,8 @@
                         },
                         "unit": {
                           "type": "string",
-                          "enum": [
-                            "mg"
-                          ],
                           "nullable": false,
-                          "description": null
+                          "description": "Can be mg, ml or your unit of choice"
                         },
                         "system": {
                           "type": "string",
@@ -1338,10 +1335,8 @@
                         },
                         "code": {
                           "type": "string",
-                          "enum": [
-                            "mg"
-                          ],
-                          "nullable": false
+                          "nullable": false,
+                          "description": "Can be mg, ml or your unit of choice"
                         }
                       },
                       "nullable": false,


### PR DESCRIPTION
Some medicine doses aren't necessarily specified in mg. We fix this so our validations pass for any unit.
