### PR TITLE
Settings page

### DIFF
--- a/.github/workflows/learn-github-actions.yml
+++ b/.github/workflows/learn-github-actions.yml
@@ -1,0 +1,13 @@
+name: learn-github-actions
+run-name: ${{ github.actor }} is learning GitHub Actions
+on: [push]
+jobs:
+  check-bats-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install -g bats
+      - run: bats -v

--- a/.github/workflows/learn-github-actions.yml
+++ b/.github/workflows/learn-github-actions.yml
@@ -11,3 +11,4 @@ jobs:
           node-version: '20'
       - run: npm install -g bats
       - run: bats -v
+  

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -802,3 +802,9 @@ span.inactive {
 .no-card-gap-filler p {
   color: #A0A0A0;
 }
+
+.settings-nav-link {
+  font-size: 20px;
+  padding-top: 20px;
+  font-weight: bold;
+}

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class SettingsController < AdminController
+  skip_after_action :verify_authorization_attempted, only: [:index]
+
+  def index
+  end
+end

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -3,56 +3,56 @@
 </h1>
 <div id="settings">
   <div id="d-flex row">
-    <div class="card d-flex mb-2">
+    <div class="card d-flex mb-2 p-3 settings-card">
       <% if current_admin.power_user? || current_admin.accessible_facilities(:manage).any? %>
-        <%= link_to(admin_facilities_path, class: "nav-link settings-nav-link #{active_controller?("admin/facilities")}") do %>
+        <%= link_to(admin_facilities_path, class: "settings-nav-link #{active_controller?("admin/facilities")}") do %>
           <h3>Facilities</h3>
-          <p>Manage and oversee facilities accessible to administrators.</p>
+          <p class="description">Manage and oversee facilities within a district.</p>
         <% end %>
       <% end %>
     </div>
-    
-    <div class="card d-flex mb-2">
+
+    <div class="card d-flex mb-2 p-3 settings-card">
       <% if current_admin.power_user? || current_admin.accessible_organizations(:manage).any? %>
-        <%= link_to(admin_organizations_path, class: "nav-link settings-nav-link #{active_controller?("admin/organizations")}", id: "nav-organizations-link") do %>
+        <%= link_to(admin_organizations_path, class: "settings-nav-link #{active_controller?("admin/organizations")}", id: "nav-organizations-link") do %>
           <h3>Organizations</h3>
-          <p>Administer and control organization-level settings and data.</p>
+          <p class="description">Add or modify organization data.</p>
         <% end %>
       <% end %>
     </div>
 
-    <div class="card d-flex mb-2">
+    <div class="card d-flex mb-2 p-3 settings-card">
       <% if current_admin.power_user? || current_admin.accessible_organizations(:manage).any? %>
-        <%= link_to(admin_protocols_path, class: "nav-link settings-nav-link #{active_controller?("admin/protocols")}") do %>
+        <%= link_to(admin_protocols_path, class: "settings-nav-link #{active_controller?("admin/protocols")}") do %>
           <h3>Mobile App Medications</h3>
-          <p>Configure and manage medication protocols available on the mobile app.</p>
+          <p class="description">Configure and manage medication protocols available on the mobile app.</p>
         <% end %>
       <% end %>
     </div>
 
-    <div class="card d-flex mb-2">
+    <div class="card d-flex mb-2 p-3 settings-card">
       <% if current_admin.power_user? || current_admin.accessible_facilities(:manage).any? %>
-        <%= link_to(admins_path, class: "nav-link settings-nav-link #{active_controller?("admins")}") do %>
+        <%= link_to(admins_path, class: "settings-nav-link #{active_controller?("admins")}") do %>
           <h3>Dashboard Admins</h3>
-          <p>Assign and oversee administrators with access to the dashboard.</p>
+          <p class="description">Assign and manage administrators with access to the dashboard.</p>
         <% end %>
       <% end %>
     </div>
 
-    <div class="card d-flex mb-2">
+    <div class="card d-flex mb-2 p-3 settings-card">
       <% if current_admin.power_user? || current_admin.accessible_users(:manage).any? %>
-        <%= link_to(admin_users_path, class: "nav-link settings-nav-link #{active_controller?("admin/users")}", id: "mobile-app-users") do %>
+        <%= link_to(admin_users_path, class: "settings-nav-link #{active_controller?("admin/users")}", id: "mobile-app-users") do %>
           <h3>Mobile App Users</h3>
-          <p>Manage user accounts and access permissions for the mobile app.</p>
+          <p class="description">Manage user accounts and access permissions for the mobile app.</p>
         <% end %>
       <% end %>
     </div>
 
-    <div class="card d-flex mb-2">
+    <div class="card d-flex mb-2 p-3 settings-card">
       <% if current_admin.power_user? %>
-        <%= link_to(new_admin_patient_import_path, class: "nav-link settings-nav-link #{active_controller?("admin/patient_imports")}", id: "patient-import") do %>
+        <%= link_to(new_admin_patient_import_path, class: "settings-nav-link #{active_controller?("admin/patient_imports")}", id: "patient-import") do %>
           <h3>Patient Import</h3>
-          <p>Import patient data into the system for easier management and access.</p>
+          <p class="description">Import patient data into the system.</p>
         <% end %>
       <% end %>
     </div>
@@ -61,40 +61,72 @@
       <div class="nav-divider"></div>
     <% end %>
 
-    <div class="card d-flex mb-2">
+    <div class="card d-flex mb-2 p-3 settings-card">
       <% if current_admin.power_user? %>
-        <%= link_to("/sidekiq", class: "nav-link settings-nav-link #{active_controller?("sidekiq")}") do %>
+        <%= link_to("/sidekiq", class: "settings-nav-link #{active_controller?("sidekiq")}") do %>
           <h3>Sidekiq</h3>
-          <p>Access Sidekiq for background job processing and monitoring.</p>
+          <p class="description">Access Sidekiq for background job processing and monitoring.</p>
         <% end %>
       <% end %>
     </div>
 
-    <div class="card d-flex mb-2">
+    <div class="card d-flex mb-2 p-3 settings-card">
       <% if current_admin.power_user? %>
-        <%= link_to("/flipper", class: "nav-link settings-nav-link #{active_controller?("flipper")}") do %>
+        <%= link_to("/flipper", class: "settings-nav-link #{active_controller?("flipper")}") do %>
           <h3>Flipper</h3>
-          <p>Manage feature flags to control the availability of features.</p>
+          <p class="description">Manage feature flags to control the availability of features.</p>
         <% end %>
       <% end %>
     </div>
 
-    <div class="card d-flex mb-2">
+    <div class="card d-flex mb-2 p-3 settings-card">
       <% if current_admin.power_user? %>
-        <%= link_to(admin_error_traces_path, class: "nav-link settings-nav-link #{active_controller?("admin/error_traces")}") do %>
+        <%= link_to(admin_error_traces_path, class: "settings-nav-link #{active_controller?("admin/error_traces")}") do %>
           <h3>Error Traces</h3>
-          <p>Review and track error traces for debugging and maintenance.</p>
+          <p class="description">Review and track error traces for debugging and maintenance.</p>
         <% end %>
       <% end %>
     </div>
 
-    <div class="card d-flex mb-2">
+    <div class="card d-flex mb-2 p-3 settings-card">
       <% if current_admin.power_user? %>
-        <%= link_to(admin_cphc_migration_path, class: "nav-link settings-nav-link #{active_controller?("admin/cphc_migration")}") do %>
+        <%= link_to(admin_cphc_migration_path, class: "settings-nav-link #{active_controller?("admin/cphc_migration")}") do %>
           <h3>CPHC Migration</h3>
-          <p>Manage and oversee data migration processes for CPHC.</p>
+          <p class="description">Manage and oversee data migration processes for CPHC.</p>
         <% end %>
       <% end %>
     </div>
   </div>
 </div>
+
+<style>
+  .settings-card {
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    background-color: #f9f9f9;
+    transition: background-color 0.3s ease;
+  }
+  .settings-card:hover {
+    background-color: #e0f0ff;
+  }
+  .settings-card h3 {
+    font-size: 18px;
+    font-weight: 600;
+    color: #0078d7;
+    margin-bottom: 4px;
+  }
+  .description {
+    font-size: 13px;
+    color: #666;
+    margin: 0;
+  }
+  .settings-nav-link {
+    display: block;
+    color: #333;
+    text-decoration: none;
+    padding: 8px;
+  }
+  .settings-nav-link:hover {
+    color: #0078d7;
+  }
+</style>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -4,99 +4,97 @@
 <div id="settings">
   <div id="d-flex row">
     <div class="card d-flex mb-2">
-  <% if current_admin.power_user? || current_admin.accessible_facilities(:manage).any? %>
-  <%= link_to (admin_facilities_path), class: "nav-link settings-nav-link #{active_controller?("admin/facilities")}" do %>
-        <h3>
-          Facilities
-        </h3>
-      
-  <% end %>
-  </div>
-  <div class="card d-flex mb-2">
-  <% if current_admin.power_user? || current_admin.accessible_organizations(:manage).any? %>
-    <%= link_to (admin_organizations_path), class: "nav-link settings-nav-link #{active_controller?("admin/organizations")}", id: "nav-organizations-link" do %>
-        <h3>
-          Organizations
-        </h3>
-    <% end %>
-  <% end %>
-  </div>
-  <div class="card d-flex mb-2">
-  <% if current_admin.power_user? || current_admin.accessible_organizations(:manage).any? %>
-    <%= link_to (admin_protocols_path), class: "nav-link settings-nav-link #{active_controller?("admin/protocols")}" do %>
-        <h3>
-          Mobile App Medications
-        </h3>
-    <% end %>
-  <% end %>
-  </div>
-  <div class="card d-flex mb-2">
-  <% if current_admin.power_user? || current_admin.accessible_facilities(:manage).any? %>
-    <%= link_to (admins_path), class: "nav-link settings-nav-link #{active_controller?("admins")}" do %>
-        <h3>
-          Dashboard Admins
-        </h3>
-    <% end %>
-  <% end %>
-  </div>
-  <div class="card d-flex mb-2">
-  <% if current_admin.power_user? || current_admin.accessible_users(:manage).any?  %>
-    <%= link_to (admin_users_path), class: "nav-link settings-nav-link #{active_controller?("admin/users")}", id: "mobile-app-users" do %>
-        <h3>
-          Mobile App Users
-        </h3>
-    <% end %>
-  <% end %>
-  </div>
-  <div class="card d-flex mb-2">
-  <% if current_admin.power_user?  %>
-    <%= link_to (new_admin_patient_import_path), class: "nav-link settings-nav-link #{active_controller?("admin/patient_imports")}", id: "patient-import" do %>
-        <h3>
-          Patient Import
-        </h3>
-    <% end %>
-  <% end %>
-  </div>
+      <% if current_admin.power_user? || current_admin.accessible_facilities(:manage).any? %>
+        <%= link_to(admin_facilities_path, class: "nav-link settings-nav-link #{active_controller?("admin/facilities")}") do %>
+          <h3>Facilities</h3>
+          <p>Manage and oversee facilities accessible to administrators.</p>
+        <% end %>
+      <% end %>
+    </div>
+    
+    <div class="card d-flex mb-2">
+      <% if current_admin.power_user? || current_admin.accessible_organizations(:manage).any? %>
+        <%= link_to(admin_organizations_path, class: "nav-link settings-nav-link #{active_controller?("admin/organizations")}", id: "nav-organizations-link") do %>
+          <h3>Organizations</h3>
+          <p>Administer and control organization-level settings and data.</p>
+        <% end %>
+      <% end %>
+    </div>
 
-  <% if current_admin.power_user? %>
-  <div class="nav-divider"></div>
-  <% end %>
+    <div class="card d-flex mb-2">
+      <% if current_admin.power_user? || current_admin.accessible_organizations(:manage).any? %>
+        <%= link_to(admin_protocols_path, class: "nav-link settings-nav-link #{active_controller?("admin/protocols")}") do %>
+          <h3>Mobile App Medications</h3>
+          <p>Configure and manage medication protocols available on the mobile app.</p>
+        <% end %>
+      <% end %>
+    </div>
 
-  <div class="card d-flex mb-2">
-  <% if current_admin.power_user? %>
-    <%= link_to ("/sidekiq"), class: "nav-link settings-nav-link settings-nav-link #{active_controller?("sidekiq")}" do %>
-        <h3>
-          Sidekiq
-        </h3>
+    <div class="card d-flex mb-2">
+      <% if current_admin.power_user? || current_admin.accessible_facilities(:manage).any? %>
+        <%= link_to(admins_path, class: "nav-link settings-nav-link #{active_controller?("admins")}") do %>
+          <h3>Dashboard Admins</h3>
+          <p>Assign and oversee administrators with access to the dashboard.</p>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="card d-flex mb-2">
+      <% if current_admin.power_user? || current_admin.accessible_users(:manage).any? %>
+        <%= link_to(admin_users_path, class: "nav-link settings-nav-link #{active_controller?("admin/users")}", id: "mobile-app-users") do %>
+          <h3>Mobile App Users</h3>
+          <p>Manage user accounts and access permissions for the mobile app.</p>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="card d-flex mb-2">
+      <% if current_admin.power_user? %>
+        <%= link_to(new_admin_patient_import_path, class: "nav-link settings-nav-link #{active_controller?("admin/patient_imports")}", id: "patient-import") do %>
+          <h3>Patient Import</h3>
+          <p>Import patient data into the system for easier management and access.</p>
+        <% end %>
+      <% end %>
+    </div>
+
+    <% if current_admin.power_user? %>
+      <div class="nav-divider"></div>
     <% end %>
-  <% end %>
+
+    <div class="card d-flex mb-2">
+      <% if current_admin.power_user? %>
+        <%= link_to("/sidekiq", class: "nav-link settings-nav-link #{active_controller?("sidekiq")}") do %>
+          <h3>Sidekiq</h3>
+          <p>Access Sidekiq for background job processing and monitoring.</p>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="card d-flex mb-2">
+      <% if current_admin.power_user? %>
+        <%= link_to("/flipper", class: "nav-link settings-nav-link #{active_controller?("flipper")}") do %>
+          <h3>Flipper</h3>
+          <p>Manage feature flags to control the availability of features.</p>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="card d-flex mb-2">
+      <% if current_admin.power_user? %>
+        <%= link_to(admin_error_traces_path, class: "nav-link settings-nav-link #{active_controller?("admin/error_traces")}") do %>
+          <h3>Error Traces</h3>
+          <p>Review and track error traces for debugging and maintenance.</p>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="card d-flex mb-2">
+      <% if current_admin.power_user? %>
+        <%= link_to(admin_cphc_migration_path, class: "nav-link settings-nav-link #{active_controller?("admin/cphc_migration")}") do %>
+          <h3>CPHC Migration</h3>
+          <p>Manage and oversee data migration processes for CPHC.</p>
+        <% end %>
+      <% end %>
+    </div>
   </div>
-  <div class="card d-flex mb-2">
-  <% if current_admin.power_user? %>
-    <%= link_to ("/flipper"), class: "nav-link settings-nav-link #{active_controller?("flipper")}" do %>
-        <h3>
-          Flipper
-        </h3>
-    <% end %>
-  <% end %>
-  </div>
-  <div class="card d-flex mb-2">
-  <% if current_admin.power_user? %>
-    <%= link_to admin_error_traces_path, class: "nav-link settings-nav-link #{active_controller?("admin/error_traces")}" do %>
-        <h3>
-          Error traces
-        </h3>
-    <% end %>
-  <% end %>
-  </div>
-  <div class="card d-flex mb-2">
-  <% if current_admin.power_user? %>
-    <%= link_to admin_cphc_migration_path, class: "nav-link settings-nav-link #{active_controller?("admin/cphc_migration")}" do %>
-        <h3>
-          CPHC Migration
-        </h3>
-    <% end %>
-  <% end %>
-  </div>
-  </div>
-<% end %>
+</div>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,0 +1,59 @@
+<h1 class="page-header">
+  Settings
+</h1>
+<div id="settings">
+  <% if current_admin.power_user? || current_admin.accessible_facilities(:manage).any? %>
+  <%= link_to (admin_facilities_path), class: "nav-link settings-nav-link #{active_controller?("admin/facilities")}" do %>
+      Facilities
+  <% end %>
+  <% if current_admin.power_user? || current_admin.accessible_organizations(:manage).any? %>
+    <%= link_to (admin_organizations_path), class: "nav-link settings-nav-link #{active_controller?("admin/organizations")}", id: "nav-organizations-link" do %>
+      Organizations
+    <% end %>
+  <% end %>
+  <% if current_admin.power_user? || current_admin.accessible_organizations(:manage).any? %>
+    <%= link_to (admin_protocols_path), class: "nav-link settings-nav-link #{active_controller?("admin/protocols")}" do %>
+      Mobile app medications
+    <% end %>
+  <% end %>
+  <% if current_admin.power_user? || current_admin.accessible_facilities(:manage).any? %>
+    <%= link_to (admins_path), class: "nav-link settings-nav-link #{active_controller?("admins")}" do %>
+      Dashboard admins
+    <% end %>
+  <% end %>
+  <% if current_admin.power_user? || current_admin.accessible_users(:manage).any?  %>
+    <%= link_to (admin_users_path), class: "nav-link settings-nav-link #{active_controller?("admin/users")}", id: "mobile-app-users" do %>
+      Mobile app users
+    <% end %>
+  <% end %>
+  <% if current_admin.power_user?  %>
+    <%= link_to (new_admin_patient_import_path), class: "nav-link settings-nav-link #{active_controller?("admin/patient_imports")}", id: "patient-import" do %>
+      Patient import
+    <% end %>
+  <% end %>
+
+  <% if current_admin.power_user? %>
+  <div class="nav-divider"></div>
+  <% end %>
+
+  <% if current_admin.power_user? %>
+    <%= link_to ("/sidekiq"), class: "nav-link settings-nav-link settings-nav-link #{active_controller?("sidekiq")}" do %>
+      Sidekiq
+    <% end %>
+  <% end %>
+  <% if current_admin.power_user? %>
+    <%= link_to ("/flipper"), class: "nav-link settings-nav-link #{active_controller?("flipper")}" do %>
+      Flipper
+    <% end %>
+  <% end %>
+  <% if current_admin.power_user? %>
+    <%= link_to admin_error_traces_path, class: "nav-link settings-nav-link #{active_controller?("admin/error_traces")}" do %>
+      Error traces
+    <% end %>
+  <% end %>
+  <% if current_admin.power_user? %>
+    <%= link_to admin_cphc_migration_path, class: "nav-link settings-nav-link #{active_controller?("admin/cphc_migration")}" do %>
+      CPHC Migration
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -2,58 +2,101 @@
   Settings
 </h1>
 <div id="settings">
+  <div id="d-flex row">
+    <div class="card d-flex mb-2">
   <% if current_admin.power_user? || current_admin.accessible_facilities(:manage).any? %>
   <%= link_to (admin_facilities_path), class: "nav-link settings-nav-link #{active_controller?("admin/facilities")}" do %>
-      Facilities
+        <h3>
+          Facilities
+        </h3>
+      
   <% end %>
+  </div>
+  <div class="card d-flex mb-2">
   <% if current_admin.power_user? || current_admin.accessible_organizations(:manage).any? %>
     <%= link_to (admin_organizations_path), class: "nav-link settings-nav-link #{active_controller?("admin/organizations")}", id: "nav-organizations-link" do %>
-      Organizations
+        <h3>
+          Organizations
+        </h3>
     <% end %>
   <% end %>
+  </div>
+  <div class="card d-flex mb-2">
   <% if current_admin.power_user? || current_admin.accessible_organizations(:manage).any? %>
     <%= link_to (admin_protocols_path), class: "nav-link settings-nav-link #{active_controller?("admin/protocols")}" do %>
-      Mobile app medications
+        <h3>
+          Mobile App Medications
+        </h3>
     <% end %>
   <% end %>
+  </div>
+  <div class="card d-flex mb-2">
   <% if current_admin.power_user? || current_admin.accessible_facilities(:manage).any? %>
     <%= link_to (admins_path), class: "nav-link settings-nav-link #{active_controller?("admins")}" do %>
-      Dashboard admins
+        <h3>
+          Dashboard Admins
+        </h3>
     <% end %>
   <% end %>
+  </div>
+  <div class="card d-flex mb-2">
   <% if current_admin.power_user? || current_admin.accessible_users(:manage).any?  %>
     <%= link_to (admin_users_path), class: "nav-link settings-nav-link #{active_controller?("admin/users")}", id: "mobile-app-users" do %>
-      Mobile app users
+        <h3>
+          Mobile App Users
+        </h3>
     <% end %>
   <% end %>
+  </div>
+  <div class="card d-flex mb-2">
   <% if current_admin.power_user?  %>
     <%= link_to (new_admin_patient_import_path), class: "nav-link settings-nav-link #{active_controller?("admin/patient_imports")}", id: "patient-import" do %>
-      Patient import
+        <h3>
+          Patient Import
+        </h3>
     <% end %>
   <% end %>
+  </div>
 
   <% if current_admin.power_user? %>
   <div class="nav-divider"></div>
   <% end %>
 
+  <div class="card d-flex mb-2">
   <% if current_admin.power_user? %>
     <%= link_to ("/sidekiq"), class: "nav-link settings-nav-link settings-nav-link #{active_controller?("sidekiq")}" do %>
-      Sidekiq
+        <h3>
+          Sidekiq
+        </h3>
     <% end %>
   <% end %>
+  </div>
+  <div class="card d-flex mb-2">
   <% if current_admin.power_user? %>
     <%= link_to ("/flipper"), class: "nav-link settings-nav-link #{active_controller?("flipper")}" do %>
-      Flipper
+        <h3>
+          Flipper
+        </h3>
     <% end %>
   <% end %>
+  </div>
+  <div class="card d-flex mb-2">
   <% if current_admin.power_user? %>
     <%= link_to admin_error_traces_path, class: "nav-link settings-nav-link #{active_controller?("admin/error_traces")}" do %>
-      Error traces
+        <h3>
+          Error traces
+        </h3>
     <% end %>
   <% end %>
+  </div>
+  <div class="card d-flex mb-2">
   <% if current_admin.power_user? %>
     <%= link_to admin_cphc_migration_path, class: "nav-link settings-nav-link #{active_controller?("admin/cphc_migration")}" do %>
-      CPHC Migration
+        <h3>
+          CPHC Migration
+        </h3>
     <% end %>
   <% end %>
+  </div>
+  </div>
 <% end %>

--- a/app/views/shared/_nav_bar.html.erb
+++ b/app/views/shared/_nav_bar.html.erb
@@ -57,72 +57,15 @@
       Resources
     ----------------->
       <%= link_to (resources_path), class: "nav-link #{active_controller?("resources")}" do %>
-        <i class="fa-regular fa-chalkboard-teacher main-menu-icon w-16px"></i> <span>Resources &amp; training</span>
+        <i class="fa-regular fa-chalkboard-teacher main-menu-icon w-16px"></i> <span>Resource &amp; training</span>
       <% end %>
 
     <!-----------------
-      Settings
+    Settings
     ----------------->
-      <a data-toggle="collapse" href="#nav-settings" role="button" aria-expanded="false" aria-controls="nav-settings" class="nav-link">
-        <i class="fa-regular fa-cog main-menu-icon w-16px"></i> <span>Settings</span>
-      </a>
-
-      <div id="nav-settings" class="nav-section collapse">
-        <% if current_admin.power_user? || current_admin.accessible_facilities(:manage).any? %>
-        <%= link_to (admin_facilities_path), class: "sub-nav-link #{active_controller?("admin/facilities")}" do %>
-            Facilities
-        <% end %>
-        <% if current_admin.power_user? || current_admin.accessible_organizations(:manage).any? %>
-          <%= link_to (admin_organizations_path), class: "sub-nav-link #{active_controller?("admin/organizations")}", id: "nav-organizations-link" do %>
-            Organizations
+          <%= link_to (settings_path), class: "nav-link #{active_controller?("settings")}" do %>
+            <i class="fa-regular fa-cog main-menu-icon w-16px"></i> <span>Settings</span>
           <% end %>
-        <% end %>
-        <% if current_admin.power_user? || current_admin.accessible_organizations(:manage).any? %>
-          <%= link_to (admin_protocols_path), class: "sub-nav-link #{active_controller?("admin/protocols")}" do %>
-            Mobile app medications
-          <% end %>
-        <% end %>
-        <% if current_admin.power_user? || current_admin.accessible_facilities(:manage).any? %>
-          <%= link_to (admins_path), class: "sub-nav-link #{active_controller?("admins")}" do %>
-            Dashboard admins
-          <% end %>
-        <% end %>
-        <% if current_admin.power_user? || current_admin.accessible_users(:manage).any?  %>
-          <%= link_to (admin_users_path), class: "sub-nav-link #{active_controller?("admin/users")}", id: "mobile-app-users" do %>
-            Mobile app users
-          <% end %>
-        <% end %>
-        <% if current_admin.power_user?  %>
-          <%= link_to (new_admin_patient_import_path), class: "sub-nav-link #{active_controller?("admin/patient_imports")}", id: "patient-import" do %>
-            Patient import
-          <% end %>
-        <% end %>
-
-        <% if current_admin.power_user? %>
-        <div class="nav-divider"></div>
-        <% end %>
-
-        <% if current_admin.power_user? %>
-          <%= link_to ("/sidekiq"), class: "sub-nav-link #{active_controller?("sidekiq")}" do %>
-            Sidekiq
-          <% end %>
-        <% end %>
-        <% if current_admin.power_user? %>
-          <%= link_to ("/flipper"), class: "sub-nav-link #{active_controller?("flipper")}" do %>
-            Flipper
-          <% end %>
-        <% end %>
-        <% if current_admin.power_user? %>
-          <%= link_to admin_error_traces_path, class: "sub-nav-link #{active_controller?("admin/error_traces")}" do %>
-            Error traces
-          <% end %>
-        <% end %>
-        <% if current_admin.power_user? %>
-          <%= link_to admin_cphc_migration_path, class: "sub-nav-link #{active_controller?("admin/cphc_migration")}" do %>
-            CPHC Migration
-          <% end %>
-        <% end %>
-      <% end %>
 
       <div class="nav-divider"></div>
 
@@ -168,6 +111,7 @@
   </script>
 
 </nav>
+</div>
 
 <div class="mobile-header d-print-none">
     <a href="#" onclick="openMenu()" class="navigation-icon"><i class="fa-regular fa-bars pr-1"></i> MENU</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -242,6 +242,10 @@ Rails.application.routes.draw do
     get "/", to: "resources#index", as: "resources"
   end
 
+  scope :settings do
+    get "/", to: "settings#index", as: "settings"
+  end
+
   namespace :admin do
     resources :organizations
 

--- a/spec/controllers/settings_controller_spec.rb
+++ b/spec/controllers/settings_controller_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe SettingsController, type: :controller do
+  let(:admin) { create(:admin) }
+
+  before do
+    sign_in(admin.email_authentication)
+  end
+
+  describe "GET #index" do
+    render_views
+
+    it "returns a success response" do
+      get :index, params: {}
+
+      expect(response).to be_successful
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

## Because

The sliding navigational bar routes to a new page when clicking each option. However, the settings option opens a dropdown of what can be over 8 items if you belong to the admin group. In proactively preparing for new settings options and clarity to users, we have added a new settings page with boxed options for each setting and a description.

## This addresses

This is implemented by creating a new route within routes.rb that triggers a SettingsController to retrieve the index.html.rb file for the settings page. The "Settings" word in the navigational page now routes to the new "/settings".  Descriptions of each setting and the styles are located within the index.html.rb file.

## Test instructions

To test this PR, load up a new instance of the Simple Server and log into a profile. You should see on the left navigational bar, the settings page when pressed should route to "/settings" and all settings (appropriate for the user's permissions) will appear in a box with a description.