### PR TITLE
import api: add status to medication

### DIFF
--- a/app/schema/api/v4/imports.rb
+++ b/app/schema/api/v4/imports.rb
@@ -417,7 +417,14 @@ class Api::V4::Imports
                           system: {type: :string,
                                    enum: ["http://www.nlm.nih.gov/research/umls/rxnorm"]},
                           code: {type: :string},
-                          display: {type: :string, description: "Name of medicine", nullable: false}
+                          display: {type: :string, description: "Name of medicine", nullable: false},
+                          status: {type: :string,
+                                   enum: %w[active inactive entered-in-error],
+                                   description: <<~DESCRIPTION,
+                                     If a prescribed medication has been replaced or removed for a patient 
+                                     (eg, during titration), ensure that it is marked as inactive.
+                                   DESCRIPTION
+                                   nullable: false}
                         },
                         required: ["display"]},
                 nullable: false,

--- a/app/services/bulk_api_import/fhir_medication_request_importer.rb
+++ b/app/services/bulk_api_import/fhir_medication_request_importer.rb
@@ -8,6 +8,12 @@ class BulkApiImport::FhirMedicationRequestImporter
     QID: :QDS
   }.with_indifferent_access
 
+  MEDICATION_STATUS_MAPPING = {
+    "active" => :active,
+    "inactive" => :inactive,
+    "entered-in-error" => :inactive
+  }
+
   def initialize(resource:, organization_id:)
     @resource = resource
     @organization_id = organization_id
@@ -37,7 +43,7 @@ class BulkApiImport::FhirMedicationRequestImporter
       frequency: frequency,
       duration_in_days: @resource.dig(:dispenseRequest, :expectedSupplyDuration, :value),
       dosage: dosage,
-      is_deleted: false,
+      is_deleted: drug_deleted?,
       **timestamps
     }.compact.with_indifferent_access
   end
@@ -57,5 +63,9 @@ class BulkApiImport::FhirMedicationRequestImporter
     else
       @resource.dig(:dosageInstruction, 0, :text)
     end
+  end
+
+  def drug_deleted?
+    MEDICATION_STATUS_MAPPING[contained_medication[:status]] == :inactive
   end
 end

--- a/spec/factories/import_resources/medication_requests.rb
+++ b/spec/factories/import_resources/medication_requests.rb
@@ -4,6 +4,7 @@ def build_medication_request_import_resource
   contained_medication = {
     resourceType: "Medication",
     id: Faker::Alphanumeric.alphanumeric,
+    status: %w[active inactive entered-in-error].sample,
     code: {
       coding: [{system: "http://www.nlm.nih.gov/research/umls/rxnorm",
                 code: Faker::Alphanumeric.alphanumeric,

--- a/spec/services/bulk_api_import/fhir_medication_request_importer_spec.rb
+++ b/spec/services/bulk_api_import/fhir_medication_request_importer_spec.rb
@@ -103,4 +103,17 @@ RSpec.describe BulkApiImport::FhirMedicationRequestImporter do
       end
     end
   end
+
+  describe "#drug_deleted?" do
+    it "infers drug deletion status" do
+      [
+        {status: "active", deletion_status: false},
+        {status: "inactive", deletion_status: true},
+        {status: "inactive", deletion_status: true}
+      ].each do |status:, deletion_status:|
+        expect(described_class.new(resource: {contained: [{status: status}]}, organization_id: "").drug_deleted?)
+          .to eq(deletion_status)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, there is no way to declare a prescription drug as `inactive` via the Import API. We use the contained medication's `status` field to indicate the same. This is required for reports like titration.

**Story card:** [sc-11562]
