### PR TITLE
add OpenSRP exporter script for Gonaduwa migration

### DIFF
--- a/app/services/one_off/opensrp/appointment_exporter.rb
+++ b/app/services/one_off/opensrp/appointment_exporter.rb
@@ -1,0 +1,362 @@
+require "fhir_models"
+
+module OneOff
+  module Opensrp
+    class AppointmentExporter
+      attr_reader :appointment
+
+      def initialize(appointment, opensrp_mapping)
+        @appointment = appointment
+        @opensrp_ids = opensrp_mapping[@appointment.facility_id]
+      end
+
+      def export
+        FHIR::Appointment.new(
+          meta: meta,
+          status: appointment_status_code,
+          start: appointment.scheduled_date.beginning_of_day.iso8601,
+          end: appointment.scheduled_date.beginning_of_day.iso8601,
+          created: appointment.device_created_at.iso8601,
+          serviceType: FHIR::CodeableConcept.new(
+            coding: [
+              FHIR::Coding.new(
+                system: "http://terminology.hl7.org/CodeSystem/service-type",
+                code: "335"
+              )
+            ]
+          ),
+          appointmentType: FHIR::CodeableConcept.new(
+            coding: [
+              FHIR::Coding.new(
+                system: "https://terminology.hl7.org/3.1.0/CodeSystem-v2-0276.html",
+                code: "FOLLOWUP"
+              )
+            ]
+          ),
+          reasonCode: [
+            FHIR::CodeableConcept.new(
+              coding: [
+                FHIR::Coding.new(
+                  system: "http://snomed.info/sct",
+                  code: "1156892006"
+                )
+              ]
+            )
+          ],
+          participant: [
+            FHIR::Appointment::Participant.new(
+              actor: FHIR::Reference.new(reference: "Patient/#{appointment.patient_id}"),
+              status: participant_status
+            ),
+            FHIR::Appointment::Participant.new(
+              actor: FHIR::Reference.new(reference: "Practitioner/#{opensrp_ids[:practitioner_id]}"),
+              status: participant_status
+            )
+          ],
+          id: appointment.id,
+          identifier: [
+            FHIR::Identifier.new(
+              value: appointment.id
+            )
+          ]
+        )
+      end
+
+      def export_encounter
+        {
+          parent_id: parent_encounter_id,
+          encounter_opensrp_ids: opensrp_ids,
+          child_encounter: FHIR::Encounter.new(
+            meta: meta,
+            status: encounter_status_code,
+            id: encounter_id,
+            identifier: [
+              FHIR::Identifier.new(
+                value: encounter_id
+              )
+            ],
+            class: FHIR::Coding.new(
+              system: "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              code: "AMB"
+            ),
+            type: [
+              FHIR::CodeableConcept.new(
+                coding: FHIR::Coding.new(
+                  system: "https://terminology.hl7.org/3.1.0/CodeSystem-v2-0276.html",
+                  code: "FOLLOWUP"
+                )
+              )
+            ],
+            serviceType: FHIR::CodeableConcept.new(
+              coding: [
+                FHIR::Coding.new(
+                  system: "http://terminology.hl7.org/CodeSystem/service-type",
+                  code: "335"
+                )
+              ]
+            ),
+            subject: FHIR::Reference.new(reference: "Patient/#{appointment.patient_id}"),
+            appointment: FHIR::Reference.new(reference: "Appointment/#{appointment.id}"),
+            period: FHIR::Period.new(start: appointment.scheduled_date.iso8601, end: appointment.scheduled_date.iso8601),
+            reasonCode: [
+              FHIR::CodeableConcept.new(
+                coding: [
+                  FHIR::Coding.new(
+                    system: "http://snomed.info/sct",
+                    code: "1156892006"
+                  )
+                ]
+              )
+            ],
+            diagnosis: nil,
+            location: nil,
+            serviceProvider: FHIR::Reference.new(reference: "Organization/#{opensrp_ids[:organization_id]}"),
+            partOf: FHIR::Reference.new(reference: "Encounter/#{parent_encounter_id}")
+          )
+        }
+      end
+
+      def export_call_outcome_task
+        call_outcome_mapping = {
+          "agreed_to_visit" => "call_outcome_follow_up",
+          "remind_to_call_later" => "rescheduled_call_outcome_follow_up"
+        }
+        latest_call_result_type = appointment.call_results.order(device_created_at: :desc).first.result_type
+        FHIR::Task.new(
+          id: task_id,
+          meta: {
+            lastUpdated: "2024-06-04T13:29:05.604+05:00",
+            tag: [
+              {
+                system: "https://smartregister.org/care-team-tag-id",
+                code: opensrp_ids[:care_team_id],
+                display: "Practitioner CareTeam"
+              },
+              {
+                system: "https://smartregister.org/location-tag-id",
+                code: opensrp_ids[:location_id],
+                display: "Practitioner Location"
+              },
+              {
+                system: "https://smartregister.org/organisation-tag-id",
+                code: opensrp_ids[:organization_id],
+                display: "Practitioner Organization"
+              },
+              {
+                system: "https://smartregister.org/practitioner-tag-id",
+                code: opensrp_ids[:practitioner_id],
+                display: "Practitioner"
+              },
+              {
+                system: "https://smartregister.org/app-version",
+                code: "1.1.0-diabetesCompass",
+                display: "Application Version"
+              }
+            ]
+          },
+          identifier: [
+            {
+              use: "official",
+              value: task_id
+            },
+            {
+              use: "secondary",
+              value: call_outcome_mapping.fetch(latest_call_result_type)
+            }
+          ],
+          # basedOn: [
+          #   {
+          #     reference: "CarePlan/a39cc7a0-e9ec-4312-ad10-16d2a30675e1"
+          #   }
+          # ],
+          status: "ready",
+          intent: "plan",
+          priority: "routine",
+          description: "Call outcome",
+          for: {
+            reference: "Patient/#{appointment.patient_id}"
+          },
+          executionPeriod: {
+            start: appointment.scheduled_date.beginning_of_day.iso8601,
+            end: appointment.scheduled_date.end_of_day.iso8601
+          },
+          authoredOn: appointment.scheduled_date.beginning_of_day.iso8601,
+          requester: {
+            reference: "Practitioner/#{opensrp_ids[:practitioner_id]}"
+          },
+          owner: {
+            reference: "Practitioner/#{opensrp_ids[:practitioner_id]}"
+          },
+          reasonReference: {
+            reference: "Questionnaire/dc-clinic-call-outcome"
+          },
+          input: [
+            {
+              type: {
+                coding: [
+                  {
+                    system: "http://smartregister.org/",
+                    code: "plan_definition",
+                    display: "Plan Definition Reference"
+                  }
+                ],
+                text: "Plan Definition Reference"
+              },
+              valueReference: {
+                reference: "PlanDefinition/dc-clinic-patient-visit"
+              }
+            }
+          ]
+        )
+      end
+
+      def export_call_outcome_flag
+        FHIR::Flag.new(
+          id: flag_id,
+          meta: {
+            lastUpdated: "2024-06-05T00:51:04.488+05:00",
+            tag: [
+              {
+                system: "https://smartregister.org/care-team-tag-id",
+                code: opensrp_ids[:care_team_id],
+                display: "Practitioner CareTeam"
+              },
+              {
+                system: "https://smartregister.org/location-tag-id",
+                code: opensrp_ids[:location_id],
+                display: "Practitioner Location"
+              },
+              {
+                system: "https://smartregister.org/organisation-tag-id",
+                code: opensrp_ids[:organization_id],
+                display: "Practitioner Organization"
+              },
+              {
+                system: "https://smartregister.org/practitioner-tag-id",
+                code: opensrp_ids[:practitioner_id],
+                display: "Practitioner"
+              },
+              {
+                system: "https://smartregister.org/app-version",
+                code: "1.1.0-diabetesCompass",
+                display: "Application Version"
+              }
+            ]
+          },
+          status: "active",
+          category: [
+            {
+              coding: [
+                {
+                  system: "http://terminology.hl7.org/CodeSystem/flag-category",
+                  code: "admin"
+                }
+              ]
+            }
+          ],
+          code: {
+            coding: [
+              {
+                system: "https://smartregister.org/",
+                code: "AGREEDTOVISITFACILITY"
+              }
+            ],
+            text: "Agreed to visit facility"
+          },
+          subject: {
+            reference: "Patient/#{appointment.patient_id}"
+          },
+          period: {
+            start: appointment.scheduled_date.beginning_of_day.iso8601,
+            end: appointment.scheduled_date.beginning_of_day.iso8601
+          },
+          encounter: {
+            reference: "Encounter/#{encounter_id}"
+          },
+          author: {
+            reference: "Practitioner/#{opensrp_ids[:practitioner_id]}"
+          }
+        )
+      end
+
+      def encounter_id
+        Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, appointment.id)
+      end
+
+      def parent_encounter_id
+        "patient-visit-#{meta.lastUpdated.to_date.iso8601}-#{appointment.patient_id}"
+      end
+
+      def task_id
+        Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, appointment.id + "_call_outcome_task")
+      end
+
+      def flag_id
+        Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, appointment.id + "_agreed_to_visit_flag")
+      end
+
+      def participant_status
+        case appointment.agreed_to_visit
+        when true then "accepted"
+        when false then "declined"
+        else "needs-action"
+        end
+      end
+
+      def appointment_status_code
+        case appointment.status
+        when "scheduled" then "booked"
+        when "visited" then "fulfilled"
+        when "cancelled" then "cancelled"
+        else raise "Invalid appointment status: #{appointment.status}"
+        end
+      end
+
+      def encounter_status_code
+        case appointment.status
+        when "scheduled" then "planned"
+        when "visited" then "finished"
+        when "cancelled" then "cancelled"
+        else raise "Invalid appointment status: #{appointment.status}"
+        end
+      end
+
+      def meta
+        FHIR::Meta.new(
+          lastUpdated: appointment.device_updated_at.iso8601,
+          tag: [
+            FHIR::Coding.new(
+              system: "https://smartregister.org/app-version",
+              code: "Not defined",
+              display: "Application Version"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/location-tag-id",
+              code: opensrp_ids[:location_id],
+              display: "Practitioner Location"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/organisation-tag-id",
+              code: opensrp_ids[:organization_id],
+              display: "Practitioner Organization"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/care-team-tag-id",
+              code: opensrp_ids[:care_team_id],
+              display: "Practitioner CareTeam"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/care-team-tag-id",
+              code: opensrp_ids[:practitioner_id],
+              display: "Practitioner"
+            )
+          ]
+        )
+      end
+
+      private
+
+      attr_reader :opensrp_ids
+    end
+  end
+end

--- a/app/services/one_off/opensrp/blood_pressure_exporter.rb
+++ b/app/services/one_off/opensrp/blood_pressure_exporter.rb
@@ -1,0 +1,179 @@
+require "fhir_models"
+
+module OneOff
+  module Opensrp
+    class BloodPressureExporter
+      attr_reader :blood_pressure
+
+      def initialize(blood_pressure, opensrp_mapping)
+        @blood_pressure = blood_pressure
+        @opensrp_ids = opensrp_mapping[@blood_pressure.facility_id]
+      end
+
+      def encounter_id
+        Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, blood_pressure.id)
+      end
+
+      def parent_encounter_id
+        "patient-visit-#{meta.lastUpdated.to_date.iso8601}-#{blood_pressure.patient_id}"
+      end
+
+      def export
+        FHIR::Observation.new(
+          meta: meta,
+          id: blood_pressure.id,
+          identifier: [
+            FHIR::Identifier.new(
+              value: blood_pressure.id
+            )
+          ],
+          code: FHIR::CodeableConcept.new(
+            coding: FHIR::Coding.new(
+              system: "http://snomed.info/sct",
+              code: "75367002",
+              display: "Blood pressure systolic & diastolic"
+            )
+          ),
+          component: [
+            observation_component("271649006", blood_pressure.systolic),
+            observation_component("271650006", blood_pressure.diastolic)
+          ],
+          subject: FHIR::Reference.new(
+            reference: "Patient/#{blood_pressure.patient_id}"
+          ),
+          performer: FHIR::Reference.new(
+            reference: "Practitioner/#{opensrp_ids[:practitioner_id]}"
+          ),
+          encounter: FHIR::Reference.new(
+            reference: "Encounter/#{encounter_id}"
+          ),
+          effectiveDateTime: blood_pressure.recorded_at.iso8601,
+          status: "final",
+          category: [
+            FHIR::CodeableConcept.new(
+              coding: [
+                FHIR::Coding.new(
+                  system: "http://terminology.hl7.org/CodeSystem/observation-category",
+                  code: "vital-signs",
+                  display: "Vital Signs"
+                )
+              ]
+            )
+          ]
+        )
+      end
+
+      def observation_component(code, value)
+        FHIR::Observation::Component.new(
+          code: FHIR::CodeableConcept.new(
+            coding: [
+              FHIR::Coding.new(
+                system: "http://snomed.info/sct",
+                code: code
+              )
+            ]
+          ),
+          valueQuantity: FHIR::Quantity.new(
+            value: value,
+            unit: "mmHg",
+            system: "http://unitsofmeasure.org",
+            code: "mm[Hg]"
+          )
+        )
+      end
+
+      def export_encounter
+        {
+          parent_id: parent_encounter_id,
+          encounter_opensrp_ids: opensrp_ids,
+          child_encounter: FHIR::Encounter.new(
+            meta: meta,
+            status: "finished",
+            id: encounter_id,
+            identifier: [
+              FHIR::Identifier.new(
+                value: encounter_id
+              )
+            ],
+            class: FHIR::Coding.new(
+              system: "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              code: "AMB"
+            ),
+            type: [
+              FHIR::CodeableConcept.new(
+                coding: FHIR::Coding.new(
+                  system: "http://snomed.info/sct",
+                  code: "38341003"
+                )
+              )
+            ],
+            serviceType: FHIR::CodeableConcept.new(
+              coding: [
+                FHIR::Coding.new(
+                  system: "http://terminology.hl7.org/CodeSystem/service-type",
+                  code: "335"
+                )
+              ]
+            ),
+            subject: FHIR::Reference.new(reference: "Patient/#{blood_pressure.patient_id}"),
+            period: FHIR::Period.new(
+              start: blood_pressure.recorded_at.iso8601,
+              end: blood_pressure.recorded_at.iso8601
+            ),
+            reasonCode: [
+              FHIR::CodeableConcept.new(
+                coding: [
+                  FHIR::Coding.new(
+                    system: "http://snomed.info/sct",
+                    code: "1156892006" # TODO
+                  )
+                ]
+              )
+            ],
+            diagnosis: nil,
+            location: nil,
+            serviceProvider: FHIR::Reference.new(reference: "Organization/#{opensrp_ids[:organization_id]}"),
+            partOf: FHIR::Reference.new(reference: "Encounter/#{parent_encounter_id}")
+          )
+        }
+      end
+
+      def meta
+        FHIR::Meta.new(
+          lastUpdated: blood_pressure.device_updated_at.iso8601,
+          tag: [
+            FHIR::Coding.new(
+              system: "https://smartregister.org/app-version",
+              code: "Not defined",
+              display: "Application Version"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/location-tag-id",
+              code: opensrp_ids[:location_id],
+              display: "Practitioner Location"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/organisation-tag-id",
+              code: opensrp_ids[:organization_id],
+              display: "Practitioner Organization"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/care-team-tag-id",
+              code: opensrp_ids[:care_team_id],
+              display: "Practitioner CareTeam"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/care-team-tag-id",
+              code: opensrp_ids[:practitioner_id],
+              display: "Practitioner"
+            )
+          ]
+        )
+      end
+
+      private
+
+      attr_reader :opensrp_ids
+    end
+  end
+end

--- a/app/services/one_off/opensrp/blood_sugar_exporter.rb
+++ b/app/services/one_off/opensrp/blood_sugar_exporter.rb
@@ -1,0 +1,196 @@
+require "fhir_models"
+
+module OneOff
+  module Opensrp
+    class BloodSugarExporter
+      attr_reader :blood_sugar, :patient
+
+      def initialize(blood_sugar_or_patient, opensrp_mapping)
+        if blood_sugar_or_patient.is_a?(Patient)
+          @patient = blood_sugar_or_patient
+          @blood_sugar = nil
+          @opensrp_ids = opensrp_mapping[@patient.assigned_facility_id]
+        else
+          @blood_sugar = blood_sugar_or_patient
+          @patient = @blood_sugar.patient
+          @opensrp_ids = opensrp_mapping[@blood_sugar.facility_id]
+        end
+      end
+
+      def export
+        unit = "mg/dL"
+        unit = "%{HemoglobinA1C}" if blood_sugar.blood_sugar_type_hba1c?
+
+        FHIR::Observation.new(
+          id: blood_sugar.id,
+          identifier: [
+            FHIR::Identifier.new(
+              value: blood_sugar.id
+            )
+          ],
+          code: FHIR::CodeableConcept.new(
+            coding: FHIR::Coding.new(
+              system: "http://snomed.info/sct",
+              code: blood_sugar_type_code
+            )
+          ),
+          valueQuantity: FHIR::Quantity.new(
+            value: blood_sugar.blood_sugar_value,
+            unit: unit,
+            system: "http://unitsofmeasure.org",
+            code: unit
+          ),
+          effectiveDateTime: blood_sugar.recorded_at.iso8601,
+          status: "final",
+          subject: FHIR::Reference.new(
+            reference: "Patient/#{blood_sugar.patient_id}"
+          ),
+          performer: FHIR::Reference.new(
+            reference: "Practitioner/#{opensrp_ids[:practitioner_id]}"
+          ),
+          encounter: FHIR::Reference.new(
+            reference: "Encounter/#{encounter_id}"
+          ),
+          meta: meta
+        )
+      end
+
+      def export_no_diabetes_observation
+        FHIR::Observation.new(
+          meta: meta,
+          code: FHIR::CodeableConcept.new(
+            coding: [
+              FHIR::Coding.new(
+                system: "https://smartregister.org",
+                code: "no_diabetes",
+                display: "No Diabetes"
+              )
+            ]
+          ),
+          subject: FHIR::Reference.new(
+            reference: "Patient/#{patient.id}"
+          ),
+          performer: FHIR::Reference.new(
+            reference: "Practitioner/#{opensrp_ids[:practitioner_id]}"
+          ),
+          encounter: FHIR::Reference.new(
+            reference: "Encounter/#{encounter_id}"
+          )
+        )
+      end
+
+      def blood_sugar_type_code
+        case blood_sugar.blood_sugar_type
+        when "random" then "271061004"
+        when "post_prandial" then "372661000119106"
+        when "fasting" then "271062006"
+        when "hba1c" then "443911005"
+        else raise "Invalid blood sugar type: #{blood_sugar.blood_sugar_type}"
+        end
+      end
+
+      def export_encounter
+        {
+          parent_id: parent_encounter_id,
+          encounter_opensrp_ids: opensrp_ids,
+          child_encounter: FHIR::Encounter.new(
+            meta: meta,
+            status: "finished",
+            id: encounter_id,
+            identifier: [
+              FHIR::Identifier.new(
+                value: encounter_id
+              )
+            ],
+            class: FHIR::Coding.new(
+              system: "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              code: "AMB"
+            ),
+            type: [
+              FHIR::CodeableConcept.new(
+                coding: [
+                  FHIR::Coding.new(
+                    system: "https://smartregister.org",
+                    code: "facility_visit"
+                  )
+                ]
+              )
+            ],
+            serviceType: FHIR::CodeableConcept.new(
+              coding: [
+                FHIR::Coding.new(
+                  system: "http://terminology.hl7.org/CodeSystem/service-type",
+                  code: "335"
+                )
+              ]
+            ),
+            subject: FHIR::Reference.new(reference: "Patient/#{blood_sugar.patient_id}"),
+            period: FHIR::Period.new(
+              start: blood_sugar.recorded_at.iso8601,
+              end: blood_sugar.recorded_at.iso8601
+            ),
+            reasonCode: [
+              FHIR::CodeableConcept.new(
+                coding: [
+                  FHIR::Coding.new(
+                    system: "https://smartregister.org",
+                    code: "glucose_measure"
+                  )
+                ]
+              )
+            ],
+            diagnosis: nil,
+            location: nil,
+            serviceProvider: FHIR::Reference.new(reference: "Organization/#{opensrp_ids[:organization_id]}"),
+            partOf: FHIR::Reference.new(reference: "Encounter/#{parent_encounter_id}")
+          )
+        }
+      end
+
+      def parent_encounter_id
+        "patient-visit-#{meta.lastUpdated.to_date.iso8601}-#{blood_sugar.patient_id}"
+      end
+
+      def encounter_id
+        Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, blood_sugar&.id || "no_diabetes_#{patient.id}")
+      end
+
+      def meta
+        FHIR::Meta.new(
+          lastUpdated: blood_sugar&.device_updated_at&.iso8601 || patient.device_updated_at.iso8601,
+          tag: [
+            FHIR::Coding.new(
+              system: "https://smartregister.org/app-version",
+              code: "Not defined",
+              display: "Application Version"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/location-tag-id",
+              code: opensrp_ids[:location_id],
+              display: "Practitioner Location"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/organisation-tag-id",
+              code: opensrp_ids[:organization_id],
+              display: "Practitioner Organization"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/care-team-tag-id",
+              code: opensrp_ids[:care_team_id],
+              display: "Practitioner CareTeam"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/care-team-tag-id",
+              code: opensrp_ids[:practitioner_id],
+              display: "Practitioner"
+            )
+          ]
+        )
+      end
+
+      private
+
+      attr_reader :opensrp_ids
+    end
+  end
+end

--- a/app/services/one_off/opensrp/encounter_generator.rb
+++ b/app/services/one_off/opensrp/encounter_generator.rb
@@ -1,0 +1,107 @@
+require "fhir_models"
+
+module OneOff
+  module Opensrp
+    class EncounterGenerator
+      attr_reader :encounters
+
+      def initialize(encounters)
+        @encounters = encounters
+      end
+
+      def generate
+        encounters.group_by { |encounter| encounter[:parent_id] }.map do |parent_id, child_encounters|
+          opensrp_ids = child_encounters.first[:encounter_opensrp_ids]
+          first_child_encounter = child_encounters.first[:child_encounter]
+          patient_ref = first_child_encounter.subject
+          encounter_period = first_child_encounter.period
+          diagnosis = first_child_encounter.diagnosis
+          service_provider = first_child_encounter.serviceProvider
+          child_encounters.pluck(:child_encounter).append(
+            FHIR::Encounter.new(
+              meta: meta(opensrp_ids),
+              status: "finished",
+              id: parent_id,
+              identifier: [
+                FHIR::Identifier.new(
+                  value: parent_id
+                )
+              ],
+              class: FHIR::Coding.new(
+                system: "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                code: "AMB"
+              ),
+              type: [
+                FHIR::CodeableConcept.new(
+                  coding: [
+                    FHIR::Coding.new(
+                      system: "https://smartregister.org",
+                      code: "facility_visit"
+                    )
+                  ]
+                )
+              ],
+              serviceType: FHIR::CodeableConcept.new(
+                coding: [
+                  FHIR::Coding.new(
+                    system: "http://terminology.hl7.org/CodeSystem/service-type",
+                    code: "335"
+                  )
+                ]
+              ),
+              subject: patient_ref,
+              period: encounter_period,
+              reasonCode: [
+                FHIR::CodeableConcept.new(
+                  coding: [
+                    FHIR::Coding.new(
+                      system: "https://smartregister.org",
+                      code: "facility_visit"
+                    )
+                  ]
+                )
+              ],
+              diagnosis: diagnosis,
+              location: nil,
+              serviceProvider: service_provider,
+              partOf: nil
+            )
+          )
+        end
+      end
+
+      def meta(location_id:, organization_id:, care_team_id:, practitioner_id:, **)
+        FHIR::Meta.new(
+          lastUpdated: encounters.first[:child_encounter].meta.lastUpdated,
+          tag: [
+            FHIR::Coding.new(
+              system: "https://smartregister.org/app-version",
+              code: "Not defined",
+              display: "Application Version"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/location-tag-id",
+              code: location_id,
+              display: "Practitioner Location"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/organisation-tag-id",
+              code: organization_id,
+              display: "Practitioner Organization"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/care-team-tag-id",
+              code: care_team_id,
+              display: "Practitioner CareTeam"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/care-team-tag-id",
+              code: practitioner_id,
+              display: "Practitioner"
+            )
+          ]
+        )
+      end
+    end
+  end
+end

--- a/app/services/one_off/opensrp/medical_history_exporter.rb
+++ b/app/services/one_off/opensrp/medical_history_exporter.rb
@@ -1,0 +1,176 @@
+require "fhir_models"
+
+module OneOff
+  module Opensrp
+    class MedicalHistoryExporter
+      attr_reader :medical_history
+
+      DM_CONDITION_MAPPING = {code: "diabetes", system: "https://smartregister.org", display: "Diabetes"}
+      HTN_CONDITION_MAPPING = {code: "38341003", system: "http://snomed.info/sct", display: "Hypertension"}
+
+      def initialize(medical_history, opensrp_mapping)
+        @medical_history = medical_history
+        @opensrp_ids = opensrp_mapping[@medical_history.patient.assigned_facility_id]
+      end
+
+      def export
+        conditions = []
+        conditions << generate_condition(DM_CONDITION_MAPPING) if medical_history.diabetes_yes?
+        conditions << generate_condition(HTN_CONDITION_MAPPING) if medical_history.hypertension_yes?
+        conditions
+      end
+
+      def generate_condition(code:, display:, system:)
+        FHIR::Condition.new(
+          id: condition_id(code),
+          subject: FHIR::Reference.new(
+            reference: "Patient/#{medical_history.patient_id}"
+          ),
+          code: FHIR::CodeableConcept.new(
+            coding: [
+              FHIR::Coding.new(
+                code: code,
+                system: system,
+                display: display
+              )
+            ],
+            text: display
+          ),
+          clinicalStatus: FHIR::CodeableConcept.new(
+            coding: [
+              FHIR::Coding.new(
+                system: "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                code: "active"
+              )
+            ]
+          ),
+          verificationStatus: FHIR::CodeableConcept.new(
+            coding: [
+              FHIR::Coding.new(
+                system: "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                code: "confirmed"
+              )
+            ]
+          ),
+          encounter: FHIR::Reference.new(
+            reference: "Encounter/#{encounter_id}"
+          ),
+          meta: meta
+        )
+      end
+
+      def export_encounter
+        codes = [
+          (HTN_CONDITION_MAPPING[:code] if medical_history.hypertension_yes?),
+          (DM_CONDITION_MAPPING[:code] if medical_history.diabetes_yes?)
+        ].compact
+        generate_export_encounter(codes) if codes.present?
+      end
+
+      def generate_export_encounter(codes)
+        {
+          parent_id: parent_encounter_id,
+          encounter_opensrp_ids: opensrp_ids,
+          child_encounter: FHIR::Encounter.new(
+            meta: meta,
+            status: "finished",
+            id: encounter_id,
+            identifier: [
+              FHIR::Identifier.new(
+                value: encounter_id
+              )
+            ],
+            class: FHIR::Coding.new(
+              system: "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              code: "AMB"
+            ),
+            type: [
+              FHIR::CodeableConcept.new(
+                coding: FHIR::Coding.new(
+                  system: "http://snomed.info/sct",
+                  code: "44054006"
+                )
+              )
+            ],
+            serviceType: FHIR::CodeableConcept.new(
+              coding: [
+                FHIR::Coding.new(
+                  system: "http://terminology.hl7.org/CodeSystem/service-type",
+                  code: "335"
+                )
+              ]
+            ),
+            subject: FHIR::Reference.new(reference: "Patient/#{medical_history.patient_id}"),
+            period: FHIR::Period.new(
+              start: medical_history.device_updated_at.iso8601,
+              end: medical_history.device_updated_at.iso8601
+            ),
+            reasonCode: [
+              FHIR::CodeableConcept.new(
+                coding: [
+                  FHIR::Coding.new(
+                    system: "http://snomed.info/sct",
+                    code: "1156892006" # TODO
+                  )
+                ]
+              )
+            ],
+            diagnosis: codes.map { |code| FHIR::Reference.new(reference: "Condition/#{condition_id(code)}") },
+            location: nil,
+            serviceProvider: FHIR::Reference.new(reference: "Organization/#{opensrp_ids[:organization_id]}"),
+            partOf: FHIR::Reference.new(reference: "Encounter/#{parent_encounter_id}")
+          )
+        }
+      end
+
+      def condition_id(code)
+        Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, medical_history.id + "_" + code)
+      end
+
+      def encounter_id
+        Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, medical_history.id)
+      end
+
+      def parent_encounter_id
+        "patient-visit-#{meta.lastUpdated.to_date.iso8601}-#{medical_history.patient_id}"
+      end
+
+      def meta
+        FHIR::Meta.new(
+          lastUpdated: medical_history.device_updated_at.iso8601,
+          tag: [
+            FHIR::Coding.new(
+              system: "https://smartregister.org/app-version",
+              code: "Not defined",
+              display: "Application Version"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/location-tag-id",
+              code: opensrp_ids[:location_id],
+              display: "Practitioner Location"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/organisation-tag-id",
+              code: opensrp_ids[:organization_id],
+              display: "Practitioner Organization"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/care-team-tag-id",
+              code: opensrp_ids[:care_team_id],
+              display: "Practitioner CareTeam"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/care-team-tag-id",
+              code: opensrp_ids[:practitioner_id],
+              display: "Practitioner"
+            )
+          ]
+        )
+      end
+
+      private
+
+      attr_reader :opensrp_ids
+    end
+  end
+end

--- a/app/services/one_off/opensrp/patient_exporter.rb
+++ b/app/services/one_off/opensrp/patient_exporter.rb
@@ -1,0 +1,431 @@
+require "fhir_models"
+
+module OneOff
+  module Opensrp
+    class PatientExporter
+      attr_reader :patient
+
+      def initialize(patient, opensrp_mapping)
+        @patient = patient
+        @opensrp_ids = opensrp_mapping[@patient.assigned_facility_id]
+      end
+
+      def export
+        FHIR::Patient.new(
+          id: patient.id,
+          identifier: patient_identifiers,
+          name: [
+            FHIR::HumanName.new(
+              use: "official",
+              text: patient.full_name,
+              given: patient.full_name.split
+            )
+          ],
+          active: patient.status_active?,
+          gender: gender,
+          birthDate: birth_date.iso8601,
+          deceased: patient.status_dead?,
+          managingOrganization: FHIR::Reference.new(
+            reference: "Organization/#{opensrp_ids[:organization_id]}"
+          ),
+          meta: meta,
+          telecom: patient.phone_numbers.map do |phone_number|
+            FHIR::ContactPoint.new(
+              system: "phone",
+              value: phone_number.number,
+              use: "mobile"
+            )
+          end,
+          address: FHIR::Address.new(
+            line: [patient.address.street_address],
+            city: patient.address.village_or_colony,
+            district: patient.address.district,
+            state: patient.address.state,
+            country: patient.address.country,
+            postalCode: patient.address.pin,
+            use: "home",
+            type: "physical",
+            text: address_text
+          ),
+          generalPractitioner: [
+            FHIR::Reference.new(reference: "Practitioner/#{opensrp_ids[:practitioner_id]}")
+          ],
+          # NOTE: these are hardcoded for now, since only Sri Lanka needs this script.
+          communication: [{
+            language: FHIR::CodeableConcept.new(
+              coding: [
+                FHIR::Coding.new(
+                  system: "urn:ietf:bcp:47",
+                  code: "si",
+                  display: "Sinhala"
+                )
+              ],
+              text: "Sinhala"
+            )
+          }]
+        )
+      end
+
+      def address_text
+        "#{patient.address.street_address} (#{patient.address.village_or_colony}), [No GND Registered]"
+      end
+
+      def patient_identifiers
+        identifiers = [
+          FHIR::Identifier.new(
+            value: patient.id,
+            use: "secondary"
+          )
+        ]
+        patient.business_identifiers.simple_bp_passport.each do |identifier|
+          identifiers.prepend(FHIR::Identifier.new(
+            value: identifier.identifier,
+            use: "secondary",
+            type: FHIR::CodeableConcept.new(
+              coding: [
+                FHIR::Coding.new(
+                  system: "https://smartregister.org/",
+                  code: "QR_CODE",
+                  display: "QR code"
+                )
+              ]
+            )
+          ))
+          identifiers.prepend(FHIR::Identifier.new(
+            value: identifier.shortcode.delete("^0-9"),
+            use: "secondary",
+            type: FHIR::CodeableConcept.new(
+              coding: [
+                FHIR::Coding.new(
+                  system: "https://smartregister.org/",
+                  code: "QR_SHORT_CODE",
+                  display: "QR short code"
+                )
+              ]
+            )
+          ))
+        end
+        patient.business_identifiers.sri_lanka_personal_health_number.each do |identifier|
+          identifiers.prepend(FHIR::Identifier.new(
+            value: identifier.identifier,
+            use: "official",
+            type: FHIR::CodeableConcept.new(
+              coding: [
+                FHIR::Coding.new(
+                  system: "https://smartregister.org/",
+                  code: "PHN",
+                  display: "PHN"
+                )
+              ]
+            )
+          ))
+        end
+        identifiers
+      end
+
+      def gender
+        return "other" unless %w[male female].include?(patient.gender)
+
+        patient.gender
+      end
+
+      def birth_date
+        return (patient.age_updated_at - patient.age.years).to_date unless patient.date_of_birth
+
+        patient.date_of_birth.to_date
+      end
+
+      def export_registration_encounter
+        {
+          parent_id: parent_encounter_id,
+          encounter_opensrp_ids: opensrp_ids,
+          child_encounter: FHIR::Encounter.new(
+            meta: meta,
+            status: "finished",
+            id: encounter_id,
+            identifier: [
+              FHIR::Identifier.new(
+                value: encounter_id
+              )
+            ],
+            class: FHIR::Coding.new(
+              system: "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              code: "HH"
+            ),
+            type: [
+              FHIR::CodeableConcept.new(
+                coding: FHIR::Coding.new(
+                  system: "http://snomed.info/sct",
+                  code: "184047000",
+                  display: "Patient registration"
+                ),
+                text: "Patient registration"
+              )
+            ],
+            priority: [
+              FHIR::CodeableConcept.new(
+                coding: FHIR::Coding.new(
+                  system: "http://snomed.info/sct",
+                  code: "17621005",
+                  display: "Normal"
+                ),
+                text: "Normal"
+              )
+            ],
+            serviceType: FHIR::CodeableConcept.new(
+              coding: [
+                FHIR::Coding.new(
+                  system: "http://terminology.hl7.org/CodeSystem/service-type",
+                  code: "335"
+                )
+              ]
+            ),
+            subject: FHIR::Reference.new(reference: "Patient/#{patient.id}"),
+            participant: {individual: FHIR::Reference.new(reference: "Practitioner/#{opensrp_ids[:practitioner_id]}")},
+            period: FHIR::Period.new(start: patient.device_created_at.iso8601, end: patient.device_created_at.iso8601),
+            reasonCode: [
+              FHIR::CodeableConcept.new(
+                coding: [
+                  FHIR::Coding.new(
+                    system: "http://smartregister.org/",
+                    code: "client_registration",
+                    display: "Client Registration"
+                  )
+                ],
+                text: "Client Registration"
+              )
+            ],
+            location: [
+              {
+                location: FHIR::Reference.new(
+                  reference: "Location/#{opensrp_ids[:location_id]}",
+                  display: opensrp_ids[:name]
+                ),
+                status: "completed",
+                period: FHIR::Period.new(
+                  start: patient.device_created_at.iso8601,
+                  end: patient.device_created_at.iso8601
+                )
+              }
+            ],
+            serviceProvider: FHIR::Reference.new(reference: "Organization/#{opensrp_ids[:organization_id]}")
+          )
+        }
+      end
+
+      def export_registration_questionnaire_response
+        FHIR::QuestionnaireResponse.new(
+          id: questionnaire_response_id,
+          meta: meta,
+          contained: [
+            FHIR::List.new(
+              id: questionnaire_response_list_id,
+              status: "current",
+              mode: "working",
+              title: "GeneratedResourcesList",
+              date: patient.device_updated_at.iso8601,
+              entry: [
+                {
+                  deleted: false,
+                  date: patient.device_updated_at.iso8601,
+                  item: {
+                    reference: "Patient/6036f25a-df55-41f0-bcfb-e46281a14f1d"
+                  }
+                },
+                {
+                  deleted: false,
+                  date: patient.device_updated_at.iso8601,
+                  item: {
+                    reference: "Encounter/63333f16-f354-5044-8e00-4379ea2edb58"
+                  }
+                }
+              ]
+            )
+          ],
+          questionnaire: "Questionnaire/dc-clinic-patient-registration",
+          status: "completed",
+          subject: FHIR::Reference.new(reference: "Patient/#{patient.id}"),
+          authored: patient.device_updated_at.iso8601,
+          author: FHIR::Reference.new(reference: "Practitioner/#{opensrp_ids[:practitioner_id]}"),
+          item: [
+            {
+              linkId: "registration-title",
+              text: "Registration date"
+            },
+            {
+              linkId: "enrollment-date",
+              answer: [
+                {valueDate: patient.device_updated_at.to_date.iso8601}
+              ]
+            },
+            {
+              linkId: "facility",
+              answer: [
+                {
+                  valueReference: FHIR::Reference.new(
+                    reference: "Location/#{opensrp_ids[:location_id]}",
+                    display: opensrp_ids[:name]
+                  ),
+                  item: [
+                    {
+                      linkId: "facility-hint",
+                      text: "Facility"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              linkId: "client-information-title",
+              text: "2. Client information"
+            },
+            {
+              linkId: "reporting-name",
+              answer: [
+                {
+                  valueString: patient.full_name,
+                  item: [
+                    {
+                      linkId: "reporting-name-hint",
+                      text: "Patient Name"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              linkId: "date-of-birth",
+              answer: [
+                {
+                  valueDate: birth_date.iso8601,
+                  item: [
+                    {
+                      linkId: "1-most-recent",
+                      text: "Date of birth"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              linkId: "gender",
+              answer: [
+                {
+                  valueCoding: {
+                    system: "http://hl7.org/fhir/administrative-gender",
+                    code: patient.gender,
+                    display: patient.gender.capitalize
+                  },
+                  item: [
+                    {
+                      linkId: "gender-hint",
+                      text: "Gender"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              linkId: "phone-number",
+              answer: patient.phone_numbers.map do |phone_number|
+                        {
+                          valueInteger: phone_number.number.delete("^0-9").to_i,
+                          item: [{linkId: "phone-number-hint", text: "Phone number (optional)"}]
+                        }
+                      end
+            },
+            {
+              linkId: "preferred-language",
+              answer: [
+                {
+                  valueCoding: FHIR::Coding.new(
+                    system: "urn:ietf:bcp:47",
+                    code: "si",
+                    display: "Sinhala"
+                  ),
+                  item: [
+                    {
+                      linkId: "preferred-language-hint",
+                      text: "Preferred SMS text language"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              linkId: "home-address-title",
+              text: "Home address"
+            },
+            {
+              linkId: "address",
+              answer: [
+                {
+                  valueString: address_text,
+                  item: [
+                    {
+                      linkId: "address-hint",
+                      text: "Address name and house number"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        )
+      end
+
+      def questionnaire_response_id
+        Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, patient.id + "_questionnaire_response")
+      end
+
+      def questionnaire_response_list_id
+        Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, patient.id + "_questionnaire_response_list")
+      end
+
+      def encounter_id
+        Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, patient.id)
+      end
+
+      def parent_encounter_id
+        "patient-visit-#{meta.lastUpdated.to_date.iso8601}-#{patient.id}"
+      end
+
+      def meta
+        FHIR::Meta.new(
+          lastUpdated: patient.device_updated_at.iso8601,
+          tag: [
+            FHIR::Coding.new(
+              system: "https://smartregister.org/app-version",
+              code: "Not defined",
+              display: "Application Version"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/location-tag-id",
+              code: opensrp_ids[:location_id],
+              display: "Practitioner Location"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/organisation-tag-id",
+              code: opensrp_ids[:organization_id],
+              display: "Practitioner Organization"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/care-team-tag-id",
+              code: opensrp_ids[:care_team_id],
+              display: "Practitioner CareTeam"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/care-team-tag-id",
+              code: opensrp_ids[:practitioner_id],
+              display: "Practitioner"
+            )
+          ]
+        )
+      end
+
+      private
+
+      attr_reader :opensrp_ids
+    end
+  end
+end

--- a/app/services/one_off/opensrp/prescription_drug_exporter.rb
+++ b/app/services/one_off/opensrp/prescription_drug_exporter.rb
@@ -1,0 +1,247 @@
+require "fhir_models"
+
+module OneOff
+  module Opensrp
+    class PrescriptionDrugExporter
+      attr_reader :prescription_drug
+
+      def initialize(prescription_drug, opensrp_mapping)
+        @prescription_drug = prescription_drug
+        @opensrp_ids = opensrp_mapping[@prescription_drug.facility_id]
+      end
+
+      def export_dosage_flag
+        FHIR::Flag.new(
+          id: flag_id,
+          meta: {
+            lastUpdated: "2024-06-11T09:14:59.356+03:00",
+            tag: [
+              {
+                system: "https://smartregister.org/care-team-tag-id",
+                code: opensrp_ids[:care_team_id],
+                display: "Practitioner CareTeam"
+              },
+              {
+                system: "https://smartregister.org/location-tag-id",
+                code: opensrp_ids[:location_id],
+                display: "Practitioner Location"
+              },
+              {
+                system: "https://smartregister.org/organisation-tag-id",
+                code: opensrp_ids[:organization_id],
+                display: "Practitioner Organization"
+              },
+              {
+                system: "https://smartregister.org/practitioner-tag-id",
+                code: opensrp_ids[:practitioner_id],
+                display: "Practitioner"
+              },
+              {
+                system: "https://smartregister.org/app-version",
+                code: "2.0.0-diabetesCompassClinic",
+                display: "Application Version"
+              }
+            ]
+          },
+          identifier: [
+            {
+              use: "usual",
+              value: flag_id
+            }
+          ],
+          status: "active",
+          category: [
+            {
+              coding: [
+                {
+                  system: "http://terminology.hl7.org/CodeSystem/flag-category",
+                  code: "clinical",
+                  display: "Clinical"
+                }
+              ],
+              text: "Clinical"
+            }
+          ],
+          code: {
+            coding: [
+              {
+                system: "https://smartregister.org/",
+                code: "GENPATIENTNOTES",
+                display: "General patient notes"
+              }
+            ],
+            text: "#{prescription_drug.name} #{prescription_drug.dosage || ""} #{prescription_drug.frequency || ""}"
+          },
+          subject: {
+            reference: "Patient/#{prescription_drug.patient_id}"
+          },
+          period: {
+            start: prescription_drug.device_created_at.beginning_of_day.iso8601,
+            end: prescription_drug.device_created_at.end_of_day.iso8601
+          },
+          encounter: {
+            reference: "Encounter/#{encounter_id}"
+          },
+          author: {
+            reference: "Practitioner/#{opensrp_ids[:practitioner_id]}"
+          }
+        )
+      end
+
+      def export_encounter
+        {
+          parent_id: parent_encounter_id,
+          encounter_opensrp_ids: opensrp_ids,
+          child_encounter: FHIR::Encounter.new(
+            meta: meta,
+            status: "finished",
+            id: encounter_id,
+            identifier: [
+              FHIR::Identifier.new(
+                value: encounter_id
+              )
+            ],
+            class: FHIR::Coding.new(
+              system: "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              code: "AMB"
+            ),
+            type: [
+              FHIR::CodeableConcept.new(
+                coding: FHIR::Coding.new(
+                  system: "http://snomed.info/sct",
+                  code: "44054006"
+                )
+              )
+            ],
+            serviceType: FHIR::CodeableConcept.new(
+              coding: [
+                FHIR::Coding.new(
+                  system: "http://terminology.hl7.org/CodeSystem/service-type",
+                  code: "335"
+                )
+              ]
+            ),
+            subject: FHIR::Reference.new(reference: "Patient/#{prescription_drug.patient_id}"),
+            period: FHIR::Period.new(start: prescription_drug.updated_at.iso8601),
+            reasonCode: [
+              FHIR::CodeableConcept.new(
+                coding: [
+                  FHIR::Coding.new(
+                    system: "http://snomed.info/sct",
+                    code: "1156892006" # TODO
+                  )
+                ]
+              )
+            ],
+            diagnosis: nil,
+            location: nil,
+            serviceProvider: FHIR::Reference.new(reference: "Organization/#{opensrp_ids[:organization_id]}"),
+            partOf: FHIR::Reference.new(reference: "Encounter/#{parent_encounter_id}")
+          )
+        }
+      end
+
+      def flag_id
+        Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, prescription_drug.id + "_dosage_flag_id")
+      end
+
+      def encounter_id
+        Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, prescription_drug.id)
+      end
+
+      def parent_encounter_id
+        "patient-visit-#{meta.lastUpdated.to_date.iso8601}-#{prescription_drug.patient_id}"
+      end
+
+      def dosage_instruction
+        unless dosage_value.present?
+          Rails.logger.warn("Dosage #{prescription_drug.dosage} does not match expected regex. Not exporting dosageInstruction")
+          return
+        end
+
+        timing = nil
+        if prescription_drug.frequency.present?
+          timing = FHIR::Timing.new(
+            code: FHIR::CodeableConcept.new(
+              coding: FHIR::Coding.new(
+                code: medication_frequency_code
+              )
+            )
+          )
+        end
+
+        [
+          FHIR::Dosage.new(
+            doseAndRate: [
+              FHIR::Dosage::DoseAndRate.new(
+                doseQuantity: FHIR::Quantity.new(
+                  value: dosage_value,
+                  unit: "mg",
+                  system: "http://unitsofmeasure.org"
+                )
+              )
+            ],
+            timing: timing
+          )
+        ]
+      end
+
+      # There are a number of ways dosage can be entered without
+      # conforming to the below regex. We're only parsing values
+      # in mg without frequency added in the dosage string. This
+      # can be updated in the future as required.
+      def dosage_value
+        dosage = prescription_drug.dosage.delete(" ").downcase
+        regex = /\A[0-9]*.?[0-9]*?mg\z/
+        dosage.match(regex)&.to_s&.delete_suffix("mg")
+      end
+
+      def medication_frequency_code
+        case prescription_drug.frequency
+        when "OD" then "QD"
+        when "BD" then "BID"
+        when "TDS" then "TID"
+        when "QDS" then "QID"
+        else raise "Invalid prescription drug frequency: #{prescription_drug.frequency}"
+        end
+      end
+
+      def meta
+        FHIR::Meta.new(
+          lastUpdated: prescription_drug.device_updated_at.iso8601,
+          tag: [
+            FHIR::Coding.new(
+              system: "https://smartregister.org/app-version",
+              code: "Not defined",
+              display: "Application Version"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/location-tag-id",
+              code: opensrp_ids[:location_id],
+              display: "Practitioner Location"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/organisation-tag-id",
+              code: opensrp_ids[:organization_id],
+              display: "Practitioner Organization"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/care-team-tag-id",
+              code: opensrp_ids[:care_team_id],
+              display: "Practitioner CareTeam"
+            ),
+            FHIR::Coding.new(
+              system: "https://smartregister.org/care-team-tag-id",
+              code: opensrp_ids[:practitioner_id],
+              display: "Practitioner"
+            )
+          ]
+        )
+      end
+
+      private
+
+      attr_reader :opensrp_ids
+    end
+  end
+end

--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -1,0 +1,121 @@
+require "faker"
+
+OPENSRP_ORG_MAP = {
+  "9109ba30-b89b-4a27-877c-c9ac420a2e0b" => {
+    name: "Gonaduwa Health Facility",
+    practitioner_id: "0c375fe8-b38f-484e-aa64-c02750ee183b",
+    organization_id: "d3363aea-66ad-4370-809a-8e4436a4218f",
+    care_team_id: "1c8100b5-222b-4815-ba4d-3ebde537c6ce",
+    location_id: "PKT0010397"
+  }
+}
+
+namespace :opensrp do
+  desc "Export simple patient-related data as opensrp fhir resources"
+  task :export, [:file_path] => :environment do |_task, args|
+    # For now we are leaving in the PII.
+    # patients = remove_pii(patients)
+    file_path = args[:file_path]
+
+    resources = []
+    encounters = []
+    Patient.where(assigned_facility_id: OPENSRP_ORG_MAP.keys).each do |patient|
+      patient_exporter = OneOff::Opensrp::PatientExporter.new(patient, OPENSRP_ORG_MAP)
+      resources << patient_exporter.export
+      resources << patient_exporter.export_registration_questionnaire_response
+      encounters << patient_exporter.export_registration_encounter
+
+      patient.blood_pressures.each do |bp|
+        bp_exporter = OneOff::Opensrp::BloodPressureExporter.new(bp, OPENSRP_ORG_MAP)
+        resources << bp_exporter.export
+        encounters << bp_exporter.export_encounter
+      end
+
+      if patient.medical_history.diabetes_no?
+        bs_exporter = OneOff::Opensrp::BloodSugarExporter.new(patient, OPENSRP_ORG_MAP)
+        resources << bs_exporter.export_no_diabetes_observation
+      else
+        patient.blood_sugars.each do |bs|
+          bs_exporter = OneOff::Opensrp::BloodSugarExporter.new(bs, OPENSRP_ORG_MAP)
+          resources << bs_exporter.export
+          encounters << bs_exporter.export_encounter
+        end
+      end
+
+      patient.prescription_drugs.each do |drug|
+        drug_exporter = OneOff::Opensrp::PrescriptionDrugExporter.new(drug, OPENSRP_ORG_MAP)
+        resources << drug_exporter.export_dosage_flag
+        encounters << drug_exporter.export_encounter
+      end
+      OneOff::Opensrp::MedicalHistoryExporter.new(patient.medical_history, OPENSRP_ORG_MAP).then do |medical_history_exporter|
+        resources << medical_history_exporter.export
+        encounters << medical_history_exporter.export_encounter
+      end
+      patient.appointments.each do |appointment|
+        next unless appointment.status_scheduled?
+        appointment_exporter = OneOff::Opensrp::AppointmentExporter.new(appointment, OPENSRP_ORG_MAP)
+        resources << appointment_exporter.export
+        if appointment.call_results.present?
+          resources << appointment_exporter.export_call_outcome_task
+          resources << appointment_exporter.export_call_outcome_flag
+        end
+        encounters << appointment_exporter.export_encounter
+      end
+    end
+    resources << OneOff::Opensrp::EncounterGenerator.new(encounters).generate
+
+    CSV.open("audit_trail.csv", "w") do |csv|
+      csv << create_audit_record(patients.first).keys
+      patients.each do |patient|
+        csv << create_audit_record(patient).values
+      end
+    end
+
+    File.open(file_path, "w+") do |f|
+      resources.flatten.each do |resource|
+        f.puts(resource.as_json.to_json)
+      end
+    end
+  end
+
+  def create_audit_record(patient)
+    {
+      patient_id: patient.id,
+      sri_lanka_personal_health_number: patient.business_identifiers.where(identifier_type: "sri_lanka_personal_health_number")&.first&.identifier,
+      patient_bp_passport_number: patient.business_identifiers.where(identifier_type: "simple_bp_passport")&.first&.identifier,
+      patient_name: patient.full_name,
+      patient_gender: patient.gender,
+      patient_date_of_birth: patient.date_of_birth || patient.age_updated_at - patient.age.years,
+      patient_address: patient.address.street_address,
+      patient_telephone: patient.phone_numbers.pluck(:number).join(";"),
+      patient_facility: OPENSRP_ORG_MAP[patient.assigned_facility_id][:name],
+      patient_preferred_language: "Sinhala",
+      patient_active: patient.status_active?,
+      patient_deceased: patient.status_dead?,
+      condition: ("HTN" if patient.medical_history.hypertension_yes?) || ("DM" if patient.medical_history.diabetes_yes?),
+      blood_pressure: patient.latest_blood_pressure&.values_at(:systolic, :diastolic)&.join("/"),
+      bmi: nil,
+      appointment_date: patient.appointments.order(device_updated_at: :desc).where(status: "scheduled")&.first&.device_updated_at&.to_date&.iso8601,
+      medication: patient.prescription_drugs.order(device_updated_at: :desc).where(is_deleted: false)&.first&.values_at(:name, :dosage)&.join(" "),
+      glucose_measure: patient.latest_blood_sugar&.blood_sugar_value.then { |bs| "%.2f" % bs if bs },
+      glucose_measure_type: patient.latest_blood_sugar&.blood_sugar_type,
+      call_outcome: patient.appointments.order(device_updated_at: :desc)&.first&.call_results&.order(device_created_at: :desc)&.first&.result_type
+    }
+  end
+
+  def remove_pii(patients)
+    country = Faker::Address.country
+    patients.each do |patient|
+      patient.full_name = Faker::Name.name
+      address = patient.address
+      address.street_address = Faker::Address.street_address
+      address.district = Faker::Address.district
+      address.state = Faker::Address.state
+      address.pin = Faker::Address.zip
+      address.country = country
+      patient.phone_numbers.each do |phone_number|
+        phone_number.number = Faker::PhoneNumber.phone_number
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a one-off script that is meant to generate a JSON data dump for one of our facilities in Sri Lanka to help the OpenSRP team conduct user testing.

The code is intentionally rough around the edges, and very specific to the export for the user test. We may write a more well-crafted and well-tested script in the future if making OpenSRP-compatible FHIR exports is something we might need outside of this one-off test. But for now the focus is on getting this data out ASAP, along with the flexibility to rapidly incorporate any changes needed for the OpenSRP export, since the new app doesn't yet have a stable contract.

**Story card:** [sc-13106](https://app.shortcut.com/simpledotorg/story/13106/share-a-dump-with-gonaduwa-patients)

## This addresses

* Adds a few services for exporting FHIR resources (in the format OpenSRP understands, which was agreed upon based on a many months of manual QA)
