### PR TITLE
Add facility size for Sri Lanka

### DIFF
--- a/app/controllers/concerns/my_facilities_filtering.rb
+++ b/app/controllers/concerns/my_facilities_filtering.rb
@@ -71,7 +71,7 @@ module MyFacilitiesFiltering
     end
 
     def sort_facility_sizes_by_size(facility_sizes)
-      sorted_facility_sizes = %w[large medium small community]
+      sorted_facility_sizes = CountryConfig.current[:sorted_facility_sizes]
       sorted_facility_sizes.select { |size| facility_sizes.include? size }
     end
 

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -82,12 +82,7 @@ class Facility < ApplicationRecord
       .distinct
   }
 
-  enum facility_size: {
-    community: "community",
-    small: "small",
-    medium: "medium",
-    large: "large"
-  }
+  enum facility_size: CountryConfig.current[:facility_sizes]
 
   SHORT_NAME_MAX_LENGTH = 30
 

--- a/app/views/shared/my_facilities/_facilities_by_size.html.erb
+++ b/app/views/shared/my_facilities/_facilities_by_size.html.erb
@@ -32,50 +32,19 @@
           <%= number_with_delimiter(@inactive_facilities.count) %>
         </td>
       </tr>
-      <tr>
-        <td>
-          <%= Facility.localized_facility_size("large") %>
-        </td>
-        <td class="text-right">
-          <%= number_with_delimiter(@facility_counts_by_size[:total]["large"].to_i) %>
-        </td>
-        <td class="text-right">
-          <%= number_with_delimiter(@facility_counts_by_size[:inactive]["large"].to_i) %>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <%= Facility.localized_facility_size("medium") %>
-        </td>
-        <td class="text-right">
-          <%= number_with_delimiter(@facility_counts_by_size[:total]["medium"].to_i) %>
-        </td>
-        <td class="text-right">
-          <%= number_with_delimiter(@facility_counts_by_size[:inactive]["medium"].to_i) %>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <%= Facility.localized_facility_size("small") %>
-        </td>
-        <td class="text-right">
-          <%= number_with_delimiter(@facility_counts_by_size[:total]["small"].to_i) %>
-        </td>
-        <td class="text-right">
-          <%= number_with_delimiter(@facility_counts_by_size[:inactive]["small"].to_i) %>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <%= Facility.localized_facility_size("community") %>
-        </td>
-        <td class="text-right">
-          <%= number_with_delimiter(@facility_counts_by_size[:total]["community"].to_i) %>
-        </td>
-        <td class="text-right">
-          <%= number_with_delimiter(@facility_counts_by_size[:inactive]["community"].to_i) %>
-        </td>
-      </tr>
+      <% CountryConfig.current[:sorted_facility_sizes].each do |facility_size| %>
+        <tr>
+          <td>
+            <%= Facility.localized_facility_size(facility_size) %>
+          </td>
+          <td class="text-right">
+            <%= number_with_delimiter(@facility_counts_by_size[:total][facility_size].to_i) %>
+          </td>
+          <td class="text-right">
+            <%= number_with_delimiter(@facility_counts_by_size[:inactive][facility_size].to_i) %>
+          </td>
+        </tr>
+      <% end %>
       </tbody>
     </table>
   </section>

--- a/config/initializers/country_config.rb
+++ b/config/initializers/country_config.rb
@@ -14,7 +14,13 @@ class CountryConfig
       supported_genders: %w[male female transgender],
       patient_line_list_show_zone: false,
       custom_drug_category_order: %w[hypertension_ccb hypertension_arb hypertension_diuretic diabetes],
-      appointment_reminders_channel: "Messaging::Bsnl::Sms"
+      appointment_reminders_channel: "Messaging::Bsnl::Sms",
+      facility_sizes: {
+        community: "community",
+        small: "small",
+        medium: "medium",
+        large: "large"
+      }
     },
     BD: {
       abbreviation: "BD",
@@ -28,7 +34,13 @@ class CountryConfig
       supported_genders: %w[male female transgender],
       patient_line_list_show_zone: true,
       enabled_diabetes_population_coverage: true,
-      appointment_reminders_channel: "Messaging::AlphaSms::Sms"
+      appointment_reminders_channel: "Messaging::AlphaSms::Sms",
+      facility_sizes: {
+        community: "community",
+        small: "small",
+        medium: "medium",
+        large: "large"
+      }
     },
     ET: {
       abbreviation: "ET",
@@ -41,7 +53,13 @@ class CountryConfig
       sms_country_code: ENV["SMS_COUNTRY_CODE"] || "+251",
       supported_genders: %w[male female],
       patient_line_list_show_zone: false,
-      appointment_reminders_channel: "Messaging::Twilio::ReminderSms"
+      appointment_reminders_channel: "Messaging::Twilio::ReminderSms",
+      facility_sizes: {
+        community: "community",
+        small: "small",
+        medium: "medium",
+        large: "large"
+      }
     },
     LK: {
       abbreviation: "LK",
@@ -54,7 +72,15 @@ class CountryConfig
       sms_country_code: ENV["SMS_COUNTRY_CODE"] || "+94",
       supported_genders: %w[male female],
       patient_line_list_show_zone: false,
-      appointment_reminders_channel: "Messaging::Twilio::ReminderSms"
+      appointment_reminders_channel: "Messaging::Twilio::ReminderSms",
+      facility_sizes: {
+        community: "community",
+        small: "small",
+        medium: "medium",
+        large: "large",
+        national_hospital: "national_hospital",
+        teaching_hospital: "teaching_hospital"
+      }
     },
     US: {
       abbreviation: "US",
@@ -66,7 +92,13 @@ class CountryConfig
       sms_country_code: ENV["SMS_COUNTRY_CODE"] || "+1",
       supported_genders: %w[male female transgender],
       patient_line_list_show_zone: false,
-      appointment_reminders_channel: "Messaging::Twilio::ReminderSms"
+      appointment_reminders_channel: "Messaging::Twilio::ReminderSms",
+      facility_sizes: {
+        community: "community",
+        small: "small",
+        medium: "medium",
+        large: "large"
+      }
     },
     UK: {
       abbreviation: "UK",
@@ -78,7 +110,13 @@ class CountryConfig
       sms_country_code: ENV["SMS_COUNTRY_CODE"] || "+44",
       supported_genders: %w[male female transgender],
       patient_line_list_show_zone: false,
-      appointment_reminders_channel: "Messaging::Twilio::ReminderSms"
+      appointment_reminders_channel: "Messaging::Twilio::ReminderSms",
+      facility_sizes: {
+        community: "community",
+        small: "small",
+        medium: "medium",
+        large: "large"
+      }
     }
   }.with_indifferent_access.freeze
 

--- a/config/initializers/country_config.rb
+++ b/config/initializers/country_config.rb
@@ -15,6 +15,7 @@ class CountryConfig
       patient_line_list_show_zone: false,
       custom_drug_category_order: %w[hypertension_ccb hypertension_arb hypertension_diuretic diabetes],
       appointment_reminders_channel: "Messaging::Bsnl::Sms",
+      sorted_facility_sizes: %w[large medium small community],
       facility_sizes: {
         community: "community",
         small: "small",
@@ -35,6 +36,7 @@ class CountryConfig
       patient_line_list_show_zone: true,
       enabled_diabetes_population_coverage: true,
       appointment_reminders_channel: "Messaging::AlphaSms::Sms",
+      sorted_facility_sizes: %w[large medium small community],
       facility_sizes: {
         community: "community",
         small: "small",
@@ -54,6 +56,7 @@ class CountryConfig
       supported_genders: %w[male female],
       patient_line_list_show_zone: false,
       appointment_reminders_channel: "Messaging::Twilio::ReminderSms",
+      sorted_facility_sizes: %w[large medium small community],
       facility_sizes: {
         community: "community",
         small: "small",
@@ -73,6 +76,7 @@ class CountryConfig
       supported_genders: %w[male female],
       patient_line_list_show_zone: false,
       appointment_reminders_channel: "Messaging::Twilio::ReminderSms",
+      sorted_facility_sizes: %w[large medium small community teaching_hospital national_hospital],
       facility_sizes: {
         community: "community",
         small: "small",
@@ -93,6 +97,7 @@ class CountryConfig
       supported_genders: %w[male female transgender],
       patient_line_list_show_zone: false,
       appointment_reminders_channel: "Messaging::Twilio::ReminderSms",
+      sorted_facility_sizes: %w[large medium small community],
       facility_sizes: {
         community: "community",
         small: "small",
@@ -111,6 +116,7 @@ class CountryConfig
       supported_genders: %w[male female transgender],
       patient_line_list_show_zone: false,
       appointment_reminders_channel: "Messaging::Twilio::ReminderSms",
+      sorted_facility_sizes: %w[large medium small community],
       facility_sizes: {
         community: "community",
         small: "small",

--- a/config/locales/en_LK.yml
+++ b/config/locales/en_LK.yml
@@ -40,8 +40,12 @@ en-LK:
         small: "Divisional Hospital"
         medium: "Base Hospital"
         large: "District General Hospital"
+        national_hospital: "National Hospital"
+        teaching_hospital: "Teaching Hospital"
       pluralized_facility_size:
         community: "Primary medical care units"
         small: "Divisional Hospitals"
         medium: "Base Hospitals"
         large: "District General Hospitals"
+        national_hospital: "National Hospitals"
+        teaching_hospital: "Teaching Hospitals"


### PR DESCRIPTION
**Story card:** [sc-12175](https://app.shortcut.com/simpledotorg/story/12175/create-2-facility-sizes-teaching-hospital-national-hospital)

## Because

We want to track tertiary hospitals (national and teaching hospitals) separately in Sri Lanka.

## This addresses

This PR makes the facility sizes enum configurable per country enabling using to add new sizes for Sri Lanka without affecting deployments in other countries.

## Test instructions

- Change the default country in `.env.development` to `LK`
- You should be able to add national and teaching facilities from the dashboard
- Once facilies are added
  - They should be seen in the facilities count on the my facilities page
  - The should be able to see national and teaching facilities as drop down option in Facilities trends page
  - The faciities trends page should have sections for national and teaching facilities. 