### PR TITLE
Send balance and expiry metrics in the alphasms balance check rake task

### DIFF
--- a/lib/tasks/alpha_sms.rake
+++ b/lib/tasks/alpha_sms.rake
@@ -4,17 +4,21 @@ namespace :alpha_sms do
     max_cost_per_day = 5000
     alert_in_days = 5
 
-    response = Messaging::AlphaSms::Api.new
-      .get_account_balance
-      .with_indifferent_access
+    response = Messaging::AlphaSms::Api.new.get_account_balance.with_indifferent_access
     expiry_date = response.dig(:data, :validity)&.to_date
     balance_amount = response.dig(:data, :balance)&.to_f
 
+    Statsd.instance.gauge("alphasms_balance_bdt", balance_amount)
+    Statsd.instance.gauge("alphasms_balance_days_till_expiry", (expiry_date - Date.current).to_i)
+    Statsd.instance.flush
+
+    # TODO: Remove these after moving to Prometheus
     if expiry_date < alert_in_days.days.from_now
       Rails.logger.error("AlphaSms account balance expires in less than #{alert_in_days}. Please recharge before #{expiry_date}.")
     elsif balance_amount < (alert_in_days * max_cost_per_day)
       Rails.logger.error("Alphasms account balance remaining is #{balance_amount} BDT. May expire in less than #{alert_in_days} days.")
     end
+
     print("Balance: #{balance_amount} BDT\nExpiry: #{expiry_date}")
   end
 end


### PR DESCRIPTION
**Story card:** [sc-11640](https://app.shortcut.com/simpledotorg/story/11640/automate-alphasms-balance-check)

## Because

- We want to continue to track this via Prometheus, and metrics are a better way to do this than by logs
- We will be able to graph our usage with metrics

## Considerations

- Since we're still sending metrics via statsd and are planning to use an exporter to translate these metrics to the Prometheus format, the metrics in this PR are also being sent via Statsd. The format is standard for both Statsd and Prometheus
- We could send the expiry days as a label on the balance metric instead of as a second metric. The statsd exporter supports conversion of Statsd tags into Prometheus labels. Keeping them as separate metrics for now since the Prometheus migration's implementation details are unknown
- I've removed the older logs, will set up metric-based alerts on Datadog until the move to Prometheus is complete
