### PR TITLE
Skip all Reports::FacilityAppointmentScheduledDays specs

### DIFF
--- a/spec/models/reports/facility_appointment_scheduled_days_spec.rb
+++ b/spec/models/reports/facility_appointment_scheduled_days_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Reports::FacilityAppointmentScheduledDays, {type: :model, reporting_spec: true} do
+RSpec.describe Reports::FacilityAppointmentScheduledDays, {type: :model, reporting_spec: true, skip: true} do
   around do |example|
     # This is in the style of ReportingHelpers::freeze_time_for_reporting_specs.
     # Since this view only keeps the last 6 months of data, the date cannot be a


### PR DESCRIPTION
CI tests are slower by 30m since the last commit to add indexes to reporting_patient_states. Skip these temporarily till we investigate why this is happening.