### PR TITLE
Fix HTN Cascade formatting error when estimated is present

### DIFF
--- a/app/components/dashboard/hypertension/hypertension_cascade_component.html.erb
+++ b/app/components/dashboard/hypertension/hypertension_cascade_component.html.erb
@@ -37,7 +37,7 @@
                                 </div>
                             </div>
                             <p class="mb-0px">
-                            <%= show_estimate? ? @estimated_population.population : "?" %>
+                            <%= show_estimate? ? number_with_delimiter(@estimated_population.population, delimiter: ",")  : "?" %>
                             </p>
                             <p class="text-grey fs-lg-14px mb-0px">
                                 Estimated people with hypertension
@@ -52,7 +52,7 @@
                                 </div>
                             </div>
                             <p class="mb-0px">
-                              <%= @cumulative_registrations %>
+                              <%= number_with_delimiter(@cumulative_registrations, delimiter: ",") %>
                             </p>
                             <p class="text-grey fs-lg-14px mb-0px">
                                 Cumulative registered patients
@@ -67,7 +67,7 @@
                                 </div>
                             </div>
                             <p class="mb-0px">
-                              <%= @under_care_patients %>
+                              <%= number_with_delimiter(@under_care_patients, delimiter: ",") %>
                             </p>
                             <p class="text-grey fs-lg-14px mb-0px">
                                 Patients under care
@@ -82,7 +82,7 @@
                                 </div>
                             </div>
                             <p class="mb-0px">
-                              <%= @controlled_patients %>
+                              <%= number_with_delimiter(@controlled_patients, delimiter: ",") %>
                             </p>
                             <p class="text-grey fs-lg-14px mb-0px">
                                 Patients with BP controlled

--- a/app/components/dashboard/hypertension/hypertension_cascade_component.rb
+++ b/app/components/dashboard/hypertension/hypertension_cascade_component.rb
@@ -7,10 +7,10 @@ class Dashboard::Hypertension::HypertensionCascadeComponent < ApplicationCompone
     @region = region
     @data = data
     @period = period
-    @estimated_population = format(@region.estimated_population)
-    @cumulative_registrations = format(data.dig(:cumulative_registrations, period))
-    @under_care_patients = format(data.dig(:under_care, period))
-    @controlled_patients = format(data.dig(:controlled_patients, period))
+    @estimated_population = @region.estimated_population
+    @cumulative_registrations = data.dig(:cumulative_registrations, period)
+    @under_care_patients = data.dig(:under_care, period)
+    @controlled_patients = data.dig(:controlled_patients, period)
   end
 
   def cumulative_registrations_rate
@@ -38,11 +38,5 @@ class Dashboard::Hypertension::HypertensionCascadeComponent < ApplicationCompone
 
   def period_end
     period.end.to_s(:day_mon_year)
-  end
-
-  private
-
-  def format(value)
-    number_with_delimiter(value, delimiter: ",")
   end
 end


### PR DESCRIPTION
**Story card:** [sc-12856](https://app.shortcut.com/simpledotorg/story/12856/changes-to-patients-protected-and-htn-cascade-components)

## Because

The HTN Cascade card not loading when a population estimate is present

## This addresses

Fixed by moving the string formatting to the views