### PR TITLE
import api: fix incorrect permission of medication request params

### DIFF
--- a/app/controllers/api/v4/imports_controller.rb
+++ b/app/controllers/api/v4/imports_controller.rb
@@ -101,7 +101,7 @@ class Api::V4::ImportsController < ApplicationController
       dosageInstruction: [
         [
           {
-            timing: {code: []},
+            timing: [:code],
             doseAndRate: [{
               doseQuantity: [:value, :unit, :system, :code]
             }]


### PR DESCRIPTION
The previous params did not correctly permit the frequency readings. We fix this.