### PR TITLE
Treatment cascade update

### DIFF
--- a/app/components/dashboard/hypertension/hypertension_cascade_component.html.erb
+++ b/app/components/dashboard/hypertension/hypertension_cascade_component.html.erb
@@ -8,8 +8,8 @@
                   <%= t("htn_cascade_copy.title") %>
                 </h3>
                 <%= render "definition_tooltip" , definitions: { "Estimated people with hypertension"=>
-                    t("total_estimated_hypertensive_population.district_copy", region_name: @region.name), "Cumulative registered patients" => t("registered_patients_copy.total_registered_patients", region_name: @region.name), 
-                    "Patients under care" => t("patients_under_care_copy"), "Patients with BP controlled" => t("patients_bp_controlled_copy", region_name: @region.name), } %>
+                    t("total_estimated_hypertensive_population.district_copy", region_name: @region.name), "Total registered patients" => t("registered_patients_copy.total_registered_patients", region_name: @region.name), 
+                    "Patients under care" => t("patients_under_care_copy"), "Patients with controlled BP" => t("patients_bp_controlled_copy", region_name: @region.name), } %>
             </div>
         </div>
         <p class="c-grey-dark">
@@ -55,7 +55,7 @@
                               <%= number_with_delimiter(@cumulative_registrations, delimiter: ",") %>
                             </p>
                             <p class="text-grey fs-lg-14px mb-0px">
-                                Cumulative registered patients
+                                Total registrations
                             </p>
                         </div>
                         <div class="coverage-column">
@@ -85,7 +85,7 @@
                               <%= number_with_delimiter(@controlled_patients, delimiter: ",") %>
                             </p>
                             <p class="text-grey fs-lg-14px mb-0px">
-                                Patients with BP controlled
+                                Patients with controlled BP
                             </p>
                         </div>
                     </div>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -8,7 +8,7 @@
 <% show_htn_cascade = %[organization state district].include?(@region.region_type) %>
 
 <% if Flipper.enabled?(:patients_protected, current_admin) %>
-<div class="d-lg-flex flex-lg-wrap mr-0">
+<div class="d-lg-flex flex-lg-wrap">
   <div class="d-lg-flex flex-fill">
     <%= render(Dashboard::Hypertension::PatientsProtectedComponent.new(
       region: @region,

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -8,8 +8,8 @@
 <% show_htn_cascade = %[organization state district].include?(@region.region_type) %>
 
 <% if Flipper.enabled?(:patients_protected, current_admin) %>
-<div class="d-lg-flex flex-lg-wrap">
-  <div class="d-lg-flex <% if Flipper.enabled?(:patients_protected_htn_cascade, current_admin) && show_htn_cascade %>pr-lg-2 w-lg-66<% end %> flex-fill">
+<div class="d-lg-flex flex-lg-wrap mr-0">
+  <div class="d-lg-flex flex-fill">
     <%= render(Dashboard::Hypertension::PatientsProtectedComponent.new(
       region: @region,
       period: @period)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,7 +142,7 @@ en:
   diabetes_ltfu_denominator_copy: "Diabetes patients assigned to %{region_name}. Dead patients are excluded."
   follow_up_patients_copy: "Hypertension patients with a BP measure taken, a blood sugar taken, an appointment scheduled, or their medications refilled during a month in %{region_name}"
   diabetes_follow_up_patients_copy: "Diabetes patients with a BP measure taken, a blood sugar taken, an appointment scheduled, or their medications refilled during a month in %{region_name}"
-  patients_under_care_copy: "Hypertension patients with a visit in the last 12 months"
+  patients_under_care_copy: "Hypertension patients with a visit in the last 12 months."
   patients_bp_controlled_copy: "Hypertension patients with BP <140/90 at their last visit in the last 3 months (from patients enrolled more than 3 months ago)."
   diabetes_patients_under_care_copy: "Diabetes patients with a visit in the last 12 months"
   bp_measures_taken_copy: "All BP measures taken in a month by healthcare workers at %{region_name}"


### PR DESCRIPTION
**Story card:** [sc-13218](https://app.shortcut.com/simpledotorg/story/13218/small-tweaks-to-treatment-cascade-and-patients-protected-charts)

## Because

Small formatting improvements for language consistency and removing an unneeded Flipper flag in the Hypertension Coverage card.

## This addresses

Small formatting improvements.

## Test instructions

Should have no errors. This was all cosmetic.
