### PR TITLE
Add a feature flag to disable recent health worker activity

### DIFF
--- a/app/views/reports/regions/_facility_details.html.erb
+++ b/app/views/reports/regions/_facility_details.html.erb
@@ -91,7 +91,8 @@
   </div>
 </div>
 
-<div class="card mt-0 pr-0 pr-md-3 pb-inside-avoid">
+<% unless Flipper.enabled?(:disable_healthworker_activiity) %>
+  <div class="card mt-0 pr-0 pr-md-3 pb-inside-avoid">
     <div class="d-flex flex-1 mb-8px">
       <h3 class="mb-0px mr-8px">
         Healthcare worker activity
@@ -148,3 +149,4 @@
       </table>
     </div>
   </div>
+<% end %>

--- a/app/views/reports/regions/diabetes.html.erb
+++ b/app/views/reports/regions/diabetes.html.erb
@@ -55,12 +55,14 @@
     current_admin: current_admin
   ) %>
 
-  <%= render Dashboard::Diabetes::RecentMeasurementsComponent.new(
-    region: @region,
-    recent_blood_sugars: @recent_blood_sugars,
-    display_model: :facility,
-    page: @page
-  ) %>
+  <% unless Flipper.enabled?(:disable_healthworker_activiity) %>
+    <%= render Dashboard::Diabetes::RecentMeasurementsComponent.new(
+      region: @region,
+      recent_blood_sugars: @recent_blood_sugars,
+      display_model: :facility,
+      page: @page
+    ) %>
+  <% end %>
 <% else %>
   <%= render Dashboard::Diabetes::RegistrationsAndFollowUpsTableComponent.new(
     region: @region,


### PR DESCRIPTION
If we enable this flag, health worker activity on facility reports is not loaded.

We are using this to debug the cause of slow dashboard loads.