### PR TITLE
fix DHIS2 exporter spec ordering bug

### DIFF
--- a/config/initializers/country_config.rb
+++ b/config/initializers/country_config.rb
@@ -83,9 +83,7 @@ class CountryConfig
   }.with_indifferent_access.freeze
 
   class << self
-    include Memery
-
-    memoize def dhis2_data_elements
+    def dhis2_data_elements
       YAML.load_file(ENV.fetch("DHIS2_DATA_ELEMENTS_FILE")).with_indifferent_access
     end
   end

--- a/spec/exporters/dhis2/ethiopia_exporter_spec.rb
+++ b/spec/exporters/dhis2/ethiopia_exporter_spec.rb
@@ -50,7 +50,9 @@ describe Dhis2::EthiopiaExporter do
       end
 
       data_value_sets = double
-      allow(Dhis2.client).to receive(:data_value_sets).and_return(data_value_sets)
+      dhis2_client = double
+      allow(Dhis2).to receive(:client).and_return(dhis2_client)
+      allow(dhis2_client).to receive(:data_value_sets).and_return(data_value_sets)
       expect(data_value_sets).to receive(:bulk_create).with(data_values: expected_values[0])
       expect(data_value_sets).to receive(:bulk_create).with(data_values: expected_values[1])
       Dhis2::EthiopiaExporter.export


### PR DESCRIPTION
The DHIS2 exporter specs (BD and ET) don't play well with each other. For one, fetching the data elements file is a memoized call, which causes the tests to break if they are both running in the same process, because the file that was loaded first is always returned, regardless of the actual change in the `DHIS2_DATA_ELEMENTS_FILE` envvar. This probably went undetected for a while because the two specs ended up running in different test runners most of the time.

This enmity between the specs runs deeper, though. It turns out that our mock in the Ethiopia exporter spec does not protect us from a method call to `Dhis2.client`. When the Ethiopia exporter spec is run first, it's not an issue, because the `Dhis2` gem creates an empty configuration object, and the call to the `:client` method will assume an uncredentialed server and work fine.

But when the Bangladesh exporter spec is run first, it configures the `Dhis2` gem with an empty username-password combination. This value is _cached_. So when we get to the Ethiopia spec, where our client is mocked, the method invocation causes it to build a URI with an empty username-password combination which causes the underlying URI parsing library to throw an exception.

The fix for the latter is to make the client itself a double and not get into the hairy details of the `Dhis2` gem caching behaviour. May the specs live in harmony again.
