### PR TITLE
Set rails log level in production using env variable

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :info
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL") { "info" }
 
   # Use a different cache store in production.
   config.cache_store = if ENV["RAILS_CACHE_REDIS_URL"].present?


### PR DESCRIPTION
**Story card:** [sc-11295](https://app.shortcut.com/simpledotorg/story/11295)

## Because

Add the ability to control the rails log level using the environment variable

## This addresses
Change production log levels to error
