### PR TITLE
Add national dashboard link in the top navigation [sc-13777]

### DIFF
--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -4,8 +4,8 @@
 
   <nav class="breadcrumb mb-0px pb-16px">
     <%= link_to "All reports", dashboard_districts_path %>
-
-    <% @region.ancestors.where(region_type: %w[state district block facility]).order(:path).each do |region| %>
+    
+    <% @region.ancestors.where(region_type: %w[organization state district block facility]).order(:path).each do |region| %>
       <i class="fas fa-chevron-right"></i>
       <%= link_to_if(accessible_region?(region, :view_reports), region.name, reports_region_path(region.slug, report_scope: region.region_type)) %>
     <% end %>


### PR DESCRIPTION
**Story card:** [sc-13777] https://app.shortcut.com/simpledotorg/story/13777/add-national-dashboard-link-in-the-top-navigation-bar-in-the-dashboard

## Because

 Breadcrumbs on top of the reports page does not show the organization name.

## This addresses

Includes the organization name in the breadcrumbs.

## Test instructions

Need to enable the organization_reports flipper