### PR TITLE
imports api: disallow non-array resources

### DIFF
--- a/spec/requests/api/imports/imports_request_spec.rb
+++ b/spec/requests/api/imports/imports_request_spec.rb
@@ -112,4 +112,38 @@ RSpec.describe "Import API", type: :request do
     )
     expect(response.status).to eq(400)
   end
+
+  it "fails to import payload with no resource key" do
+    allow(Rails.logger).to receive(:info)
+
+    put route,
+      params: [build_condition_import_resource.merge(subject: {identifier: patient_identifier.identifier})].to_json,
+      headers: headers
+
+    expect(Rails.logger).to have_received(:info).with(
+      hash_including(
+        msg: "import_api_error",
+        controller: "Api::V4::ImportsController",
+        action: "import",
+        organization_id: organization.id
+      )
+    )
+    expect(response.status).to eq(400)
+  end
+
+  it "fails to import payload with non-array resources" do
+    allow(Rails.logger).to receive(:info)
+
+    put route, params: {resources: {invalid: :type}}.to_json, headers: headers
+
+    expect(Rails.logger).to have_received(:info).with(
+      hash_including(
+        msg: "import_api_error",
+        controller: "Api::V4::ImportsController",
+        action: "import",
+        organization_id: organization.id
+      )
+    )
+    expect(response.status).to eq(400)
+  end
 end


### PR DESCRIPTION
There was a bug where we allowed non-array values within the top-level "resources" key of the Import API payload. This caused an exception to be thrown later in the request lifecycle. This bug fix ensures any non-array values fail at the controller layer and return the appropriate error code (ie, 400 Bad Request).

**Story card:** [sc-12003]
