### PR TITLE
Resolve failed data migration in SL experimentation setup

### DIFF
--- a/db/data/20240725175328_set_up_mobitel_test_sms_reminder_sri_lanka_2024_july.rb
+++ b/db/data/20240725175328_set_up_mobitel_test_sms_reminder_sri_lanka_2024_july.rb
@@ -13,23 +13,25 @@ class SetUpMobitelTestSmsReminderSriLanka2024July < ActiveRecord::Migration[6.1]
   def up
     return unless CountryConfig.current_country?("Sri Lanka") && SimpleServer.env.production?
 
-    ActiveRecord::Base.transaction do
-      Experimentation::Experiment.current_patients.create!(
-        name: EXPERIMENT_NAME,
-        start_time: EXPERIMENT_START_TIME,
-        end_time: EXPERIMENT_END_TIME,
-        max_patients_per_day: PATIENTS_PER_DAY,
-        filters: REGION_FILTERS
-      ).tap do |experiment|
-        cascade = experiment.treatment_groups.create!(description: "sms_reminders_cascade - #{EXPERIMENT_NAME}")
-        cascade.reminder_templates.create!(message: "notifications.sri_lanka.one_day_before_appointment", remind_on_in_days: -1)
-        cascade.reminder_templates.create!(message: "notifications.sri_lanka.three_days_missed_appointment", remind_on_in_days: 3)
-      end
-    end
+    # Skipping the setup because there's already a current patient experiment for July
+    #
+    # ActiveRecord::Base.transaction do
+    #   Experimentation::Experiment.current_patients.create!(
+    #     name: EXPERIMENT_NAME,
+    #     start_time: EXPERIMENT_START_TIME,
+    #     end_time: EXPERIMENT_END_TIME,
+    #     max_patients_per_day: PATIENTS_PER_DAY,
+    #     filters: REGION_FILTERS
+    #   ).tap do |experiment|
+    #     cascade = experiment.treatment_groups.create!(description: "sms_reminders_cascade - #{EXPERIMENT_NAME}")
+    #     cascade.reminder_templates.create!(message: "notifications.sri_lanka.one_day_before_appointment", remind_on_in_days: -1)
+    #     cascade.reminder_templates.create!(message: "notifications.sri_lanka.three_days_missed_appointment", remind_on_in_days: 3)
+    #   end
+    # end
   end
 
   def down
     return unless CountryConfig.current_country?("Sri Lanka") && SimpleServer.env.production?
-    Experimentation::Experiment.current_patients.find_by_name(EXPERIMENT_NAME)&.cancel
+    # Experimentation::Experiment.current_patients.find_by_name(EXPERIMENT_NAME)&.cancel
   end
 end


### PR DESCRIPTION
**Story card:** [sc-12899](https://app.shortcut.com/simpledotorg/story/12899/test-sms-in-dh-gornaduwa)

## Because

The experiment setup migration failed because there's an existing current-patient experiment setup for July

To not to go back and revert the migration in every country instance, we'll make this migration go through by skipping the content of the migration.
