### PR TITLE
Setup SMS Reminders in Sri Lanka till Dec 2024

### DIFF
--- a/db/data/20240812170559_set_up_sms_reminder_sri_lanka_2024_aug_dec.rb
+++ b/db/data/20240812170559_set_up_sms_reminder_sri_lanka_2024_aug_dec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class SetUpSmsReminderSriLanka2024AugDec < ActiveRecord::Migration[6.1]
+  PATIENTS_PER_DAY = 5000
+  EXPERIMENTS_DATA = %w[Aug Sept Oct Nov Dec].map do |month|
+    {
+      start_time: "#{month} 2024".to_datetime.beginning_of_month,
+      end_time: "#{month} 2024".to_datetime.end_of_month,
+      current_patients_experiment_name: "Current Patient #{month} 2024"
+    }
+  end
+
+  def up
+    return unless CountryConfig.current_country?("Sri Lanka") && SimpleServer.env.production?
+
+    EXPERIMENTS_DATA.each do |experiment_data|
+      ActiveRecord::Base.transaction do
+        Experimentation::Experiment.current_patients.create!(
+          name: experiment_data[:current_patients_experiment_name],
+          start_time: experiment_data[:start_time],
+          end_time: experiment_data[:end_time],
+          max_patients_per_day: PATIENTS_PER_DAY
+        ).tap do |experiment|
+          cascade = experiment.treatment_groups.create!(description: "sms_reminders_cascade - #{experiment_data[:current_patients_experiment_name]}")
+          cascade.reminder_templates.create!(message: "notifications.sri_lanka.one_day_before_appointment", remind_on_in_days: -1)
+          cascade.reminder_templates.create!(message: "notifications.sri_lanka.three_days_missed_appointment", remind_on_in_days: 3)
+        end
+      end
+    end
+  end
+
+  def down
+    return unless CountryConfig.current_country?("Sri Lanka") && SimpleServer.env.production?
+    EXPERIMENTS_DATA.map do |experiment_data|
+      Experimentation::Experiment.current_patients.find_by_name(experiment_data[:current_patients_experiment_name])&.cancel
+    end
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240801194910)
+DataMigrate::Data.define(version: 20240812170559)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7755,3 +7755,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240522054839'),
 ('20240716132001'),
 ('20240719202605');
+
+


### PR DESCRIPTION
**Story card:** [sc-13197](https://app.shortcut.com/simpledotorg/story/13197/setup-sms-reminders-in-sri-lanka-till-the-end-of-2024)

## Because

We want to setup SMS reminders till end of the year for SL