### PR TITLE
Fix slow page loads for facility regions

### DIFF
--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -101,9 +101,15 @@ class Reports::RegionsController < AdminController
     }
 
     if @region.facility_region?
-      @recent_blood_pressures = paginate(
-        @region.source.blood_pressures.for_recent_bp_log.includes(:patient, :facility)
-      )
+      @recent_blood_pressures = if Flipper.enabled?(:fast_bp_log)
+        paginate(
+          BloodPressure.where(facility_id: @region.source_id).for_recent_bp_log.includes(:patient, :facility)
+        )
+      else
+        paginate(
+          @region.source.blood_pressures.for_recent_bp_log.includes(:patient, :facility)
+        )
+      end
     end
 
     # ======================

--- a/app/views/reports/regions/_facility_details.html.erb
+++ b/app/views/reports/regions/_facility_details.html.erb
@@ -91,62 +91,60 @@
   </div>
 </div>
 
-<% unless Flipper.enabled?(:disable_healthworker_activiity) %>
-  <div class="card mt-0 pr-0 pr-md-3 pb-inside-avoid">
-    <div class="d-flex flex-1 mb-8px">
-      <h3 class="mb-0px mr-8px">
-        Healthcare worker activity
-      </h3>
-      <%= render "definition_tooltip",
-                 definitions: { "Monthly registered patients" => t("registered_patients_copy.monthly_registered_patients", region_name: @region.name),
-                                "BP measures taken" => t("bp_measures_taken_copy", region_name: @region.name) } %>
-    </div>
-    <div class="table-responsive-md">
-      <table class="analytics-table table-compact">
-        <colgroup>
-          <col class="table-first-col">
-          <col>
-          <col class="table-divider">
-          <col>
-          <col>
-          <col>
-          <col>
-          <col>
-        </colgroup>
-        <thead>
-        <!-- Healthcare worker activity headers -->
+<div class="card mt-0 pr-0 pr-md-3 pb-inside-avoid">
+  <div class="d-flex flex-1 mb-8px">
+    <h3 class="mb-0px mr-8px">
+      Healthcare worker activity
+    </h3>
+    <%= render "definition_tooltip",
+               definitions: { "Monthly registered patients" => t("registered_patients_copy.monthly_registered_patients", region_name: @region.name),
+                              "BP measures taken" => t("bp_measures_taken_copy", region_name: @region.name) } %>
+  </div>
+  <div class="table-responsive-md">
+    <table class="analytics-table table-compact">
+      <colgroup>
+        <col class="table-first-col">
+        <col>
+        <col class="table-divider">
+        <col>
+        <col>
+        <col>
+        <col>
+        <col>
+      </colgroup>
+      <thead>
+      <!-- Healthcare worker activity headers -->
+      <tr>
+        <th></th>
+        <th colspan="6">
+          BP measures taken
+        </th>
+      </tr>
+      <tr class="sorts" data-sort-method="thead">
+        <th class="row-label sort-label sort-label-small ta-center sticky" data-sort-default>
+          Users
+        </th>
+        <% @details_period_range.each do |period| %>
+          <th class="row-label sort-label sort-label-small sticky" data-sort-method="number">
+            <%= period %>
+          </th>
+        <% end %>
+      </tr>
+      </thead>
+      <tbody>
+      <% current_admin.accessible_users(:view_reports).order(:full_name).each do |resource| %>
+        <% next unless sum_bp_measures(@repository, slug: @region.slug, user_id: resource.id)&.nonzero? %>
         <tr>
-          <th></th>
-          <th colspan="6">
-            BP measures taken
-          </th>
-        </tr>
-        <tr class="sorts" data-sort-method="thead">
-          <th class="row-label sort-label sort-label-small ta-center sticky" data-sort-default>
-            Users
-          </th>
+          <td class="row-title">
+            <%= link_to resource.full_name, admin_user_path(resource, period: @period) %>
           <% @details_period_range.each do |period| %>
-            <th class="row-label sort-label sort-label-small sticky" data-sort-method="number">
-              <%= period %>
-            </th>
+              <td class="ta-right">
+              <%= number_or_dash_with_delimiter(@repository.bp_measures_by_user.dig(@region.slug, period, resource.id)) %>
+            </td>
           <% end %>
         </tr>
-        </thead>
-        <tbody>
-        <% current_admin.accessible_users(:view_reports).order(:full_name).each do |resource| %>
-          <% next unless sum_bp_measures(@repository, slug: @region.slug, user_id: resource.id)&.nonzero? %>
-          <tr>
-            <td class="row-title">
-              <%= link_to resource.full_name, admin_user_path(resource, period: @period) %>
-            <% @details_period_range.each do |period| %>
-                <td class="ta-right">
-                <%= number_or_dash_with_delimiter(@repository.bp_measures_by_user.dig(@region.slug, period, resource.id)) %>
-              </td>
-            <% end %>
-          </tr>
-        <% end %>
-        </tbody>
-      </table>
-    </div>
+      <% end %>
+      </tbody>
+    </table>
   </div>
-<% end %>
+</div>

--- a/app/views/reports/regions/diabetes.html.erb
+++ b/app/views/reports/regions/diabetes.html.erb
@@ -55,14 +55,12 @@
     current_admin: current_admin
   ) %>
 
-  <% unless Flipper.enabled?(:disable_healthworker_activiity) %>
-    <%= render Dashboard::Diabetes::RecentMeasurementsComponent.new(
+  <%= render Dashboard::Diabetes::RecentMeasurementsComponent.new(
       region: @region,
       recent_blood_sugars: @recent_blood_sugars,
       display_model: :facility,
       page: @page
-    ) %>
-  <% end %>
+  ) %>
 <% else %>
   <%= render Dashboard::Diabetes::RegistrationsAndFollowUpsTableComponent.new(
     region: @region,


### PR DESCRIPTION
**Story card:** [sc-12796](https://app.shortcut.com/simpledotorg/story/12796/investigate-slow-loading-facility-dashboard-bangladesh)

## Because

Our facility-level reports in Bangladesh have become very slow.

## This addresses

The query that fetches the recent BP measurements on the facility reports page does so with superfluous joins without using the facility ID field on Blood Pressures which is indexed. We put this behind a feature flag so we can monitor the difference in performance in production.

We don't need any of the encounter or observation data, so we change the query to not require any joins. This should help speed up our facility report load times.

While we are at it, we also remove some other feature flags we had added to debug the cause of slow loads.

### Analyzed Query Plan in BD: Before

![image](https://github.com/user-attachments/assets/9966413d-75bf-4ab7-8f60-390c11fc9b4d)

### Analyzed Query Plan in BD: After

![image](https://github.com/user-attachments/assets/74939a9d-62a4-4619-8c35-2c2b7e649ebf)

## Test instructions

Enable the feature flag `fast_bp_logs` on flipper