### PR TITLE
add reassignment eligibility to patient

### DIFF
--- a/app/controllers/api/v3/patients_controller.rb
+++ b/app/controllers/api/v3/patients_controller.rb
@@ -116,6 +116,7 @@ class Api::V3::PatientsController < Api::V3::SyncController
         :deleted_reason,
         :registration_facility_id,
         :assigned_facility_id,
+        :eligible_for_reassignment,
         phone_numbers: [permitted_phone_number_params],
         address: permitted_address_params,
         business_identifiers: [permitted_business_identifier_params]

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -14,9 +14,14 @@ class Patient < ApplicationRecord
   ANONYMIZED_DATA_FIELDS = %w[id created_at registration_date registration_facility_name user_id age gender]
   DELETED_REASONS = %w[duplicate unknown accidental_registration].freeze
 
+  REASSIGNMENT_ELIGIBILITY = %w[yes no unknown].freeze
+
   enum status: STATUSES.zip(STATUSES).to_h, _prefix: true
 
   enum deleted_reason: DELETED_REASONS.zip(DELETED_REASONS).to_h, _prefix: true
+
+  enum eligible_for_reassignment: REASSIGNMENT_ELIGIBILITY.zip(REASSIGNMENT_ELIGIBILITY).to_h,
+    _prefix: true, _default: "unknown"
 
   enum reminder_consent: {
     granted: "granted",
@@ -113,6 +118,7 @@ class Patient < ApplicationRecord
 
   validate :past_date_of_birth
   validates :status, presence: true
+  validates :eligible_for_reassignment, presence: true
 
   validates :device_created_at, presence: true
   validates :device_updated_at, presence: true

--- a/app/schema/api/v3/models.rb
+++ b/app/schema/api/v3/models.rb
@@ -18,7 +18,8 @@ class Api::V3::Models
          registration_facility_id: {"$ref" => "#/definitions/nullable_uuid"},
          assigned_facility_id: {"$ref" => "#/definitions/nullable_uuid"},
          reminder_consent: {type: :string, enum: Patient.reminder_consents.keys},
-         deleted_reason: {type: ["null", :string], enum: Patient::DELETED_REASONS + [nil]}
+         deleted_reason: {type: ["null", :string], enum: Patient::DELETED_REASONS + [nil]},
+         eligible_for_reassignment: {type: :string, enum: Patient::REASSIGNMENT_ELIGIBILITY}
        },
        required: %w[id gender full_name created_at updated_at status]}
     end

--- a/app/validators/api/v3/patient_payload_validator.rb
+++ b/app/validators/api/v3/patient_payload_validator.rb
@@ -22,7 +22,8 @@ class Api::V3::PatientPayloadValidator < Api::V3::PayloadValidator
     :call_result,
     :reminder_consent,
     :deleted_reason,
-    :skip_facility_authorization
+    :skip_facility_authorization,
+    :eligible_for_reassignment
   )
 
   attr_writer :request_user_id

--- a/db/migrate/20240522054839_add_eligible_for_reassignment_to_patient.rb
+++ b/db/migrate/20240522054839_add_eligible_for_reassignment_to_patient.rb
@@ -1,0 +1,5 @@
+class AddEligibleForReassignmentToPatient < ActiveRecord::Migration[6.1]
+  def change
+    add_column :patients, :eligible_for_reassignment, :text, default: "unknown", null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -885,7 +885,8 @@ CREATE TABLE public.patients (
     reminder_consent character varying DEFAULT 'denied'::character varying NOT NULL,
     deleted_by_user_id uuid,
     deleted_reason character varying,
-    assigned_facility_id uuid
+    assigned_facility_id uuid,
+    eligible_for_reassignment text DEFAULT 'unknown'::text NOT NULL
 );
 
 
@@ -7695,6 +7696,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230713065420'),
 ('20230713135154'),
 ('20231208091419'),
-('20240411074916');
+('20240411074916'),
+('20240522054839');
 
 

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     date_of_birth { nil }
     age { rand(18..100) }
     age_updated_at { Time.current }
+    eligible_for_reassignment { Patient::REASSIGNMENT_ELIGIBILITY.sample }
     device_created_at { Time.current }
     device_updated_at { Time.current }
     recorded_at { device_created_at }

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -111,12 +111,21 @@ describe Patient, type: :model do
     it "validates deleted reason" do
       patient = Patient.new
 
-      # valid deleted reasons should not cause problems
-      Patient::DELETED_REASONS.each { |reason| patient.deleted_reason = reason }
-      # nil is also a valid reason
-      patient.deleted_reason = nil
+      expect {
+        Patient::DELETED_REASONS.each { |reason| patient.deleted_reason = reason }
+      }.not_to raise_error
 
       expect { patient.deleted_reason = "something else" }.to raise_error(ArgumentError)
+    end
+
+    it "validates reassignment eligibility" do
+      patient = Patient.new
+
+      expect {
+        Patient::REASSIGNMENT_ELIGIBILITY.each { |eligibility| patient.eligible_for_reassignment = eligibility }
+      }.not_to raise_error
+
+      expect { patient.eligible_for_reassignment = "something else" }.to raise_error(ArgumentError)
     end
   end
 

--- a/spec/payloads/api/v3/patient_payload_validator_spec.rb
+++ b/spec/payloads/api/v3/patient_payload_validator_spec.rb
@@ -101,6 +101,12 @@ describe Api::V3::PatientPayloadValidator, type: :model do
         expect(payload.valid?).to be false
         expect(payload.errors[:schema]).to be_present
       end
+
+      it "validates that the reassignment eligibility is present in the prescribed enum" do
+        payload = new_patient_payload("eligible_for_reassignment" => "foo")
+        expect(payload.valid?).to be false
+        expect(payload.errors[:schema]).to be_present
+      end
     end
 
     describe "Data validations" do

--- a/swagger/v3/swagger.json
+++ b/swagger/v3/swagger.json
@@ -1557,6 +1557,14 @@
             "accidental_registration",
             null
           ]
+        },
+        "eligible_for_reassignment": {
+          "type": "string",
+          "enum": [
+            "yes",
+            "no",
+            "unknown"
+          ]
         }
       },
       "required": [
@@ -1759,6 +1767,14 @@
             "unknown",
             "accidental_registration",
             null
+          ]
+        },
+        "eligible_for_reassignment": {
+          "type": "string",
+          "enum": [
+            "yes",
+            "no",
+            "unknown"
           ]
         },
         "address": {

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -1814,6 +1814,14 @@
             null
           ]
         },
+        "eligible_for_reassignment": {
+          "type": "string",
+          "enum": [
+            "yes",
+            "no",
+            "unknown"
+          ]
+        },
         "address": {
           "$ref": "#/definitions/address"
         },


### PR DESCRIPTION
**Story card:** [sc-12577]

## Because

[Link to PRD](https://docs.google.com/document/d/1R6NnMMYIqs0VfFlyT_LQdCoa3Vdcl3URS9tNn6X0EsI/edit?usp=sharing)

This is a part of the CC reassignment feature for use in Bangladesh. We add a new field on the patient model which helps address sync issues from the Android side. The field is non-nullable with a default value of "unknown". This value is not manipulated by the server by any means, it only exists as a placeholder for the value evaluated on the Android side.

Rationale for having this on the server side and as an enum:
https://docs.google.com/document/d/1R6NnMMYIqs0VfFlyT_LQdCoa3Vdcl3URS9tNn6X0EsI/edit#heading=h.saxgwg5kcdd0

## This addresses

This patch includes a DB migration to add this field, relevant validations, and backwards-compatible changes to the patient sync model.

## Test instructions

(I have already done this, so you don't have to, but in case you want to, read on)

* Deploy this PR on QA (already done).
* Run the latest dev build of the Android App (and enable the feature flag called `patient_reassignment_v0`).
* Select Bangladesh > UHC Krishna.
* The only patient in this UHC, Ramesh Babu, has met the eligibility criteria (see PRD).
* Press back and select not now, and sync the changes.
* SSH in the QA server, the value of `eligible_for_reassignment` should be set to "yes".
* Repeat this by changing any other criteria of eligibility (either by reassigning or changing medicines or adding uncontrolled BP) and sync to server.
* The value on server should now say "no".
* On syncing, the value should stay consistent, ie, at no point should the flag get reset as the server is not touching this field's value.