### PR TITLE
Fix name of the data migration class to match with filename

### DIFF
--- a/db/data/20240527121747_set_up_sms_reminder_india_2024_june_july.rb
+++ b/db/data/20240527121747_set_up_sms_reminder_india_2024_june_july.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SetUpSmsRemindersIndiaJuneJuly2024 < ActiveRecord::Migration[6.1]
+class SetUpSmsReminderIndia2024JuneJuly < ActiveRecord::Migration[6.1]
   INCLUDED_FACILITY_SLUGS = [
     Facility.where(district: "Chennai").pluck(:slug),
     Facility.where(state: "West Bengal").pluck(:slug)


### PR DESCRIPTION
**Story card:** [sc-12546](https://app.shortcut.com/simpledotorg/story/12546/setup-sms-reminders-in-ihci-states-in-india-for-the-month-of-may-and-june)

## Because

This fixes a typo in the class name of a data migration.