### PR TITLE
Add index to patient follow-ups

### DIFF
--- a/db/migrate/20240719202605_add_index_to_reporting_patient_follow_ups.rb
+++ b/db/migrate/20240719202605_add_index_to_reporting_patient_follow_ups.rb
@@ -1,0 +1,5 @@
+class AddIndexToReportingPatientFollowUps < ActiveRecord::Migration[6.1]
+  def change
+    add_index :reporting_patient_follow_ups, :facility_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6987,6 +6987,13 @@ CREATE UNIQUE INDEX index_reporting_facility_appointment_scheduled_days ON publi
 
 
 --
+-- Name: index_reporting_patient_follow_ups_on_facility_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_reporting_patient_follow_ups_on_facility_id ON public.reporting_patient_follow_ups USING btree (facility_id);
+
+
+--
 -- Name: index_reporting_patient_states_on_age; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7746,6 +7753,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20231208091419'),
 ('20240411074916'),
 ('20240522054839'),
-('20240716132001');
-
-
+('20240716132001'),
+('20240719202605');


### PR DESCRIPTION
**Story card:** [sc-12988](https://app.shortcut.com/simpledotorg/story/12988/add-indexes-to-reporting-facility-follow-ups)

## Because

Our facility reports are slow due to there being only a suboptimal compound index on the patient follow ups matview.

## This addresses

We add an index on the facility ID which when analysed on Sandbox offered better query plans and performance characteristics—it used a Bitmap Index Scan along with a Bitmap Heap Scan, instead of a slow Index Scan that read too many blocks.

## Query plans on Sandbox

### Before the migration
<img width="443" alt="image" src="https://github.com/user-attachments/assets/2e2adf07-158f-4ce7-93eb-771d555e96fa">
<img width="405" alt="image" src="https://github.com/user-attachments/assets/4ff0b951-ecf8-4d31-8cae-6d5fa26325e3">

### After the migration that adds index on `facility_id`

<img width="461" alt="image" src="https://github.com/user-attachments/assets/7fde09d5-14ef-46c5-a19b-937180db2354">
<img width="487" alt="image" src="https://github.com/user-attachments/assets/9e5b9868-c8cc-43a4-995d-c1811b32bfc8">

### Other approaches evaluated

I tried the following compound indexes as well, but the query plans, cost and times were not all that different:

* (facility_id, user_id)
* (facility_id, hypertension, user_id)
* (facility_id, user_id, month_date)

For the first two, the `user_id` didn't appear to be used at all, and for the latter, the index was utilised properly, but it didn't make a huge difference, it was also in the <100ms ballpark.