### PR TITLE
Remove india prod capistrano deployment config

### DIFF
--- a/config/deploy/india/production.rb
+++ b/config/deploy/india/production.rb
@@ -1,7 +1,0 @@
-server "ec2-65-0-121-242.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db]
-server "ec2-3-6-43-89.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db]
-server "ec2-3-110-79-4.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app cron db]
-server "ec2-3-111-50-131.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db whitelist_phone_numbers]
-server "ec2-3-111-56-99.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web app db]
-server "ec2-3-110-91-74.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web sidekiq]
-server "ec2-43-205-92-179.ap-south-1.compute.amazonaws.com", user: "deploy", roles: %w[web sidekiq]


### PR DESCRIPTION
**Story card:** [sc-11227](https://app.shortcut.com/simpledotorg/story/11227)

## Because

India production environment is migrated to the new AWS EKS environment