### PR TITLE
Add docker cphc worker startup script

### DIFF
--- a/bin/docker-worker-cphc
+++ b/bin/docker-worker-cphc
@@ -17,6 +17,9 @@ cd linux_phat_client
 cd ../
 
 # VPN login
+vpn_login () {
+  yes | naclient login -profile $CPHC_VPN_PROFILE  -user $CPHC_VPN_USER  -password $CPHC_VPN_PASSWORD
+}
 vpn_login
 
 # Monitor VPN connection
@@ -30,10 +33,6 @@ STATUS_LOG_PATH="/home/app/log/vpn_client_status.log"
 
 slack_alert () {
   curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$1\"}" $CPHC_VPN_ALERTS_WEBHOOK_URL
-}
-
-vpn_login () {
-  yes | naclient login -profile $CPHC_VPN_PROFILE  -user $CPHC_VPN_USER  -password $CPHC_VPN_PASSWORD
 }
 
 echo_with_time () {

--- a/bin/docker-worker-cphc
+++ b/bin/docker-worker-cphc
@@ -63,7 +63,4 @@ monitor () {
 monitor &
 
 # Start sikdekiq
-# bundle exec sidekiq  -C config/sidekiq.yml -e production -q $CPHC_SIDEKIQ_QUEUE
-
-# Test only vpn
-sleep 99999999999999
+bundle exec sidekiq  -C config/sidekiq.yml -e production -q $CPHC_SIDEKIQ_QUEUE

--- a/bin/docker-worker-cphc
+++ b/bin/docker-worker-cphc
@@ -62,4 +62,4 @@ monitor () {
 monitor &
 
 # Start sikdekiq
-bundle exec sidekiq  -C config/sidekiq.yml -e production -q $CPHC_SIDEKIQ_QUEUE
+su -l app -c "bundle exec sidekiq  -C config/sidekiq.yml -e production -q $CPHC_SIDEKIQ_QUEUE"

--- a/bin/docker-worker-cphc
+++ b/bin/docker-worker-cphc
@@ -61,4 +61,7 @@ monitor () {
 monitor &
 
 # Start sikdekiq
-bundle exec sidekiq  -C config/sidekiq.yml -e production -q $CPHC_SIDEKIQ_QUEUE
+# bundle exec sidekiq  -C config/sidekiq.yml -e production -q $CPHC_SIDEKIQ_QUEUE
+
+# Test only vpn
+sleep 99999999999999

--- a/bin/docker-worker-cphc
+++ b/bin/docker-worker-cphc
@@ -7,7 +7,9 @@
 echo $CPHC_VPN_CONFIG > linux_phat_client/linux_phat_client/naclient.cfg
 
 # Install
-linux_phat_client/install_linux_phat_client.sh
+cd linux_phat_client
+./install_linux_phat_client.sh
+cd ../
 
 # Setup tun device
 mkdir -p /dev/net 

--- a/bin/docker-worker-cphc
+++ b/bin/docker-worker-cphc
@@ -29,7 +29,7 @@ LAST_ALERT_TIME=0
 STATUS_LOG_PATH="/home/app/log/vpn_client_status.log"
 
 slack_alert () {
-  curl -X POST -H 'Content-type: application/json' --data '{"text":"$1"}' $CPHC_VPN_ALERTS_WEBHOOK_URL
+  curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$1\"}" $CPHC_VPN_ALERTS_WEBHOOK_URL
 }
 
 vpn_login () {

--- a/bin/docker-worker-cphc
+++ b/bin/docker-worker-cphc
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Run crontab process in background, mainly for log archival
+/usr/sbin/cron -f &
+
+# Create config
+echo $CPHC_VPN_CONFIG > linux_phat_client/linux_phat_client/naclient.cfg
+
+# Install
+linux_phat_client/install_linux_phat_client.sh
+
+# Setup tun device
+mkdir -p /dev/net 
+mknod /dev/net/tun c 10 200 
+chmod 600 /dev/net/tun
+
+# VPN login
+vpn_login
+
+# Monitor VPN connection
+ALERT_MIN_FAILURES=2
+ALERT_FREQUENCY_SECONDS=300
+ALERT_STATUS_POLLING_INTERVAL=5
+ALERT_MESSAGE="Unable to connect CPHC VPN"
+CONSECUTIVE_FAILURES=0
+LAST_ALERT_TIME=0
+STATUS_LOG_PATH="/home/app/log/vpn_client_status.log"
+
+slack_alert () {
+  curl -X POST -H 'Content-type: application/json' --data '{"text":"$1"}' $CPHC_VPN_ALERTS_WEBHOOK_URL
+}
+
+vpn_login () {
+  yes | naclient login -profile $CPHC_VPN_PROFILE  -user $CPHC_VPN_USER  -password $CPHC_VPN_PASSWORD
+}
+
+echo_with_time () {
+  echo "$(date '+TIME:%H:%M:%S') $1" | tee -a $STATUS_LOG_PATH
+}
+
+monitor () {
+  while true; do
+    naclient status
+    if [ $? -eq 1 ]; then
+      echo_with_time "VPN is connected"
+    else
+      CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
+      vpn_login
+      if [ $? -eq 1 ]; then
+        echo_with_time "Successfully connected to VPN"
+        CONSECUTIVE_FAILURES=0
+        LAST_ALERT_TIME=0
+      elif [ $CONSECUTIVE_FAILURES -gt $ALERT_MIN_FAILURES ] && [ $(($(date +%s) - $LAST_ALERT_TIME)) -ge $((ALERT_FREQUENCY_SECONDS)) ]; then
+        echo_with_time $ALERT_MESSAGE && slack_alert $ALERT_MESSAGE
+        LAST_ALERT_TIME=$(date +%s)
+      fi
+    fi
+    sleep $ALERT_STATUS_POLLING_INTERVAL
+  done
+}
+monitor &
+
+# Start sikdekiq
+bundle exec sidekiq  -C config/sidekiq.yml -e production -q $CPHC_SIDEKIQ_QUEUE

--- a/bin/docker-worker-cphc
+++ b/bin/docker-worker-cphc
@@ -6,15 +6,15 @@
 # Create config
 echo $CPHC_VPN_CONFIG > linux_phat_client/linux_phat_client/naclient.cfg
 
-# Install
-cd linux_phat_client
-./install_linux_phat_client.sh
-cd ../
-
 # Setup tun device
 mkdir -p /dev/net 
 mknod /dev/net/tun c 10 200 
 chmod 600 /dev/net/tun
+
+# Install
+cd linux_phat_client
+./install_linux_phat_client.sh
+cd ../
 
 # VPN login
 vpn_login
@@ -53,7 +53,7 @@ monitor () {
         CONSECUTIVE_FAILURES=0
         LAST_ALERT_TIME=0
       elif [ $CONSECUTIVE_FAILURES -gt $ALERT_MIN_FAILURES ] && [ $(($(date +%s) - $LAST_ALERT_TIME)) -ge $((ALERT_FREQUENCY_SECONDS)) ]; then
-        echo_with_time $ALERT_MESSAGE && slack_alert $ALERT_MESSAGE
+        echo_with_time "$ALERT_MESSAGE" && slack_alert "$ALERT_MESSAGE"
         LAST_ALERT_TIME=$(date +%s)
       fi
     fi


### PR DESCRIPTION
**Story card:** [sc-11629](https://app.shortcut.com/simpledotorg/story/11629)

## Because

The CPHC data migration requires a VPN to connect to the CPHC environment. The same needs to be enabled in the k8s environment to complete the migration