### PR TITLE
Allow duplication of business identifiers for every org

### DIFF
--- a/app/controllers/api/v4/imports_controller.rb
+++ b/app/controllers/api/v4/imports_controller.rb
@@ -10,10 +10,10 @@ class Api::V4::ImportsController < ApplicationController
   def import
     return head :not_found unless Flipper.enabled?(:imports_api)
 
-    errors = BulkApiImport::Validator.new(organization: header_organization_id, resources: import_params).validate
+    errors = BulkApiImport::Validator.new(organization: organization_id, resources: import_params).validate
 
     unless Flipper.enabled?(:mock_imports_api)
-      BulkApiImportJob.perform_later(resources: import_params) unless errors.present?
+      BulkApiImportJob.perform_later(resources: import_params, organization_id: organization_id) unless errors.present?
     end
 
     response = {errors: errors}
@@ -131,12 +131,12 @@ class Api::V4::ImportsController < ApplicationController
 
   def validate_token_organization
     token_organization = MachineUser.find_by(id: doorkeeper_token.application&.owner_id)&.organization_id
-    unless token_organization.present? && token_organization == header_organization_id
+    unless token_organization.present? && token_organization == organization_id
       head :forbidden
     end
   end
 
-  def header_organization_id
+  def organization_id
     request.headers["HTTP_X_ORGANIZATION_ID"]
   end
 end

--- a/app/jobs/bulk_api_import_job.rb
+++ b/app/jobs/bulk_api_import_job.rb
@@ -1,5 +1,5 @@
 class BulkApiImportJob < ApplicationJob
-  def perform(resources:)
-    BulkApiImport::Importer.new(resource_list: resources).import
+  def perform(resources:, organization_id:)
+    BulkApiImport::Importer.new(resource_list: resources, organization_id: organization_id).import
   end
 end

--- a/app/services/bulk_api_import/fhir_appointment_importer.rb
+++ b/app/services/bulk_api_import/fhir_appointment_importer.rb
@@ -3,8 +3,9 @@ class BulkApiImport::FhirAppointmentImporter
 
   STATUS_MAPPING = {"pending" => "scheduled", "fulfilled" => "visited", "cancelled" => "cancelled"}
 
-  def initialize(appointment_resource)
-    @resource = appointment_resource
+  def initialize(resource:, organization_id:)
+    @resource = resource
+    @organization_id = organization_id
   end
 
   def import
@@ -25,8 +26,8 @@ class BulkApiImport::FhirAppointmentImporter
 
   def build_attributes
     {
-      id: translate_id(@resource.dig(:identifier, 0, :value)),
-      patient_id: translate_id(@resource.dig(:participant, 0, :actor, :identifier)),
+      id: translate_id(@resource.dig(:identifier, 0, :value), org_id: @organization_id),
+      patient_id: translate_id(@resource.dig(:participant, 0, :actor, :identifier), org_id: @organization_id),
       facility_id: facility_id,
       scheduled_date: scheduled_date,
       status: STATUS_MAPPING[@resource[:status]],
@@ -37,7 +38,7 @@ class BulkApiImport::FhirAppointmentImporter
   end
 
   def facility_id
-    @facility_id ||= translate_facility_id(@resource.dig(:appointmentOrganization, :identifier))
+    @facility_id ||= translate_facility_id(@resource.dig(:appointmentOrganization, :identifier), org_id: @organization_id)
   end
 
   def scheduled_date

--- a/app/services/bulk_api_import/fhir_condition_importer.rb
+++ b/app/services/bulk_api_import/fhir_condition_importer.rb
@@ -6,8 +6,9 @@ class BulkApiImport::FhirConditionImporter
     "73211009" => :diabetes
   }.with_indifferent_access
 
-  def initialize(condition_resource)
-    @resource = condition_resource
+  def initialize(resource:, organization_id:)
+    @resource = resource
+    @organization_id = organization_id
   end
 
   def import
@@ -25,8 +26,8 @@ class BulkApiImport::FhirConditionImporter
 
   def build_attributes
     {
-      id: translate_id(@resource.dig(:identifier, 0, :value)),
-      patient_id: translate_id(@resource[:subject][:identifier]),
+      id: translate_id(@resource.dig(:identifier, 0, :value), org_id: @organization_id),
+      patient_id: translate_patient_id(@resource[:subject][:identifier], org_id: @organization_id),
       prior_heart_attack: "unknown",
       prior_stroke: "unknown",
       chronic_kidney_disease: "unknown",

--- a/app/services/bulk_api_import/fhir_importable.rb
+++ b/app/services/bulk_api_import/fhir_importable.rb
@@ -14,11 +14,24 @@ module BulkApiImport::FhirImportable
     }
   end
 
-  def translate_id(id, ns_prefix: "")
-    Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE + ns_prefix, id)
+  def translate_id(id, org_id:, ns_prefix: "")
+    Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE + org_id + ns_prefix, id)
   end
 
-  def translate_facility_id(id)
-    FacilityBusinessIdentifier.find_by(identifier: id, identifier_type: :external_org_facility_id).facility.id
+  def translate_facility_id(id, org_id:)
+    FacilityBusinessIdentifier
+      .joins(facility: :facility_group)
+      .where(identifier_type: :external_org_facility_id,
+        facility_business_identifiers: {identifier: id},
+        facility_groups: {organization_id: org_id})
+      .take.facility.id
+  end
+
+  def translate_patient_id(id, org_id:)
+    translate_id(
+      id,
+      org_id: org_id,
+      ns_prefix: "patient_business_identifier"
+    )
   end
 end

--- a/app/services/bulk_api_import/fhir_importable.rb
+++ b/app/services/bulk_api_import/fhir_importable.rb
@@ -21,10 +21,10 @@ module BulkApiImport::FhirImportable
   def translate_facility_id(id, org_id:)
     FacilityBusinessIdentifier
       .joins(facility: :facility_group)
-      .where(identifier_type: :external_org_facility_id,
+      .find_by(identifier_type: :external_org_facility_id,
         facility_business_identifiers: {identifier: id},
         facility_groups: {organization_id: org_id})
-      .take.facility.id
+      .facility.id
   end
 
   def translate_patient_id(id, org_id:)

--- a/app/services/bulk_api_import/fhir_medication_request_importer.rb
+++ b/app/services/bulk_api_import/fhir_medication_request_importer.rb
@@ -8,8 +8,9 @@ class BulkApiImport::FhirMedicationRequestImporter
     QID: :QDS
   }.with_indifferent_access
 
-  def initialize(med_request_resource)
-    @resource = med_request_resource
+  def initialize(resource:, organization_id:)
+    @resource = resource
+    @organization_id = organization_id
   end
 
   def import
@@ -27,9 +28,9 @@ class BulkApiImport::FhirMedicationRequestImporter
 
   def build_attributes
     {
-      id: translate_id(@resource.dig(:identifier, 0, :value)),
-      patient_id: translate_id(@resource[:subject][:identifier]),
-      facility_id: translate_facility_id(@resource[:performer][:identifier]),
+      id: translate_id(@resource.dig(:identifier, 0, :value), org_id: @organization_id),
+      patient_id: translate_patient_id(@resource[:subject][:identifier], org_id: @organization_id),
+      facility_id: translate_facility_id(@resource[:performer][:identifier], org_id: @organization_id),
       is_protocol_drug: false,
       name: contained_medication[:code][:coding][0][:display],
       rxnorm_code: contained_medication[:code][:coding][0][:code],

--- a/app/services/bulk_api_import/fhir_observation_importer.rb
+++ b/app/services/bulk_api_import/fhir_observation_importer.rb
@@ -9,8 +9,9 @@ class BulkApiImport::FhirObservationImporter
                     "88365-2" => :fasting,
                     "4548-4" => :hba1c}
 
-  def initialize(observation_resource)
-    @resource = observation_resource
+  def initialize(resource:, organization_id:)
+    @resource = resource
+    @organization_id = organization_id
   end
 
   def import
@@ -41,9 +42,9 @@ class BulkApiImport::FhirObservationImporter
 
   def build_blood_pressure_attributes
     {
-      id: translate_id(@resource.dig(:identifier, 0, :value)),
-      patient_id: translate_id(@resource[:subject][:identifier]),
-      facility_id: translate_facility_id(@resource[:performer][0][:identifier]),
+      id: translate_id(@resource.dig(:identifier, 0, :value), org_id: @organization_id),
+      patient_id: translate_patient_id(@resource[:subject][:identifier], org_id: @organization_id),
+      facility_id: translate_facility_id(@resource[:performer][0][:identifier], org_id: @organization_id),
       user_id: import_user.id,
       recorded_at: @resource[:effectiveDateTime],
       **dig_blood_pressure,
@@ -61,9 +62,9 @@ class BulkApiImport::FhirObservationImporter
 
   def build_blood_sugar_attributes
     {
-      id: translate_id(@resource.dig(:identifier, 0, :value)),
-      patient_id: translate_id(@resource[:subject][:identifier]),
-      facility_id: translate_facility_id(@resource[:performer][0][:identifier]),
+      id: translate_id(@resource.dig(:identifier, 0, :value), org_id: @organization_id),
+      patient_id: translate_patient_id(@resource[:subject][:identifier], org_id: @organization_id),
+      facility_id: translate_facility_id(@resource[:performer][0][:identifier], org_id: @organization_id),
       user_id: import_user.id,
       recorded_at: @resource[:effectiveDateTime],
       **dig_blood_sugar,

--- a/app/services/bulk_api_import/importer.rb
+++ b/app/services/bulk_api_import/importer.rb
@@ -1,6 +1,7 @@
 class BulkApiImport::Importer
-  def initialize(resource_list:)
+  def initialize(resource_list:, organization_id:)
     @resources = resource_list
+    @organization_id = organization_id
   end
 
   IMPORTERS = {
@@ -13,13 +14,13 @@ class BulkApiImport::Importer
 
   def import
     @resources.each do |resource|
-      resource_importer(resource).import
+      resource_importer(resource, @organization_id).import
     end
   end
 
-  def resource_importer(resource)
+  def resource_importer(resource, organization_id)
     importer = IMPORTERS[resource[:resourceType]]
     raise NotImplementedError unless importer.present?
-    importer.new(resource)
+    importer.new(resource: resource, organization_id: organization_id)
   end
 end

--- a/spec/jobs/bulk_api_import_job_spec.rb
+++ b/spec/jobs/bulk_api_import_job_spec.rb
@@ -1,15 +1,15 @@
 require "rails_helper"
 
-RSpec.describe ImportFacilitiesJob do
+RSpec.describe BulkApiImportJob do
   include ActiveJob::TestHelper
   before { FactoryBot.create(:facility) } # needed for our bot import user
 
   describe "#perform_later" do
     let(:resource) { build_condition_import_resource }
-    let(:job) { BulkApiImportJob.perform_later(resources: [resource]) }
+    let(:job) { described_class.perform_later(resources: [resource], organization_id: "org_id") }
 
     it "queues the job" do
-      expect { job }.to have_enqueued_job(BulkApiImportJob).once.on_queue("default")
+      expect { job }.to have_enqueued_job(described_class).once.on_queue("default")
     end
 
     it "runs the importer" do

--- a/spec/services/bulk_api_import/fhir_importable_spec.rb
+++ b/spec/services/bulk_api_import/fhir_importable_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe BulkApiImport::FhirImportable do
   before { create(:facility) }
   let(:import_user) { ImportUser.find_or_create }
   let(:facility) { import_user.facility }
+  let(:org_id) { facility.organization_id }
   let(:facility_identifiers) do
     create(:facility_business_identifier, facility: facility, identifier_type: :external_org_facility_id)
   end
@@ -14,8 +15,21 @@ RSpec.describe BulkApiImport::FhirImportable do
 
   describe "#translate_facility_id" do
     it "translates the facility ID correctly" do
-      expect(Object.new.extend(described_class).translate_facility_id(facility_identifiers.identifier))
+      expect(Object.new.extend(described_class).translate_facility_id(facility_identifiers.identifier, org_id: org_id))
         .to eq(facility.id)
+    end
+
+    it "provides a different translation for a different organization having the same facility identifier" do
+      identifier_from_first_org = facility_identifiers.identifier
+      other_org = create(:organization, id: SecureRandom.uuid, name: "Another Org")
+      other_facility_group = create(:facility_group, organization: other_org)
+      other_facility = create(:facility, facility_group: other_facility_group)
+      create(:facility_business_identifier, identifier: identifier_from_first_org,
+             facility: other_facility, identifier_type: :external_org_facility_id)
+
+      expect(Object.new.extend(described_class)
+          .translate_facility_id(facility_identifiers.identifier, org_id: other_org.id))
+        .to eq(other_facility.id)
     end
   end
 

--- a/spec/services/bulk_api_import/fhir_patient_importer_spec.rb
+++ b/spec/services/bulk_api_import/fhir_patient_importer_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe BulkApiImport::FhirPatientImporter do
   before { create(:facility) }
   let(:import_user) { ImportUser.find_or_create }
+  let(:org_id) { import_user.organization_id }
   let(:facility) { import_user.facility }
   let(:facility_identifier) do
     create(:facility_business_identifier, facility: facility, identifier_type: :external_org_facility_id)
@@ -12,9 +13,10 @@ RSpec.describe BulkApiImport::FhirPatientImporter do
     it "imports a patient" do
       expect {
         described_class.new(
-          build_patient_import_resource
+          resource: build_patient_import_resource
             .merge(managingOrganization: [{value: facility_identifier.identifier}])
-            .except(:registrationOrganization)
+            .except(:registrationOrganization),
+          organization_id: org_id
         ).import
       }.to change(Patient, :count).by(1)
         .and change(PatientBusinessIdentifier, :count).by(1)
@@ -26,9 +28,10 @@ RSpec.describe BulkApiImport::FhirPatientImporter do
 
         expect {
           described_class.new(
-            patient_resource
+            resource: patient_resource
               .merge(managingOrganization: [{value: facility_identifier.identifier}])
-              .except(:registrationOrganization)
+              .except(:registrationOrganization),
+            organization_id: org_id
           ).import
         }.to change(Patient, :count).by(1)
           .and change(PatientBusinessIdentifier, :count).by(1)
@@ -36,9 +39,10 @@ RSpec.describe BulkApiImport::FhirPatientImporter do
 
         expect {
           described_class.new(
-            patient_resource
+            resource: patient_resource
               .merge(managingOrganization: [{value: facility_identifier.identifier}])
-              .except(:registrationOrganization)
+              .except(:registrationOrganization),
+            organization_id: org_id
           ).import
         }.to change(Patient, :count).by(0)
           .and change(PatientBusinessIdentifier, :count).by(0)
@@ -54,7 +58,8 @@ RSpec.describe BulkApiImport::FhirPatientImporter do
           .merge(managingOrganization: [{value: facility_identifier.identifier}])
           .except(:registrationOrganization)
 
-        attributes = described_class.new(patient_resource).build_attributes
+        attributes = described_class.new(resource: patient_resource, organization_id: org_id)
+          .build_attributes
           .merge(request_user_id: import_user)
 
         expect(Api::V3::PatientPayloadValidator.new(attributes)).to be_valid
@@ -71,7 +76,8 @@ RSpec.describe BulkApiImport::FhirPatientImporter do
           .merge(managingOrganization: [{value: facility_identifier.identifier}], gender: input)
           .except(:registrationOrganization)
 
-        expect(described_class.new(patient_resource).build_attributes[:gender]).to eq(expected)
+        expect(described_class.new(resource: patient_resource, organization_id: org_id).build_attributes[:gender])
+          .to eq(expected)
       end
     end
 
@@ -80,7 +86,8 @@ RSpec.describe BulkApiImport::FhirPatientImporter do
         .merge(managingOrganization: [{value: facility_identifier.identifier}], name: {text: "naem"})
         .except(:registrationOrganization)
 
-      expect(described_class.new(patient_resource).build_attributes[:full_name]).to eq("naem")
+      expect(described_class.new(resource: patient_resource, organization_id: org_id).build_attributes[:full_name])
+        .to eq("naem")
     end
 
     it "generates a name when not present in the resource" do
@@ -88,7 +95,8 @@ RSpec.describe BulkApiImport::FhirPatientImporter do
         .merge(managingOrganization: [{value: facility_identifier.identifier}])
         .except(:registrationOrganization, :name)
 
-      expect(described_class.new(patient_resource).build_attributes[:full_name]).to match(/Anonymous \w/)
+      expect(described_class.new(resource: patient_resource, organization_id: org_id).build_attributes[:full_name])
+        .to match(/Anonymous \w/)
     end
   end
 
@@ -100,7 +108,7 @@ RSpec.describe BulkApiImport::FhirPatientImporter do
         {input: {deceasedBoolean: false, active: true}, expected_value: "active"},
         {input: {deceasedBoolean: false, active: false}, expected_value: "inactive"}
       ].each do |input:, expected_value:|
-        expect(described_class.new(input).status).to eq(expected_value)
+        expect(described_class.new(resource: input, organization_id: org_id).status).to eq(expected_value)
       end
     end
   end
@@ -114,28 +122,33 @@ RSpec.describe BulkApiImport::FhirPatientImporter do
         {input: {identifier: [value: "foo"], telecom: [{use: "temp"}]}, expected_phone_type: "landline", expected_active: true},
         {input: {identifier: [value: "foo"], telecom: [{use: "old"}]}, expected_phone_type: "mobile", expected_active: false}
       ].each do |input:, expected_phone_type:, expected_active:|
-        expect(described_class.new(input).phone_numbers[0])
+        expect(described_class.new(resource: input, organization_id: org_id).phone_numbers[0])
           .to include(phone_type: expected_phone_type, active: expected_active)
       end
     end
   end
 
   describe "#address" do
-    specify do
-      expect(described_class.new({
-        identifier: [value: "foo"],
-        address: [{line: %w[a b],
-                   district: "xyz",
-                   state: "foo",
-                   postalCode: "000"}]
-      }).address).to include(street_address: "a\nb", district: "xyz", state: "foo", pin: "000")
+    it "correctly extracts address details" do
+      expect(
+        described_class.new(
+          resource: {
+            identifier: [value: "foo"],
+            address: [{line: %w[a b], district: "xyz", state: "foo", postalCode: "000"}]
+          },
+          organization_id: org_id
+        ).address
+      ).to include(street_address: "a\nb", district: "xyz", state: "foo", pin: "000")
     end
   end
 
   describe "#business_identifiers" do
-    specify do
-      expect(described_class.new({identifier: [{value: "abc"}]}).business_identifiers.first)
-        .to include(identifier: "abc", identifier_type: :external_import_id)
+    it "correctly extracts business identifiers" do
+      expect(
+        described_class.new(
+          resource: {identifier: [{value: "abc"}]}, organization_id: org_id
+        ).business_identifiers.first
+      ).to include(identifier: "abc", identifier_type: :external_import_id)
     end
   end
 end


### PR DESCRIPTION
**Story card:** sc-11347

An organization that is using the import API is forced to ensure that
their identifiers (for facilities and patients) do not clash with any
identifier chosen by other organizations. This is a bug we did not
intend to introduce, and was caused by us failing to include the
organization ID in our UUID hash when deriving our own resource IDs.

Thus our translation from partner org ID to Simple ID previously looked
like:

    UUIDv5(their_resource_ID) => Simple Resource ID

The issue is that if some Org1 has a Patient with ID of 1, and Org2 has
a Patient with ID of 2, they will be translated to the same UUID value
in Simple.

To fix this, we now have:

    UUIDv5(their_org_ID + their_resource_ID) => Simple Resource ID

which was the intended design.