### PR TITLE
SMS reminders: disable in Bangladesh

### DIFF
--- a/db/data/20240902213036_disable_sms_reminders_bd_sep_oct_2024.rb
+++ b/db/data/20240902213036_disable_sms_reminders_bd_sep_oct_2024.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class DisableSmsRemindersBdSepOct2024 < ActiveRecord::Migration[6.1]
+  EXPERIMENTS_TO_CANCEL = %w[Sep Oct].map do |month|
+    {
+      current_experiment_name: "Current patients #{month} 2024",
+      stale_experiment_name: "Stale patients #{month} 2024"
+    }
+  end
+
+  def up
+    return unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
+
+    EXPERIMENTS_TO_CANCEL.each do |experiment_data|
+      Experimentation::Experiment.current_patients.find_by_name(experiment_data[:current_experiment_name])&.cancel
+      Experimentation::Experiment.stale_patients.find_by_name(experiment_data[:stale_experiment_name])&.cancel
+    end
+  end
+
+  def down
+    return unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
+    puts "This migration cannot be reversed. To reenable SMSs, create a new migration."
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240812170559)
+DataMigrate::Data.define(version: 20240902213036)


### PR DESCRIPTION
**Story card:** [sc-13347](https://app.shortcut.com/simpledotorg/story/13347/disable-sms-reminders-in-bd)

## Because

The NHF has requested that we stop sending SMS in Bangladesh (all districts) till further notice as they have drug stock outs at the moment and so they don't want patients getting reminders to come to the facilities.
