### PR TITLE
Add options to configure Sidekiq log level

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -48,6 +48,8 @@ Sidekiq.configure_server do |config|
   SidekiqUniqueJobs::Server.configure(config)
 end
 
+Sidekiq.logger.level = Rails.logger.level
+
 Sidekiq::Throttled.setup!
 SidekiqUniqueJobs.configure do |config|
   config.enabled = !Rails.env.test?


### PR DESCRIPTION
**Story card:** [sc-11295](https://app.shortcut.com/simpledotorg/story/11295)

## Because

The Sidekiq log volume is huge due to the info log level

## This addresses

We've set the Sidekiq log level to 'error' in order to reduce the log volume