### PR TITLE
import api: fix patient name extraction

### DIFF
--- a/app/services/bulk_api_import/fhir_patient_importer.rb
+++ b/app/services/bulk_api_import/fhir_patient_importer.rb
@@ -28,7 +28,7 @@ class BulkApiImport::FhirPatientImporter
   def build_attributes
     {
       id: translate_id(identifier),
-      full_name: @resource.dig(:name, :value) || "Anonymous " + Faker::Name.first_name,
+      full_name: @resource.dig(:name, :text) || "Anonymous " + Faker::Name.first_name,
       gender: gender,
       status: status,
       date_of_birth: @resource[:birthDate],


### PR DESCRIPTION
There was a goof-up with name extraction. Staring at the deeply nested semi-uniform patterns of the FHIR spec has caused semantic satiation in this author which has introduced this bug in the patient importer, where instead of trying to extract `patient.name.text` for the name (as per the FHIR spec), the code is trying to extract `patient.name.value`, which always returns `nil`.

This is promptly fixed, with some unit tests that should have been there to catch this slip in the first place.