### PR TITLE
Import API: Validate existence of patients

### DIFF
--- a/spec/api/v4/imports/imports_spec.rb
+++ b/spec/api/v4/imports/imports_spec.rb
@@ -8,7 +8,11 @@ describe "Import v4 API", swagger_doc: "v4/import.json" do
     let(:facility_identifier) do
       create(:facility_business_identifier, facility: facility, identifier_type: :external_org_facility_id)
     end
-    let(:organization) { facility.facility_group.organization }
+    let(:patient) { create(:patient, assigned_facility: facility) }
+    let(:patient_identifier) do
+      create(:patient_business_identifier, patient: patient, identifier_type: :external_import_id)
+    end
+    let(:organization) { facility.organization }
     let(:machine_user) { FactoryBot.create(:machine_user, organization: organization) }
     let(:application) { FactoryBot.create(:oauth_application, owner: machine_user) }
     let(:token) {
@@ -29,7 +33,10 @@ describe "Import v4 API", swagger_doc: "v4/import.json" do
       response "202", "Accepted" do
         let(:HTTP_X_ORGANIZATION_ID) { organization.id }
         let(:Authorization) { "Bearer #{token.token}" }
-        let(:import_request) { {"resources" => [build_condition_import_resource]} }
+        let(:import_request) do
+          {"resources" => [build_condition_import_resource
+            .merge(subject: {identifier: patient_identifier.identifier})]}
+        end
         run_test!
       end
 

--- a/spec/requests/oauth_spec.rb
+++ b/spec/requests/oauth_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "OAuth Credentials", type: :request do
   context "import API" do
     before { Flipper.enable(:imports_api) }
+
     context "when unauthorized" do
       let(:resource) { build_condition_import_resource }
       it "fails with HTTP 401" do
@@ -16,8 +17,12 @@ RSpec.describe "OAuth Credentials", type: :request do
     end
 
     context "when authorization header present" do
-      let(:organization) { FactoryBot.create(:organization) }
-      let(:resource) { build_condition_import_resource }
+      let(:patient) { create(:patient) }
+      let(:patient_identifier) do
+        create(:patient_business_identifier, patient: patient, identifier_type: :external_import_id)
+      end
+      let(:organization) { patient.assigned_facility.organization }
+      let(:resource) { build_condition_import_resource.merge(subject: {identifier: patient_identifier.identifier}) }
       let(:machine_user) { FactoryBot.create(:machine_user, organization: organization) }
       let(:application) { FactoryBot.create(:oauth_application, owner: machine_user) }
       let(:token_write_scope) {
@@ -67,7 +72,7 @@ RSpec.describe "OAuth Credentials", type: :request do
         put "/api/v4/import",
           headers: {"Content-Type": "application/json",
                     Authorization: "Bearer " + token_write_scope.token,
-                    HTTP_X_ORGANIZATION_ID: SecureRandom.uuid},
+                    HTTP_X_ORGANIZATION_ID: "invalid_org_id"},
           params: {resources: [resource]}.to_json
 
         expect(response).to have_http_status(:forbidden)

--- a/spec/services/bulk_api_import/validator_spec.rb
+++ b/spec/services/bulk_api_import/validator_spec.rb
@@ -2,8 +2,12 @@ require "rails_helper"
 
 RSpec.describe BulkApiImport::Validator do
   let(:facility) { create(:facility) }
+  let(:patient) { create(:patient) }
   let(:facility_identifier) do
     create(:facility_business_identifier, facility: facility, identifier_type: :external_org_facility_id)
+  end
+  let(:patient_identifier) do
+    create(:patient_business_identifier, patient: patient, identifier_type: :external_import_id)
   end
   let(:organization) { facility.facility_group.organization }
 
@@ -14,7 +18,8 @@ RSpec.describe BulkApiImport::Validator do
           described_class.new(
             organization: organization.id,
             resources: [build_medication_request_import_resource
-                         .merge(performer: {identifier: facility_identifier.identifier})]
+                         .merge(performer: {identifier: facility_identifier.identifier},
+                           subject: {identifier: patient_identifier.identifier})]
           ).validate
         ).to be_nil
       end
@@ -26,7 +31,8 @@ RSpec.describe BulkApiImport::Validator do
           described_class.new(
             organization: organization.id,
             resources: [build_medication_request_import_resource
-                         .merge(performer: {identifier: "unmapped_identifier"})]
+                          .merge(performer: {identifier: "unmapped_identifier"},
+                            subject: {identifier: patient_identifier.identifier})]
           ).validate
         ).to have_key(:invalid_facility_error)
       end
@@ -44,10 +50,24 @@ RSpec.describe BulkApiImport::Validator do
       end
     end
 
+    context "valid resources and facility ID, but invalid patient ID" do
+      it "returns an error for unmapped patient IDs" do
+        expect(
+          described_class.new(
+            organization: organization.id,
+            resources: [build_medication_request_import_resource
+                          .merge(performer: {identifier: facility_identifier.identifier},
+                            subject: {identifier: "unmapped_patient"})]
+          ).validate
+        ).to have_key(:invalid_patient_error)
+      end
+    end
+
     context "valid resources and valid facility ID, but invalid HTN observation codes" do
-      it "returns an error for unmapped facility IDs" do
+      it "returns an error about invalid observation codes" do
         bp_with_two_diastolic_codes = build_observation_import_resource(:blood_pressure).merge(
           performer: [{identifier: facility_identifier.identifier}],
+          subject: {identifier: patient_identifier.identifier},
           component: [
             {code: {coding: [system: "http://loinc.org", code: "8462-4"]},
              valueQuantity: blood_pressure_value_quantity(:systolic)},
@@ -129,6 +149,44 @@ RSpec.describe BulkApiImport::Validator do
                          .merge(performer: {identifier: facility_identifier.identifier})]
           ).validate_facilities
         ).to have_key(:invalid_facility_error)
+      end
+    end
+  end
+
+  describe "#validate_patients" do
+    context "valid patient IDs" do
+      it "does not return any errors" do
+        expect(
+          described_class.new(
+            organization: organization.id,
+            resources: [build_medication_request_import_resource
+                          .merge(subject: {identifier: patient_identifier.identifier})]
+          ).validate_patients
+        ).to be_nil
+      end
+    end
+
+    context "invalid patient ID" do
+      it "returns an error for unmapped patient IDs" do
+        expect(
+          described_class.new(
+            organization: organization.id,
+            resources: [build_medication_request_import_resource
+                          .merge(subject: {identifier: "unmapped_identifier"})]
+          ).validate_patients
+        ).to have_key(:invalid_patient_error)
+      end
+    end
+
+    context "valid resources and valid patient ID, but incorrect organization" do
+      it "returns an error for unmapped facility IDs" do
+        expect(
+          described_class.new(
+            organization: "some_other_organization",
+            resources: [build_medication_request_import_resource
+                          .merge(subject: {identifier: patient_identifier.identifier})]
+          ).validate_patients
+        ).to have_key(:invalid_patient_error)
       end
     end
   end
@@ -249,6 +307,60 @@ RSpec.describe BulkApiImport::Validator do
             build_medication_request_import_resource.merge(performer: {identifier: "xyz"})
           ]
         ).medication_request_resource_facilities
+      ).to match_array(%w[abc xyz])
+    end
+  end
+
+  describe "resource patient extractors" do
+    it "extracts patients from appointment resources" do
+      expect(
+        described_class.new(
+          organization: "",
+          resources: [
+            build_appointment_import_resource
+              .merge(participant: [{actor: {identifier: "abc"}}]),
+            build_appointment_import_resource
+              .merge(participant: [{actor: {identifier: "xyz"}}])
+          ]
+        ).appointment_resource_patients
+      ).to match_array(%w[abc xyz])
+    end
+
+    it "extracts patients from observation resources" do
+      expect(
+        described_class.new(
+          organization: "",
+          resources: [
+            build_observation_import_resource(:blood_sugar).merge(subject: {identifier: "abc"}),
+            build_observation_import_resource(:blood_pressure).merge(subject: {identifier: "xyz"})
+          ]
+        ).observation_resource_patients
+      ).to match_array(%w[abc xyz])
+    end
+
+    it "extracts patients from medication request resources" do
+      expect(
+        described_class.new(
+          organization: "",
+          resources: [
+            build_medication_request_import_resource.merge(subject: {identifier: "abc"}),
+            build_medication_request_import_resource.merge(subject: {identifier: "xyz"})
+          ]
+        ).medication_request_resource_patients
+      ).to match_array(%w[abc xyz])
+    end
+
+    it "extracts patients from condition resources" do
+      expect(
+        described_class.new(
+          organization: "",
+          resources: [
+            build_condition_import_resource
+              .merge(subject: {identifier: "abc"}),
+            build_condition_import_resource
+              .merge(subject: {identifier: "xyz"})
+          ]
+        ).condition_resource_patients
       ).to match_array(%w[abc xyz])
     end
   end


### PR DESCRIPTION
**Story card:** [sc-11348]

We previously allowed dangling references to patients from its associated resources like appointments to allow integrators of the API to send resources in any order they please. But experience with testing the API on a sandbox has made it clear that the problem of dangling patient references is more pressing than we initially assumed. This change ensures that any dependent resource references a patient that already exists in the Simple database. It returns an error similar to the one about unmapped facility if this patient is not found.