### PR TITLE
Handle default when ENV variable is missing

### DIFF
--- a/app/controllers/reports/patient_lists_controller.rb
+++ b/app/controllers/reports/patient_lists_controller.rb
@@ -22,7 +22,7 @@ class Reports::PatientListsController < AdminController
     response.headers["Last-Modified"] = Time.zone.now.ctime.to_s
     zip_kit_stream(filename: "#{file_name}.zip") do |zip|
       zip.write_deflated_file("#{file_name}.csv") do |sink|
-        exporter.csv_enumerator(patients, display_blood_sugars: model.region.diabetes_management_enabled?, batch_size: (ENV.fetch("REPORT_ENUMERATOR_BATCH_SIZE") || 1000).to_i).each do |chunk|
+        exporter.csv_enumerator(patients, display_blood_sugars: model.region.diabetes_management_enabled?, batch_size: (ENV.fetch("REPORT_ENUMERATOR_BATCH_SIZE", 1000)).to_i).each do |chunk|
           sink << chunk.map(&:to_csv).join
         end
       end

--- a/app/controllers/reports/patient_lists_controller.rb
+++ b/app/controllers/reports/patient_lists_controller.rb
@@ -22,7 +22,7 @@ class Reports::PatientListsController < AdminController
     response.headers["Last-Modified"] = Time.zone.now.ctime.to_s
     zip_kit_stream(filename: "#{file_name}.zip") do |zip|
       zip.write_deflated_file("#{file_name}.csv") do |sink|
-        exporter.csv_enumerator(patients, display_blood_sugars: model.region.diabetes_management_enabled?, batch_size: (ENV.fetch("REPORT_ENUMERATOR_BATCH_SIZE", 1000)).to_i).each do |chunk|
+        exporter.csv_enumerator(patients, display_blood_sugars: model.region.diabetes_management_enabled?, batch_size: ENV.fetch("REPORT_ENUMERATOR_BATCH_SIZE", 1000).to_i).each do |chunk|
           sink << chunk.map(&:to_csv).join
         end
       end

--- a/spec/controllers/reports/patient_lists_controller_spec.rb
+++ b/spec/controllers/reports/patient_lists_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Reports::PatientListsController, type: :controller do
       expect(response.status).to eq(200)
     end
 
-    it "works even when ENV variable - 'REPORT_ENUMERATOR_BATCH_SIZE' is not defined" do
+    it "falls back to a default batch size when 'REPORT_ENUMERATOR_BATCH_SIZE' is not set" do
       ENV.delete("REPORT_ENUMERATOR_BATCH_SIZE")
       admin_with_pii.accesses.create!(resource: facility_group)
       sign_in(admin_with_pii.email_authentication)

--- a/spec/controllers/reports/patient_lists_controller_spec.rb
+++ b/spec/controllers/reports/patient_lists_controller_spec.rb
@@ -61,5 +61,13 @@ RSpec.describe Reports::PatientListsController, type: :controller do
       get :show, params: {id: facility.region.slug, report_scope: "facility"}
       expect(response.status).to eq(200)
     end
+
+    it "works even when ENV variable - 'REPORT_ENUMERATOR_BATCH_SIZE' is not defined" do
+      ENV.delete("REPORT_ENUMERATOR_BATCH_SIZE")
+      admin_with_pii.accesses.create!(resource: facility_group)
+      sign_in(admin_with_pii.email_authentication)
+      get :show, params: {id: facility_group.slug, report_scope: "district"}
+      expect { response.body }.not_to raise_error(KeyError)
+    end
   end
 end


### PR DESCRIPTION
**Story card:** [sc-12604](https://app.shortcut.com/simpledotorg/story/12604/patient-line-list-download-in-et-gives-empty-file)

## Because

Patient Line list download in ET was giving an empty CSV(0 bytes). This happened because we haven't initialised the ENV variable - ENV['REPORT_ENUMERATOR_BATCH_SIZE'] in ET production. 
 
## This addresses

- Handles the exporter when ENV variable is missing by using a default batch size.