### PR TITLE
Setup test SMS remidners in SL and switch vendor to Mobitel

### DIFF
--- a/config/initializers/country_config.rb
+++ b/config/initializers/country_config.rb
@@ -75,7 +75,7 @@ class CountryConfig
       sms_country_code: ENV["SMS_COUNTRY_CODE"] || "+94",
       supported_genders: %w[male female],
       patient_line_list_show_zone: false,
-      appointment_reminders_channel: "Messaging::Twilio::ReminderSms",
+      appointment_reminders_channel: "Messaging::Mobitel::Sms",
       sorted_facility_sizes: %w[large medium small community teaching_hospital national_hospital],
       facility_sizes: {
         community: "community",

--- a/db/data/20240725175328_set_up_mobitel_test_sms_reminder_sri_lanka_2024_july.rb
+++ b/db/data/20240725175328_set_up_mobitel_test_sms_reminder_sri_lanka_2024_july.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class SetUpMobitelTestSmsReminderSriLanka2024July < ActiveRecord::Migration[6.1]
+  PATIENTS_PER_DAY = 5000
+  EXPERIMENT_DATE = "Jul 2024"
+  EXPERIMENT_START_TIME = EXPERIMENT_DATE.to_datetime.beginning_of_month
+  EXPERIMENT_END_TIME = EXPERIMENT_DATE.to_datetime.end_of_month
+  EXPERIMENT_NAME = "Mobitel Test: Current Patient #{EXPERIMENT_DATE}"
+
+  INCLUDED_FACILITY_SLUGS = Facility.where(slug: "dh-gonaduwa").pluck(:slug)
+  REGION_FILTERS = {"facilities" => {"include" => INCLUDED_FACILITY_SLUGS}}
+
+  def up
+    return unless CountryConfig.current_country?("Sri Lanka") && SimpleServer.env.production?
+
+    ActiveRecord::Base.transaction do
+      Experimentation::Experiment.current_patients.create!(
+        name: EXPERIMENT_NAME,
+        start_time: EXPERIMENT_START_TIME,
+        end_time: EXPERIMENT_END_TIME,
+        max_patients_per_day: PATIENTS_PER_DAY,
+        filters: REGION_FILTERS
+      ).tap do |experiment|
+        cascade = experiment.treatment_groups.create!(description: "sms_reminders_cascade - #{EXPERIMENT_NAME}")
+        cascade.reminder_templates.create!(message: "notifications.sri_lanka.one_day_before_appointment", remind_on_in_days: -1)
+        cascade.reminder_templates.create!(message: "notifications.sri_lanka.three_days_missed_appointment", remind_on_in_days: 3)
+      end
+    end
+  end
+
+  def down
+    return unless CountryConfig.current_country?("Sri Lanka") && SimpleServer.env.production?
+    Experimentation::Experiment.current_patients.find_by_name(EXPERIMENT_NAME)&.cancel
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240620115011)
+DataMigrate::Data.define(version: 20240701183555)


### PR DESCRIPTION
**Story card:** [sc-12899](https://app.shortcut.com/simpledotorg/story/12899/test-sms-in-dh-gornaduwa)

## Because

We want to test the new SMS vendor: Mobitel in Sri Lanka with a facility (DH Gonaduwa) where we can monitor the experiment closely.

## Notes
- We are also switching the vendor from Twilio to Mobitel in this PR