### PR TITLE
Fix validation errors for import user numbers

### DIFF
--- a/spec/services/patient_import/import_user_spec.rb
+++ b/spec/services/patient_import/import_user_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ImportUser do
   describe ".find" do
     it "finds existing import user by phone number" do
       org_id = build_stubbed(:organization).id
-      import_user = create(:user, phone_number: ImportUser::IMPORT_USER_PHONE_NUMBER, organization_id: org_id)
+      import_user = create(:user, phone_number: ImportUser.bot_phone_number(org_id), organization_id: org_id)
 
       expect(ImportUser.find(org_id)).to eq(import_user)
     end
@@ -15,7 +15,7 @@ RSpec.describe ImportUser do
 
     it "returns nil if it does not exist in the given organization" do
       org_id = build_stubbed(:organization).id
-      _user = create(:user, phone_number: ImportUser::IMPORT_USER_PHONE_NUMBER, organization_id: org_id)
+      _user = create(:user, phone_number: ImportUser.bot_phone_number(org_id), organization_id: org_id)
 
       expect(ImportUser.find("bar")).to be_nil
     end
@@ -24,7 +24,7 @@ RSpec.describe ImportUser do
   describe ".find_or_create" do
     it "finds existing import user by phone number" do
       org_id = build_stubbed(:organization).id
-      import_user = create(:user, phone_number: ImportUser::IMPORT_USER_PHONE_NUMBER, organization_id: org_id)
+      import_user = create(:user, phone_number: ImportUser.bot_phone_number(org_id), organization_id: org_id)
 
       expect { ImportUser.find_or_create(org_id: org_id) }.not_to change { User.count }
       expect(ImportUser.find_or_create(org_id: org_id)).to eq(import_user)
@@ -33,8 +33,10 @@ RSpec.describe ImportUser do
     it "creates a new user if not found" do
       facility = create(:facility)
       import_user = ImportUser.find_or_create(org_id: facility.organization_id)
+      import_user_phone_number = ImportUser.bot_phone_number(facility.organization_id)
+
       expect(import_user).to be_persisted
-      expect(import_user.phone_number).to eq(ImportUser::IMPORT_USER_PHONE_NUMBER)
+      expect(import_user.phone_number).to eq(import_user_phone_number)
     end
 
     it "ensures the new user cannot sync data" do
@@ -43,6 +45,14 @@ RSpec.describe ImportUser do
 
       expect(import_user.otp_valid?).to eq(false)
       expect(import_user).to be_sync_approval_status_denied
+    end
+  end
+
+  describe "#bot_phone_number" do
+    it "always gives the same output for an org ID" do
+      some_org_id = SecureRandom.uuid
+
+      expect(5.times.map { ImportUser.bot_phone_number(some_org_id) }.uniq.length).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Switching to an import user per organization introduced a bug where creating a new Import User causes a bug because the phone number fails the uniqueness validations. We no longer have a globally constant phone number—we instead generate a random string as our fake phone number that is unique to each organization and guaranteed to not collide again.

Explanations for some choices:
* We convert the UUID of the org into a url-safe base64 representation because:
    * It is simple and reversible
    * It is only 22 bytes, which is shorter than the 36-byte UUID representation (this helps with displaying and copying)
    * There's guaranteed to be no collisions since organizations are universally unique
* We do not include a data migration to migrate the existing "0000000001" numbers because the phone number of a bot user is a filler value with no intrinsic purpose.