### PR TITLE
Treatment cascade formatting

### DIFF
--- a/app/components/dashboard/hypertension/hypertension_cascade_component.html.erb
+++ b/app/components/dashboard/hypertension/hypertension_cascade_component.html.erb
@@ -1,5 +1,5 @@
 <div id="htn-cascade" data-period="<%= @period.to_s %>" class="mt-8px mx-0px mb-16px pb-4px bg-white br-4px bs-small d-lg-flex fd-lg-column
-                justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black">
+                justify-lg-between h-lg-full w-lg-full mt-lg-0 pb-inside-avoid b-print-black mr-lg-2">
 
     <div class="pt-20px px-20px">
         <div class="d-flex mb-8px">

--- a/app/components/dashboard/hypertension/hypertension_cascade_component.html.erb
+++ b/app/components/dashboard/hypertension/hypertension_cascade_component.html.erb
@@ -8,8 +8,8 @@
                   <%= t("htn_cascade_copy.title") %>
                 </h3>
                 <%= render "definition_tooltip" , definitions: { "Estimated people with hypertension"=>
-                    t("total_estimated_hypertensive_population.district_copy", region_name: @region.name),
-                    "Patients under care" => t("patients_under_care_copy") } %>
+                    t("total_estimated_hypertensive_population.district_copy", region_name: @region.name), "Cumulative registered patients" => t("registered_patients_copy.total_registered_patients", region_name: @region.name), 
+                    "Patients under care" => t("patients_under_care_copy"), "Patients with BP controlled" => t("patients_bp_controlled_copy", region_name: @region.name), } %>
             </div>
         </div>
         <p class="c-grey-dark">

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -14,14 +14,6 @@
       region: @region,
       period: @period)) %>
   </div>
-  <% if show_htn_cascade && Flipper.enabled?(:patients_protected_htn_cascade, current_admin)%>
-    <div class="d-lg-flex w-lg-33 pl-lg-2">
-      <%= render(Dashboard::Hypertension::HypertensionCascadeComponent.new(
-        region: @region,
-        data: @data,
-        period: @period)) %>
-    </div>
-  <% end %>
 </div>
 <% end %>
 
@@ -229,6 +221,23 @@
   </div>
   <%= render(Dashboard::Hypertension::LostToFollowUpComponent.new(data: @data, region: @region, period: @period)) %>
 </div>
+<% if show_htn_cascade && Flipper.enabled?(:patients_protected_htn_cascade, current_admin)%>
+  <div class="d-lg-flex flex-lg-wrap">
+    <div class="d-lg-flex w-lg-33">
+      <%= render(Dashboard::Hypertension::HypertensionCascadeComponent.new(
+        region: @region,
+        data: @data,
+        period: @period)) %>
+    </div>
+    <div class="d-lg-flex w-lg-66 pl-lg-2 hidden mb-16px">
+      <div class="no-card-gap-filler">
+        <p>
+        Intentionally blank
+        </p>
+      </div>
+    </div>
+  </div>
+<% end %>
 
 <%= render "treatment_outcomes_card" %>
 
@@ -293,11 +302,11 @@
     period: @period,
     with_non_contactable: @with_non_contactable)) %>
   <div class="d-lg-flex w-lg-50 pl-lg-2 hidden mb-16px">
-  <div class="no-card-gap-filler">
-    <p>
-    Intentionally blank
-    </p>
-  </div>
+    <div class="no-card-gap-filler">
+      <p>
+      Intentionally blank
+      </p>
+    </div>
   </div>
   <%= render(Dashboard::Hypertension::OverduePatientsCalledTableComponent.new(
     region: @region,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,7 @@ en:
   follow_up_patients_copy: "Hypertension patients with a BP measure taken, a blood sugar taken, an appointment scheduled, or their medications refilled during a month in %{region_name}"
   diabetes_follow_up_patients_copy: "Diabetes patients with a BP measure taken, a blood sugar taken, an appointment scheduled, or their medications refilled during a month in %{region_name}"
   patients_under_care_copy: "Hypertension patients with a visit in the last 12 months"
+  patients_bp_controlled_copy: "Hypertension patients with BP <140/90 at their last visit in the last 3 months (from patients enrolled more than 3 months ago)."
   diabetes_patients_under_care_copy: "Diabetes patients with a visit in the last 12 months"
   bp_measures_taken_copy: "All BP measures taken in a month by healthcare workers at %{region_name}"
   bs_measures_taken_copy: "All blood sugar measurements taken in a month by healthcare workers at %{region_name}"


### PR DESCRIPTION
**Story card:** None

## Because

Varshana asked to move the cascade to the bottom of the Program Indicators in the dashboard, based on feedback from the team.

## This addresses

Adds full definitions to the cascade card. Moves the cascade lower in the reports.

## Test instructions

Please test at Org and regional levels to make sure it's displaying correctly.