### PR TITLE
import user: separate users from multiple orgs

### DIFF
--- a/app/services/bulk_api_import/fhir_appointment_importer.rb
+++ b/app/services/bulk_api_import/fhir_appointment_importer.rb
@@ -6,6 +6,7 @@ class BulkApiImport::FhirAppointmentImporter
   def initialize(resource:, organization_id:)
     @resource = resource
     @organization_id = organization_id
+    @import_user = find_or_create_import_user(organization_id)
   end
 
   def import
@@ -16,12 +17,12 @@ class BulkApiImport::FhirAppointmentImporter
     appointment = Appointment.merge(transformed_params)
     appointment.update_patient_status
 
-    AuditLog.merge_log(import_user, appointment) if appointment.present?
+    AuditLog.merge_log(@import_user, appointment) if appointment.present?
     appointment
   end
 
   def request_metadata
-    {user_id: import_user.id}
+    {user_id: @import_user.id}
   end
 
   def build_attributes

--- a/app/services/bulk_api_import/fhir_condition_importer.rb
+++ b/app/services/bulk_api_import/fhir_condition_importer.rb
@@ -9,6 +9,7 @@ class BulkApiImport::FhirConditionImporter
   def initialize(resource:, organization_id:)
     @resource = resource
     @organization_id = organization_id
+    @import_user = find_or_create_import_user(organization_id)
   end
 
   def import
@@ -16,12 +17,12 @@ class BulkApiImport::FhirConditionImporter
       .then { Api::V3::MedicalHistoryTransformer.from_request(_1).merge(metadata) }
       .then { MedicalHistory.merge(_1) }
 
-    AuditLog.merge_log(import_user, merge_result) if merge_result.present?
+    AuditLog.merge_log(@import_user, merge_result) if merge_result.present?
     merge_result
   end
 
   def metadata
-    {user_id: import_user.id}
+    {user_id: @import_user.id}
   end
 
   def build_attributes

--- a/app/services/bulk_api_import/fhir_importable.rb
+++ b/app/services/bulk_api_import/fhir_importable.rb
@@ -1,6 +1,6 @@
 module BulkApiImport::FhirImportable
-  def import_user
-    ImportUser.find_or_create
+  def find_or_create_import_user(org_id)
+    ImportUser.find_or_create(org_id: org_id)
   end
 
   def import

--- a/app/services/bulk_api_import/fhir_medication_request_importer.rb
+++ b/app/services/bulk_api_import/fhir_medication_request_importer.rb
@@ -17,6 +17,7 @@ class BulkApiImport::FhirMedicationRequestImporter
   def initialize(resource:, organization_id:)
     @resource = resource
     @organization_id = organization_id
+    @import_user = find_or_create_import_user(organization_id)
   end
 
   def import
@@ -24,12 +25,12 @@ class BulkApiImport::FhirMedicationRequestImporter
       .then { Api::V3::PrescriptionDrugTransformer.from_request(_1).merge(metadata) }
       .then { PrescriptionDrug.merge(_1) }
 
-    AuditLog.merge_log(import_user, merge_result) if merge_result.present?
+    AuditLog.merge_log(@import_user, merge_result) if merge_result.present?
     merge_result
   end
 
   def metadata
-    {user_id: import_user.id}
+    {user_id: @import_user.id}
   end
 
   def build_attributes

--- a/app/services/bulk_api_import/fhir_observation_importer.rb
+++ b/app/services/bulk_api_import/fhir_observation_importer.rb
@@ -12,6 +12,7 @@ class BulkApiImport::FhirObservationImporter
   def initialize(resource:, organization_id:)
     @resource = resource
     @organization_id = organization_id
+    @import_user = find_or_create_import_user(organization_id)
   end
 
   def import
@@ -24,7 +25,7 @@ class BulkApiImport::FhirObservationImporter
       raise "unknown observation type"
     end
 
-    AuditLog.merge_log(import_user, merge_result) if merge_result.present?
+    AuditLog.merge_log(@import_user, merge_result) if merge_result.present?
     merge_result
   end
 
@@ -45,7 +46,7 @@ class BulkApiImport::FhirObservationImporter
       id: translate_id(@resource.dig(:identifier, 0, :value), org_id: @organization_id),
       patient_id: translate_id(@resource[:subject][:identifier], org_id: @organization_id),
       facility_id: translate_facility_id(@resource[:performer][0][:identifier], org_id: @organization_id),
-      user_id: import_user.id,
+      user_id: @import_user.id,
       recorded_at: @resource[:effectiveDateTime],
       **dig_blood_pressure,
       **timestamps
@@ -65,7 +66,7 @@ class BulkApiImport::FhirObservationImporter
       id: translate_id(@resource.dig(:identifier, 0, :value), org_id: @organization_id),
       patient_id: translate_id(@resource[:subject][:identifier], org_id: @organization_id),
       facility_id: translate_facility_id(@resource[:performer][0][:identifier], org_id: @organization_id),
-      user_id: import_user.id,
+      user_id: @import_user.id,
       recorded_at: @resource[:effectiveDateTime],
       **dig_blood_sugar,
       **timestamps
@@ -88,6 +89,6 @@ class BulkApiImport::FhirObservationImporter
 
   # For compatibility with SyncEncounterObservation
   def current_user
-    import_user
+    @import_user
   end
 end

--- a/app/services/import_user.rb
+++ b/app/services/import_user.rb
@@ -1,16 +1,20 @@
 class ImportUser
   IMPORT_USER_PHONE_NUMBER = "0000000001"
 
-  def self.find_or_create
-    find || create
+  def self.find_or_create(org_id:)
+    find(org_id) || create(org_id)
   end
 
-  def self.find
-    PhoneNumberAuthentication.find_by(phone_number: IMPORT_USER_PHONE_NUMBER)&.user
+  def self.find(org_id)
+    PhoneNumberAuthentication.joins(:user)
+      .find_by(phone_number: IMPORT_USER_PHONE_NUMBER, user: {organization_id: org_id})&.user
   end
 
-  def self.create
-    facility = Facility.first
+  def self.create(org_id)
+    facility = Organization.find_by(id: org_id).facilities.first
+    unless facility.present?
+      raise ArgumentError, "given organization: #{org_id} does not exist or has no facilities"
+    end
 
     user = User.new(
       full_name: "import-user",

--- a/app/services/patient_import/importer.rb
+++ b/app/services/patient_import/importer.rb
@@ -52,7 +52,7 @@ class PatientImport::Importer
   def import_patient(params)
     MergePatientService.new(params, request_metadata: {
       request_facility_id: facility.id,
-      request_user_id: ImportUser.find_or_create.id
+      request_user_id: ImportUser.find_or_create(org_id: facility.organization_id).id
     }).merge
   end
 
@@ -79,6 +79,6 @@ class PatientImport::Importer
 
   # SyncEncounterObservation compability
   def current_user
-    ImportUser.find_or_create
+    ImportUser.find_or_create(org_id: facility.organization_id)
   end
 end

--- a/app/services/patient_import/spreadsheet_transformer.rb
+++ b/app/services/patient_import/spreadsheet_transformer.rb
@@ -217,7 +217,7 @@ module PatientImport
     end
 
     def import_user
-      @import_user = ImportUser.find_or_create
+      @import_user = ImportUser.find_or_create(org_id: facility.organization_id)
     end
 
     def patient_status(row)

--- a/spec/jobs/bulk_api_import_job_spec.rb
+++ b/spec/jobs/bulk_api_import_job_spec.rb
@@ -2,11 +2,11 @@ require "rails_helper"
 
 RSpec.describe BulkApiImportJob do
   include ActiveJob::TestHelper
-  before { FactoryBot.create(:facility) } # needed for our bot import user
+  let(:facility) { create(:facility) }
 
   describe "#perform_later" do
     let(:resource) { build_condition_import_resource }
-    let(:job) { described_class.perform_later(resources: [resource], organization_id: "org_id") }
+    let(:job) { described_class.perform_later(resources: [resource], organization_id: facility.organization_id) }
 
     it "queues the job" do
       expect { job }.to have_enqueued_job(described_class).once.on_queue("default")

--- a/spec/services/bulk_api_import/fhir_appointment_importer_spec.rb
+++ b/spec/services/bulk_api_import/fhir_appointment_importer_spec.rb
@@ -1,10 +1,9 @@
 require "rails_helper"
 
 RSpec.describe BulkApiImport::FhirAppointmentImporter do
-  before { create(:facility) }
-  let(:import_user) { ImportUser.find_or_create }
-  let(:org_id) { import_user.organization_id }
-  let(:facility) { import_user.facility }
+  let(:facility) { create(:facility) }
+  let(:org_id) { facility.organization_id }
+  let(:import_user) { ImportUser.find_or_create(org_id: org_id) }
   let(:facility_identifiers) do
     create(:facility_business_identifier, facility: facility, identifier_type: :external_org_facility_id)
   end

--- a/spec/services/bulk_api_import/fhir_condition_importer_spec.rb
+++ b/spec/services/bulk_api_import/fhir_condition_importer_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe BulkApiImport::FhirConditionImporter do
-  before { create(:facility) }
-  let(:import_user) { ImportUser.find_or_create }
-  let(:org_id) { import_user.organization_id }
+  let(:facility) { create(:facility) }
+  let(:org_id) { facility.organization_id }
+  let(:import_user) { ImportUser.find_or_create(org_id: org_id) }
   let(:identifier) { SecureRandom.uuid }
   let(:patient) do
     build_stubbed(:patient, id: Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE + org_id, identifier))

--- a/spec/services/bulk_api_import/fhir_importable_spec.rb
+++ b/spec/services/bulk_api_import/fhir_importable_spec.rb
@@ -1,16 +1,15 @@
 require "rails_helper"
 
 RSpec.describe BulkApiImport::FhirImportable do
-  before { create(:facility) }
-  let(:import_user) { ImportUser.find_or_create }
-  let(:facility) { import_user.facility }
+  let(:facility) { create(:facility) }
   let(:org_id) { facility.organization_id }
+  let(:import_user) { ImportUser.find_or_create(org_id: org_id) }
   let(:facility_identifiers) do
     create(:facility_business_identifier, facility: facility, identifier_type: :external_org_facility_id)
   end
 
-  describe "#import_user" do
-    specify { expect(Object.new.extend(described_class).import_user).to eq(import_user) }
+  describe "#find_or_create_import_user" do
+    specify { expect(Object.new.extend(described_class).find_or_create_import_user(org_id)).to eq(import_user) }
   end
 
   describe "#translate_facility_id" do

--- a/spec/services/bulk_api_import/fhir_medication_request_importer_spec.rb
+++ b/spec/services/bulk_api_import/fhir_medication_request_importer_spec.rb
@@ -1,10 +1,9 @@
 require "rails_helper"
 
 RSpec.describe BulkApiImport::FhirMedicationRequestImporter do
-  before { create(:facility) }
-  let(:import_user) { ImportUser.find_or_create }
-  let(:facility) { import_user.facility }
+  let(:facility) { create(:facility) }
   let(:org_id) { facility.organization_id }
+  let(:import_user) { ImportUser.find_or_create(org_id: org_id) }
   let(:facility_identifier) do
     create(:facility_business_identifier, facility: facility, identifier_type: :external_org_facility_id)
   end
@@ -48,7 +47,7 @@ RSpec.describe BulkApiImport::FhirMedicationRequestImporter do
 
   describe "#contained_medication" do
     it "fetches the contained medication" do
-      expect(described_class.new(resource: {contained: [{code: {}}]}, organization_id: "").contained_medication)
+      expect(described_class.new(resource: {contained: [{code: {}}]}, organization_id: org_id).contained_medication)
         .to eq({code: {}})
     end
   end
@@ -65,7 +64,7 @@ RSpec.describe BulkApiImport::FhirMedicationRequestImporter do
           resource: {
             dosageInstruction: [{timing: {code: input_code}}]
           },
-          organization_id: ""
+          organization_id: org_id
         ).frequency).to eq(expected_value)
       end
     end
@@ -111,7 +110,7 @@ RSpec.describe BulkApiImport::FhirMedicationRequestImporter do
         {status: "inactive", deletion_status: true},
         {status: "inactive", deletion_status: true}
       ].each do |status:, deletion_status:|
-        expect(described_class.new(resource: {contained: [{status: status}]}, organization_id: "").drug_deleted?)
+        expect(described_class.new(resource: {contained: [{status: status}]}, organization_id: org_id).drug_deleted?)
           .to eq(deletion_status)
       end
     end

--- a/spec/services/bulk_api_import/fhir_observation_importer_spec.rb
+++ b/spec/services/bulk_api_import/fhir_observation_importer_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe BulkApiImport::FhirObservationImporter do
-  before { create(:facility) }
-  let(:import_user) { ImportUser.find_or_create }
-  let(:facility) { import_user.facility }
+  let(:facility) { create(:facility) }
+  let(:org_id) { facility.organization_id }
+  let(:import_user) { ImportUser.find_or_create(org_id: org_id) }
   let(:org_id) { facility.organization_id }
   let(:facility_identifier) do
     create(:facility_business_identifier, facility: facility, identifier_type: :external_org_facility_id)

--- a/spec/services/bulk_api_import/fhir_patient_importer_spec.rb
+++ b/spec/services/bulk_api_import/fhir_patient_importer_spec.rb
@@ -1,10 +1,9 @@
 require "rails_helper"
 
 RSpec.describe BulkApiImport::FhirPatientImporter do
-  before { create(:facility) }
-  let(:import_user) { ImportUser.find_or_create }
-  let(:org_id) { import_user.organization_id }
-  let(:facility) { import_user.facility }
+  let(:facility) { create(:facility) }
+  let(:org_id) { facility.organization_id }
+  let(:import_user) { ImportUser.find_or_create(org_id: org_id) }
   let(:facility_identifier) do
     create(:facility_business_identifier, facility: facility, identifier_type: :external_org_facility_id)
   end

--- a/spec/services/bulk_api_import/importer_spec.rb
+++ b/spec/services/bulk_api_import/importer_spec.rb
@@ -1,10 +1,8 @@
 require "rails_helper"
 
 RSpec.describe BulkApiImport::Importer do
-  before { FactoryBot.create(:facility) } # needed for our bot import user
-
   describe "#import" do
-    let(:facility) { Facility.first }
+    let(:facility) { create(:facility) }
     let(:organization_id) { facility.organization_id }
     let(:facility_identifier) do
       create(:facility_business_identifier, facility: facility, identifier_type: :external_org_facility_id)
@@ -80,7 +78,8 @@ RSpec.describe BulkApiImport::Importer do
 
   describe "#resource_importer" do
     it "fetches the correct importer" do
-      importer = described_class.new(resource_list: [], organization_id: "org_id")
+      org_id = create(:facility).organization_id
+      importer = described_class.new(resource_list: [], organization_id: org_id)
 
       [
         {input: {resourceType: "Patient"}, expected_importer: BulkApiImport::FhirPatientImporter},
@@ -89,7 +88,7 @@ RSpec.describe BulkApiImport::Importer do
         {input: {resourceType: "MedicationRequest"}, expected_importer: BulkApiImport::FhirMedicationRequestImporter},
         {input: {resourceType: "Condition"}, expected_importer: BulkApiImport::FhirConditionImporter}
       ].each do |input:, expected_importer:|
-        expect(importer.resource_importer(input, "org_id"))
+        expect(importer.resource_importer(input, org_id))
           .to be_an_instance_of(expected_importer)
       end
     end

--- a/spec/services/patient_import/import_user_spec.rb
+++ b/spec/services/patient_import/import_user_spec.rb
@@ -3,34 +3,43 @@ require "rails_helper"
 RSpec.describe ImportUser do
   describe ".find" do
     it "finds existing import user by phone number" do
-      import_user = create(:user, phone_number: ImportUser::IMPORT_USER_PHONE_NUMBER)
+      org_id = build_stubbed(:organization).id
+      import_user = create(:user, phone_number: ImportUser::IMPORT_USER_PHONE_NUMBER, organization_id: org_id)
 
-      expect(ImportUser.find).to eq(import_user)
+      expect(ImportUser.find(org_id)).to eq(import_user)
     end
 
     it "returns nil if not found" do
-      expect(ImportUser.find).to be_nil
+      expect(ImportUser.find("foo")).to be_nil
+    end
+
+    it "returns nil if it does not exist in the given organization" do
+      org_id = build_stubbed(:organization).id
+      _user = create(:user, phone_number: ImportUser::IMPORT_USER_PHONE_NUMBER, organization_id: org_id)
+
+      expect(ImportUser.find("bar")).to be_nil
     end
   end
 
   describe ".find_or_create" do
     it "finds existing import user by phone number" do
-      import_user = create(:user, phone_number: ImportUser::IMPORT_USER_PHONE_NUMBER)
+      org_id = build_stubbed(:organization).id
+      import_user = create(:user, phone_number: ImportUser::IMPORT_USER_PHONE_NUMBER, organization_id: org_id)
 
-      expect { ImportUser.find_or_create }.not_to change { User.count }
-      expect(ImportUser.find_or_create).to eq(import_user)
+      expect { ImportUser.find_or_create(org_id: org_id) }.not_to change { User.count }
+      expect(ImportUser.find_or_create(org_id: org_id)).to eq(import_user)
     end
 
     it "creates a new user if not found" do
-      _facility = create(:facility)
-      import_user = ImportUser.find_or_create
+      facility = create(:facility)
+      import_user = ImportUser.find_or_create(org_id: facility.organization_id)
       expect(import_user).to be_persisted
       expect(import_user.phone_number).to eq(ImportUser::IMPORT_USER_PHONE_NUMBER)
     end
 
     it "ensures the new user cannot sync data" do
-      _facility = create(:facility)
-      import_user = ImportUser.find_or_create
+      facility = create(:facility)
+      import_user = ImportUser.find_or_create(org_id: facility.organization_id)
 
       expect(import_user.otp_valid?).to eq(false)
       expect(import_user).to be_sync_approval_status_denied

--- a/spec/services/patient_import/spreadsheet_transformer_spec.rb
+++ b/spec/services/patient_import/spreadsheet_transformer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PatientImport::SpreadsheetTransformer do
   it "parses patient data" do
     params = PatientImport::SpreadsheetTransformer.call(data, facility: facility)
 
-    import_user = ImportUser.find_or_create
+    import_user = ImportUser.find_or_create(org_id: facility.organization_id)
     patient = params.find { |p| p[:patient][:full_name] == "Basic Patient 1" }.deep_symbolize_keys
     patient_id = patient[:patient][:id]
     registration_time = Time.parse("2020-10-16").rfc3339


### PR DESCRIPTION
The Import User was previously created by finding the first facility in the database and assigning the user to that facility. This is a problem in any instance that has more than one organization, since it will affiliate the import user with whichever organization that first facility belonged to.

We resolve this by requiring an organization ID when finding or creating an Import User.

**Story card:** [sc-11563]

## Test instructions

Call the import API from two different organizations, and ensure that there are two different import users with the correct organization affiliations.