### PR TITLE
Expose request path in prometheus metrics

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,6 +1,8 @@
 require "prometheus_exporter/client"
 require "prometheus_exporter/middleware"
 
+Dir.glob(Rails.root.join("lib", "prometheus_middleware", "**", "*.rb")).sort.each { |f| require f }
+
 CLIENT = PrometheusExporter::Client.default
 REGISTERED_COLLECTORS = {}
 
@@ -24,5 +26,5 @@ end
 
 if Rails.env.production?
   # This reports stats per request like HTTP status and timings
-  Rails.application.middleware.unshift PrometheusExporter::Middleware
+  Rails.application.middleware.unshift SimplePrometheusMiddleware
 end

--- a/lib/prometheus_middleware/simple_prometheus_middleware.rb
+++ b/lib/prometheus_middleware/simple_prometheus_middleware.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SimplePrometheusMiddleware < PrometheusExporter::Middleware
+  def custom_labels(env)
+    {path: env["PATH_INFO"]}
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

## Because

We want to be able to see the exact path (not just the action name and controller for our slowest requests).

That way, we can tell whether a slow load is, for example, happening within a district, organisation or facility-level region. Or even a specific facility.

## This addresses

* Adds a custom label that takes the path information from the Rack environment. Ref: https://github.com/discourse/prometheus_exporter?tab=readme-ov-file#metrics-collected-by-rails-integration-middleware

## Results

Along with the changes to the Grafana dashboard to include the path label, we get this (left-middle and middle tables):

![image](https://github.com/user-attachments/assets/9fe07ec9-f0a7-4457-8331-45de04bf2b0e)