### PR TITLE
import api: fix incorrect permission of patient request

### DIFF
--- a/app/controllers/api/v4/imports_controller.rb
+++ b/app/controllers/api/v4/imports_controller.rb
@@ -49,13 +49,13 @@ class Api::V4::ImportsController < ApplicationController
       :birthDate,
       :deceasedBoolean,
       :telecom,
-      :name,
       :active,
+      name: [:text],
       meta: [:lastUpdated, :createdAt],
       identifier: [:value],
       managingOrganization: [:value],
       registrationOrganization: [:value],
-      address: [:line, :district, :city, :postalCode]
+      address: [:district, :city, :postalCode, line: []]
     )
   end
 


### PR DESCRIPTION
We should be permitting the nested `"text"` attribute inside the `"name"` attribute.
