### PR TITLE
Log BSNL token refresh failures

### DIFF
--- a/lib/tasks/scripts/refresh_bsnl_sms_jwt.rb
+++ b/lib/tasks/scripts/refresh_bsnl_sms_jwt.rb
@@ -25,6 +25,7 @@ class RefreshBsnlSmsJwt
       config = Configuration.find_or_create_by(name: "bsnl_sms_jwt")
       config.update!(value: jwt)
     else
+      Rails.logger.error("BSNL JWT token refresh failed with error #{response.message}")
       response.error!
     end
   end


### PR DESCRIPTION
**Story card:** [sc-11151](https://app.shortcut.com/simpledotorg/story/11151/bsnl-bug-add-alert-for-bsnl-token-refresh-failure)

## Because

We want to add a log-based alert for when the BSNL token refresh job fails.

## This addresses

This PR logs the error when a token refresh failure occurs.
