### PR TITLE
spec reporting helpers: fix out of range month

### DIFF
--- a/spec/reporting_helpers.rb
+++ b/spec/reporting_helpers.rb
@@ -22,7 +22,7 @@ module ReportingHelpers
     {
       now: now,
       long_ago: now - 5.years,
-      under_12_months_ago: timezone.local(year - 1, month + 1, 1, 0, 0, 1),
+      under_12_months_ago: now - 11.months + 1.second,
       over_12_months_ago: now - 11.months - 1.second,
       month_string: "#{year}-#{"%02d" % month}",
       beginning_of_month: now,


### PR DESCRIPTION
This is a December special bug 🎁 . The month added to 13, which breaks the time construction. We instead try to match the original intent of the code by using ActiveSupport time arithmetic.

Example failure: https://simple.semaphoreci.com/workflows/3d2e4248-1cb5-4032-b862-4951ac4485b2/summary?pipeline_id=5d9b7866-fb0d-45fb-8552-9fbda1fb854f