### PR TITLE
HTN cascade: Aggregate estimate population count at org level

### DIFF
--- a/app/components/dashboard/hypertension/hypertension_cascade_component.html.erb
+++ b/app/components/dashboard/hypertension/hypertension_cascade_component.html.erb
@@ -37,7 +37,7 @@
                                 </div>
                             </div>
                             <p class="mb-0px">
-                            <%= show_estimate? ? number_with_delimiter(@estimated_population.population, delimiter: ",")  : "?" %>
+                            <%= show_estimate? ? number_with_delimiter(estimated_population_count, delimiter: ",")  : "?" %>
                             </p>
                             <p class="text-grey fs-lg-14px mb-0px">
                                 Estimated people with hypertension

--- a/app/components/dashboard/hypertension/hypertension_cascade_component.rb
+++ b/app/components/dashboard/hypertension/hypertension_cascade_component.rb
@@ -15,17 +15,25 @@ class Dashboard::Hypertension::HypertensionCascadeComponent < ApplicationCompone
 
   def cumulative_registrations_rate
     return FIXED_RATE_WHEN_NO_ESTIMATE unless show_estimate?
-    number_to_percentage(@cumulative_registrations * 100 / @estimated_population.population, precision: 0)
+    number_to_percentage(@cumulative_registrations * 100 / estimated_population_count, precision: 0)
   end
 
   def under_care_patients_rate
     return FIXED_RATE_WHEN_NO_ESTIMATE unless show_estimate?
-    number_to_percentage(@under_care_patients * 100 / @estimated_population.population, precision: 0)
+    number_to_percentage(@under_care_patients * 100 / estimated_population_count, precision: 0)
   end
 
   def controlled_patients_rate
     return FIXED_RATE_WHEN_NO_ESTIMATE unless show_estimate?
-    number_to_percentage(@controlled_patients * 100 / @estimated_population.population, precision: 0)
+    number_to_percentage(@controlled_patients * 100 / estimated_population_count, precision: 0)
+  end
+
+  def estimated_population_count
+    if @region.organization_region?
+      @region.state_regions.map(&:estimated_population).map(&:population).sum
+    else
+      @estimated_population.population
+    end
   end
 
   def show_estimate?


### PR DESCRIPTION
**Story card:** [sc-13213](https://app.shortcut.com/simpledotorg/story/13213/fix-htn-estimate-not-working-summing-up-at-the-org-level)

## Because

Reports-view at the org level with estimate set for all sub-regions was throwing an error because `EstimatedPopulation` doesn't roll up at the org level

## This addresses

We'll roll up the estimated population for Org-level regions on demand.