### PR TITLE
data migration: remove old invalid BUHS drugs

### DIFF
--- a/db/data/20240401110047_remove_invalid_buhs_drugs.rb
+++ b/db/data/20240401110047_remove_invalid_buhs_drugs.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class RemoveInvalidBuhsDrugs < ActiveRecord::Migration[6.1]
+  ORG_ID = "afb485a8-094e-4d86-812f-0bac90934d89"
+
+  def up
+    unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
+      return print "RemoveInvalidBuhsDrugs is only for production Bangladesh"
+    end
+
+    destroyed_drugs = PrescriptionDrug
+      .joins(facility: {facility_group: :organization})
+      .where(organization: {id: ORG_ID})
+      .where("prescription_drugs.updated_at < ?", Date.new(2024, 3, 8))
+      .destroy_all
+
+    puts "deleted:\n #{destroyed_drugs.size} drugs"
+  end
+
+  def down
+    puts "This migration cannot be reversed."
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240301082336)
+DataMigrate::Data.define(version: 20240401110047)


### PR DESCRIPTION
BUHS' integration with the import API had a bug which caused duplicate drug data to be sent. We delete all the data sent before March 8 (which is around the time the error was fixed) as per their request. Thankfully, we don't have to be too exact with the date boundary, as there was no drug data sent between 17th January to 11th March.

You can confirm this yourself by running this query, which is generated from our migration's activerecord query, with only the date value changed to 1st April:
```sql
SELECT prescription_drugs.*
FROM prescription_drugs
INNER JOIN facilities ON facilities.deleted_at IS NULL
AND facilities.id = prescription_drugs.facility_id
INNER JOIN facility_groups ON facility_groups.deleted_at IS NULL
AND facility_groups.deleted_at IS NULL
AND facility_groups.id = facilities.facility_group_id
INNER JOIN organizations organization ON organization.deleted_at IS NULL
AND organization.id = facility_groups.organization_id
WHERE prescription_drugs.deleted_at IS NULL
  AND organization.id = 'afb485a8-094e-4d86-812f-0bac90934d89' -- org ID of BUHS
  AND (prescription_drugs.updated_at < '2024-04-1')
ORDER BY prescription_drugs.updated_at DESC; -- I added this bit
```

Since BUHS will resend all the drug data again, these should be safe to delete.

**Story card:** [sc-12178]