### PR TITLE
SMS experiments: disable in Rajshahi district

### DIFF
--- a/db/data/20240801194910_disable_sms_reminders_bd_sylhet_rajshahi_aug_oct_2024.rb
+++ b/db/data/20240801194910_disable_sms_reminders_bd_sylhet_rajshahi_aug_oct_2024.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class DisableSmsRemindersBdSylhetRajshahiAugOct2024 < ActiveRecord::Migration[6.1]
+  # excluded districts: Sylhet, Rajshahi
+  DISTRICTS = %w[Moulvibazar Habiganj Sunamganj Barishal Jhalokathi Feni
+    Chattogram Bandarban Pabna Sirajganj Sherpur Jamalpur].freeze
+
+  INCLUDED_FACILITY_SLUG = Facility.where(facility_type: "UHC", district: DISTRICTS).pluck(:slug)
+
+  UPDATED_REGION_FILTERS = {
+    "facilities" => {"include" => INCLUDED_FACILITY_SLUG}
+  }.freeze
+
+  def up
+    return unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
+
+    %w[Aug Sep Oct].each do |month|
+      Experimentation::Experiment.find_by_name("Current patient #{month} 2024")&.update!(filters: UPDATED_REGION_FILTERS)
+      Experimentation::Experiment.find_by_name("Stale patient #{month} 2024")&.update!(filters: UPDATED_REGION_FILTERS)
+    end
+  end
+
+  def down
+    return unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
+    puts "This migration cannot be reversed. To include Sylhet/Rajshahi again, create a new migration."
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-13080](https://app.shortcut.com/simpledotorg/story/13080/stop-sending-sms-in-rajshahi-district-bangladesh)

## Because

We got a request to disable SMS reminders in Rajshahi as well due to floods:
https://simpledotorg.slack.com/archives/C01FMV58MEC/p1721891293461409?thread_ts=1713379471.671909&cid=C01FMV58MEC
