### PR TITLE
data migration: clear ICDDRB prescription_drugs

### DIFF
--- a/db/data/20240215112358_destroy_icddrb_prescription_drugs.rb
+++ b/db/data/20240215112358_destroy_icddrb_prescription_drugs.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class DestroyIcddrbPrescriptionDrugs < ActiveRecord::Migration[6.1]
+  ORG_ID = "1bb836eb-9a0b-4646-96ad-7342b53a9155"
+
+  def up
+    unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
+      return print "DestroyIcddrbPrescriptionDrugs is only for production Bangladesh"
+    end
+
+    destroyed_drugs = PrescriptionDrug
+      .joins(facility: {facility_group: :organization})
+      .where(organization: {id: ORG_ID})
+      .destroy_all
+
+    puts "deleted:\n #{destroyed_drugs.size} drugs"
+  end
+
+  def down
+    puts "This migration cannot be reversed."
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-12002]

## How do I know this is correct?

I converted the activerecord query on rails console like this:

```ruby
    destroyed_drugs = PrescriptionDrug
      .joins(facility: {facility_group: :organization})
      .where(organization: {id: ORG_ID})
      .to_sql
```

I pasted the resulting SQL output on Metabase BD and inspected the result to ensure that I would be deleting the right thing.