### PR TITLE
Setup SMS reminders for Sri Lanka for June July 2024

### DIFF
--- a/db/data/20240620115011_set_up_sms_reminder_sri_lanka_2024_june_july.rb
+++ b/db/data/20240620115011_set_up_sms_reminder_sri_lanka_2024_june_july.rb
@@ -19,8 +19,7 @@ class SetUpSmsReminderSriLanka2024JuneJuly < ActiveRecord::Migration[6.1]
           name: experiment_data[:current_patients_experiment_name],
           start_time: experiment_data[:start_time],
           end_time: experiment_data[:end_time],
-          max_patients_per_day: PATIENTS_PER_DAY,
-          filters: REGION_FILTERS
+          max_patients_per_day: PATIENTS_PER_DAY
         ).tap do |experiment|
           cascade = experiment.treatment_groups.create!(description: "sms_reminders_cascade - #{experiment_data[:current_patients_experiment_name]}")
           cascade.reminder_templates.create!(message: "notifications.sri_lanka.one_day_before_appointment", remind_on_in_days: -1)

--- a/db/data/20240620115011_set_up_sms_reminder_sri_lanka_2024_june_july.rb
+++ b/db/data/20240620115011_set_up_sms_reminder_sri_lanka_2024_june_july.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class SetUpSmsReminderSriLanka2024JuneJuly < ActiveRecord::Migration[6.1]
+  PATIENTS_PER_DAY = 5000
+  EXPERIMENTS_DATA = %w[Jun Jul].map do |month|
+    {
+      start_time: "#{month} 2024".to_datetime.beginning_of_month,
+      end_time: "#{month} 2024".to_datetime.end_of_month,
+      current_patients_experiment_name: "Current Patient #{month} 2024"
+    }
+  end
+
+  def up
+    return unless CountryConfig.current_country?("Sri Lanka") && SimpleServer.env.production?
+
+    EXPERIMENTS_DATA.each do |experiment_data|
+      ActiveRecord::Base.transaction do
+        Experimentation::Experiment.current_patients.create!(
+          name: experiment_data[:current_patients_experiment_name],
+          start_time: experiment_data[:start_time],
+          end_time: experiment_data[:end_time],
+          max_patients_per_day: PATIENTS_PER_DAY,
+          filters: REGION_FILTERS
+        ).tap do |experiment|
+          cascade = experiment.treatment_groups.create!(description: "sms_reminders_cascade - #{experiment_data[:current_patients_experiment_name]}")
+          cascade.reminder_templates.create!(message: "notifications.sri_lanka.one_day_before_appointment", remind_on_in_days: -1)
+          cascade.reminder_templates.create!(message: "notifications.sri_lanka.three_days_missed_appointment", remind_on_in_days: 3)
+        end
+      end
+    end
+  end
+
+  def down
+    return unless CountryConfig.current_country?("Sri Lanka") && SimpleServer.env.production?
+    EXPERIMENTS_DATA.map do |experiment_data|
+      Experimentation::Experiment.current_patients.find_by_name(experiment_data[:current_patients_experiment_name])&.cancel
+    end
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240527121747)
+DataMigrate::Data.define(version: 20240620115011)


### PR DESCRIPTION


**Story card:** [sc-12668](https://app.shortcut.com/simpledotorg/story/12668/set-up-sms-reminders-in-sri-lanka)

## Because

We want to setup SMS reminders with the following configurations for the months of June and July 2024

- Cascade on day -1 and 3 after scheduled appointment
- Templates
  - one_day_before_appointment
  - three_days_missed_appointment

## Test instructions

Run `bin/rails data:migrate` to run this migration.