### PR TITLE
Fix Mobitel incorrectly marking SMSs as errors

### DIFF
--- a/app/services/messaging/mobitel/sms.rb
+++ b/app/services/messaging/mobitel/sms.rb
@@ -26,8 +26,8 @@ class Messaging::Mobitel::Sms < Messaging::Channel
   end
 
   def raise_api_errors(body)
-    code = body[:resultcode].to_i
-    message = body[:response]
+    code = body["resultcode"].to_i
+    message = body["response"]
     unless code == API_SUCCESS_RESPONSE
       raise Messaging::Mobitel::Error.new("API failed with code: #{code} and message: #{message}", code)
     end

--- a/spec/services/messaging/mobitel/sms_spec.rb
+++ b/spec/services/messaging/mobitel/sms_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Messaging::Mobitel::Sms do
       mock_api = double("MobitelApiDouble")
       allow(Messaging::Mobitel::Api).to receive(:new).and_return(mock_api)
       allow(mock_api).to receive(:send_sms)
-      allow(mock_api).to receive(:send_sms).and_return({resultcode: "165", response: "No recipients found"})
+      allow(mock_api).to receive(:send_sms).and_return({"resultcode" => "165", "response" => "No recipients found"})
 
       expect(mock_api).to receive(:send_sms).with(
         recipient_number: "+11001100",
@@ -26,7 +26,7 @@ RSpec.describe Messaging::Mobitel::Sms do
       mock_api = double("MobitelApiDouble")
       allow(Messaging::Mobitel::Api).to receive(:new).and_return(mock_api)
       allow(mock_api).to receive(:send_sms)
-      allow(mock_api).to receive(:send_sms).and_return({resultcode: "200", response: "Message sent OK"})
+      allow(mock_api).to receive(:send_sms).and_return({"resultcode" => "200", "response" => "Message sent OK"})
 
       communication = described_class.send_message(
         recipient_number: phone_number,
@@ -40,7 +40,7 @@ RSpec.describe Messaging::Mobitel::Sms do
       mock_api = double("MobitelApiDouble")
       allow(Messaging::Mobitel::Api).to receive(:new).and_return(mock_api)
       allow(mock_api).to receive(:send_sms)
-      allow(mock_api).to receive(:send_sms).and_return({resultcode: "200", response: "Message sent OK"})
+      allow(mock_api).to receive(:send_sms).and_return({"resultcode" => "200", "response" => "Message sent OK"})
 
       expect { |b|
         described_class.send_message(


### PR DESCRIPTION
**Story card:** [sc-13084](https://app.shortcut.com/simpledotorg/story/13084/bug-multiline-smss-not-working-with-mobitel)

## Because

The SMS service is incorrectly labelling the API response as an error because the hashmap was not parsed correctly