### PR TITLE
data migration: remove duplicate medical histories for ICDDRB

### DIFF
--- a/db/data/20240318132105_dedupe_icddrb_medical_histories_2.rb
+++ b/db/data/20240318132105_dedupe_icddrb_medical_histories_2.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class DedupeIcddrbMedicalHistories2 < ActiveRecord::Migration[6.1]
+  FACILITY_IDS = %w[
+    4280917c-a10e-4125-bb79-5cf6ebe4bd2b
+    75bdedd2-ca3a-483a-a81c-9f923d723489
+    8207fda1-a37b-4c19-be25-6056c47e374b
+    8a34af23-f0a4-46e1-8932-4b390b0bee64
+    8c6840c6-9ce8-4e01-82ee-1b8af00675a2
+    f472c5db-188f-4563-9bc7-9f86a6ed6403
+    fdb34f45-923c-4612-aa15-3f8b6cc3175f
+  ]
+
+  def up
+    unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
+      return print "DedupeIcddrbMedicalHistories2 is only for production Bangladesh"
+    end
+
+    # NOTE: these merge resolution rules do not account for the case where the
+    # attribute to merge is blank. Since we have verified that this blank edge
+    # case does not occur in ICDDRB's data, we can get away with fewer rules.
+    merge_resolution_rules = {
+      Set["no"] => "no",
+      Set["yes"] => "yes",
+      Set["unknown"] => "unknown",
+      Set["no", "yes"] => "yes",
+      Set["no", "unknown"] => "no",
+      Set["yes", "unknown"] => "yes",
+      Set["yes", "no", "unknown"] => "yes"
+    }
+
+    fields_to_resolve = MedicalHistory.defined_enums.keys
+
+    transaction do
+      medical_histories_by_patient = MedicalHistory.joins(:patient)
+        .where(patient: {assigned_facility_id: FACILITY_IDS})
+        .group_by(&:patient_id)
+
+      medical_histories_by_patient.each_value do |merge_candidates|
+        next if merge_candidates.size < 2
+        merged_med_history_attrs = merge_candidates.first&.attributes&.except("id")
+        fields_to_resolve.each do |field_name|
+          conflicting_values = merge_candidates.map(&field_name.to_sym).to_set
+          merged_med_history_attrs[field_name] = merge_resolution_rules.fetch(conflicting_values)
+        end
+        MedicalHistory.create!(merged_med_history_attrs)
+        merge_candidates.map(&:discard!)
+      end
+    end
+  end
+
+  def down
+    puts "This migration cannot be reversed."
+  end
+end

--- a/spec/data/dedupe_icddrb_medical_histories_2_spec.rb
+++ b/spec/data/dedupe_icddrb_medical_histories_2_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+require Rails.root.join("db", "data", "20240318132105_dedupe_icddrb_medical_histories_2.rb")
+
+describe DedupeIcddrbMedicalHistories2 do
+  before do
+    allow(CountryConfig).to receive(:current_country?).with("Bangladesh").and_return true
+    stub_const("SIMPLE_SERVER_ENV", "production")
+  end
+
+  describe "when the data migration is run" do
+    it "deduplicates medical histories and deletes older medical history records" do
+      facility = create(:facility, id: "8c6840c6-9ce8-4e01-82ee-1b8af00675a2")
+      patients = create_list(:patient, 3, :without_medical_history, assigned_facility_id: facility.id)
+
+      medical_history1 = create(:medical_history, patient: patients[0], hypertension: "yes", diabetes: "no")
+
+      medical_history2 = create(:medical_history, patient: patients[1], hypertension: "yes", diabetes: "no")
+      medical_history3 = create(:medical_history, patient: patients[1], hypertension: "no", diabetes: "no")
+      medical_history4 = create(:medical_history, patient: patients[1], hypertension: "no", diabetes: "yes")
+
+      medical_history5 = create(:medical_history, patient: patients[2], hypertension: "no", diabetes: "no")
+      medical_history6 = create(:medical_history, patient: patients[2], hypertension: "no", diabetes: "no")
+
+      described_class.new.up
+
+      deduped_patient2 = MedicalHistory.find_by(patient_id: patients[1].id)
+      deduped_patient3 = MedicalHistory.find_by(patient_id: patients[2].id)
+
+      expect(medical_history1.reload.deleted_at).to be_nil
+
+      expect(medical_history2.reload.deleted_at).to be_a(Time)
+      expect(medical_history3.reload.deleted_at).to be_a(Time)
+      expect(medical_history4.reload.deleted_at).to be_a(Time)
+      expect(deduped_patient2).to have_attributes(hypertension: "yes", diabetes: "yes")
+
+      expect(medical_history5.reload.deleted_at).to be_a(Time)
+      expect(medical_history6.reload.deleted_at).to be_a(Time)
+      expect(deduped_patient3).to have_attributes(hypertension: "no", diabetes: "no")
+    end
+  end
+end


### PR DESCRIPTION
ICDDRB had pushed some duplicate medical history data in production due to an error in their import API integration. We have had to fix this before under different circumstances in #5378, and we are mostly repeating that same data migration from the aforementioned PR, but for all the facilities that have the duplicate as of this day.

**Story card:** [sc-12139]
