### PR TITLE
Added metrics to prometheus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ gem "table_print"
 gem "doorkeeper", "~> 5.6"
 gem "prometheus_exporter"
 gem "zip_kit"
+gem "sendgrid-ruby"
 
 group :development, :test do
   gem "active_record_query_trace", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,7 +426,7 @@ GEM
     prawn (2.4.0)
       pdf-core (~> 0.9.0)
       ttfunk (~> 1.7)
-    prometheus_exporter (2.1.0)
+    prometheus_exporter (2.0.8)
       webrick
     prosopite (1.1.3)
     pry (0.14.1)
@@ -568,6 +568,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-statistics (3.0.0)
     ruby2_keywords (0.0.5)
+    ruby_http_client (3.5.5)
     rubyzip (2.3.2)
     sanitize (6.0.0)
       crass (~> 1.0.2)
@@ -589,6 +590,8 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
+    sendgrid-ruby (6.7.0)
+      ruby_http_client (~> 3.4)
     sentry-rails (5.4.2)
       railties (>= 5.0)
       sentry-ruby (~> 5.4.2)
@@ -807,6 +810,7 @@ DEPENDENCIES
   sassc-rails
   scenic
   scientist
+  sendgrid-ruby
   sentry-rails
   sentry-ruby
   sentry-sidekiq

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -10,13 +10,13 @@ class MetricsController < ApplicationController
       render plain: "Error fetching metrics: #{result[:error]}", status: :unprocessable_entity
     else
       metrics = {
-        sendgrid_total_emails: result[:total],
+        sendgrid_email_limit_count: result[:total],
         sendgrid_emails_remaining_count: result[:remain],
         sendgrid_email_used_count: result[:used],
         sendgrid_plan_limit_expire: result[:plan_completion_status],
         sendgrid_email_limit_exceeded_by_threshold_limit: result[:exceeded_limit_status],
-        sendgrid_http_return_code: result[:http_return_code],
-        sendgrid_http_response_time: result[:http_response_time].round(2)
+        sendgrid_monitoring_http_return_code: result[:http_return_code],
+        sendgrid_monitoring_http_response_time_seconds: result[:http_response_time].round(2)
       }
       render plain: metrics_to_plain(metrics)
     end

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -13,8 +13,7 @@ class MetricsController < ApplicationController
         sendgrid_email_limit_count: result[:total],
         sendgrid_emails_remaining_count: result[:remain],
         sendgrid_email_used_count: result[:used],
-        sendgrid_plan_limit_expire: result[:plan_completion_status],
-        sendgrid_email_limit_exceeded_by_threshold_limit: result[:exceeded_limit_status],
+        sendgrid_plan_expiration_seconds: result[:time_until_expiration_seconds],
         sendgrid_monitoring_http_return_code: result[:http_return_code],
         sendgrid_monitoring_http_response_time_seconds: result[:http_response_time].round(2)
       }

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -3,7 +3,7 @@
 # MetricsController is responsible for handling requests related to metrics,
 # including exposing SendGrid-related metrics in a format compatible with Prometheus.
 class MetricsController < ApplicationController
-  def index # rubocop:disable Metrics/MethodLength
+  def index
     result = SendgridService.new.check_credits
 
     if result[:error]

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,5 +1,9 @@
+# frozen_string_literal: true
+
+# MetricsController is responsible for handling requests related to metrics,
+# including exposing SendGrid-related metrics in a format compatible with Prometheus.
 class MetricsController < ApplicationController
-  def index
+  def index # rubocop:disable Metrics/MethodLength
     result = SendgridService.new.check_credits
 
     if result[:error]
@@ -14,7 +18,6 @@ class MetricsController < ApplicationController
         sendgrid_http_return_code: result[:http_return_code],
         sendgrid_http_response_time: result[:http_response_time].round(2)
       }
-
       render plain: metrics_to_plain(metrics)
     end
   end

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,0 +1,33 @@
+class MetricsController < ApplicationController
+  def index
+    result = SendgridService.new.check_credits
+
+    if result[:error]
+      render plain: "Error fetching metrics: #{result[:error]}", status: :unprocessable_entity
+    else
+      metrics = {
+        sendgrid_total_emails: result[:total],
+        sendgrid_emails_remaining_count: result[:remain],
+        sendgrid_email_used_count: result[:used],
+        sendgrid_plan_limit_expire: result[:plan_completion_status],
+        sendgrid_email_limit_exceeded_by_threshold_limit: result[:exceeded_limit_status],
+        sendgrid_http_return_code: result[:http_return_code],
+        sendgrid_http_response_time: result[:http_response_time].round(2)
+      }
+
+      render plain: metrics_to_plain(metrics)
+    end
+  end
+
+  private
+
+  def metrics_to_plain(metrics)
+    metrics.map do |key, value|
+      <<~METRIC
+        # HELP #{key} #{key.to_s.humanize}
+        # TYPE #{key} gauge
+        #{key} #{value}
+      METRIC
+    end.join("\n")
+  end
+end

--- a/app/services/sendgrid_service.rb
+++ b/app/services/sendgrid_service.rb
@@ -1,0 +1,53 @@
+class SendgridService
+  THRESHOLD = 45_000
+
+  def check_credits
+    start_time = Time.now
+    Rails.logger.info("SendGrid balance check started...")
+
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+    response = sg.client.user.credits.get
+
+    response_time = Time.now - start_time
+    http_return_code = response.status_code.to_i
+
+    return handle_error(response) unless http_return_code == 200
+
+    data = JSON.parse(response.body)
+    metrics = parse_metrics(data).merge(
+      http_return_code: http_return_code,
+      http_response_time: response_time
+    )
+
+    Rails.logger.info("SendGrid balance check completed.")
+    metrics
+  rescue StandardError => e
+    Rails.logger.error("Error during SendGrid balance check: #{e.message}")
+    { error: e.message }
+  end
+
+  private
+
+  def parse_metrics(data)
+    total = data['total']
+    remain = data['remain']
+    used = data['used']
+    plan_reset_date = Date.parse(data['next_reset']) + 1
+    plan_completion_status = (Date.today < plan_reset_date) ? 1 : 0
+    exceeded_limit_status = (used > THRESHOLD) ? 1 : 0
+
+    {
+      total: total,
+      remain: remain,
+      used: used,
+      plan_reset_date: plan_reset_date,
+      plan_completion_status: plan_completion_status,
+      exceeded_limit_status: exceeded_limit_status
+    }
+  end
+
+  def handle_error(response)
+    Rails.logger.error("Failed to fetch SendGrid credits: #{response.body}")
+    { error: response.body }
+  end
+end

--- a/app/services/sendgrid_service.rb
+++ b/app/services/sendgrid_service.rb
@@ -5,7 +5,7 @@ class SendgridService
     start_time = Time.now
     Rails.logger.info("SendGrid balance check started...")
 
-    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+    sg = SendGrid::API.new(api_key: ENV["SENDGRID_API_KEY"])
     response = sg.client.user.credits.get
 
     response_time = Time.now - start_time
@@ -21,20 +21,20 @@ class SendgridService
 
     Rails.logger.info("SendGrid balance check completed.")
     metrics
-  rescue StandardError => e
+  rescue => e
     Rails.logger.error("Error during SendGrid balance check: #{e.message}")
-    { error: e.message }
+    {error: e.message}
   end
 
   private
 
   def parse_metrics(data)
-    total = data['total']
-    remain = data['remain']
-    used = data['used']
-    plan_reset_date = Date.parse(data['next_reset']) + 1
-    plan_completion_status = (Date.today < plan_reset_date) ? 1 : 0
-    exceeded_limit_status = (used > THRESHOLD) ? 1 : 0
+    total = data["total"]
+    remain = data["remain"]
+    used = data["used"]
+    plan_reset_date = Date.parse(data["next_reset"]) + 1
+    plan_completion_status = Date.today < plan_reset_date ? 1 : 0
+    exceeded_limit_status = used > THRESHOLD ? 1 : 0
 
     {
       total: total,
@@ -48,6 +48,6 @@ class SendgridService
 
   def handle_error(response)
     Rails.logger.error("Failed to fetch SendGrid credits: #{response.body}")
-    { error: response.body }
+    {error: response.body}
   end
 end

--- a/app/services/sendgrid_service.rb
+++ b/app/services/sendgrid_service.rb
@@ -33,16 +33,12 @@ class SendgridService
     remain = data["remain"]
     used = data["used"]
     plan_reset_date = Date.parse(data["next_reset"]) + 1
-    plan_completion_status = Date.today < plan_reset_date ? 1 : 0
-    exceeded_limit_status = used > THRESHOLD ? 1 : 0
-
+    time_until_expiration_seconds = [(plan_reset_date - Date.today).to_i * 24 * 60 * 60, 0].max
     {
       total: total,
       remain: remain,
       used: used,
-      plan_reset_date: plan_reset_date,
-      plan_completion_status: plan_completion_status,
-      exceeded_limit_status: exceeded_limit_status
+      time_until_expiration_seconds: time_until_expiration_seconds
     }
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,7 +194,7 @@ Rails.application.routes.draw do
   get "/dashboard/districts/", to: redirect("/reports/districts/")
   get "/dashboard/districts/:slug", to: redirect("/reports/districts/%{slug}")
   get "/reports/districts/", to: redirect("/reports/regions/")
-  get 'metrics', to: 'metrics#index'
+  get "metrics", to: "metrics#index"
 
   namespace :reports do
     resources :patient_lists, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,6 @@ Rails.application.routes.draw do
 
   mount Rswag::Ui::Engine => "/api-docs"
   mount Rswag::Api::Engine => "/api-docs"
-  # mount PrometheusExporter::Server::Rack, at: '/metrics'
 
   concern :sync_routes do
     scope "/patients" do
@@ -169,7 +168,6 @@ Rails.application.routes.draw do
       resources :drug_stocks, only: [:index]
 
       get "states", to: "states#index"
-
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
   mount Rswag::Ui::Engine => "/api-docs"
   mount Rswag::Api::Engine => "/api-docs"
+  # mount PrometheusExporter::Server::Rack, at: '/metrics'
 
   concern :sync_routes do
     scope "/patients" do
@@ -168,6 +169,7 @@ Rails.application.routes.draw do
       resources :drug_stocks, only: [:index]
 
       get "states", to: "states#index"
+
     end
   end
 
@@ -194,6 +196,7 @@ Rails.application.routes.draw do
   get "/dashboard/districts/", to: redirect("/reports/districts/")
   get "/dashboard/districts/:slug", to: redirect("/reports/districts/%{slug}")
   get "/reports/districts/", to: redirect("/reports/regions/")
+  get 'metrics', to: 'metrics#index'
 
   namespace :reports do
     resources :patient_lists, only: [:show]

--- a/spec/controllers/metrics_controller_spec.rb
+++ b/spec/controllers/metrics_controller_spec.rb
@@ -1,0 +1,59 @@
+# spec/controllers/metrics_controller_spec.rb
+require 'rails_helper'
+
+RSpec.describe MetricsController, type: :controller do
+  let(:sendgrid_service) { instance_double(SendgridService) }
+  let(:metrics) do
+    {
+      total: 1000,
+      remain: 500,
+      used: 500,
+      plan_completion_status: 1,
+      exceeded_limit_status: 0,
+      http_return_code: 200,
+      http_response_time: 0.23
+    }
+  end
+
+  before do
+    allow(SendgridService).to receive(:new).and_return(sendgrid_service)
+  end
+
+  describe 'GET #index' do
+    context 'when the SendGrid service call is successful' do
+      before do
+        allow(sendgrid_service).to receive(:check_credits).and_return(metrics)
+        get :index
+      end
+
+      it 'returns a successful response' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns the correct metrics format' do
+        expect(response.body).to include("sendgrid_total_emails #{metrics[:total]}")
+        expect(response.body).to include("sendgrid_emails_remaining_count #{metrics[:remain]}")
+        expect(response.body).to include("sendgrid_email_used_count #{metrics[:used]}")
+        expect(response.body).to include("sendgrid_plan_limit_expire #{metrics[:plan_completion_status]}")
+        expect(response.body).to include("sendgrid_email_limit_exceeded_by_threshold_limit #{metrics[:exceeded_limit_status]}")
+        expect(response.body).to include("sendgrid_http_return_code #{metrics[:http_return_code]}")
+        expect(response.body).to include("sendgrid_http_response_time #{metrics[:http_response_time]}")
+      end
+    end
+
+    context 'when the SendGrid service call fails' do
+      before do
+        allow(sendgrid_service).to receive(:check_credits).and_return({ error: 'Some error' })
+        get :index
+      end
+
+      it 'returns an unprocessable entity status' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns the correct error message' do
+        expect(response.body).to include("Error fetching metrics: Some error")
+      end
+    end
+  end
+end

--- a/spec/controllers/metrics_controller_spec.rb
+++ b/spec/controllers/metrics_controller_spec.rb
@@ -1,5 +1,5 @@
 # spec/controllers/metrics_controller_spec.rb
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe MetricsController, type: :controller do
   let(:sendgrid_service) { instance_double(SendgridService) }
@@ -19,18 +19,18 @@ RSpec.describe MetricsController, type: :controller do
     allow(SendgridService).to receive(:new).and_return(sendgrid_service)
   end
 
-  describe 'GET #index' do
-    context 'when the SendGrid service call is successful' do
+  describe "GET #index" do
+    context "when the SendGrid service call is successful" do
       before do
         allow(sendgrid_service).to receive(:check_credits).and_return(metrics)
         get :index
       end
 
-      it 'returns a successful response' do
+      it "returns a successful response" do
         expect(response).to have_http_status(:ok)
       end
 
-      it 'returns the correct metrics format' do
+      it "returns the correct metrics format" do
         expect(response.body).to include("sendgrid_total_emails #{metrics[:total]}")
         expect(response.body).to include("sendgrid_emails_remaining_count #{metrics[:remain]}")
         expect(response.body).to include("sendgrid_email_used_count #{metrics[:used]}")
@@ -41,17 +41,17 @@ RSpec.describe MetricsController, type: :controller do
       end
     end
 
-    context 'when the SendGrid service call fails' do
+    context "when the SendGrid service call fails" do
       before do
-        allow(sendgrid_service).to receive(:check_credits).and_return({ error: 'Some error' })
+        allow(sendgrid_service).to receive(:check_credits).and_return({error: "Some error"})
         get :index
       end
 
-      it 'returns an unprocessable entity status' do
+      it "returns an unprocessable entity status" do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
-      it 'returns the correct error message' do
+      it "returns the correct error message" do
         expect(response.body).to include("Error fetching metrics: Some error")
       end
     end

--- a/spec/controllers/metrics_controller_spec.rb
+++ b/spec/controllers/metrics_controller_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe MetricsController, type: :controller do
       total: 1000,
       remain: 500,
       used: 500,
-      plan_completion_status: 1,
-      exceeded_limit_status: 0,
+      time_until_expiration_seconds: 86400, # 1 day until expiration
       http_return_code: 200,
       http_response_time: 0.23
     }
@@ -34,8 +33,7 @@ RSpec.describe MetricsController, type: :controller do
         expect(response.body).to include("sendgrid_email_limit_count #{metrics[:total]}")
         expect(response.body).to include("sendgrid_emails_remaining_count #{metrics[:remain]}")
         expect(response.body).to include("sendgrid_email_used_count #{metrics[:used]}")
-        expect(response.body).to include("sendgrid_plan_limit_expire #{metrics[:plan_completion_status]}")
-        expect(response.body).to include("sendgrid_email_limit_exceeded_by_threshold_limit #{metrics[:exceeded_limit_status]}")
+        expect(response.body).to include("sendgrid_plan_expiration_seconds #{metrics[:time_until_expiration_seconds]}")
         expect(response.body).to include("sendgrid_monitoring_http_return_code #{metrics[:http_return_code]}")
         expect(response.body).to include("sendgrid_monitoring_http_response_time_seconds #{metrics[:http_response_time]}")
       end

--- a/spec/controllers/metrics_controller_spec.rb
+++ b/spec/controllers/metrics_controller_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe MetricsController, type: :controller do
       end
 
       it "returns the correct metrics format" do
-        expect(response.body).to include("sendgrid_total_emails #{metrics[:total]}")
+        expect(response.body).to include("sendgrid_email_limit_count #{metrics[:total]}")
         expect(response.body).to include("sendgrid_emails_remaining_count #{metrics[:remain]}")
         expect(response.body).to include("sendgrid_email_used_count #{metrics[:used]}")
         expect(response.body).to include("sendgrid_plan_limit_expire #{metrics[:plan_completion_status]}")
         expect(response.body).to include("sendgrid_email_limit_exceeded_by_threshold_limit #{metrics[:exceeded_limit_status]}")
-        expect(response.body).to include("sendgrid_http_return_code #{metrics[:http_return_code]}")
-        expect(response.body).to include("sendgrid_http_response_time #{metrics[:http_response_time]}")
+        expect(response.body).to include("sendgrid_monitoring_http_return_code #{metrics[:http_return_code]}")
+        expect(response.body).to include("sendgrid_monitoring_http_response_time_seconds #{metrics[:http_response_time]}")
       end
     end
 


### PR DESCRIPTION
**Story card:** [sc-12274]

## Because

Added metrics to prometheus

## This addresses

It provides metrics to prometheus such as sendgrid_http_response_time, sendgrid_total_emails,sendgrid_emails_remaining_count,sendgrid_email_used_count,sendgrid_plan_limit_expire,sendgrid_email_limit_exceeded_by_threshold_limit

## Test instructions
Need to configure prometheus, alertmanager and check that metrics are exposed to prometheus.