### PR TITLE
Integrate Mobitel as an SMS provider for SL

### DIFF
--- a/app/models/mobitel_delivery_detail.rb
+++ b/app/models/mobitel_delivery_detail.rb
@@ -1,0 +1,29 @@
+class MobitelDeliveryDetail < DeliveryDetail
+  # Mobitel APIs are not capable of providing delivery details.
+  # Hence we consider all the requests that passed the API validation as successful
+  def successful?
+    true
+  end
+
+  def unsuccessful?
+    false
+  end
+
+  def in_progress?
+    false
+  end
+
+  def self.create_with_communication!(message:, recipient_number:)
+    ActiveRecord::Base.transaction do
+      delivery_detail = create!(
+        message: message,
+        recipient_number: recipient_number
+      )
+
+      Communication.create!(
+        communication_type: Messaging::Mobitel::Sms.communication_type,
+        detailable: delivery_detail
+      )
+    end
+  end
+end

--- a/app/services/messaging/mobitel/api.rb
+++ b/app/services/messaging/mobitel/api.rb
@@ -1,0 +1,70 @@
+class Messaging::Mobitel::Api
+  HOST = "https://msmsenterpriseapi.mobitel.lk"
+  URL_PATHS = {
+    send_sms: "/EnterpriseSMSV3/esmsproxy.php",
+    send_sms_multi_lang: "/EnterpriseSMSV3/esmsproxy_multilang.php"
+  }
+  MESSAGE_TYPE = {
+    non_promotional: 0,
+    promotional: 1
+  }
+
+  def initialize
+    raise Messaging::Mobitel::Error.new("Missing Mobitel SMS Alias") if message_alias.blank?
+    raise Messaging::Mobitel::Error.new("Missing Mobitel username") if api_username.blank?
+    raise Messaging::Mobitel::Error.new("Missing Mobitel password") if api_password.blank?
+  end
+
+  def send_sms(recipient_number:, message:)
+    get(URL_PATHS[:send_sms_multi_lang], {
+      m: message,
+      r: recipient_number,
+      a: message_alias,
+      u: api_username,
+      p: api_password,
+      t: message_type
+    })
+  end
+
+  private
+
+  def message_type
+    MESSAGE_TYPE[:non_promotional]
+  end
+
+  def message_alias
+    ENV["MOBITEL_SMS_ALIAS"]
+  end
+
+  def api_username
+    ENV["MOBITEL_API_USERNAME"]
+  end
+
+  def api_password
+    ENV["MOBITEL_API_PASSWORD"]
+  end
+
+  def get(path, params = {})
+    uri = URI("#{HOST}#{path}")
+    uri.query = URI.encode_www_form(params)
+
+    response = Net::HTTP.get_response(uri)
+
+    unless response.is_a?(Net::HTTPSuccess)
+      raise Messaging::Mobitel::Error.new(
+        "Mobitel API returned #{response.code} with #{response.body}"
+      )
+    end
+    is_success(response)
+  end
+
+  def is_success(response)
+    code = response.body
+    unless code.to_i.to_s == code
+      raise Messaging::Mobitel::Error.new(
+        "Non standard response received for Mobitel API: #{response.body}"
+      )
+    end
+    code.to_i
+  end
+end

--- a/app/services/messaging/mobitel/error.rb
+++ b/app/services/messaging/mobitel/error.rb
@@ -1,0 +1,29 @@
+class Messaging::Mobitel::Error < Messaging::Error
+  API_RESPONSE_CODE = {
+    200 => :ok,
+    151 => :invalid_session,
+    152 => :session_in_use,
+    155 => :service_halted,
+    156 => :other_networking_messaging_disabled,
+    157 => :idd_messages_disabled,
+    159 => :failed_credit_check,
+    160 => :no_message_found,
+    161 => :message_exceeding_160_characters,
+    162 => :invalid_message_type_found,
+    164 => :invalid_group,
+    165 => :no_recipients_found,
+    166 => :recipient_list_exceeding_allowed_limit,
+    167 => :invalid_long_number,
+    168 => :invalid_short_code,
+    169 => :invalid_alias,
+    170 => :black_listed_numbers_in_number_list,
+    171 => :non_white_listed_numbers_in_number_list
+  }
+
+  def initialize(message, error_code = nil)
+    @message = "Error while calling Mobitel API: #{message}"
+    @reason = API_RESPONSE_CODE[error_code]
+  end
+
+  attr_reader :message, :reason
+end

--- a/app/services/messaging/mobitel/sms.rb
+++ b/app/services/messaging/mobitel/sms.rb
@@ -1,0 +1,44 @@
+class Messaging::Mobitel::Sms < Messaging::Channel
+  API_SUCCESS_RESPONSE = 200
+
+  def self.communication_type
+    Communication.communication_types[:sms]
+  end
+
+  def send_message(recipient_number:, message:, &with_communication_do)
+    track_metrics do
+      send_sms(recipient_number, message)
+      create_communication(
+        recipient_number,
+        message,
+        &with_communication_do
+      )
+    end
+  end
+
+  private
+
+  def send_sms(recipient_number, message)
+    Messaging::Mobitel::Api.new.send_sms(
+      recipient_number: recipient_number,
+      message: message
+    ).tap { |response| raise_api_errors(response) }
+  end
+
+  def raise_api_errors(code)
+    unless code == API_SUCCESS_RESPONSE
+      raise Messaging::Mobitel::Error.new("API failed with code: #{code}", code)
+    end
+  end
+
+  def create_communication(recipient_number, message, &with_communication_do)
+    ActiveRecord::Base.transaction do
+      MobitelDeliveryDetail.create_with_communication!(
+        message: message,
+        recipient_number: recipient_number
+      ).tap do |communication|
+        with_communication_do&.call(communication)
+      end
+    end
+  end
+end

--- a/db/migrate/20240716132001_create_mobitel_delivery_details.rb
+++ b/db/migrate/20240716132001_create_mobitel_delivery_details.rb
@@ -1,0 +1,10 @@
+class CreateMobitelDeliveryDetails < ActiveRecord::Migration[6.1]
+  def change
+    create_table :mobitel_delivery_details do |t|
+      t.string :recipient_number, null: false
+      t.string :message
+      t.timestamp :deleted_at
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1512,6 +1512,39 @@ CREATE TABLE public.medicine_purposes (
 
 
 --
+-- Name: mobitel_delivery_details; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.mobitel_delivery_details (
+    id bigint NOT NULL,
+    recipient_number character varying NOT NULL,
+    message character varying,
+    deleted_at timestamp without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: mobitel_delivery_details_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.mobitel_delivery_details_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: mobitel_delivery_details_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.mobitel_delivery_details_id_seq OWNED BY public.mobitel_delivery_details.id;
+
+
+--
 -- Name: notifications; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5349,6 +5382,13 @@ ALTER TABLE ONLY public.flipper_gates ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
+-- Name: mobitel_delivery_details id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.mobitel_delivery_details ALTER COLUMN id SET DEFAULT nextval('public.mobitel_delivery_details_id_seq'::regclass);
+
+
+--
 -- Name: observations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -5630,6 +5670,14 @@ ALTER TABLE ONLY public.machine_users
 
 ALTER TABLE ONLY public.medical_histories
     ADD CONSTRAINT medical_histories_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: mobitel_delivery_details mobitel_delivery_details_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.mobitel_delivery_details
+    ADD CONSTRAINT mobitel_delivery_details_pkey PRIMARY KEY (id);
 
 
 --
@@ -7697,6 +7745,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230713135154'),
 ('20231208091419'),
 ('20240411074916'),
-('20240522054839');
+('20240522054839'),
+('20240716132001');
 
 

--- a/spec/factories/mobitel_delivery_details.rb
+++ b/spec/factories/mobitel_delivery_details.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :mobitel_delivery_detail do
+    recipient_number { Faker::PhoneNumber.phone_number }
+    message { "Test message" }
+
+    association :communication
+  end
+end

--- a/spec/models/mobitel_delivery_detail_spec.rb
+++ b/spec/models/mobitel_delivery_detail_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe MobitelDeliveryDetail, type: :model do
+  describe "Associations" do
+    it { is_expected.to have_one(:communication) }
+  end
+
+  describe "#in_progress?" do
+    it "is always false because messages are either successful or fails at API validation" do
+      expect(described_class.new.in_progress?).to be false
+    end
+  end
+
+  describe "#unsuccessful?" do
+    it "is always false because messages are either successful or fails at API validation" do
+      expect(described_class.new.unsuccessful?).to be false
+    end
+  end
+
+  describe "#successful?" do
+    it "is always false because messages are either successful or fails at API validation" do
+      expect(described_class.new.successful?).to be true
+    end
+  end
+
+  describe ".create_with_communication!" do
+    it "creates a communication channel with delivery details" do
+      phone_number = Faker::PhoneNumber.phone_number
+      message = "Test Message"
+      communication = described_class.create_with_communication!(
+        recipient_number: phone_number,
+        message: message
+      )
+
+      expect(communication.detailable.recipient_number).to eq phone_number
+      expect(communication.detailable.message).to eq message
+    end
+  end
+end

--- a/spec/services/messaging/mobitel/api_spec.rb
+++ b/spec/services/messaging/mobitel/api_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe Messaging::Mobitel::Api do
+  def stub_credentials(*keys)
+    env_variables = {
+      alias: "MOBITEL_SMS_ALIAS",
+      username: "MOBITEL_API_USERNAME",
+      password: "MOBITEL_API_PASSWORD"
+    }
+    allow(ENV).to receive(:[]).and_call_original
+    keys.each do |key|
+      allow(ENV).to receive(:[]).with(env_variables[key]).and_return("TEST")
+    end
+  end
+
+  describe "#new" do
+    it "does not raise any errors when all the ENV variables are present" do
+      stub_credentials(:username, :password, :alias)
+      expect { described_class.new }.not_to raise_error
+    end
+
+    it "raises an error if SMS Alias is missing" do
+      stub_credentials(:username, :password)
+      expect { described_class.new }.to raise_error(Messaging::Mobitel::Error).with_message("Error while calling Mobitel API: Missing Mobitel SMS Alias")
+    end
+
+    it "raises an error if username is missing" do
+      stub_credentials(:password, :alias)
+      expect { described_class.new }.to raise_error(Messaging::Mobitel::Error).with_message("Error while calling Mobitel API: Missing Mobitel username")
+    end
+
+    it "raises an error if password is missing" do
+      stub_credentials(:username, :alias)
+      expect { described_class.new }.to raise_error(Messaging::Mobitel::Error).with_message("Error while calling Mobitel API: Missing Mobitel password")
+    end
+  end
+
+  describe "#send_message" do
+    it "makes an API call" do
+      stub_credentials(:username, :password, :alias)
+      message = "Test Message"
+      recipient_number = Faker::PhoneNumber.phone_number
+
+      request = stub_request(:get, "https://msmsenterpriseapi.mobitel.lk/EnterpriseSMSV3/esmsproxy_multilang.php")
+        .with(query: hash_including({}))
+        .to_return(body: "200")
+      described_class.new.send_sms(recipient_number: recipient_number, message: message)
+      expect(request).to have_been_made
+    end
+
+    it "raises an exception if non 200 resopnse is received" do
+      stub_credentials(:username, :password, :alias)
+      message = "Test Message"
+      recipient_number = Faker::PhoneNumber.phone_number
+
+      stub_request(:get, "https://msmsenterpriseapi.mobitel.lk/EnterpriseSMSV3/esmsproxy_multilang.php")
+        .with(query: hash_including({}))
+        .to_return(body: "Not found")
+
+      expect {
+        described_class.new.send_sms(recipient_number: recipient_number, message: message)
+      }.to raise_error(Messaging::Mobitel::Error).with_message("Error while calling Mobitel API: Non standard response received for Mobitel API: Not found")
+    end
+  end
+end

--- a/spec/services/messaging/mobitel/sms_spec.rb
+++ b/spec/services/messaging/mobitel/sms_spec.rb
@@ -2,23 +2,6 @@ require "rails_helper"
 
 RSpec.describe Messaging::Mobitel::Sms do
   describe "#send_message" do
-    it "passes sanitised variable content to the API" do
-      mock_api = double("MobitelApiDouble")
-      allow(Messaging::Mobitel::Api).to receive(:new).and_return(mock_api)
-      allow(mock_api).to receive(:send_sms)
-      allow(mock_api).to receive(:send_sms).and_return(200)
-
-      expect(mock_api).to receive(:send_sms).with(
-        recipient_number: "+11001100",
-        message: "Test message"
-      )
-
-      described_class.send_message(
-        recipient_number: "+11001100",
-        message: "Test message"
-      )
-    end
-
     it "raises any response whose body is non 200 as exception" do
       mock_api = double("MobitelApiDouble")
       allow(Messaging::Mobitel::Api).to receive(:new).and_return(mock_api)

--- a/spec/services/messaging/mobitel/sms_spec.rb
+++ b/spec/services/messaging/mobitel/sms_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Messaging::Mobitel::Sms do
+  describe "#send_message" do
+    it "passes sanitised variable content to the API" do
+      mock_api = double("MobitelApiDouble")
+      allow(Messaging::Mobitel::Api).to receive(:new).and_return(mock_api)
+      allow(mock_api).to receive(:send_sms)
+      allow(mock_api).to receive(:send_sms).and_return(200)
+
+      expect(mock_api).to receive(:send_sms).with(
+        recipient_number: "+11001100",
+        message: "Test message"
+      )
+
+      described_class.send_message(
+        recipient_number: "+11001100",
+        message: "Test message"
+      )
+    end
+
+    it "raises any response whose body is non 200 as exception" do
+      mock_api = double("MobitelApiDouble")
+      allow(Messaging::Mobitel::Api).to receive(:new).and_return(mock_api)
+      allow(mock_api).to receive(:send_sms)
+      allow(mock_api).to receive(:send_sms).and_return(159)
+
+      expect(mock_api).to receive(:send_sms).with(
+        recipient_number: "+11001100",
+        message: "Test message"
+      )
+
+      expect {
+        described_class.send_message(
+          recipient_number: "+11001100",
+          message: "Test message"
+        )
+      }.to raise_error(Messaging::Mobitel::Error)
+    end
+  end
+end

--- a/spec/services/messaging/mobitel/sms_spec.rb
+++ b/spec/services/messaging/mobitel/sms_spec.rb
@@ -37,5 +37,33 @@ RSpec.describe Messaging::Mobitel::Sms do
         )
       }.to raise_error(Messaging::Mobitel::Error)
     end
+
+    it "creates a detailable and a communication and returns it" do
+      phone_number = Faker::PhoneNumber.phone_number
+      mock_api = double("MobitelApiDouble")
+      allow(Messaging::Mobitel::Api).to receive(:new).and_return(mock_api)
+      allow(mock_api).to receive(:send_sms)
+      allow(mock_api).to receive(:send_sms).and_return(200)
+
+      communication = described_class.send_message(
+        recipient_number: phone_number,
+        message: "Test message"
+      )
+
+      expect(communication.detailable.recipient_number).to eq(phone_number)
+    end
+
+    it "yields with a Communication instance when send_message is called" do
+      mock_api = double("MobitelApiDouble")
+      allow(Messaging::Mobitel::Api).to receive(:new).and_return(mock_api)
+      allow(mock_api).to receive(:send_sms)
+      allow(mock_api).to receive(:send_sms).and_return(200)
+
+      expect { |b|
+        described_class.send_message(
+          recipient_number: "+110011001", message: "Test message", &b
+        )
+      }.to yield_with_args(instance_of(Communication))
+    end
   end
 end

--- a/spec/services/notification_dispatch_service_spec.rb
+++ b/spec/services/notification_dispatch_service_spec.rb
@@ -63,6 +63,20 @@ RSpec.describe NotificationDispatchService do
     described_class.call(notification)
   end
 
+  it "calls send_message for Mobitel with the right args supplied" do
+    messaging_channel = Messaging::Mobitel::Sms
+    allow(CountryConfig.current).to receive(:[]).and_call_original
+    allow(CountryConfig.current).to receive(:[]).with(:appointment_reminders_channel).and_return(messaging_channel.to_s)
+
+    notification = create(:notification)
+    expect(messaging_channel).to receive(:send_message).with(
+      recipient_number: notification.patient.latest_mobile_number,
+      message: notification.localized_message
+    )
+
+    described_class.call(notification)
+  end
+
   it "accepts a messaging_channel as an override to the country config" do
     mock = mock_messaging_channel
     messaging_channel = Messaging::Bsnl::Sms


### PR DESCRIPTION
**Story card:** [sc-12889](https://app.shortcut.com/simpledotorg/story/12889/integrate-mobitel-api-for-lk)

## Because

Mobitel is a new SMS vendor that we'll be using in SL.

## This addresses

### Note
- Mobitel does not have a delivery status, once the API is sent, it can only be perceived as delivered.
- There are no callback APIs, or status check APIs to check if the SMS is delivered. So we'll consider all SMSs that passed the API validation checks successful.

## Test instructions

The following ENV variables should be added to test out this vendor
- `MOBITEL_API_USERNAME`
- `MOBITEL_API_PASSWORD`
- `MOBITEL_SMS_ALIAS`

You can find the credentials in our vault