### PR TITLE
Fix the offset in ltfu_since_date calculation

### DIFF
--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -94,7 +94,7 @@ class Period
   end
 
   def ltfu_since_date
-    self.begin.advance(months: -13).end_of_month.to_s(:day_mon_year)
+    self.begin.advance(months: -12).end_of_month.to_s(:day_mon_year)
   end
 
   def ltfu_end_date

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
         bp_control_start_date: "1-Oct-2019",
         bp_control_end_date: "31-Dec-2019",
         ltfu_end_date: "31-Dec-2019",
-        ltfu_since_date: "30-Nov-2018",
+        ltfu_since_date: "31-Dec-2018",
         bp_control_registration_date: "30-Sep-2019"
       }
       expect(data[:period_info][dec_2019_period]).to eq(period_hash)

--- a/spec/models/period_spec.rb
+++ b/spec/models/period_spec.rb
@@ -202,4 +202,9 @@ RSpec.describe Period, type: :model do
       expect(period.month?).to eq false
     end
   end
+
+  it "returns ltfu since date" do
+    current_month_date = Date.parse("January 1st, 2024")
+    expect(Period.month(current_month_date).ltfu_since_date).to eq("31-Jan-2023")
+  end
 end


### PR DESCRIPTION
**Story card:** [sc-12779](https://app.shortcut.com/simpledotorg/story/12779/fix-the-ltfu-since-date-in-the-simple-dashboard)

## Because

The `ltfu_since_date` in the dashboard was off by a month

## This addresses

Fix the offset in the `ltfu_since_date` calculation
