### PR TITLE
Exclude Sylhet in ongoing Bangladesh experiments

### DIFF
--- a/db/data/20240701183555_disable_sms_reminders_bd_sylhet_july_2024.rb
+++ b/db/data/20240701183555_disable_sms_reminders_bd_sylhet_july_2024.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class DisableSmsRemindersBdSylhetJuly2024 < ActiveRecord::Migration[6.1]
+  DISTRICTS_NO_SYLHET = %w[Moulvibazar Habiganj Sunamganj Barishal Jhalokathi Feni
+    Chattogram Bandarban Pabna Rajshahi Sirajganj Sherpur Jamalpur].freeze
+
+  INCLUDED_FACILITY_SLUG = Facility.where(facility_type: "UHC", district: DISTRICTS).pluck(:slug)
+
+  UPDATED_REGION_FILTERS = {
+    "facilities" => {"include" => INCLUDED_FACILITY_SLUG}
+  }.freeze
+
+  def up
+    return unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
+
+    %w[Jul Aug Sep Oct].each do |month|
+      Experimentation::Experiment.find_by_name("Current patient #{month} 2024")&.update!(filters: UPDATED_REGION_FILTERS)
+      Experimentation::Experiment.find_by_name("Stale patient #{month} 2024")&.update!(filters: UPDATED_REGION_FILTERS)
+    end
+  end
+
+  def down
+    return unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
+    puts "This migration cannot be reversed. To include Sylhet again, create a new migration."
+  end
+end


### PR DESCRIPTION
We create a data migration that updates the region filters for ongoing experiments in Bangladesh (as seen in
#5415) to exclude Sylhet.

**Story card:** [sc-12869](https://app.shortcut.com/simpledotorg/story/12869/stop-sending-sms-to-sylhet)
