### PR TITLE
Fixed the padding-right on patients protected card

### DIFF
--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -9,7 +9,7 @@
 
 <% if Flipper.enabled?(:patients_protected, current_admin) %>
 <div class="d-lg-flex flex-lg-wrap">
-  <div class="d-lg-flex <% if Flipper.enabled?(:patients_protected_htn_cascade, current_admin) %>pr-lg-2 w-lg-66<% end %> flex-fill">
+  <div class="d-lg-flex <% if Flipper.enabled?(:patients_protected_htn_cascade, current_admin) && show_htn_cascade %>pr-lg-2 w-lg-66<% end %> flex-fill">
     <%= render(Dashboard::Hypertension::PatientsProtectedComponent.new(
       region: @region,
       period: @period)) %>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -9,7 +9,7 @@
 
 <% if Flipper.enabled?(:patients_protected, current_admin) %>
 <div class="d-lg-flex flex-lg-wrap">
-  <div class="d-lg-flex <%= show_htn_cascade ? "pr-lg-2" : "" %> w-lg-66 flex-fill">
+  <div class="d-lg-flex <% if Flipper.enabled?(:patients_protected_htn_cascade, current_admin) %>pr-lg-2 w-lg-66<% end %> flex-fill">
     <%= render(Dashboard::Hypertension::PatientsProtectedComponent.new(
       region: @region,
       period: @period)) %>


### PR DESCRIPTION
Fixes a tiny padding bug on the Patients Protected card when the Treatment Cascade is not visible.

**Story card:** NONE

## Because

The Patients Protected card had a small extra padding on the right when the Cascade isn't displayed.

## This addresses

Uses Flipper to only have PR-2 padding when the cascade is visible.

## Test instructions

None