### PR TITLE
Fix: Mobitel unable to send multi-line SMS

### DIFF
--- a/app/services/messaging/mobitel/sms.rb
+++ b/app/services/messaging/mobitel/sms.rb
@@ -25,9 +25,11 @@ class Messaging::Mobitel::Sms < Messaging::Channel
     ).tap { |response| raise_api_errors(response) }
   end
 
-  def raise_api_errors(code)
+  def raise_api_errors(body)
+    code = body[:resultcode].to_i
+    message = body[:response]
     unless code == API_SUCCESS_RESPONSE
-      raise Messaging::Mobitel::Error.new("API failed with code: #{code}", code)
+      raise Messaging::Mobitel::Error.new("API failed with code: #{code} and message: #{message}", code)
     end
   end
 

--- a/spec/services/messaging/mobitel/api_spec.rb
+++ b/spec/services/messaging/mobitel/api_spec.rb
@@ -41,20 +41,20 @@ RSpec.describe Messaging::Mobitel::Api do
       message = "Test Message"
       recipient_number = Faker::PhoneNumber.phone_number
 
-      request = stub_request(:get, "https://msmsenterpriseapi.mobitel.lk/EnterpriseSMSV3/esmsproxy_multilang.php")
-        .with(query: hash_including({}))
-        .to_return(body: "200")
+      request = stub_request(:post, "https://msmsenterpriseapi.mobitel.lk/EnterpriseSMSV3/esmsproxyMultilang.php")
+        .with(body: hash_including({}))
+        .to_return(body: "{\"resultcode\":\"200\",\"response\":\"Message sent OK\"}")
       described_class.new.send_sms(recipient_number: recipient_number, message: message)
       expect(request).to have_been_made
     end
 
-    it "raises an exception if non 200 resopnse is received" do
+    it "raises an exception if non JSON resopnse is received" do
       stub_credentials(:username, :password, :alias)
       message = "Test Message"
       recipient_number = Faker::PhoneNumber.phone_number
 
-      stub_request(:get, "https://msmsenterpriseapi.mobitel.lk/EnterpriseSMSV3/esmsproxy_multilang.php")
-        .with(query: hash_including({}))
+      stub_request(:post, "https://msmsenterpriseapi.mobitel.lk/EnterpriseSMSV3/esmsproxyMultilang.php")
+        .with(body: hash_including({}))
         .to_return(body: "Not found")
 
       expect {

--- a/spec/services/messaging/mobitel/sms_spec.rb
+++ b/spec/services/messaging/mobitel/sms_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Messaging::Mobitel::Sms do
       mock_api = double("MobitelApiDouble")
       allow(Messaging::Mobitel::Api).to receive(:new).and_return(mock_api)
       allow(mock_api).to receive(:send_sms)
-      allow(mock_api).to receive(:send_sms).and_return(159)
+      allow(mock_api).to receive(:send_sms).and_return({resultcode: "165", response: "No recipients found"})
 
       expect(mock_api).to receive(:send_sms).with(
         recipient_number: "+11001100",
@@ -26,7 +26,7 @@ RSpec.describe Messaging::Mobitel::Sms do
       mock_api = double("MobitelApiDouble")
       allow(Messaging::Mobitel::Api).to receive(:new).and_return(mock_api)
       allow(mock_api).to receive(:send_sms)
-      allow(mock_api).to receive(:send_sms).and_return(200)
+      allow(mock_api).to receive(:send_sms).and_return({resultcode: "200", response: "Message sent OK"})
 
       communication = described_class.send_message(
         recipient_number: phone_number,
@@ -40,7 +40,7 @@ RSpec.describe Messaging::Mobitel::Sms do
       mock_api = double("MobitelApiDouble")
       allow(Messaging::Mobitel::Api).to receive(:new).and_return(mock_api)
       allow(mock_api).to receive(:send_sms)
-      allow(mock_api).to receive(:send_sms).and_return(200)
+      allow(mock_api).to receive(:send_sms).and_return({resultcode: "200", response: "Message sent OK"})
 
       expect { |b|
         described_class.send_message(


### PR DESCRIPTION
**Story card:** [sc-13084](https://app.shortcut.com/simpledotorg/story/13084/bug-multiline-smss-not-working-with-mobitel)

## Because

The old Mobitel API does not support multi-line SMS body.

## This addresses

We're replacing that with a new API provided by the Mobitel team.
