### PR TITLE
Hotfix: Handle exception and log debug info while recording a visit on a treatment group membership

### DIFF
--- a/app/models/experimentation/treatment_group_membership.rb
+++ b/app/models/experimentation/treatment_group_membership.rb
@@ -63,7 +63,7 @@ module Experimentation
         **visit_status_fields
       )
     rescue NoMethodError
-      Rails.logger.error("Error recording visit: Membership id: #{self.id} Blood pressure: #{blood_pressure&.id} Blood sugar: #{blood_sugar&.id} Prescription drug: #{prescription_drug&.id}")
+      Rails.logger.error("Error recording visit: Membership id: #{id} Blood pressure: #{blood_pressure&.id} Blood sugar: #{blood_sugar&.id} Prescription drug: #{prescription_drug&.id}")
     end
 
     private

--- a/app/models/experimentation/treatment_group_membership.rb
+++ b/app/models/experimentation/treatment_group_membership.rb
@@ -62,6 +62,8 @@ module Experimentation
         days_to_visit: days_to_visit,
         **visit_status_fields
       )
+    rescue NoMethodError
+      Rails.logger.error("Error recording visit: Membership id: #{self.id} Blood pressure: #{blood_pressure&.id} Blood sugar: #{blood_sugar&.id} Prescription drug: #{prescription_drug&.id}")
     end
 
     private


### PR DESCRIPTION
**Story card:** [sc-11504](https://app.shortcut.com/simpledotorg/story/11504)

This is a hotfix for the bug where, when recording a visit on a treatment
group membership, a NoMethodError is raised when the facility
association on a visit doesn't exist for whatever reason. Details of the preliminary investigation are captured
in the card.

This fix handles the exception and logs some debugging information.