### PR TITLE
Add logging to the Imports Controller

### DIFF
--- a/app/controllers/api/v4/imports_controller.rb
+++ b/app/controllers/api/v4/imports_controller.rb
@@ -71,6 +71,7 @@ class Api::V4::ImportsController < ApplicationController
       meta: [:lastUpdated, :createdAt],
       identifier: [:value],
       appointmentOrganization: [:identifier],
+      appointmentCreationOrganization: [:identifier],
       participant: [
         actor: [:identifier]
       ]

--- a/spec/api/v4/imports/imports_spec.rb
+++ b/spec/api/v4/imports/imports_spec.rb
@@ -46,6 +46,13 @@ describe "Import v4 API", swagger_doc: "v4/import.json" do
         let(:import_request) { {"resources" => [{"invalid" => "invalid"}]} }
         run_test!
       end
+
+      response "403", "Forbidden" do
+        let(:HTTP_X_ORGANIZATION_ID) { "wrong_org" }
+        let(:Authorization) { "Bearer #{token.token}" }
+        let(:import_request) { {"resources" => [{"doesn't" => "matter"}]} }
+        run_test!
+      end
     end
   end
 end

--- a/spec/requests/api/imports/imports_request_spec.rb
+++ b/spec/requests/api/imports/imports_request_spec.rb
@@ -98,8 +98,18 @@ RSpec.describe "Import API", type: :request do
   end
 
   it "fails to import invalid resources" do
+    allow(Rails.logger).to receive(:info)
+
     put route, params: {resources: [invalid_payload]}.to_json, headers: headers
 
+    expect(Rails.logger).to have_received(:info).with(
+      hash_including(
+        msg: "import_api_error",
+        controller: "Api::V4::ImportsController",
+        action: "import",
+        organization_id: organization.id
+      )
+    )
     expect(response.status).to eq(400)
   end
 end


### PR DESCRIPTION
**Story card:** [sc-11514]

What we are logging:
* Failure modes from the Import Controller layer. Validation errors are logged.

Why we aren't logging the request payload:
* Not sure if we should, given it's PII. Can make a debug log if needed.
* Successful merges can be verified with the audit log.