### PR TITLE
Improve CI test run time and inconsistency 

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -52,6 +52,7 @@ blocks:
             - psql $DATABASE_URL -c "SELECT count(*) FROM pg_stat_activity;"
             - psql $DATABASE_URL -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'simple-server_test$TEST_ENV_NUMBER';"
             - psql $DATABASE_URL -c "SELECT count(*) FROM pg_stat_activity;"
+            - psql $DATABASE_URL -c "DROP DATABASE IF EXISTS 'simple-server_test$TEST_ENV_NUMBER';"
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -42,7 +42,7 @@ blocks:
             - bundle install
             - "bundle exec standardrb"
         - name: RSpec
-          parallelism: 64
+          parallelism: 32
           commands:
             - checkout
             - docker run -d --name postgres14-$SEMAPHORE_JOB_INDEX -p 543$SEMAPHORE_JOB_INDEX:5432 -e POSTGRES_HOST_AUTH_METHOD=trust postgres:14

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -52,7 +52,7 @@ blocks:
             - psql $DATABASE_URL -c "SELECT count(*) FROM pg_stat_activity;"
             - psql $DATABASE_URL -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'simple-server_test$SEMAPHORE_JOB_INDEX';"
             - psql $DATABASE_URL -c "SELECT count(*) FROM pg_stat_activity;"
-            - psql $DATABASE_URL -c "DROP DATABASE IF EXISTS 'simple-server_test$SEMAPHORE_JOB_INDEX';"
+            - psql $DATABASE_URL -c "DROP DATABASE IF EXISTS \"simple-server_test$SEMAPHORE_JOB_INDEX\";"
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -44,7 +44,7 @@ blocks:
             - bundle install
             - "bundle exec standardrb"
         - name: RSpec
-          parallelism: 8
+          parallelism: 7
           commands:
             - checkout
             - TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX script/semaphore_setup

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -44,7 +44,7 @@ blocks:
             - bundle install
             - "bundle exec standardrb"
         - name: RSpec
-          parallelism: 7
+          parallelism: 32
           commands:
             - checkout
             - TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX script/semaphore_setup

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -29,7 +29,7 @@ blocks:
     task:
       env_vars:
         - name: DATABASE_URL
-          value: "postgresql://postgres:@0.0.0.0:5432"
+          value: "postgresql://postgres:@localhost:5432"
         - name: RAILS_ENV
           value: "test"
         - name: TB_RSPEC_OPTIONS
@@ -43,12 +43,13 @@ blocks:
             - bundle config set path 'vendor/bundle'
             - bundle install
             - "bundle exec standardrb"
+            - docker rm postgres14 && docker run -d --name postgres14 -p 5432:5432
         - name: RSpec
           parallelism: 32
           commands:
             - checkout
             - TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX script/semaphore_setup
-            - TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT
+            - timeout 600s TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT || TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT
             - psql $DATABASE_URL -c "SELECT count(*) FROM pg_stat_activity;"
             - psql $DATABASE_URL -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'simple-server_test$SEMAPHORE_JOB_INDEX';"
             - psql $DATABASE_URL -c "SELECT count(*) FROM pg_stat_activity;"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -50,9 +50,9 @@ blocks:
             - TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX script/semaphore_setup
             - TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT
             - psql $DATABASE_URL -c "SELECT count(*) FROM pg_stat_activity;"
-            - psql $DATABASE_URL -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'simple-server_test$TEST_ENV_NUMBER';"
+            - psql $DATABASE_URL -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'simple-server_test$SEMAPHORE_JOB_INDEX';"
             - psql $DATABASE_URL -c "SELECT count(*) FROM pg_stat_activity;"
-            - psql $DATABASE_URL -c "DROP DATABASE IF EXISTS 'simple-server_test$TEST_ENV_NUMBER';"
+            - psql $DATABASE_URL -c "DROP DATABASE IF EXISTS 'simple-server_test$SEMAPHORE_JOB_INDEX';"
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -42,7 +42,7 @@ blocks:
             - bundle install
             - "bundle exec standardrb"
         - name: RSpec
-          parallelism: 4
+          parallelism: 64
           commands:
             - checkout
             - docker run -d --name postgres14-$SEMAPHORE_JOB_INDEX -p 543$SEMAPHORE_JOB_INDEX:5432 -e POSTGRES_HOST_AUTH_METHOD=trust postgres:14

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -47,8 +47,8 @@ blocks:
           parallelism: 8
           commands:
             - checkout
-            - TEST_ENV_NUMBER=$SEMAPHORE_JOB_COUNT script/semaphore_setup
-            - TEST_ENV_NUMBER=$SEMAPHORE_JOB_COUNT rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT
+            - TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX script/semaphore_setup
+            - TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -48,7 +48,7 @@ blocks:
           commands:
             - checkout
             - TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX script/semaphore_setup
-            - TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT
+            - timeout 300s bash -c 'TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT' || (echo "Timeout occurred, re-running the command."; exec $0)
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -48,7 +48,7 @@ blocks:
           commands:
             - checkout
             - TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX script/semaphore_setup
-            - timeout 300s bash -c 'TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT' || (echo "Timeout occurred, re-running the command."; exec $0)
+            - timeout 300s TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT || (echo "Command timed out, rerunning..."; TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT)
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,8 +28,6 @@ blocks:
   - name: Tests
     task:
       env_vars:
-        - name: DATABASE_URL
-          value: "postgresql://postgres:@localhost:5432"
         - name: RAILS_ENV
           value: "test"
         - name: TB_RSPEC_OPTIONS
@@ -43,17 +41,15 @@ blocks:
             - bundle config set path 'vendor/bundle'
             - bundle install
             - "bundle exec standardrb"
-            - docker rm postgres14 && docker run -d --name postgres14 -p 5432:5432
         - name: RSpec
-          parallelism: 32
+          parallelism: 4
           commands:
             - checkout
-            - TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX script/semaphore_setup
-            - timeout 600s TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT || TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT
-            - psql $DATABASE_URL -c "SELECT count(*) FROM pg_stat_activity;"
-            - psql $DATABASE_URL -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'simple-server_test$SEMAPHORE_JOB_INDEX';"
-            - psql $DATABASE_URL -c "SELECT count(*) FROM pg_stat_activity;"
-            - psql $DATABASE_URL -c "DROP DATABASE IF EXISTS \"simple-server_test$SEMAPHORE_JOB_INDEX\";"
+            - docker run -d --name postgres14-$SEMAPHORE_JOB_INDEX -p 543$SEMAPHORE_JOB_INDEX:5432 -e POSTGRES_HOST_AUTH_METHOD=trust postgres:14
+            - export DATABASE_URL=postgresql://postgres@localhost:543$SEMAPHORE_JOB_INDEX
+            - export TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX
+            - script/semaphore_setup
+            - rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -29,7 +29,7 @@ blocks:
     task:
       env_vars:
         - name: DATABASE_URL
-          value: "postgresql://postgres:@0.0.0.0:5432/myapp_test"
+          value: "postgresql://postgres:@0.0.0.0:5432"
         - name: RAILS_ENV
           value: "test"
         - name: TB_RSPEC_OPTIONS

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -47,8 +47,8 @@ blocks:
           parallelism: 8
           commands:
             - checkout
-            - script/semaphore_setup
-            - rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT
+            - TEST_ENV_NUMBER=$SEMAPHORE_JOB_COUNT script/semaphore_setup
+            - TEST_ENV_NUMBER=$SEMAPHORE_JOB_COUNT rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -48,7 +48,10 @@ blocks:
           commands:
             - checkout
             - TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX script/semaphore_setup
-            - timeout 300s TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT || (echo "Command timed out, rerunning..."; TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT)
+            - TEST_ENV_NUMBER=$SEMAPHORE_JOB_INDEX rspec_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT
+            - psql $DATABASE_URL -c "SELECT count(*) FROM pg_stat_activity;"
+            - psql $DATABASE_URL -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'simple-server_test$TEST_ENV_NUMBER';"
+            - psql $DATABASE_URL -c "SELECT count(*) FROM pg_stat_activity;"
       epilogue:
         always:
           commands:


### PR DESCRIPTION
**Story card:** [sc-12505](https://app.shortcut.com/simpledotorg/story/12505)

The CI test job is working inconsistently and takes a variable amount of time to complete each run.

The number of parallelisms has been increased to 32, and each parallel run will receive a Docker-based dedicated PostgreSQL instance.