### PR TITLE
Fix Mobitel errors for SMSs with newline characters

### DIFF
--- a/app/services/messaging/mobitel/api.rb
+++ b/app/services/messaging/mobitel/api.rb
@@ -17,7 +17,7 @@ class Messaging::Mobitel::Api
 
   def send_sms(recipient_number:, message:)
     get(URL_PATHS[:send_sms_multi_lang], {
-      m: message,
+      m: message.tr("\n", " "),
       r: recipient_number,
       a: message_alias,
       u: api_username,


### PR DESCRIPTION
**Story card:** [sc-13084](https://app.shortcut.com/simpledotorg/story/13084/bug-multiline-smss-not-working-with-mobitel)

## Because

Mobitel doesn't support newline messages even with URL encoding. Temporarily we'll replace newlines with space for SMSs going out with Mobitel while we figure out a more permanent solution.
