### PR TITLE
Fix incorrect exporter mapping in Bangladesh

### DIFF
--- a/app/jobs/dhis2/bangladesh_disaggregated_diabetes_exporter_job.rb
+++ b/app/jobs/dhis2/bangladesh_disaggregated_diabetes_exporter_job.rb
@@ -11,8 +11,8 @@ module Dhis2
     def facility_data_for_period(region, period)
       {
         dm_cumulative_assigned: PatientStates::Diabetes::CumulativeAssignedPatientsQuery.new(region, period).call,
-        dm_controlled: PatientStates::Diabetes::BsBelow200PatientsQuery.new(region, period).call,
-        dm_uncontrolled: PatientStates::Diabetes::BsOver200PatientsQuery.new(region, period).call,
+        dm_bs_below_200: PatientStates::Diabetes::BsBelow200PatientsQuery.new(region, period).call,
+        dm_bs_over_200: PatientStates::Diabetes::BsOver200PatientsQuery.new(region, period).call,
         dm_missed_visits: PatientStates::Diabetes::MissedVisitsPatientsQuery.new(region, period).call,
         dm_ltfu: PatientStates::Diabetes::LostToFollowUpPatientsQuery.new(region, period).call,
         dm_dead: PatientStates::Diabetes::DeadPatientsQuery.new(region, period).call,

--- a/config/data/dhis2/bangladesh-production.yml
+++ b/config/data/dhis2/bangladesh-production.yml
@@ -21,10 +21,10 @@ disaggregated_dhis2_data_elements:
   htn_missed_visits: "DktVuX67zy3"
 
 disaggregated_diabetes_dhis2_data_elements:
-  dm_patients_with_bs_below_200: "Yer5NiM1jJK"
-  dm_patients_with_bs_over_200: "CKjtDbqnfFx"
-  dm_cumulative_assigned_patients: "dwxbGnWc9Ay"
-  dm_cumulative_assigned_patients_adjusted: "bqvyLmLfNon"
+  dm_bs_below_200: "Yer5NiM1jJK"
+  dm_bs_over_200: "CKjtDbqnfFx"
+  dm_cumulative_assigned: "dwxbGnWc9Ay"
+  dm_cumulative_assigned_adjusted: "bqvyLmLfNon"
   dm_cumulative_registrations: "GU00VagwQiF"
   dm_dead: "MMPJ7RUkxpw"
   dm_monthly_registrations: "xWJKOFUbqm5"

--- a/spec/jobs/dhis2/bangladesh_disaggregated_diabetes_exporter_job_spec.rb
+++ b/spec/jobs/dhis2/bangladesh_disaggregated_diabetes_exporter_job_spec.rb
@@ -15,8 +15,8 @@ describe Dhis2::BangladeshDisaggregatedDiabetesExporterJob do
     let(:facility_data) {
       {
         dm_cumulative_assigned: :dm_cumulative_assigned,
-        dm_controlled: :dm_controlled,
-        dm_uncontrolled: :dm_uncontrolled,
+        dm_bs_below_200: :dm_bs_below_200,
+        dm_bs_over_200: :dm_bs_over_200,
         dm_missed_visits: :dm_missed_visits,
         dm_ltfu: :dm_ltfu,
         dm_dead: :dm_dead,
@@ -47,8 +47,8 @@ describe Dhis2::BangladeshDisaggregatedDiabetesExporterJob do
       end
 
       allow_any_instance_of(PatientStates::Diabetes::CumulativeAssignedPatientsQuery).to receive(:call).and_return(:dm_cumulative_assigned)
-      allow_any_instance_of(PatientStates::Diabetes::BsBelow200PatientsQuery).to receive(:call).and_return(:dm_controlled)
-      allow_any_instance_of(PatientStates::Diabetes::BsOver200PatientsQuery).to receive(:call).and_return(:dm_uncontrolled)
+      allow_any_instance_of(PatientStates::Diabetes::BsBelow200PatientsQuery).to receive(:call).and_return(:dm_bs_below_200)
+      allow_any_instance_of(PatientStates::Diabetes::BsOver200PatientsQuery).to receive(:call).and_return(:dm_bs_over_200)
       allow_any_instance_of(PatientStates::Diabetes::MissedVisitsPatientsQuery).to receive(:call).and_return(:dm_missed_visits)
       allow_any_instance_of(PatientStates::Diabetes::LostToFollowUpPatientsQuery).to receive(:call).and_return(:dm_ltfu)
       allow_any_instance_of(PatientStates::Diabetes::DeadPatientsQuery).to receive(:call).and_return(:dm_dead)


### PR DESCRIPTION
## Because

The DHIS2 disaggregated diabetes exporter relies on the `bangladesh-production.yml` file to determine which data elements the values should be sent to. The lookup would break in production because the keys on the backend do not exactly match the keys in the YAML file.

**Story card:** Part of [sc-12888](https://app.shortcut.com/simpledotorg/story/12888/turn-on-flag-to-schedule-monthly-transfer-of-dm-data-bangladesh)

## This addresses

 We unify the names and make them consistent with the key names convention established in the hypertension exporter.