### PR TITLE
import api: fix duplication of nested patient resources

### DIFF
--- a/app/services/bulk_api_import/fhir_importable.rb
+++ b/app/services/bulk_api_import/fhir_importable.rb
@@ -14,8 +14,8 @@ module BulkApiImport::FhirImportable
     }
   end
 
-  def translate_id(id)
-    Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, id)
+  def translate_id(id, ns_prefix: "")
+    Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE + ns_prefix, id)
   end
 
   def translate_facility_id(id)


### PR DESCRIPTION
Sending the same patient resource more than once (either on accident or for an attribute update) leads to the addresses, phone numbers and business identifiers being duplicated, because we are generating a new ID for them every time. We now ensure that these IDs are generated deterministically so that the resource merge merely updates these values rather than creating new instances.