### PR TITLE
Clear CI build cache to fix CI lib error

### DIFF
--- a/script/semaphore_setup
+++ b/script/semaphore_setup
@@ -5,7 +5,7 @@ set -e
 source ~/.toolbox/toolbox
 
 # Temporarily turn on cache clear if Semaphore has weird bundling issues
-# cache clear
+cache clear
 
 export DD_PROFILING_NO_EXTENSION=true
 sem-version ruby 2.7.4


### PR DESCRIPTION
**Story card:** [sc-12034](https://app.shortcut.com/simpledotorg/story/12034)

## Because

CI is failing due to old CI cache