### PR TITLE
Mapping the data elements to ethiopia prod DHIS2 instance

### DIFF
--- a/config/data/dhis2/ethiopia-production.yml
+++ b/config/data/dhis2/ethiopia-production.yml
@@ -1,8 +1,8 @@
 dhis2_data_elements:
   htn_enrolled_under_care: "EBJOc6MwpUE"
   htn_enrolled_under_care_treatment: "Z9LhFzvk1pG"
-  htn_by_enrollment_time: FegpLg25B6l
-  htn_cohort_registered: x4c7Oa9GoCQ
+  htn_by_enrollment_time: V3I330eoIWi
+  htn_cohort_registered: TnxpgPlHdGJ
   htn_cohort_outcome: O7vl9TZXgPx
 
 dhis2_age_gender_category_elements:
@@ -20,8 +20,8 @@ dhis2_treatment_category_elements:
   pharma_management: cHCvSLCnh18
 
 dhis2_enrollment_time_category_elements:
-  newly_enrolled: bn7fE1Eucm0
-  previously_enrolled: xbP4EYANBA8
+  newly_enrolled: RZdSv3uSaEY
+  previously_enrolled: dMkEK66TNLC
 
 dhis2_cohort_category_elements:
   controlled: WPjwKs4ZivK


### PR DESCRIPTION
**Story card:** [sc-12898](https://app.shortcut.com/simpledotorg/story/12898/enable-dhis2-export-on-ethiopia)

## Because

Ethiopia has new DHIS2 prod instance, hence the data element IDs in the yml needs to be mapped correctly to it.
DHIS2 instance - https://dhis.moh.gov.et/
To get all the DHIS2 data element Ids - https://dhis.moh.gov.et/api/dataElements.json?fields=id,name,categoryCombo%5bcategoryOptionCombos%5bid,name%5d%5d&filter=name:$like:simple_&paging=false

## This addresses

Mapping the data elements to their respective DHIS2 Ids

## Test instructions

Run ethiopia exporter job, and verify there is no mismatch for the data element Ids.