### PR TITLE
 Fix XSS vulnerability on new district page

### DIFF
--- a/app/assets/javascripts/common/facility_group_block_fields.js
+++ b/app/assets/javascripts/common/facility_group_block_fields.js
@@ -13,9 +13,14 @@ FacilityGroupBlockFields = function() {
     return $template;
   }
 
+  this.sanitizeInput = (input) => {
+    return $("<div/>").text(input).html();
+  }
+
   this.submitAddBlock = () => {
     let $blockInput = $("#new-block-name")
-    this.addBlock($blockInput.val());
+    let $blockName = this.sanitizeInput($blockInput.val());
+    this.addBlock($blockName);
     $blockInput.val("");
     this.scrollBlockListToBottom();
   }

--- a/app/assets/javascripts/common/facility_group_block_fields.js
+++ b/app/assets/javascripts/common/facility_group_block_fields.js
@@ -2,7 +2,7 @@ FacilityGroupBlockFields = function() {
   this.newBlockRow = (name) => {
     let template = $("template#block-row").html()
     let $template = $(template);
-    $template.find(".block-name").html(name);
+    $template.find(".block-name").text(name);
     $template.attr("data-block-identifier", name);
     $template.find(".remove-block").attr("data-block-identifier", name);
     $template.find(".remove-block").attr(

--- a/app/assets/javascripts/common/facility_teleconsult_fields.js
+++ b/app/assets/javascripts/common/facility_teleconsult_fields.js
@@ -12,9 +12,9 @@ FacilityTeleconsultFields = function () {
     let userID = user["userId"];
 
     $card.find(".medical-officer-id").val(userID);
-    $card.find(".medical-officer-name").html(user["userFullName"]);
-    $card.find(".medical-officer-registration-facility").html(user["userRegistrationFacility"]);
-    $card.find(".medical-officer-phone-number").html(user["userTeleconsultationPhoneNumber"]);
+    $card.find(".medical-officer-name").text(user["userFullName"]);
+    $card.find(".medical-officer-registration-facility").text(user["userRegistrationFacility"]);
+    $card.find(".medical-officer-phone-number").text(user["userTeleconsultationPhoneNumber"]);
     $card.find("[data-user-id]").attr("data-user-id", userID);
     $card.attr("data-user-id", userID);
     $card.find("a").attr("href", `/admin/users/${userID}/edit`);

--- a/app/assets/javascripts/common/regions_search.js
+++ b/app/assets/javascripts/common/regions_search.js
@@ -17,7 +17,7 @@ RegionsSearch = function () {
   this.noResultsFound = (searchQuery) => {
     let html = $("template.no-results-found").html();
     let $html = $(html);
-    $html.find(".search-query").html(searchQuery);
+    $html.find(".search-query").text(searchQuery);
 
     return $html;
   }

--- a/app/assets/javascripts/common/regions_search.js
+++ b/app/assets/javascripts/common/regions_search.js
@@ -16,7 +16,7 @@ RegionsSearch = function () {
   }
 
   this.sanitizeInput = (input) => {
-    return $("<div/>").html(input).text()
+    return $("<div/>").text(input).html()
   }
 
   this.noResultsFound = (searchQuery) => {

--- a/app/assets/javascripts/common/regions_search.js
+++ b/app/assets/javascripts/common/regions_search.js
@@ -1,6 +1,7 @@
 RegionsSearch = function () {
+
   this.resultToRow = (searchQuery, result) => {
-    const name = result["name"]
+    const name = this.sanitizeInput(result["name"])
     const regex = new RegExp(searchQuery, "ig")
     const highlightedName = name.replace(regex, "<strong class='bg-yellow-light'>$&</strong>")
 
@@ -9,9 +10,13 @@ RegionsSearch = function () {
 
     let link = $html.find("a")
     link.prepend(highlightedName)
-    $html.find(".subtitle").append(result["subtitle"])
+    $html.find(".subtitle").append(this.sanitizeInput(result["subtitle"]))
     link.attr("href", result["link"])
     return $html
+  }
+
+  this.sanitizeInput = (input) => {
+    return $("<div/>").html(input).text()
   }
 
   this.noResultsFound = (searchQuery) => {

--- a/app/assets/javascripts/common/user_teleconsult_search.js
+++ b/app/assets/javascripts/common/user_teleconsult_search.js
@@ -18,7 +18,7 @@ UserTeleconsultSearch = function () {
   this.noUsersFound = (searchQuery) => {
     let html = $("template#user-search-no-results-found").html();
     let $html = $(html);
-    $html.find(".search-query").html(searchQuery);
+    $html.find(".search-query").text(searchQuery);
 
     return $html;
   }

--- a/app/assets/javascripts/common/user_teleconsult_search.js
+++ b/app/assets/javascripts/common/user_teleconsult_search.js
@@ -5,14 +5,18 @@ UserTeleconsultSearch = function () {
 
     $html.attr({
       "data-user-id": user["id"],
-      "data-user-full-name": user["full_name"],
-      "data-user-registration-facility": user["registration_facility"],
-      "data-user-teleconsultation-phone-number": user["teleconsultation_phone_number"]
+      "data-user-full-name": this.sanitizeString(user["full_name"]),
+      "data-user-registration-facility": this.sanitizeString(user["registration_facility"]),
+      "data-user-teleconsultation-phone-number": this.sanitizeString(user["teleconsultation_phone_number"])
     })
     $html.find(".user-full-name").text(user["full_name"])
     $html.find(".user-registration-facility").text(user["registration_facility"])
 
     return $html;
+  }
+
+  this.sanitizeString = (string) => {
+    return $("<div/>").text(string).html();
   }
 
   this.noUsersFound = (searchQuery) => {

--- a/spec/features/admin/facilities/new_spec.rb
+++ b/spec/features/admin/facilities/new_spec.rb
@@ -1,0 +1,24 @@
+require "features_helper"
+
+RSpec.feature "New facility page functionality", type: :feature do
+  let(:admin) { create(:admin, :power_user) }
+  new_facility_page = AdminPage::Facilities::New.new
+
+  context "teleconsultation enabled" do
+    before(:each) do
+      facility_group = create(:facility_group, organization: create(:organization))
+      visit root_path
+      sign_in(admin.email_authentication)
+      visit new_admin_facility_group_facility_path(facility_group.id)
+      new_facility_page.enable_teleconsultation
+    end
+    it "escapes html tags in the user teleconsulation search" do
+      search_query = "<script>alert('hi')</script>"
+      expect {
+        accept_prompt do
+          new_facility_page.search_user(search_query)
+        end
+      }.to raise_error(Capybara::ModalNotFound, "Unable to find modal dialog")
+    end
+  end
+end

--- a/spec/features/admin/facility_groups/new_spec.rb
+++ b/spec/features/admin/facility_groups/new_spec.rb
@@ -1,0 +1,27 @@
+require "features_helper"
+
+RSpec.feature "New facility group page functionality", type: :feature do
+  let(:admin) { create(:admin, :power_user) }
+  facility_group_page = AdminPage::FacilityGroups::New.new
+
+  context "within the new facility group page" do
+    before(:each) do
+      visit root_path
+      sign_in(admin.email_authentication)
+    end
+
+    it "does not execute malicious input when adding a block" do
+      organization = create(:organization)
+      create(:facility_group, organization: organization)
+      visit new_admin_facility_group_path
+
+      block_name = "<script>alert('hi')</script>"
+
+      expect {
+        accept_prompt do
+          facility_group_page.add_new_block(block_name)
+        end
+      }.to raise_error(Capybara::ModalNotFound, "Unable to find modal dialog")
+    end
+  end
+end

--- a/spec/features/admin/facility_groups/new_spec.rb
+++ b/spec/features/admin/facility_groups/new_spec.rb
@@ -4,13 +4,13 @@ RSpec.feature "New facility group page functionality", type: :feature do
   let(:admin) { create(:admin, :power_user) }
   facility_group_page = AdminPage::FacilityGroups::New.new
 
-  context "within the new facility group page" do
+  context "add new block" do
     before(:each) do
       visit root_path
       sign_in(admin.email_authentication)
     end
 
-    it "does not execute malicious input when adding a block" do
+    it "escapes html tags in the input" do
       organization = create(:organization)
       create(:facility_group, organization: organization)
       visit new_admin_facility_group_path

--- a/spec/features/my_facilities/index_spec.rb
+++ b/spec/features/my_facilities/index_spec.rb
@@ -1,0 +1,33 @@
+require "features_helper"
+
+RSpec.feature "My facilities page functionality", type: :feature do
+  let(:admin) { create(:admin, :power_user) }
+  my_facilities_page = MyFacilitiesPage::Index.new
+
+  context "region search bar" do
+    before(:each) do
+      visit root_path
+      sign_in(admin.email_authentication)
+    end
+    it "sanitizes the search query" do
+      create(:facility)
+      visit my_facilities_overview_path
+      search_query = "<script>alert('hi')</script>"
+      expect {
+        accept_prompt do
+          my_facilities_page.search_region(search_query)
+        end
+      }.to raise_error(Capybara::ModalNotFound, "Unable to find modal dialog")
+    end
+    it "sanitizes fields of search result facilities" do
+      search_query = "<script>alert('hi')</script>"
+      create(:facility, name: search_query)
+      visit my_facilities_overview_path
+      expect {
+        accept_prompt do
+          my_facilities_page.search_region("<script>")
+        end
+      }.to raise_error(Capybara::ModalNotFound, "Unable to find modal dialog")
+    end
+  end
+end

--- a/spec/pages/admin/facilities/new.rb
+++ b/spec/pages/admin/facilities/new.rb
@@ -1,0 +1,16 @@
+module AdminPage
+  module Facilities
+    class New < ApplicationPage
+      TELECONSULTATION_CHECKBOX = {id: "facility_enable_teleconsultation"}
+      USER_SEARCH_BOX = {id: "search_query"}
+
+      def enable_teleconsultation
+        check(TELECONSULTATION_CHECKBOX)
+      end
+
+      def search_user(search_query)
+        type(USER_SEARCH_BOX, search_query)
+      end
+    end
+  end
+end

--- a/spec/pages/admin/facility_groups/new.rb
+++ b/spec/pages/admin/facility_groups/new.rb
@@ -9,7 +9,7 @@ module AdminPage
       SUCCESSFUL_MESSAGE = {css: "div.alert-primary"}.freeze
       MESSAGE_CROSS_BUTTON = {css: "button.close"}.freeze
       UPDATE_FACILITY_GROUP_BUTTON = {css: "input[value='Save district']"}.freeze
-      BLOCK_INPUT_FIELD = {id: "new_block_name"}.freeze
+      BLOCK_INPUT_FIELD = {id: "new-block-name"}.freeze
       ADD_BLOCK_BUTTON = {css: ".input-group-append>a.add-block"}
 
       def select_organisation_name_dropdown(value)
@@ -59,7 +59,7 @@ module AdminPage
       end
 
       def add_new_block(block_name)
-        fill_in("Add new block", with: block_name)
+        type(BLOCK_INPUT_FIELD, block_name)
         click(ADD_BLOCK_BUTTON)
       end
     end

--- a/spec/pages/admin/facility_groups/new.rb
+++ b/spec/pages/admin/facility_groups/new.rb
@@ -9,6 +9,8 @@ module AdminPage
       SUCCESSFUL_MESSAGE = {css: "div.alert-primary"}.freeze
       MESSAGE_CROSS_BUTTON = {css: "button.close"}.freeze
       UPDATE_FACILITY_GROUP_BUTTON = {css: "input[value='Save district']"}.freeze
+      BLOCK_INPUT_FIELD = {id: "new_block_name"}.freeze
+      ADD_BLOCK_BUTTON = {css: ".input-group-append>a.add-block"}
 
       def select_organisation_name_dropdown(value)
         find(:xpath, "//select[@name='facility_group[organization_id]']").find(:option, value).select_option
@@ -54,6 +56,11 @@ module AdminPage
 
       def click_on_update_facility_group_button
         click(UPDATE_FACILITY_GROUP_BUTTON)
+      end
+
+      def add_new_block(block_name)
+        fill_in("Add new block", with: block_name)
+        click(ADD_BLOCK_BUTTON)
       end
     end
   end

--- a/spec/pages/my_facilities/index.rb
+++ b/spec/pages/my_facilities/index.rb
@@ -1,0 +1,9 @@
+module MyFacilitiesPage
+  class Index < ApplicationPage
+    SEARCH_BAR = {id: "search_query"}
+
+    def search_region(query)
+      type(SEARCH_BAR, query)
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-11561](https://app.shortcut.com/simpledotorg/story/11561/fix-xss-vulnerability-on-new-district-page)

## Because

The `Add block` input field on the `new district` page has an XSS vulnerability due to the use of the [.html](https://api.jquery.com/html/) JQuery method to insert user input into HTML elements. So if the user input contains malicious code, it will get executed.

A couple of other places with this vulnerability:
- The region search bar, used in a couple of places, like /my_facilities
- On the edit facility page (/admin/facilities > facility name > Edit facility), in the search bar under the title `Medical officers available for teleconsultation` when you check `Teleconsultation enabled?`

## This addresses

This PR changes all the [.html](https://api.jquery.com/html/) JQuery methods to .text while inserting user input.
For hygiene, it also sanitizes input given to methods such as .prepend and .append, that also injest html strings.

## Test instructions
None of these should execute input with html

- New facility page
  - Go to /admin/facility_groups/<facility_group>/facilities/new
  - Check "Enable teleconsultation"
  - Input a small script like "<script>alert("hi"</script>" in the search field to find medical officers
- New district page
  - Go to /admin/facility_groups/new
  - Input some html in the 'Add new block' search field
  - Click on 'Add'
- My Faclities / Reports page
  - Go to /my_facilities, /reports/regions, or any region's dashboard
  - Input some html in the region search bar on top
- Region search with bad facility name
  - Create a facility with html tags in its name
  - Go to a page with the region search bar
  - Searc for the facility name