### PR TITLE
Remove redundant check for facility in notification worker

### DIFF
--- a/app/jobs/appointment_notification/worker.rb
+++ b/app/jobs/appointment_notification/worker.rb
@@ -12,17 +12,10 @@ class AppointmentNotification::Worker
 
     notification = Notification.find(notification_id)
 
-    NotificationDispatchService.call(notification) if scheduled?(notification) && facility_present?(notification)
+    NotificationDispatchService.call(notification) if scheduled?(notification)
   end
 
   private
-
-  def facility_present?(notification)
-    return true if notification.patient.assigned_facility.present? || notification.subject&.facility.present?
-
-    Rails.logger.error "skipping notification #{notification.id}, facility deleted"
-    false
-  end
 
   def scheduled?(notification)
     return true if notification.status_scheduled?

--- a/spec/jobs/appointment_notification/worker_spec.rb
+++ b/spec/jobs/appointment_notification/worker_spec.rb
@@ -55,26 +55,5 @@ RSpec.describe AppointmentNotification::Worker, type: :job do
         described_class.drain
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
-
-    it "only sends notifications if either the patient's or subject's facility exists" do
-      mock_successful_twilio_delivery
-
-      notification1 = create(:notification, status: :scheduled)
-      notification1.patient.assigned_facility.discard!
-      notification1.patient.reload
-
-      notification2 = create(:notification, status: :scheduled)
-      notification2.subject.facility.discard!
-      notification2.subject.reload
-      notification2.patient.assigned_facility.discard!
-      notification2.patient.reload
-
-      described_class.perform_async(notification1.id)
-      described_class.perform_async(notification2.id)
-      described_class.drain
-
-      expect(notification1.reload.status).to eq("sent")
-      expect(notification2.reload.status).to eq("scheduled")
-    end
   end
 end


### PR DESCRIPTION
Since the notification model checks for the presence of a facility for the patient to return to before creating the notification, the same check in the appointment notification worker is no longer required. Then notification dispatch service will handle any related errors raised by the notification model.