### PR TITLE
import api: validate incorrect observation codes

### DIFF
--- a/app/schema/api/v4/imports.rb
+++ b/app/schema/api/v4/imports.rb
@@ -1,4 +1,7 @@
 class Api::V4::Imports
+  ALLOWED_BP_CODES = %w[8480-6 8462-4]
+  ALLOWED_BS_CODES = %w[2339-0 87422-2 88365-2 4548-4]
+
   class << self
     def all_definitions
       {
@@ -257,7 +260,7 @@ class Api::V4::Imports
                          coding: {type: "array",
                                   items: codeable_concept(
                                     system: "http://loinc.org",
-                                    codes: %w[8480-6 8462-4],
+                                    codes: ALLOWED_BP_CODES,
                                     description: "8480-6 for Systolic, 8462-4 for Diastolic"
                                   ),
                                   nullable: false, minItems: 1, maxItems: 1}
@@ -319,7 +322,7 @@ class Api::V4::Imports
                          coding: {type: "array",
                                   items: codeable_concept(
                                     system: "http://loinc.org",
-                                    codes: %w[2339-0 87422-2 88365-2 4548-4],
+                                    codes: ALLOWED_BS_CODES,
                                     description: "2339-0 for random, \
                                                   87422-2 for post-prandial, \
                                                   88365-2 for fasting, \

--- a/spec/services/bulk_api_import/validator_spec.rb
+++ b/spec/services/bulk_api_import/validator_spec.rb
@@ -44,6 +44,27 @@ RSpec.describe BulkApiImport::Validator do
       end
     end
 
+    context "valid resources and valid facility ID, but invalid HTN observation codes" do
+      it "returns an error for unmapped facility IDs" do
+        bp_with_two_diastolic_codes = build_observation_import_resource(:blood_pressure).merge(
+          performer: [{identifier: facility_identifier.identifier}],
+          component: [
+            {code: {coding: [system: "http://loinc.org", code: "8462-4"]},
+             valueQuantity: blood_pressure_value_quantity(:systolic)},
+            {code: {coding: [system: "http://loinc.org", code: "8462-4"]},
+             valueQuantity: blood_pressure_value_quantity(:systolic)}
+          ]
+        )
+
+        expect(
+          described_class.new(
+            organization: organization.id,
+            resources: [bp_with_two_diastolic_codes]
+          ).validate
+        ).to have_key(:invalid_observation_codes_error)
+      end
+    end
+
     context "invalid resource" do
       it "returns a schema error" do
         expect(
@@ -108,6 +129,70 @@ RSpec.describe BulkApiImport::Validator do
                          .merge(performer: {identifier: facility_identifier.identifier})]
           ).validate_facilities
         ).to have_key(:invalid_facility_error)
+      end
+    end
+  end
+
+  describe "#validate_observation_codes" do
+    context "valid non-observation resources" do
+      it "does not return any error" do
+        expect(
+          described_class.new(
+            organization: organization.id,
+            resources: [build_medication_request_import_resource]
+          ).validate_observation_codes
+        ).to be_nil
+      end
+    end
+
+    context "valid observation resources" do
+      it "does not return any error" do
+        expect(
+          described_class.new(
+            organization: organization.id,
+            resources: [build_observation_import_resource(:blood_sugar)]
+          ).validate_observation_codes
+        ).to be_nil
+      end
+    end
+
+    context "invalid observation resources" do
+      it "returns an error highlighting any unknown codes" do
+        bp_with_unknown_code = build_observation_import_resource(:blood_pressure).merge(
+          performer: [{identifier: facility_identifier.identifier}],
+          component: [
+            {code: {coding: [system: "http://loinc.org", code: "foo"]},
+             valueQuantity: blood_pressure_value_quantity(:systolic)},
+            {code: {coding: [system: "http://loinc.org", code: "8462-4"]},
+             valueQuantity: blood_pressure_value_quantity(:diastolic)}
+          ]
+        )
+
+        expect(
+          described_class.new(
+            organization: organization.id,
+            resources: [bp_with_unknown_code]
+          ).validate_observation_codes[:invalid_observation_codes_error]
+        ).to include(invalid_observations: {bp_with_unknown_code[:identifier][0][:value] => %w[foo 8462-4]})
+      end
+
+      it "returns an error when an HTN code is duplicated" do
+        bp_with_duplicate_code = build_observation_import_resource(:blood_pressure).merge(
+          performer: [{identifier: facility_identifier.identifier}],
+          component: [
+            {code: {coding: [system: "http://loinc.org", code: "8480-6"]},
+             valueQuantity: blood_pressure_value_quantity(:systolic)},
+            {code: {coding: [system: "http://loinc.org", code: "8480-6"]},
+             valueQuantity: blood_pressure_value_quantity(:diastolic)}
+          ]
+        )
+
+        expect(
+          described_class.new(
+            organization: organization.id,
+            resources: [bp_with_duplicate_code]
+          ).validate_observation_codes[:invalid_observation_codes_error]
+        ).to include(invalid_observations: {bp_with_duplicate_code[:identifier][0][:value] => %w[8480-6 8480-6]})
       end
     end
   end


### PR DESCRIPTION
# Why

Our OpenAPI schema validator is not flexible enough to capture some edge cases for observation resources–namely, it is possible to pass in a blood pressure observation, with the systolic or diastolic code specified twice. This will cause a failure at the database constraint level. We instead validate this at the time of a request so that the user is immediately informed of this error, and the request is not propagated any further.

# The fix

We add new validations in our Imports API validator class. Any observation resource must satisfy either one of these conditions:
* It contains a single component that is a valid Blood Sugar measurement LOINC code.
* It contains two components, one of which is a valid systolic BP measurement and the other is a valid diastolic BP measurement.
