### PR TITLE
Fix: Patients protected does not show last 3Y data

### DIFF
--- a/app/components/dashboard/hypertension/patients_protected_component.rb
+++ b/app/components/dashboard/hypertension/patients_protected_component.rb
@@ -1,16 +1,15 @@
 class Dashboard::Hypertension::PatientsProtectedComponent < ApplicationComponent
-  attr_reader :data, :contactable, :period, :period_start
+  attr_reader :period, :period_start
 
-  def initialize(region:, data:, period:)
+  def initialize(region:, period:)
     @region = region
-    @data = data
     # Show only data up to last month
     @period = period.advance(months: -1)
     @period_start = period.advance(months: -36)
+    @repo = Reports::Repository.new(@region, periods: Range.new(@period_start, @period))
   end
 
   def graph_data
-    patients_protected = fill_empty_period_data(:controlled_patients)
     {
       patientsProtected: patients_protected,
       patientsProtectedWithSuffix: patients_protected.map { |k, v| [k, "#{v} patients"] }.to_h
@@ -19,10 +18,10 @@ class Dashboard::Hypertension::PatientsProtectedComponent < ApplicationComponent
 
   private
 
-  def fill_empty_period_data(key)
+  def patients_protected
     period_range = (period_start..period)
     period_range.each_with_object(Hash.new(0)) do |period, info|
-      info[period] = data[key].fetch(period, 0)
+      info[period] = @repo.controlled[@region.slug].fetch(period, 0)
     end
   end
 end

--- a/app/components/dashboard/hypertension/patients_protected_component.rb
+++ b/app/components/dashboard/hypertension/patients_protected_component.rb
@@ -12,11 +12,15 @@ class Dashboard::Hypertension::PatientsProtectedComponent < ApplicationComponent
   def graph_data
     {
       patientsProtected: patients_protected,
-      patientsProtectedWithSuffix: patients_protected.map { |k, v| [k, "#{v} patients"] }.to_h
+      patientsProtectedWithSuffix: patients_protected_with_suffix
     }
   end
 
   private
+
+  def patients_protected_with_suffix
+    patients_protected.transform_values { |v| "#{number_with_delimiter(v, delimiter: ",")} patients" }.to_h
+  end
 
   def patients_protected
     period_range = (period_start..period)

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -12,7 +12,6 @@
   <div class="d-lg-flex <%= show_htn_cascade ? "pr-lg-2" : "" %> w-lg-66 flex-fill">
     <%= render(Dashboard::Hypertension::PatientsProtectedComponent.new(
       region: @region,
-      data: @data,
       period: @period)) %>
   </div>
   <% if show_htn_cascade && Flipper.enabled?(:patients_protected_htn_cascade, current_admin)%>


### PR DESCRIPTION
**Story card:** [sc-12887](https://app.shortcut.com/simpledotorg/story/12887/bug-patients-protected-not-showing-last-36-months-of-data)

## Because

On the dashboard, we only show 18 months of data. Reports::MAX_MONTHS_OF_DATA configures this. Changing this value, however, will make all the charts on the dashboard display 36 months of data.

## This addresses

We're creating a new repository object in the patients-protected component to override the max number of months value.

## Test instructions

Enable the `patients_protected` feature flag to see this graph