### PR TITLE
Enable configuration of the Sentry sample rate using env

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,2 +1,3 @@
 Sentry.init do |config|
+  config.sample_rate = ENV.fetch("SENTRY_SAMPLE_RATE", 1.0).to_f
 end


### PR DESCRIPTION
Enable configuration of the Sentry sample rate using the env

**Story card:** [sc-11416](https://app.shortcut.com/simpledotorg/story/11416)

## Because
The monthly quota for Sentry events is being exhausted within 15 days of usage. To address this issue, we can reduce the sample rate

## This addresses
Implement a fix for the exhaustion of the Sentry monthly events quota by adjusting the sample rate
