### PR TITLE
Initialise questionnaire forms one month in advance for ET

### DIFF
--- a/lib/tasks/questionnaires.rake
+++ b/lib/tasks/questionnaires.rake
@@ -4,7 +4,7 @@ namespace :questionnaires do
     # Due to mismatch in Gregorian<>Ethiopian calendars,
     # Dynamic forms initialization had a delay of 20+ days in Ethiopia.
     # To avoid this delay, we initialize dynamic forms 1 month in advance in Ethiopia.
-    date = CountryConfig.current_country?("Ethiopia") ? Date.current : 1.month.ago
+    date = CountryConfig.current_country?("Ethiopia") ? 1.month.from_now : 1.month.ago
 
     if Flipper.enabled?(:monthly_screening_reports)
       QuestionnaireResponses::MonthlyScreeningReports.new(date).seed

--- a/lib/tasks/questionnaires.rake
+++ b/lib/tasks/questionnaires.rake
@@ -2,8 +2,8 @@ namespace :questionnaires do
   desc "Initialize questionnaire responses"
   task initialize: :environment do
     # Due to mismatch in Gregorian<>Ethiopian calendars,
-    # Dynamic forms initialization had a delay of 20+ days in Ethiopia.
-    # To avoid this delay, we initialize dynamic forms 1 month in advance in Ethiopia.
+    # Dynamic forms initialization had a delay of 30+ days in Ethiopia.
+    # To avoid this delay, we initialize dynamic forms 2 months in advance in Ethiopia.
     date = CountryConfig.current_country?("Ethiopia") ? 1.month.from_now : 1.month.ago
 
     if Flipper.enabled?(:monthly_screening_reports)


### PR DESCRIPTION
**Story card:** [sc-12507](https://app.shortcut.com/simpledotorg/story/12507/as-a-user-i-am-unable-to-see-the-screening-forms-in-ethiopia-for-the-current-month-at-the-beginning-of-the-month)

## Because

The screening forms appear only after a week in Ethiopia. 
The ET reporting period for the 8th month is `7/21/2016 - 8/20/2016` in the ET calendar (in the Gregorian calendar, it's `30/03/2024 - 28/04/2024`). They expect to see the 8th-month form by `8/20/2016`. Since we initialise the current month form on the first of every month in the Gregorian Calendar, the form for the 8th month appears only on `8-23-2016` (`01-05-2024` in the Gregorian Calendar). That's about a week after the start of the 8th month.

## This addresses

So we have decided to initialise forms two months in advance once. After that, we would initialise the form every month in ET for the next month. Whereas in other countries, we will continue to initialise the previous month form every month.