### PR TITLE
Add new indexes on reporting_patient_states

### DIFF
--- a/db/migrate/20231208091419_add_indexes_to_reporting_patient_states.rb
+++ b/db/migrate/20231208091419_add_indexes_to_reporting_patient_states.rb
@@ -1,6 +1,9 @@
 class AddIndexesToReportingPatientStates < ActiveRecord::Migration[6.1]
+  # Cannot create index concurrently inside a transaction block
+  self.disable_ddl_transaction = true
+
   def change
-    add_index :reporting_patient_states, %i[month_date assigned_facility_id], name: "patient_states_month_date_assigned_facility"
-    add_index :reporting_patient_states, %i[month_date assigned_facility_region_id], name: "patient_states_month_date_assigned_facility_region"
+    add_index :reporting_patient_states, %i[month_date assigned_facility_id], name: "patient_states_month_date_assigned_facility", algorithm: :concurrently
+    add_index :reporting_patient_states, %i[month_date assigned_facility_region_id], name: "patient_states_month_date_assigned_facility_region", algorithm: :concurrently
   end
 end

--- a/db/migrate/20231208091419_add_indexes_to_reporting_patient_states.rb
+++ b/db/migrate/20231208091419_add_indexes_to_reporting_patient_states.rb
@@ -1,0 +1,6 @@
+class AddIndexesToReportingPatientStates < ActiveRecord::Migration[6.1]
+  def change
+    add_index :reporting_patient_states, %i[month_date assigned_facility_id], name: "patient_states_month_date_assigned_facility"
+    add_index :reporting_patient_states, %i[month_date assigned_facility_region_id], name: "patient_states_month_date_assigned_facility_region"
+  end
+end

--- a/db/migrate/20231208091419_add_indexes_to_reporting_patient_states.rb
+++ b/db/migrate/20231208091419_add_indexes_to_reporting_patient_states.rb
@@ -5,5 +5,7 @@ class AddIndexesToReportingPatientStates < ActiveRecord::Migration[6.1]
   def change
     add_index :reporting_patient_states, %i[month_date assigned_facility_id], name: "patient_states_month_date_assigned_facility", algorithm: :concurrently
     add_index :reporting_patient_states, %i[month_date assigned_facility_region_id], name: "patient_states_month_date_assigned_facility_region", algorithm: :concurrently
+    add_index :reporting_patient_states, %i[month_date registration_facility_id], name: "patient_states_month_date_reg_facility", algorithm: :concurrently
+    add_index :reporting_patient_states, %i[month_date registration_facility_region_id], name: "patient_states_month_date_reg_facility_region", algorithm: :concurrently
   end
 end

--- a/db/migrate/20231208091419_add_indexes_to_reporting_patient_states.rb
+++ b/db/migrate/20231208091419_add_indexes_to_reporting_patient_states.rb
@@ -5,7 +5,7 @@ class AddIndexesToReportingPatientStates < ActiveRecord::Migration[6.1]
   def change
     add_index :reporting_patient_states, %i[month_date assigned_facility_id], name: "patient_states_month_date_assigned_facility", algorithm: :concurrently
     add_index :reporting_patient_states, %i[month_date assigned_facility_region_id], name: "patient_states_month_date_assigned_facility_region", algorithm: :concurrently
-    add_index :reporting_patient_states, %i[month_date registration_facility_id], name: "patient_states_month_date_reg_facility", algorithm: :concurrently
-    add_index :reporting_patient_states, %i[month_date registration_facility_region_id], name: "patient_states_month_date_reg_facility_region", algorithm: :concurrently
+    add_index :reporting_patient_states, %i[month_date registration_facility_id], name: "patient_states_month_date_registration_facility", algorithm: :concurrently
+    add_index :reporting_patient_states, %i[month_date registration_facility_region_id], name: "patient_states_month_date_registration_facility_region", algorithm: :concurrently
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7141,6 +7141,20 @@ CREATE INDEX patient_states_care_state ON public.reporting_patient_states USING 
 
 
 --
+-- Name: patient_states_month_date_assigned_facility; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX patient_states_month_date_assigned_facility ON public.reporting_patient_states USING btree (month_date, assigned_facility_id);
+
+
+--
+-- Name: patient_states_month_date_assigned_facility_region; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX patient_states_month_date_assigned_facility_region ON public.reporting_patient_states USING btree (month_date, assigned_facility_region_id);
+
+
+--
 -- Name: patient_states_month_date_patient_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7644,6 +7658,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230614171507'),
 ('20230713065237'),
 ('20230713065420'),
-('20230713135154');
+('20230713135154'),
+('20231208091419');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7162,6 +7162,20 @@ CREATE UNIQUE INDEX patient_states_month_date_patient_id ON public.reporting_pat
 
 
 --
+-- Name: patient_states_month_date_reg_facility; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX patient_states_month_date_reg_facility ON public.reporting_patient_states USING btree (month_date, registration_facility_id);
+
+
+--
+-- Name: patient_states_month_date_reg_facility_region; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX patient_states_month_date_reg_facility_region ON public.reporting_patient_states USING btree (month_date, registration_facility_region_id);
+
+
+--
 -- Name: patient_visits_patient_id_month_date; Type: INDEX; Schema: public; Owner: -
 --
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7162,17 +7162,17 @@ CREATE UNIQUE INDEX patient_states_month_date_patient_id ON public.reporting_pat
 
 
 --
--- Name: patient_states_month_date_reg_facility; Type: INDEX; Schema: public; Owner: -
+-- Name: patient_states_month_date_registration_facility; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX patient_states_month_date_reg_facility ON public.reporting_patient_states USING btree (month_date, registration_facility_id);
+CREATE INDEX patient_states_month_date_registration_facility ON public.reporting_patient_states USING btree (month_date, registration_facility_id);
 
 
 --
--- Name: patient_states_month_date_reg_facility_region; Type: INDEX; Schema: public; Owner: -
+-- Name: patient_states_month_date_registration_facility_region; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX patient_states_month_date_reg_facility_region ON public.reporting_patient_states USING btree (month_date, registration_facility_region_id);
+CREATE INDEX patient_states_month_date_registration_facility_region ON public.reporting_patient_states USING btree (month_date, registration_facility_region_id);
 
 
 --


### PR DESCRIPTION
**Story card:** [sc-11600](https://app.shortcut.com/simpledotorg/story/11600/optimize-queries-used-by-dhis2-exporter)

## Because

The current queries for our monthly DHIS2 exports are slow. We want to add a couple of indexes to the reporting_patient_states table to improve this.

## This addresses

This PR adds a migration to create four composite indexes:
- on month_date and assigned_facility_id
- on month_date and assigned_facility_region_id
- on month_date and registration_facility_id
- on month_date and registration_facility_region_id

We're accounting for both the facility and the facility region because both these fields are used throughout the codebase and we don't want one query to pick up the correct index and not another.