### PR TITLE
updating feature flag to work conditionally with the user

### DIFF
--- a/app/components/dashboard/diabetes/bs_below200_graph_component.html.erb
+++ b/app/components/dashboard/diabetes/bs_below200_graph_component.html.erb
@@ -1,8 +1,7 @@
-<% use_who_standard = Flipper.enabled?(:diabetes_who_standard_indicator, @current_admin) %>
-<% title_text = use_who_standard ? t("bs_below_200_copy.reports_card_title_fbs") : t("bs_below_200_copy.reports_card_title") %>
-<% subtitle_text = use_who_standard ? t("bs_below_200_copy.reports_card_subtitle_fbs", region_name: region.name) : t("bs_below_200_copy.reports_card_subtitle", region_name: region.name) %>
-<% numerator_text = use_who_standard ? t("bs_below_200_copy.numerator_fbs") : t("bs_below_200_copy.numerator") %>
-<% summary_text = use_who_standard ? t("bs_below_200_copy.summary_fbs") : t("bs_below_200_copy.summary") %>
+<% title_text = @use_who_standard ? t("bs_below_200_copy.reports_card_title_fbs") : t("bs_below_200_copy.reports_card_title") %>
+<% subtitle_text = @use_who_standard ? t("bs_below_200_copy.reports_card_subtitle_fbs", region_name: region.name) : t("bs_below_200_copy.reports_card_subtitle", region_name: region.name) %>
+<% numerator_text = @use_who_standard ? t("bs_below_200_copy.numerator_fbs") : t("bs_below_200_copy.numerator") %>
+<% summary_text = @use_who_standard ? t("bs_below_200_copy.summary_fbs") : t("bs_below_200_copy.summary") %>
 
 <div id="bs-below-200" class="d-lg-flex w-lg-50 pr-lg-2">
   <%= render Dashboard::Card::GraphComponent.new(id: "bsBelow200PatientsTrend", data: graph_data, period: period) do |c| %>

--- a/app/components/dashboard/diabetes/bs_below200_graph_component.html.erb
+++ b/app/components/dashboard/diabetes/bs_below200_graph_component.html.erb
@@ -1,4 +1,4 @@
-<% use_who_standard = Flipper.enabled?(:diabetes_who_standard_indicator) %>
+<% use_who_standard = Flipper.enabled?(:diabetes_who_standard_indicator, @current_admin) %>
 <% title_text = use_who_standard ? t("bs_below_200_copy.reports_card_title_fbs") : t("bs_below_200_copy.reports_card_title") %>
 <% subtitle_text = use_who_standard ? t("bs_below_200_copy.reports_card_subtitle_fbs", region_name: region.name) : t("bs_below_200_copy.reports_card_subtitle", region_name: region.name) %>
 <% numerator_text = use_who_standard ? t("bs_below_200_copy.numerator_fbs") : t("bs_below_200_copy.numerator") %>

--- a/app/components/dashboard/diabetes/bs_below200_graph_component.rb
+++ b/app/components/dashboard/diabetes/bs_below200_graph_component.rb
@@ -4,12 +4,12 @@ class Dashboard::Diabetes::BsBelow200GraphComponent < ApplicationComponent
   attr_reader :period
   attr_reader :with_ltfu
 
-  def initialize(data:, region:, period:, current_admin:, with_ltfu: false)
+  def initialize(data:, region:, period:, use_who_standard:, with_ltfu: false)
     @data = data
     @region = region
     @period = period
     @with_ltfu = with_ltfu
-    @current_admin = current_admin
+    @use_who_standard = use_who_standard
   end
 
   def denominator_copy

--- a/app/components/dashboard/diabetes/bs_below200_graph_component.rb
+++ b/app/components/dashboard/diabetes/bs_below200_graph_component.rb
@@ -4,11 +4,12 @@ class Dashboard::Diabetes::BsBelow200GraphComponent < ApplicationComponent
   attr_reader :period
   attr_reader :with_ltfu
 
-  def initialize(data:, region:, period:, with_ltfu: false)
+  def initialize(data:, region:, period:, with_ltfu: false, current_admin:)
     @data = data
     @region = region
     @period = period
     @with_ltfu = with_ltfu
+    @current_admin = current_admin
   end
 
   def denominator_copy

--- a/app/components/dashboard/diabetes/bs_below200_graph_component.rb
+++ b/app/components/dashboard/diabetes/bs_below200_graph_component.rb
@@ -4,7 +4,7 @@ class Dashboard::Diabetes::BsBelow200GraphComponent < ApplicationComponent
   attr_reader :period
   attr_reader :with_ltfu
 
-  def initialize(data:, region:, period:, with_ltfu: false, current_admin:)
+  def initialize(data:, region:, period:, current_admin:, with_ltfu: false)
     @data = data
     @region = region
     @period = period

--- a/app/components/dashboard/diabetes/bs_over200_graph_component.html.erb
+++ b/app/components/dashboard/diabetes/bs_over200_graph_component.html.erb
@@ -1,15 +1,14 @@
-<% use_who_standard = Flipper.enabled?(:diabetes_who_standard_indicator, @current_admin) %>
-<% title_text = use_who_standard ? t("bs_over_200_copy.reports_card_title_fbs") : t("bs_over_200_copy.reports_card_title") %>
-<% subtitle_text = use_who_standard ? t("bs_over_200_copy.reports_card_subtitle_fbs", region_name: @region.name) : t("bs_over_200_copy.reports_card_subtitle", region_name: @region.name) %>
-<% bs_over_300_summary_text = use_who_standard ? t("bs_over_200_copy.bs_over_300.summary_fbs") : t("bs_over_200_copy.bs_over_300.summary") %>
-<% bs_200_to_299_summary_text = use_who_standard ? t("bs_over_200_copy.bs_200_to_299.summary_fbs") : t("bs_over_200_copy.bs_200_to_299.summary") %>
+<% title_text = @use_who_standard ? t("bs_over_200_copy.reports_card_title_fbs") : t("bs_over_200_copy.reports_card_title") %>
+<% subtitle_text = @use_who_standard ? t("bs_over_200_copy.reports_card_subtitle_fbs", region_name: @region.name) : t("bs_over_200_copy.reports_card_subtitle", region_name: @region.name) %>
+<% bs_over_300_summary_text = @use_who_standard ? t("bs_over_200_copy.bs_over_300.summary_fbs") : t("bs_over_200_copy.bs_over_300.summary") %>
+<% bs_200_to_299_summary_text = @use_who_standard ? t("bs_over_200_copy.bs_200_to_299.summary_fbs") : t("bs_over_200_copy.bs_200_to_299.summary") %>
 
 <div id="bs-over-200" class="d-lg-flex w-lg-50 pr-lg-2">
   <%= render Dashboard::Card::GraphComponent.new(id: "bsOver200PatientsTrend", data: graph_data, period: period) do |c| %>
     <%= c.title(
       title: title_text.html_safe,
       subtitle: subtitle_text) do |title| %>
-      <% if use_who_standard %>
+      <% if @use_who_standard %>
         <%= title.tooltip({ "Blood sugar 126-199 numerator" => t("bs_over_200_copy.bs_200_to_299.numerator_fbs"),
                             "Blood sugar ≥200 numerator" => t("bs_over_200_copy.bs_over_300.numerator_fbs"),
                             "Denominator" => t(denominator_copy, region_name: @region.name) }) %>

--- a/app/components/dashboard/diabetes/bs_over200_graph_component.html.erb
+++ b/app/components/dashboard/diabetes/bs_over200_graph_component.html.erb
@@ -1,4 +1,4 @@
-<% use_who_standard = Flipper.enabled?(:diabetes_who_standard_indicator) %>
+<% use_who_standard = Flipper.enabled?(:diabetes_who_standard_indicator, @current_admin) %>
 <% title_text = use_who_standard ? t("bs_over_200_copy.reports_card_title_fbs") : t("bs_over_200_copy.reports_card_title") %>
 <% subtitle_text = use_who_standard ? t("bs_over_200_copy.reports_card_subtitle_fbs", region_name: @region.name) : t("bs_over_200_copy.reports_card_subtitle", region_name: @region.name) %>
 <% bs_over_300_summary_text = use_who_standard ? t("bs_over_200_copy.bs_over_300.summary_fbs") : t("bs_over_200_copy.bs_over_300.summary") %>

--- a/app/components/dashboard/diabetes/bs_over200_graph_component.rb
+++ b/app/components/dashboard/diabetes/bs_over200_graph_component.rb
@@ -4,12 +4,12 @@ class Dashboard::Diabetes::BsOver200GraphComponent < ApplicationComponent
   attr_reader :period
   attr_reader :with_ltfu
 
-  def initialize(data:, region:, period:, current_admin:, with_ltfu: false)
+  def initialize(data:, region:, period:, use_who_standard:, with_ltfu: false)
     @data = data
     @region = region
     @period = period
     @with_ltfu = with_ltfu
-    @current_admin = current_admin
+    @use_who_standard = use_who_standard
   end
 
   def graph_data

--- a/app/components/dashboard/diabetes/bs_over200_graph_component.rb
+++ b/app/components/dashboard/diabetes/bs_over200_graph_component.rb
@@ -4,7 +4,7 @@ class Dashboard::Diabetes::BsOver200GraphComponent < ApplicationComponent
   attr_reader :period
   attr_reader :with_ltfu
 
-  def initialize(data:, region:, period:, with_ltfu: false, current_admin:)
+  def initialize(data:, region:, period:, current_admin:, with_ltfu: false)
     @data = data
     @region = region
     @period = period

--- a/app/components/dashboard/diabetes/bs_over200_graph_component.rb
+++ b/app/components/dashboard/diabetes/bs_over200_graph_component.rb
@@ -4,11 +4,12 @@ class Dashboard::Diabetes::BsOver200GraphComponent < ApplicationComponent
   attr_reader :period
   attr_reader :with_ltfu
 
-  def initialize(data:, region:, period:, with_ltfu: false)
+  def initialize(data:, region:, period:, with_ltfu: false, current_admin:)
     @data = data
     @region = region
     @period = period
     @with_ltfu = with_ltfu
+    @current_admin = current_admin
   end
 
   def graph_data

--- a/app/components/dashboard/diabetes/missed_visits_graph_component.rb
+++ b/app/components/dashboard/diabetes/missed_visits_graph_component.rb
@@ -4,7 +4,7 @@ class Dashboard::Diabetes::MissedVisitsGraphComponent < ApplicationComponent
   attr_reader :period
   attr_reader :with_ltfu
 
-  def initialize(data:, region:, period:, with_ltfu: false, current_admin:)
+  def initialize(data:, region:, period:, current_admin:, with_ltfu: false)
     @data = data
     @region = region
     @period = period

--- a/app/components/dashboard/diabetes/missed_visits_graph_component.rb
+++ b/app/components/dashboard/diabetes/missed_visits_graph_component.rb
@@ -4,11 +4,12 @@ class Dashboard::Diabetes::MissedVisitsGraphComponent < ApplicationComponent
   attr_reader :period
   attr_reader :with_ltfu
 
-  def initialize(data:, region:, period:, with_ltfu: false)
+  def initialize(data:, region:, period:, with_ltfu: false, current_admin:)
     @data = data
     @region = region
     @period = period
     @with_ltfu = with_ltfu
+    @current_admin = current_admin
   end
 
   def graph_data

--- a/app/components/dashboard/diabetes/missed_visits_graph_component.rb
+++ b/app/components/dashboard/diabetes/missed_visits_graph_component.rb
@@ -4,12 +4,12 @@ class Dashboard::Diabetes::MissedVisitsGraphComponent < ApplicationComponent
   attr_reader :period
   attr_reader :with_ltfu
 
-  def initialize(data:, region:, period:, current_admin:, with_ltfu: false)
+  def initialize(data:, region:, period:, use_who_standard:, with_ltfu: false)
     @data = data
     @region = region
     @period = period
     @with_ltfu = with_ltfu
-    @current_admin = current_admin
+    @use_who_standard = use_who_standard
   end
 
   def graph_data

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -167,7 +167,7 @@ class Reports::RegionsController < AdminController
   def diabetes
     start_period = @period.advance(months: -(Reports::MAX_MONTHS_OF_DATA - 1))
     range = Range.new(start_period, @period)
-    @repository = Reports::Repository.new(@region, periods: range)
+    @repository = Reports::Repository.new(@region, periods: range, current_admin: current_admin)
     @presenter = Reports::RepositoryPresenter.new(@repository)
     @data = @presenter.call(@region)
     @with_ltfu = with_ltfu?

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -170,7 +170,7 @@ class Reports::RegionsController < AdminController
     range = Range.new(start_period, @period)
     @repository = Reports::Repository.new(@region, periods: range, use_who_standard: @use_who_standard)
     @presenter = Reports::RepositoryPresenter.new(@repository)
-    @data = @presenter.call(@region, @use_who_standard)
+    @data = @presenter.call(@region)
     @with_ltfu = with_ltfu?
     @latest_period = Period.current
 

--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -18,7 +18,7 @@ module Reports
     attr_reader :current_admin
     alias_method :range, :periods
 
-    def initialize(regions, periods:, current_admin: nil)
+    def initialize(regions, periods:, use_who_standard: nil)
       @regions = Array(regions).map(&:region)
       @periods = if periods.is_a?(Period)
         Range.new(periods, periods)
@@ -33,7 +33,7 @@ module Reports
       @registered_patients_query = RegisteredPatientsQuery.new
       @overdue_patient_query = OverduePatientsQuery.new
       @overdue_calls_query = OverdueCallsQuery.new
-      @current_admin = current_admin
+      @use_who_standard = use_who_standard
     end
 
     delegate :cache, :logger, to: Rails

--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -15,9 +15,10 @@ module Reports
     attr_reader :registered_patients_query
     attr_reader :overdue_patient_query
     attr_reader :schema
+    attr_reader :current_admin
     alias_method :range, :periods
 
-    def initialize(regions, periods:)
+    def initialize(regions, periods:, current_admin: nil)
       @regions = Array(regions).map(&:region)
       @periods = if periods.is_a?(Period)
         Range.new(periods, periods)
@@ -32,6 +33,7 @@ module Reports
       @registered_patients_query = RegisteredPatientsQuery.new
       @overdue_patient_query = OverduePatientsQuery.new
       @overdue_calls_query = OverdueCallsQuery.new
+      @current_admin = current_admin
     end
 
     delegate :cache, :logger, to: Rails

--- a/app/models/reports/repository.rb
+++ b/app/models/reports/repository.rb
@@ -15,7 +15,7 @@ module Reports
     attr_reader :registered_patients_query
     attr_reader :overdue_patient_query
     attr_reader :schema
-    attr_reader :current_admin
+    attr_reader :use_who_standard
     alias_method :range, :periods
 
     def initialize(regions, periods:, use_who_standard: nil)

--- a/app/presenters/reports/repository_presenter.rb
+++ b/app/presenters/reports/repository_presenter.rb
@@ -1,19 +1,18 @@
 module Reports
   class RepositoryPresenter < SimpleDelegator
-    def self.create(regions, period:, months: Reports::MAX_MONTHS_OF_DATA, current_admin: nil)
+    def self.create(regions, period:, months: Reports::MAX_MONTHS_OF_DATA, use_who_standard: nil)
       start_period = period.advance(months: -(months - 1))
       range = Range.new(start_period, period)
-      repo = Reports::Repository.new(regions, periods: range, current_admin: current_admin)
+      repo = Reports::Repository.new(regions, periods: range, use_who_standard: use_who_standard)
       new(repo)
     end
 
-    def call(region)
-      to_hash(region)
+    def call(region, use_who_standard = nil)
+      to_hash(region, use_who_standard)
     end
 
-    def to_hash(region)
+    def to_hash(region, use_who_standard = nil)
       slug = region.slug
-      use_who_standard = Flipper.enabled?(:diabetes_who_standard_indicator, current_admin)
       {
         adjusted_patient_counts_with_ltfu: adjusted_patients_with_ltfu[slug],
         adjusted_patient_counts: adjusted_patients_without_ltfu[slug],

--- a/app/presenters/reports/repository_presenter.rb
+++ b/app/presenters/reports/repository_presenter.rb
@@ -1,9 +1,9 @@
 module Reports
   class RepositoryPresenter < SimpleDelegator
-    def self.create(regions, period:, months: Reports::MAX_MONTHS_OF_DATA)
+    def self.create(regions, period:, months: Reports::MAX_MONTHS_OF_DATA, current_admin: nil)
       start_period = period.advance(months: -(months - 1))
       range = Range.new(start_period, period)
-      repo = Reports::Repository.new(regions, periods: range)
+      repo = Reports::Repository.new(regions, periods: range, current_admin: current_admin)
       new(repo)
     end
 
@@ -13,7 +13,7 @@ module Reports
 
     def to_hash(region)
       slug = region.slug
-      use_who_standard = Flipper.enabled?(:diabetes_who_standard_indicator)
+      use_who_standard = Flipper.enabled?(:diabetes_who_standard_indicator, current_admin)
       {
         adjusted_patient_counts_with_ltfu: adjusted_patients_with_ltfu[slug],
         adjusted_patient_counts: adjusted_patients_without_ltfu[slug],

--- a/app/presenters/reports/repository_presenter.rb
+++ b/app/presenters/reports/repository_presenter.rb
@@ -7,11 +7,11 @@ module Reports
       new(repo)
     end
 
-    def call(region, use_who_standard = nil)
-      to_hash(region, use_who_standard)
+    def call(region)
+      to_hash(region)
     end
 
-    def to_hash(region, use_who_standard = nil)
+    def to_hash(region)
       slug = region.slug
       {
         adjusted_patient_counts_with_ltfu: adjusted_patients_with_ltfu[slug],

--- a/app/views/reports/regions/_diabetes_footnotes.html.erb
+++ b/app/views/reports/regions/_diabetes_footnotes.html.erb
@@ -1,4 +1,4 @@
-<% use_who_standard = Flipper.enabled?(:diabetes_who_standard_indicator) %>
+<% use_who_standard = Flipper.enabled?(:diabetes_who_standard_indicator, @current_admin) %>
 
 <div class="row mt-5 mb-64px">
     <div class="col-lg-7">

--- a/app/views/reports/regions/_diabetes_footnotes.html.erb
+++ b/app/views/reports/regions/_diabetes_footnotes.html.erb
@@ -1,5 +1,3 @@
-<% use_who_standard = Flipper.enabled?(:diabetes_who_standard_indicator, @current_admin) %>
-
 <div class="row mt-5 mb-64px">
     <div class="col-lg-7">
       <h4 class="mb-16px pb-8px">
@@ -47,11 +45,11 @@
       </div>
       <div class="mb-24px">
         <p class="mb-8px fs-16px fw-bold c-grey-dark">
-          <%= use_who_standard ? t("bs_below_200_copy.reports_card_title_fbs") : t("bs_below_200_copy.reports_card_title") %>
+          <%= @use_who_standard ? t("bs_below_200_copy.reports_card_title_fbs") : t("bs_below_200_copy.reports_card_title") %>
         </p>
         <div class="pl-16px">
           <p class="mb-8px fs-14px c-grey-dark">
-            <strong>Numerator:</strong> <%= use_who_standard ? t("bs_below_200_copy.numerator_fbs") : t("bs_below_200_copy.numerator") %>
+            <strong>Numerator:</strong> <%= @use_who_standard ? t("bs_below_200_copy.numerator_fbs") : t("bs_below_200_copy.numerator") %>
           </p>
           <p class="mb-0px fs-14px c-grey-dark">
             <strong>Denominator:</strong> <%= t("diabetes_denominator_copy", region_name: @region.name) %>
@@ -60,11 +58,11 @@
       </div>
       <div class="mb-24px">
         <p class="mb-8px fs-16px fw-bold c-grey-dark">
-          <%= use_who_standard ? t("bs_over_200_copy.bs_200_to_299.title_fbs") : t("bs_over_200_copy.bs_200_to_299.title") %>
+          <%= @use_who_standard ? t("bs_over_200_copy.bs_200_to_299.title_fbs") : t("bs_over_200_copy.bs_200_to_299.title") %>
         </p>
         <div class="pl-16px">
           <p class="mb-8px fs-14px c-grey-dark">
-            <strong>Numerator:</strong> <%= use_who_standard ? t("bs_over_200_copy.bs_200_to_299.numerator_fbs") : t("bs_over_200_copy.bs_200_to_299.numerator") %>
+            <strong>Numerator:</strong> <%= @use_who_standard ? t("bs_over_200_copy.bs_200_to_299.numerator_fbs") : t("bs_over_200_copy.bs_200_to_299.numerator") %>
           </p>
           <p class="mb-0px fs-14px c-grey-dark">
             <strong>Denominator:</strong> <%= t("diabetes_denominator_copy", region_name: @region.name) %>
@@ -73,11 +71,11 @@
       </div>
       <div class="mb-24px">
         <p class="mb-8px fs-16px fw-bold c-grey-dark">
-          <%= use_who_standard ? t("bs_over_200_copy.bs_over_300.title_fbs") : t("bs_over_200_copy.bs_over_300.title") %>
+          <%= @use_who_standard ? t("bs_over_200_copy.bs_over_300.title_fbs") : t("bs_over_200_copy.bs_over_300.title") %>
         </p>
         <div class="pl-16px">
           <p class="mb-8px fs-14px c-grey-dark">
-            <strong>Numerator:</strong> <%= use_who_standard ? t("bs_over_200_copy.bs_over_300.numerator_fbs") : t("bs_over_200_copy.bs_over_300.numerator") %>
+            <strong>Numerator:</strong> <%= @use_who_standard ? t("bs_over_200_copy.bs_over_300.numerator_fbs") : t("bs_over_200_copy.bs_over_300.numerator") %>
           </p>
           <p class="mb-0px fs-14px c-grey-dark">
             <strong>Denominator:</strong> <%= t("diabetes_denominator_copy", region_name: @region.name) %>

--- a/app/views/reports/regions/diabetes.html.erb
+++ b/app/views/reports/regions/diabetes.html.erb
@@ -5,7 +5,7 @@
 <%= render "header" %>
 
 <% args = { data: @data, region: @region, period: @period } %>
-<% args_with_ltfu = { data: @data, region: @region, period: @period, with_ltfu: @with_ltfu, current_admin: current_admin } %>
+<% args_with_ltfu = { data: @data, region: @region, period: @period, with_ltfu: @with_ltfu, use_who_standard: @use_who_standard } %>
 
 <div class="d-lg-flex flex-lg-wrap">
   <%= render Dashboard::Diabetes::BsBelow200GraphComponent.new(args_with_ltfu) %>

--- a/app/views/reports/regions/diabetes.html.erb
+++ b/app/views/reports/regions/diabetes.html.erb
@@ -5,7 +5,7 @@
 <%= render "header" %>
 
 <% args = { data: @data, region: @region, period: @period } %>
-<% args_with_ltfu = { data: @data, region: @region, period: @period, with_ltfu: @with_ltfu } %>
+<% args_with_ltfu = { data: @data, region: @region, period: @period, with_ltfu: @with_ltfu, current_admin: current_admin } %>
 
 <div class="d-lg-flex flex-lg-wrap">
   <%= render Dashboard::Diabetes::BsBelow200GraphComponent.new(args_with_ltfu) %>

--- a/spec/components/dashboard/diabetes/bs_below200_graph_component_spec.rb
+++ b/spec/components/dashboard/diabetes/bs_below200_graph_component_spec.rb
@@ -8,11 +8,13 @@ describe Dashboard::Diabetes::BsBelow200GraphComponent, type: :component do
   let(:region) { distict_with_facilities[:region] }
   let(:facility_1) { distict_with_facilities[:facility_1] }
   let(:region_data) { presenter.call(region) }
+  let(:user) { create(:user) }
   let(:bs_below200_graph_component) {
     described_class.new(
       region: region,
       data: region_data,
-      period: Period.current
+      period: Period.current,
+      current_admin: user
     )
   }
 
@@ -26,7 +28,7 @@ describe Dashboard::Diabetes::BsBelow200GraphComponent, type: :component do
 
   context "with the feature flag for global diabetes indicator enabled" do
     before do
-      Flipper.enable(:diabetes_who_standard_indicator)
+      Flipper.enable(:diabetes_who_standard_indicator, user)
     end
 
     it "has the updated labels" do

--- a/spec/components/dashboard/diabetes/bs_below200_graph_component_spec.rb
+++ b/spec/components/dashboard/diabetes/bs_below200_graph_component_spec.rb
@@ -8,13 +8,13 @@ describe Dashboard::Diabetes::BsBelow200GraphComponent, type: :component do
   let(:region) { distict_with_facilities[:region] }
   let(:facility_1) { distict_with_facilities[:facility_1] }
   let(:region_data) { presenter.call(region) }
-  let(:user) { create(:user) }
+  let(:use_who_standard) { false }
   let(:bs_below200_graph_component) {
     described_class.new(
       region: region,
       data: region_data,
       period: Period.current,
-      current_admin: user
+      use_who_standard: use_who_standard
     )
   }
 
@@ -27,9 +27,7 @@ describe Dashboard::Diabetes::BsBelow200GraphComponent, type: :component do
   end
 
   context "with the feature flag for global diabetes indicator enabled" do
-    before do
-      Flipper.enable(:diabetes_who_standard_indicator, user)
-    end
+    let(:use_who_standard) { true }
 
     it "has the updated labels" do
       render_inline(bs_below200_graph_component)

--- a/spec/components/dashboard/diabetes/bs_over200_graph_component_spec.rb
+++ b/spec/components/dashboard/diabetes/bs_over200_graph_component_spec.rb
@@ -8,13 +8,13 @@ describe Dashboard::Diabetes::BsOver200GraphComponent, type: :component do
   let(:region) { distict_with_facilities[:region] }
   let(:facility_1) { distict_with_facilities[:facility_1] }
   let(:region_data) { presenter.call(region) }
-  let(:user) { create(:user) }
+  let(:use_who_standard) { false }
   let(:bs_over200_graph_component) {
     described_class.new(
       region: region,
       data: region_data,
       period: Period.current,
-      current_admin: user
+      use_who_standard: use_who_standard
     )
   }
 
@@ -29,9 +29,7 @@ describe Dashboard::Diabetes::BsOver200GraphComponent, type: :component do
   end
 
   context "with the feature flag for global diabetes indicator enabled" do
-    before do
-      Flipper.enable(:diabetes_who_standard_indicator, user)
-    end
+    let(:use_who_standard) { true }
 
     it "has the updated labels" do
       render_inline(bs_over200_graph_component)

--- a/spec/components/dashboard/diabetes/bs_over200_graph_component_spec.rb
+++ b/spec/components/dashboard/diabetes/bs_over200_graph_component_spec.rb
@@ -8,11 +8,13 @@ describe Dashboard::Diabetes::BsOver200GraphComponent, type: :component do
   let(:region) { distict_with_facilities[:region] }
   let(:facility_1) { distict_with_facilities[:facility_1] }
   let(:region_data) { presenter.call(region) }
+  let(:user) { create(:user) }
   let(:bs_over200_graph_component) {
     described_class.new(
       region: region,
       data: region_data,
-      period: Period.current
+      period: Period.current,
+      current_admin: user
     )
   }
 
@@ -28,7 +30,7 @@ describe Dashboard::Diabetes::BsOver200GraphComponent, type: :component do
 
   context "with the feature flag for global diabetes indicator enabled" do
     before do
-      Flipper.enable(:diabetes_who_standard_indicator)
+      Flipper.enable(:diabetes_who_standard_indicator, user)
     end
 
     it "has the updated labels" do

--- a/spec/presenters/reports/repository_presenter_spec.rb
+++ b/spec/presenters/reports/repository_presenter_spec.rb
@@ -7,7 +7,7 @@ describe Reports::RepositoryPresenter do
   let(:use_who_standard) { nil }
 
   it "create works" do
-    expect(presenter.to_hash(region, use_who_standard).keys).to include(:adjusted_patient_counts_with_ltfu, :period_info)
+    expect(presenter.to_hash(region).keys).to include(:adjusted_patient_counts_with_ltfu, :period_info)
   end
 
   describe "#to_hash" do
@@ -102,7 +102,7 @@ describe Reports::RepositoryPresenter do
         :contactable_patients_returned_with_result_remind_to_call_later_rates,
         :contactable_patients_returned_with_result_removed_from_list_rates
       ]
-      expect(presenter.to_hash(region, use_who_standard).keys).to match_array(expected_keys)
+      expect(presenter.to_hash(region).keys).to match_array(expected_keys)
     end
 
     context "when the feature flag for global diabetes indicator is enabled" do
@@ -115,7 +115,7 @@ describe Reports::RepositoryPresenter do
         expect(presenter.schema).to receive(:bs_200_to_300_rates_fasting_and_hba1c).twice.and_call_original
         expect(presenter.schema).to receive(:bs_over_300_patients_fasting_and_hba1c).and_call_original
         expect(presenter.schema).to receive(:bs_over_300_rates_fasting_and_hba1c).twice.and_call_original
-        presenter.to_hash(region, use_who_standard)
+        presenter.to_hash(region)
       end
     end
   end

--- a/spec/presenters/reports/repository_presenter_spec.rb
+++ b/spec/presenters/reports/repository_presenter_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 describe Reports::RepositoryPresenter do
   let(:facility) { create(:facility) }
   let(:region) { facility.region }
-  let(:presenter) { described_class.create(region, period: Reports.default_period) }
+  let(:presenter) { described_class.create(region, period: Reports.default_period, current_admin: user) }
+  let(:user) { create(:user) }
 
   it "create works" do
     expect(presenter.to_hash(region).keys).to include(:adjusted_patient_counts_with_ltfu, :period_info)
@@ -106,7 +107,7 @@ describe Reports::RepositoryPresenter do
 
     context "when the feature flag for global diabetes indicator is enabled" do
       before do
-        Flipper.enable(:diabetes_who_standard_indicator)
+        Flipper.enable(:diabetes_who_standard_indicator, user)
       end
 
       it "includes fasting and hba1c counts and rates" do

--- a/spec/presenters/reports/repository_presenter_spec.rb
+++ b/spec/presenters/reports/repository_presenter_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 describe Reports::RepositoryPresenter do
   let(:facility) { create(:facility) }
   let(:region) { facility.region }
-  let(:presenter) { described_class.create(region, period: Reports.default_period, current_admin: user) }
-  let(:user) { create(:user) }
+  let(:presenter) { described_class.create(region, period: Reports.default_period, use_who_standard: use_who_standard) }
+  let(:use_who_standard) { nil }
 
   it "create works" do
-    expect(presenter.to_hash(region).keys).to include(:adjusted_patient_counts_with_ltfu, :period_info)
+    expect(presenter.to_hash(region, use_who_standard).keys).to include(:adjusted_patient_counts_with_ltfu, :period_info)
   end
 
   describe "#to_hash" do
@@ -102,13 +102,11 @@ describe Reports::RepositoryPresenter do
         :contactable_patients_returned_with_result_remind_to_call_later_rates,
         :contactable_patients_returned_with_result_removed_from_list_rates
       ]
-      expect(presenter.to_hash(region).keys).to match_array(expected_keys)
+      expect(presenter.to_hash(region, use_who_standard).keys).to match_array(expected_keys)
     end
 
     context "when the feature flag for global diabetes indicator is enabled" do
-      before do
-        Flipper.enable(:diabetes_who_standard_indicator, user)
-      end
+      let(:use_who_standard) { true }
 
       it "includes fasting and hba1c counts and rates" do
         expect(presenter.schema).to receive(:bs_below_200_patients_fasting_and_hba1c).and_call_original
@@ -117,7 +115,7 @@ describe Reports::RepositoryPresenter do
         expect(presenter.schema).to receive(:bs_200_to_300_rates_fasting_and_hba1c).twice.and_call_original
         expect(presenter.schema).to receive(:bs_over_300_patients_fasting_and_hba1c).and_call_original
         expect(presenter.schema).to receive(:bs_over_300_rates_fasting_and_hba1c).twice.and_call_original
-        presenter.to_hash(region)
+        presenter.to_hash(region, use_who_standard)
       end
     end
   end

--- a/spec/views/reports/regions/_diabetes_footnotes.html.erb_spec.rb
+++ b/spec/views/reports/regions/_diabetes_footnotes.html.erb_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 RSpec.describe "reports/regions/_diabetes_footnotes.html.erb", type: :view do
   let(:distict_with_facilities) { setup_district_with_facilities }
   let(:region) { distict_with_facilities[:region] }
-  let(:user) { create(:user) }
+  let(:use_who_standard) { false }
 
   it "has the correct labels" do
     assign(:region, region)
-    assign(:current_admin, user)
+    assign(:use_who_standard, use_who_standard)
     render
     all_texts = Capybara.string(rendered).all("p")
     expect(all_texts[8].text.strip).to eq("Blood sugar < 200")
@@ -19,13 +19,11 @@ RSpec.describe "reports/regions/_diabetes_footnotes.html.erb", type: :view do
   end
 
   context "with the feature flag for global diabetes indicator enabled" do
-    before do
-      Flipper.enable(:diabetes_who_standard_indicator, user)
-    end
+    let(:use_who_standard) { true }
 
     it "has the updated labels" do
       assign(:region, region)
-      assign(:current_admin, user)
+      assign(:use_who_standard, use_who_standard)
       render
       all_texts = Capybara.string(rendered).all("p")
       expect(all_texts[8].text.strip).to eq("Blood sugar < 126")

--- a/spec/views/reports/regions/_diabetes_footnotes.html.erb_spec.rb
+++ b/spec/views/reports/regions/_diabetes_footnotes.html.erb_spec.rb
@@ -3,9 +3,11 @@ require "rails_helper"
 RSpec.describe "reports/regions/_diabetes_footnotes.html.erb", type: :view do
   let(:distict_with_facilities) { setup_district_with_facilities }
   let(:region) { distict_with_facilities[:region] }
+  let(:user) { create(:user) }
 
   it "has the correct labels" do
     assign(:region, region)
+    assign(:current_admin, user)
     render
     all_texts = Capybara.string(rendered).all("p")
     expect(all_texts[8].text.strip).to eq("Blood sugar < 200")
@@ -18,11 +20,12 @@ RSpec.describe "reports/regions/_diabetes_footnotes.html.erb", type: :view do
 
   context "with the feature flag for global diabetes indicator enabled" do
     before do
-      Flipper.enable(:diabetes_who_standard_indicator)
+      Flipper.enable(:diabetes_who_standard_indicator, user)
     end
 
     it "has the updated labels" do
       assign(:region, region)
+      assign(:current_admin, user)
       render
       all_texts = Capybara.string(rendered).all("p")
       expect(all_texts[8].text.strip).to eq("Blood sugar < 126")


### PR DESCRIPTION
**Story card:** https://app.shortcut.com/simpledotorg/story/13321/make-feature-flag-take-logged-in-user-into-consideration

## Because

We wanted the feature flag for global diabetes indicator to work with logged in users, for making it easier to test on prod before making it live for everyone

## This addresses

updating diabetes_who_standard_indicator, wherever it's used, to work with logged in user

## Test instructions

Login to Simple dashboard -> Go to Flipper UI and enable diabetes_who_standard_indicator flag only for an actor. 
Log in with the same actor.
Feature flag should work only for the actors added and not for other users.