### PR TITLE
Add a feature flag to disable recent health worker activitiy

### DIFF
--- a/app/views/reports/regions/_facility_details.html.erb
+++ b/app/views/reports/regions/_facility_details.html.erb
@@ -91,7 +91,8 @@
   </div>
 </div>
 
-<div class="card mt-0 pr-0 pr-md-3 pb-inside-avoid">
+<% if Flipper.enabled?(:display_healthworker_activiity) %>
+  <div class="card mt-0 pr-0 pr-md-3 pb-inside-avoid">
     <div class="d-flex flex-1 mb-8px">
       <h3 class="mb-0px mr-8px">
         Healthcare worker activity
@@ -148,3 +149,4 @@
       </table>
     </div>
   </div>
+<% end %>

--- a/app/views/reports/regions/diabetes.html.erb
+++ b/app/views/reports/regions/diabetes.html.erb
@@ -55,12 +55,14 @@
     current_admin: current_admin
   ) %>
 
-  <%= render Dashboard::Diabetes::RecentMeasurementsComponent.new(
-    region: @region,
-    recent_blood_sugars: @recent_blood_sugars,
-    display_model: :facility,
-    page: @page
-  ) %>
+  <% if Flipper.enabled?(:display_healthworker_activiity) %>
+    <%= render Dashboard::Diabetes::RecentMeasurementsComponent.new(
+      region: @region,
+      recent_blood_sugars: @recent_blood_sugars,
+      display_model: :facility,
+      page: @page
+    ) %>
+  <% end %>
 <% else %>
   <%= render Dashboard::Diabetes::RegistrationsAndFollowUpsTableComponent.new(
     region: @region,


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

## Because

The facilities page takes too long to load in certain facilities

## This addresses

We show a paginated list of recent blood pressure and blood sugars on the facilities page, this makes the page load extremely slow. This add a feature flag as a stop gap solution so that we can disable the rendering the recent health worker activity section. 