### PR TITLE
Fix docker build

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -22,7 +22,7 @@ class Prometheus
   end
 end
 
-if Rails.env.production? && Flipper.enabled?(:prometheus_metrics)
+if Rails.env.production?
   # This reports stats per request like HTTP status and timings
   Rails.application.middleware.unshift PrometheusExporter::Middleware
 end


### PR DESCRIPTION
Adding a feature flag in the initializer breaks the docker build since then it expects a postgres connection during assets:precomile phase. This breaks the docker build. 