### PR TITLE
import api: deprecate expectedSupplyDuration from MedicationRequest

### DIFF
--- a/app/schema/api/v4/imports.rb
+++ b/app/schema/api/v4/imports.rb
@@ -466,12 +466,14 @@ class Api::V4::Imports
          },
          dispenseRequest: {
            type: [:object, :null],
+           deprecated: true,
+           description: "This is a deprecated field. It will be ignored. Do not include this in your payload.",
            properties: {
              expectedSupplyDuration: value_quantity(
                system: "http://unitsofmeasure.org",
                unit: "days",
                code: "d"
-             ).merge!(type: [:object, :null], nullable: true)
+             ).merge!(type: [:object, :null], nullable: true, deprecated: true)
            }
          },
          dosageInstruction: {

--- a/app/services/bulk_api_import/fhir_medication_request_importer.rb
+++ b/app/services/bulk_api_import/fhir_medication_request_importer.rb
@@ -42,7 +42,6 @@ class BulkApiImport::FhirMedicationRequestImporter
       name: contained_medication[:code][:coding][0][:display],
       rxnorm_code: contained_medication[:code][:coding][0][:code],
       frequency: frequency,
-      duration_in_days: @resource.dig(:dispenseRequest, :expectedSupplyDuration, :value),
       dosage: dosage,
       is_deleted: drug_deleted?,
       **timestamps

--- a/spec/services/bulk_api_import/fhir_medication_request_importer_spec.rb
+++ b/spec/services/bulk_api_import/fhir_medication_request_importer_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe BulkApiImport::FhirMedicationRequestImporter do
         expect(attributes[:patient_id]).to eq(patient.id)
       end
     end
+
+    it "ignores the deprecated supply duration field" do
+      med_request_resource = build_medication_request_import_resource
+        .merge(performer: {identifier: facility_identifier.identifier},
+          subject: {identifier: patient_identifier.identifier})
+
+      attributes = described_class.new(resource: med_request_resource, organization_id: org_id).build_attributes
+
+      expect(attributes[:duration_in_days]).to be_nil
+    end
   end
 
   describe "#contained_medication" do

--- a/swagger/v4/import.json
+++ b/swagger/v4/import.json
@@ -1243,6 +1243,8 @@
             "object",
             "null"
           ],
+          "deprecated": true,
+          "description": "This is a deprecated field. It will be ignored. Do not include this in your payload.",
           "properties": {
             "expectedSupplyDuration": {
               "type": [
@@ -1283,7 +1285,8 @@
                 "unit",
                 "system",
                 "code"
-              ]
+              ],
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
This field is not used internally for any of Simple's reporting; it is an artefact of the now-unused teleconsultations feature. Accepting this field only complicates our reporting because partners would have to now be careful to not update the duration for existing medications since this would break reports that rely on the assumption that medications are only ever mutated to mark them as inactive.

Asking partners to not update this field ever is hard to enforce. Therefore, we remove this field. To avoid breaking any existing integrations, we simply drop the field while converting it from FHIR to Simple's format.

This is technically a breaking change, but since we only have one partner in production, we will inform them directly so they can make the necessary changes on their backend.

I considered returning a warning informing the client about this deprecation, but decided against it since it only burdens the controller and validations with more code and given that we have one partner, it didn't seem worth it to include it only for them.

This is how the deprecation looks like in the API docs:
![image](https://github.com/simpledotorg/simple-server/assets/24277692/a4a76a02-dd2d-4976-896c-01151b0c5387)


**Story card:** [sc-12022]
