### PR TITLE
Add a size limit to docker logrotate config

### DIFF
--- a/.docker/config/logrotate/cron
+++ b/.docker/config/logrotate/cron
@@ -1,5 +1,6 @@
 /home/deploy/apps/simple-server/shared/log/*.log {
   su root root
+  size 500M
   daily
   rotate 3
   missingok


### PR DESCRIPTION
**Story card:** [sc-13302](https://app.shortcut.com/simpledotorg/story/13302)

## This addresses
Fix large log file size issue in sandbox