### PR TITLE
Automate AlphaSms balance check

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -50,6 +50,12 @@ every :day, at: local("02:00 pm"), roles: [:cron] do
   end
 end
 
+every :day, at: local("02:00 pm"), roles: [:cron] do
+  if CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
+    rake "alpha_sms:check_balance"
+  end
+end
+
 every :day, at: local("05:30 pm"), roles: [:cron] do
   runner "Messaging::Bsnl::Sms.get_message_statuses"
 end

--- a/lib/tasks/alpha_sms.rake
+++ b/lib/tasks/alpha_sms.rake
@@ -1,8 +1,6 @@
-require "net/http"
-
 namespace :alpha_sms do
-  desc "Fetch account balance and alert if we're running low or close to expiry"
-  task alert_on_low_balance: :environment do
+  desc "Fetch account balance and log if we're running low or close to expiry"
+  task check_balance: :environment do
     max_cost_per_day = 5000
     alert_in_days = 5
 
@@ -12,10 +10,11 @@ namespace :alpha_sms do
     expiry_date = response.dig(:data, :validity)&.to_date
     balance_amount = response.dig(:data, :balance)&.to_f
 
-    if expiry_date < alert_in_days.from.now
+    if expiry_date < alert_in_days.days.from_now
       Rails.logger.error("Account balance expires in less than #{alert_in_days}. Please recharge before #{expiry_date}.")
     elsif balance_amount < (alert_in_days * max_cost_per_day)
       Rails.logger.error("Remaining account balance is #{balance_amount} BDT. May expire in less than #{alert_in_days} days.")
     end
+    print("Balance: #{balance_amount} BDT\nExpiry: #{expiry_date}")
   end
 end

--- a/lib/tasks/alpha_sms.rake
+++ b/lib/tasks/alpha_sms.rake
@@ -1,0 +1,21 @@
+require "net/http"
+
+namespace :alpha_sms do
+  desc "Fetch account balance and alert if we're running low or close to expiry"
+  task alert_on_low_balance: :environment do
+    max_cost_per_day = 5000
+    alert_in_days = 5
+
+    response = Messaging::AlphaSms::Api.new
+      .get_account_balance
+      .with_indifferent_access
+    expiry_date = response.dig(:data, :validity)&.to_date
+    balance_amount = response.dig(:data, :balance)&.to_f
+
+    if expiry_date < alert_in_days.from.now
+      Rails.logger.error("Account balance expires in less than #{alert_in_days}. Please recharge before #{expiry_date}.")
+    elsif balance_amount < (alert_in_days * max_cost_per_day)
+      Rails.logger.error("Remaining account balance is #{balance_amount} BDT. May expire in less than #{alert_in_days} days.")
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-11640](https://app.shortcut.com/simpledotorg/story/11640/automate-alphasms-balance-check)

We want to automate balance check in Bangladesh and alert on low balance.

The reason the error message is being logged and not raised as an exception is so we can add a Datadog alert on the log. The corresponding BSNL task relies on Sentry to alert on an uncaught exception for low balance, but we have to manually resolve the alert each time for it to show up again next time. This is not an issue on Datadog.