### PR TITLE
Asynchronous patient line list generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ gem "rswag-api"
 gem "rswag-ui"
 gem "ruby-progressbar", require: false
 gem "rubyzip"
+gem "zip_tricks"
 gem "sassc-rails"
 gem "scenic"
 gem "scientist"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -697,6 +697,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.0)
+    zip_tricks (5.6.0)
 
 PLATFORMS
   ruby
@@ -831,6 +832,7 @@ DEPENDENCIES
   webpacker (= 6.0.0.rc.6)
   whenever
   wkhtmltoimage-binary
+  zip_tricks
 
 RUBY VERSION
    ruby 2.7.4p191

--- a/app/controllers/reports/patient_lists_controller.rb
+++ b/app/controllers/reports/patient_lists_controller.rb
@@ -9,25 +9,27 @@ class Reports::PatientListsController < AdminController
 
   def show
     if Flipper.enabled?(:patient_list_direct_download)
-      patients = @region.assigned_patients.excluding_dead
-      enumerator = PatientsWithHistoryExporter.csv_enumerator(patients)
+      Datadog::Tracing.trace("Direct patient line list download") do
+        patients = @region.assigned_patients.excluding_dead
+        enumerator = PatientsWithHistoryExporter.csv_enumerator(patients)
 
-      file_name = "patient-list_#{@region.region_type}_#{@region.name}_#{I18n.l(Date.current)}"
-      csv_file_name = "#{file_name}.csv"
-      zip_archive_name = "#{file_name}.zip"
-      response.headers["Content-Disposition"] = ActionDispatch::Http::ContentDisposition.format(
-        disposition: "attachment",
-        filename: zip_archive_name
-      )
+        file_name = "patient-list_#{@region.region_type}_#{@region.name}_#{I18n.l(Date.current)}"
+        csv_file_name = "#{file_name}.csv"
+        zip_archive_name = "#{file_name}.zip"
+        response.headers["Content-Disposition"] = ActionDispatch::Http::ContentDisposition.format(
+          disposition: "attachment",
+          filename: zip_archive_name
+        )
 
-      first_row = enumerator.peek
-      response.headers["Last-Modified"] = first_row.second
+        first_row = enumerator.peek
+        response.headers["Last-Modified"] = first_row.second
 
-      return zip_tricks_stream do |zip|
-        zip.write_deflated_file(csv_file_name) do |sink|
-          CSV(sink) do |csv_write|
-            enumerator.each do |row|
-              csv_write << row
+        return zip_tricks_stream do |zip|
+          zip.write_deflated_file(csv_file_name) do |sink|
+            CSV(sink) do |csv_write|
+              enumerator.each do |row|
+                csv_write << row
+              end
             end
           end
         end

--- a/app/controllers/reports/patient_lists_controller.rb
+++ b/app/controllers/reports/patient_lists_controller.rb
@@ -1,4 +1,6 @@
 class Reports::PatientListsController < AdminController
+  include ZipTricks::RailsStreaming
+
   attr_reader :scope, :region, :download_params
 
   before_action :set_scope, only: [:show, :diabetes]
@@ -6,6 +8,32 @@ class Reports::PatientListsController < AdminController
   before_action :set_download_params, only: [:show, :diabetes]
 
   def show
+    if Flipper.enabled?(:patient_list_direct_download)
+      patients = @region.assigned_patients.excluding_dead
+      enumerator = PatientsWithHistoryExporter.csv_enumerator(patients)
+
+      file_name = "patient-list_#{@region.region_type}_#{@region.name}_#{I18n.l(Date.current)}"
+      csv_file_name = "#{file_name}.csv"
+      zip_archive_name = "#{file_name}.zip"
+      response.headers["Content-Disposition"] = ActionDispatch::Http::ContentDisposition.format(
+        disposition: "attachment",
+        filename: zip_archive_name
+      )
+
+      first_row = enumerator.peek
+      response.headers["Last-Modified"] = first_row.second
+
+      return zip_tricks_stream do |zip|
+        zip.write_deflated_file(csv_file_name) do |sink|
+          CSV(sink) do |csv_write|
+            enumerator.each do |row|
+              csv_write << row
+            end
+          end
+        end
+      end
+    end
+
     PatientListDownloadJob.perform_async(recipient_email, region_class, download_params)
 
     redirect_back(

--- a/app/exporters/patients_with_history_exporter.rb
+++ b/app/exporters/patients_with_history_exporter.rb
@@ -33,6 +33,27 @@ class PatientsWithHistoryExporter
     new.csv(*args)
   end
 
+  def self.csv_enumerator(*args)
+    new.csv_enumerator(*args)
+  end
+
+  def csv_enumerator(patients, display_blood_sugars: true)
+    @display_blood_sugars = display_blood_sugars
+    summary = MaterializedPatientSummary.where(patient: patients)
+
+    Enumerator.new do |yeilder|
+      yeilder << timestamp
+      yeilder << measurement_headers
+      yeilder << csv_headers
+
+      summary.in_batches(of: BATCH_SIZE).each do |batch|
+        batch.each do |patient_summary|
+          yeilder << csv_fields(patient_summary)
+        end
+      end
+    end
+  end
+
   def csv(patients, display_blood_sugars: true)
     @display_blood_sugars = display_blood_sugars
     summary = MaterializedPatientSummary.where(patient: patients)

--- a/spec/exporters/patients_with_history_exporter_spec.rb
+++ b/spec/exporters/patients_with_history_exporter_spec.rb
@@ -337,6 +337,20 @@ RSpec.describe PatientsWithHistoryExporter, type: :model do
     MaterializedPatientSummary.refresh
   end
 
+  describe "#csv_enumerator" do
+    it "enumerates the rows of the CSV of patient records" do
+      Timecop.freeze do
+        timestamp = ["Report generated at:", Time.current]
+        enumerator = subject.csv_enumerator(Patient.all)
+
+        expect(enumerator.next).to eq(timestamp)
+        expect(enumerator.next).to eq(measurement_headers)
+        expect(enumerator.next).to eq(headers)
+        expect(enumerator.next).to eq(fields)
+      end
+    end
+  end
+
   describe "#csv" do
     it "generates a CSV of patient records" do
       Timecop.freeze do


### PR DESCRIPTION
**Story card:** [sc-10665](https://app.shortcut.com/simpledotorg/story/10665/fix-to-enable-automating-chennai-patient-line-list)

## Because

Line lists are currently generated in memory. This can consume a lot of memory for large regions, causing the sidekiq processes to crash. 

## This addresses

This adds an alternative code path to test downloading the linelist through an asynchronous rack process instead of a sidekiq job. Since each line of the generated csv will be flushed immediately, downloading a linelist should not cause a spike in resource consumption. 

Additionally, the use can see the downloading file in their browsers downloads tab. 

This PR also adds instrumentation to test this thesis in production before replacing the existing codepath. 