### PR TITLE
Added Diabetes Report Section & Total registered patients

### DIFF
--- a/app/components/progress_tab/diabetes/diagnosis_report_component.html.erb
+++ b/app/components/progress_tab/diabetes/diagnosis_report_component.html.erb
@@ -8,9 +8,26 @@
       <%= inline_file("chevron-left.svg") %>
       back
     </a>
+    <div class="pr-16px pl-16px">
+      <h1 class="m-0px mb-8px fw-bold fs-24px">
+        <%= t("progress_tab.diabetes_report_title") %> <%= t("progress_tab.report") %>
+      </h1>
+      <p class="m-0px p-0px ta-left fw-normal fs-16px c-grey-dark">
+        <%= t("progress_tab.last_updated_at",
+              date: display_date(@last_updated_at),
+              time: display_time(@last_updated_at))
+        %>
+      </p>
+    </div>
   </div>
   <%= render(Reports::ProgressAssignedPatientsComponent.new(
     assigned_patients: diabetes_reports_data[:assigned_patients],
+    region: diabetes_reports_data[:region],
+    diagnosis: "diabetes"
+  )) %>
+  <%= render(Reports::ProgressTotalRegistrationsComponent.new(
+    total_registrations: diabetes_reports_data[:total_registrations],
+    period_info: diabetes_reports_data[:period_info],
     region: diabetes_reports_data[:region],
     diagnosis: "diabetes"
   )) %>

--- a/app/components/progress_tab/diabetes/diagnosis_report_component.rb
+++ b/app/components/progress_tab/diabetes/diagnosis_report_component.rb
@@ -6,7 +6,8 @@ class ProgressTab::Diabetes::DiagnosisReportComponent < ApplicationComponent
 
   attr_reader :diabetes_reports_data
 
-  def initialize(diabetes_reports_data:)
+  def initialize(diabetes_reports_data:, last_updated_at:)
     @diabetes_reports_data = diabetes_reports_data
+    @last_updated_at = last_updated_at
   end
 end

--- a/app/components/reports/progress_total_registrations_component.html.erb
+++ b/app/components/reports/progress_total_registrations_component.html.erb
@@ -5,7 +5,7 @@
     </h2>
   </div>
   <p class="m-0px mb-24px p-0px ta-left fw-normal fs-16px lh-150 c-grey-dark">
-    <%= t("progress_tab.diagnosis_report.total_registered_patients.subtitle", facility_name: @region.name, diagnosis: "hypertension") %>
+    <%= t("progress_tab.diagnosis_report.total_registered_patients.subtitle", facility_name: @region.name, diagnosis: @diagnosis) %>
   </p>
   <%= render partial: "api/v3/analytics/user_analytics/data_bar_graph",
              locals: {

--- a/app/components/reports/progress_total_registrations_component.rb
+++ b/app/components/reports/progress_total_registrations_component.rb
@@ -6,7 +6,7 @@ class Reports::ProgressTotalRegistrationsComponent < ViewComponent::Base
 
   attr_reader :total_registrations, :period_info, :region
 
-  def initialize(total_registrations:, period_info:, region:, diagnosis:nil)
+  def initialize(total_registrations:, period_info:, region:, diagnosis: nil)
     @total_registrations = total_registrations
     @period_info = period_info
     @region = region

--- a/app/components/reports/progress_total_registrations_component.rb
+++ b/app/components/reports/progress_total_registrations_component.rb
@@ -6,9 +6,10 @@ class Reports::ProgressTotalRegistrationsComponent < ViewComponent::Base
 
   attr_reader :total_registrations, :period_info, :region
 
-  def initialize(total_registrations:, period_info:, region:)
+  def initialize(total_registrations:, period_info:, region:, diagnosis:nil)
     @total_registrations = total_registrations
     @period_info = period_info
     @region = region
+    @diagnosis = diagnosis || "hypertension"
   end
 end

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -90,8 +90,11 @@ module Reports
 
     def diabetes_reports_data
       {
+        total_registrations: repository.cumulative_diabetes_registrations[@region.slug],
         assigned_patients: repository.cumulative_assigned_diabetic_patients[@region.slug][@period],
-        region: @region
+        period_info: repository.period_info(@region),
+        region: @region,
+        current_user: @current_user
       }
     end
 

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -93,8 +93,7 @@ module Reports
         total_registrations: repository.cumulative_diabetes_registrations[@region.slug],
         assigned_patients: repository.cumulative_assigned_diabetic_patients[@region.slug][@period],
         period_info: repository.period_info(@region),
-        region: @region,
-        current_user: @current_user
+        region: @region
       }
     end
 

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -232,7 +232,8 @@
     %>
 
     <%= render(ProgressTab::Diabetes::DiagnosisReportComponent.new(
-      diabetes_reports_data: @service.diabetes_reports_data
+      diabetes_reports_data: @service.diabetes_reports_data,
+      last_updated_at: @user_analytics.last_updated_at
     ))
     %>
     <!--  TODO:  The partial "api/v3/analytics/user_analytics/diagnosis_report" need to be removed once the Diabetes reports are released -->

--- a/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
   end
 
   it "displays the last updated date and time" do
-    formatted_date = Time.zone.now.strftime("%d-%b-%Y at %I:%M %p")
-    expect(subject).to have_text("Data last updated on #{formatted_date}")
+    formatted_date_time = last_updated_at.strftime("%d-%b-%Y at %I:%M %p")
+    expect(subject).to have_text("Data last updated on #{formatted_date_time}")
   end
 
   it "renders the Reports::ProgressTotalRegistrationsComponent" do

--- a/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
@@ -13,19 +13,13 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
         period_july => 44,
         period_august => 49
       },
-      assigned_patients: {
-        region.slug => {
-          period_june => 10,
-          period_july => 12,
-          period_august => 15
-        }
-      },
       period_info: {
         period_june => {name: "Jun-2024", ltfu_since_date: "30-Jun-2023", ltfu_end_date: "30-Jun-2024"},
         period_july => {name: "Jul-2024", ltfu_since_date: "31-Jul-2023", ltfu_end_date: "31-Jul-2024"},
         period_august => {name: "Aug-2024", ltfu_since_date: "31-Aug-2023", ltfu_end_date: "31-Aug-2024"}
       },
-      region: region
+      region: region,
+      assigned_patients: 100,
     }
   end
 

--- a/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
@@ -2,20 +2,22 @@ require "rails_helper"
 
 RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component do
   let(:region) { double("Region", slug: "region_slug", name: "Region 1") }
+  let(:period_june) { double("Period", type: "month", value: "2024-06-01") }
+  let(:period_july) { double("Period", type: "month", value: "2024-07-01") }
+  let(:period_august) { double("Period", type: "month", value: "2024-08-01") }
   let(:repository) { double("Repository") }
-
-  let(:current_date) { Date.new(2024, 9, 1) }
   let(:diabetes_reports_data) do
-    periods = (1..3).map { |n| current_date - n.months }
     {
-      total_registrations: periods.index_with { |date| 40 + date.month },
-      period_info: periods.index_with do |date|
-        {
-          name: date.strftime("%b-%Y"),
-          ltfu_since_date: (date - 1.year).end_of_month.strftime("%d-%b-%Y"),
-          ltfu_end_date: date.end_of_month.strftime("%d-%b-%Y")
-        }
-      end,
+      total_registrations: {
+        period_june => 42,
+        period_july => 44,
+        period_august => 49
+      },
+      period_info: {
+        period_june => {name: "Jun-2024", ltfu_since_date: "30-Jun-2023", ltfu_end_date: "30-Jun-2024"},
+        period_july => {name: "Jul-2024", ltfu_since_date: "31-Jul-2023", ltfu_end_date: "31-Jul-2024"},
+        period_august => {name: "Aug-2024", ltfu_since_date: "31-Aug-2023", ltfu_end_date: "31-Aug-2024"}
+      },
       region: region,
       assigned_patients: 100,
       diagnosis: "diabetes"
@@ -62,6 +64,6 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
 
   it "renders the Reports::ProgressTotalRegistrationsComponent" do
     expect(subject).to have_text(region.name)
-    expect(subject).to have_text("48")
+    expect(subject).to have_text("49")
   end
 end

--- a/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
       },
       region: region,
       assigned_patients: 100,
+      diagnosis: "diabetes"
     }
   end
 
@@ -52,7 +53,7 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
 
   it "renders the Reports::ProgressAssignedPatientsComponent with correct data" do
     expect(subject).to have_text(region.name)
-    expect(subject).to have_text("15")
+    expect(subject.text).to include(diabetes_reports_data[:assigned_patients].to_s)
     expect(subject).to have_text("diabetes")
   end
 

--- a/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
@@ -2,34 +2,76 @@ require "rails_helper"
 
 RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component do
   include ApplicationHelper
+
+  let(:region) { double("Region", slug: "region_slug", name: "Region 1") }
+  let(:period_june) { double("Period", type: "month", value: "2024-06-01") }
+  let(:period_july) { double("Period", type: "month", value: "2024-07-01") }
+  let(:period_august) { double("Period", type: "month", value: "2024-08-01") }
+  let(:repository) { double("Repository") }
   let(:diabetes_reports_data) do
     {
-      assigned_patients: 100,
-      region: double("Region", name: "Region 1"),
-      diagnosis: "diabetes"
+      total_registrations: {
+        period_june => 42,
+        period_july => 44,
+        period_august => 49
+      },
+      assigned_patients: {
+        region.slug => {
+          period_june => 10,
+          period_july => 12,
+          period_august => 15
+        }
+      },
+      period_info: {
+        period_june => {name: "Jun-2024", ltfu_since_date: "30-Jun-2023", ltfu_end_date: "30-Jun-2024"},
+        period_july => {name: "Jul-2024", ltfu_since_date: "31-Jul-2023", ltfu_end_date: "31-Jul-2024"},
+        period_august => {name: "Aug-2024", ltfu_since_date: "31-Aug-2023", ltfu_end_date: "31-Aug-2024"}
+      },
+      region: region
     }
   end
+
   let(:last_updated_at) { Time.current }
 
-  subject { render_inline(described_class.new(diabetes_reports_data: diabetes_reports_data, last_updated_at: last_updated_at)) }
+  before do
+    allow(repository).to receive(:cumulative_diabetes_registrations).and_return(diabetes_reports_data[:total_registrations])
+    allow(repository).to receive(:cumulative_assigned_diabetic_patients).and_return(diabetes_reports_data[:assigned_patients])
+    allow(repository).to receive(:period_info).and_return(diabetes_reports_data[:period_info])
+    allow(region).to receive(:slug).and_return("region_slug")
+  end
+
+  subject do
+    render_inline(described_class.new(
+      diabetes_reports_data: diabetes_reports_data,
+      last_updated_at: last_updated_at
+    ))
+  end
 
   it "renders the diabetes report section" do
     expect(subject).to have_css("div#diabetes-report")
   end
 
   it "renders the back link with correct text and onclick behavior" do
-    expect(subject).to have_css('a[onclick="goToPage(id=\'diabetes-report\', \'home-page\'); return false;"]', text: "back")
+    expect(subject).to have_css(
+      'a[onclick="goToPage(id=\'diabetes-report\', \'home-page\'); return false;"]',
+      text: "back"
+    )
   end
 
   it "renders the Reports::ProgressAssignedPatientsComponent with correct data" do
-    expect(subject.text).to include("Region 1")
-    expect(subject.text).to include(diabetes_reports_data[:assigned_patients].to_s)
-    expect(subject.text).to include("diabetes")
+    expect(subject).to have_text("Region 1")
+    expect(subject).to have_text("15")
+    expect(subject).to have_text("diabetes")
   end
 
   it "displays the last updated date and time" do
     formatted_date = display_date(last_updated_at)
     formatted_time = display_time(last_updated_at)
     expect(subject).to have_text(I18n.t("progress_tab.last_updated_at", date: formatted_date, time: formatted_time))
+  end
+
+  it "renders the Reports::ProgressTotalRegistrationsComponent" do
+    expect(subject).to have_text("Region 1")
+    expect(subject).to have_text("49")
   end
 end

--- a/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component do
-  include ApplicationHelper
-
   let(:region) { double("Region", slug: "region_slug", name: "Region 1") }
   let(:period_june) { double("Period", type: "month", value: "2024-06-01") }
   let(:period_july) { double("Period", type: "month", value: "2024-07-01") }
@@ -59,19 +57,18 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
   end
 
   it "renders the Reports::ProgressAssignedPatientsComponent with correct data" do
-    expect(subject).to have_text("Region 1")
+    expect(subject).to have_text(region.name)
     expect(subject).to have_text("15")
     expect(subject).to have_text("diabetes")
   end
 
   it "displays the last updated date and time" do
-    formatted_date = display_date(last_updated_at)
-    formatted_time = display_time(last_updated_at)
-    expect(subject).to have_text(I18n.t("progress_tab.last_updated_at", date: formatted_date, time: formatted_time))
+    formatted_date = Time.zone.now.strftime("%d-%b-%Y at %I:%M %p")
+    expect(subject).to have_text("Data last updated on #{formatted_date}")
   end
 
   it "renders the Reports::ProgressTotalRegistrationsComponent" do
-    expect(subject).to have_text("Region 1")
+    expect(subject).to have_text(region.name)
     expect(subject).to have_text("49")
   end
 end

--- a/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component do
+  include ApplicationHelper
   let(:diabetes_reports_data) do
     {
       assigned_patients: 100,
@@ -8,7 +9,9 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
       diagnosis: "diabetes"
     }
   end
-  subject { render_inline(described_class.new(diabetes_reports_data: diabetes_reports_data)) }
+  let(:last_updated_at) {Time.current}
+
+  subject { render_inline(described_class.new(diabetes_reports_data: diabetes_reports_data, last_updated_at: last_updated_at)) }
 
   it "renders the diabetes report section" do
     expect(subject).to have_css("div#diabetes-report")
@@ -22,5 +25,11 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
     expect(subject.text).to include("Region 1")
     expect(subject.text).to include(diabetes_reports_data[:assigned_patients].to_s)
     expect(subject.text).to include("diabetes")
+  end
+
+  it "displays the last updated date and time" do
+    formatted_date = display_date(last_updated_at)
+    formatted_time = display_time(last_updated_at)
+    expect(subject).to have_text(I18n.t("progress_tab.last_updated_at", date: formatted_date, time: formatted_time))
   end
 end

--- a/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
@@ -2,22 +2,20 @@ require "rails_helper"
 
 RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component do
   let(:region) { double("Region", slug: "region_slug", name: "Region 1") }
-  let(:period_june) { double("Period", type: "month", value: "2024-06-01") }
-  let(:period_july) { double("Period", type: "month", value: "2024-07-01") }
-  let(:period_august) { double("Period", type: "month", value: "2024-08-01") }
   let(:repository) { double("Repository") }
+
+  let(:current_date) { Date.new(2024, 9, 1) }
   let(:diabetes_reports_data) do
+    periods = (1..3).map { |n| current_date - n.months }
     {
-      total_registrations: {
-        period_june => 42,
-        period_july => 44,
-        period_august => 49
-      },
-      period_info: {
-        period_june => {name: "Jun-2024", ltfu_since_date: "30-Jun-2023", ltfu_end_date: "30-Jun-2024"},
-        period_july => {name: "Jul-2024", ltfu_since_date: "31-Jul-2023", ltfu_end_date: "31-Jul-2024"},
-        period_august => {name: "Aug-2024", ltfu_since_date: "31-Aug-2023", ltfu_end_date: "31-Aug-2024"}
-      },
+      total_registrations: periods.index_with { |date| 40 + date.month },
+      period_info: periods.index_with do |date|
+        {
+          name: date.strftime("%b-%Y"),
+          ltfu_since_date: (date - 1.year).end_of_month.strftime("%d-%b-%Y"),
+          ltfu_end_date: date.end_of_month.strftime("%d-%b-%Y")
+        }
+      end,
       region: region,
       assigned_patients: 100,
       diagnosis: "diabetes"
@@ -64,6 +62,6 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
 
   it "renders the Reports::ProgressTotalRegistrationsComponent" do
     expect(subject).to have_text(region.name)
-    expect(subject).to have_text("49")
+    expect(subject).to have_text("48")
   end
 end

--- a/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
       diagnosis: "diabetes"
     }
   end
-  let(:last_updated_at) {Time.current}
+  let(:last_updated_at) { Time.current }
 
   subject { render_inline(described_class.new(diabetes_reports_data: diabetes_reports_data, last_updated_at: last_updated_at)) }
 

--- a/spec/components/reports/progress_total_registrations_component_spec.rb
+++ b/spec/components/reports/progress_total_registrations_component_spec.rb
@@ -2,25 +2,27 @@ require "rails_helper"
 
 RSpec.describe Reports::ProgressTotalRegistrationsComponent, type: :component do
   let(:region) { double("Region", name: "Region 1") }
-  let(:total_registrations) do
+  let(:total_registrations_data) do
     {
-      Period.new(type: :month, value: "2024-06-01") => 42,
-      Period.new(type: :month, value: "2024-07-01") => 44,
-      Period.new(type: :month, value: "2024-08-01") => 49,
-      Period.new(type: :month, value: "2024-09-01") => 56,
-      Period.new(type: :month, value: "2024-10-01") => 61,
-      Period.new(type: :month, value: "2024-11-01") => 62
+      "2024-06-01" => 42,
+      "2024-07-01" => 44,
+      "2024-08-01" => 49,
+      "2024-09-01" => 56,
+      "2024-10-01" => 61,
+      "2024-11-01" => 62
     }
   end
+
+  let(:total_registrations) do
+    total_registrations_data.map { |date, value| [Period.new(type: :month, value: date), value] }.to_h
+  end
+
   let(:period_info) do
-    {
-      Period.new(type: :month, value: "2024-06-01") => {name: "Jun-2024", ltfu_since_date: "30-Jun-2023"},
-      Period.new(type: :month, value: "2024-07-01") => {name: "Jul-2024", ltfu_since_date: "31-Jul-2023"},
-      Period.new(type: :month, value: "2024-08-01") => {name: "Aug-2024", ltfu_since_date: "31-Aug-2023"},
-      Period.new(type: :month, value: "2024-09-01") => {name: "Sep-2024", ltfu_since_date: "30-Sep-2023"},
-      Period.new(type: :month, value: "2024-10-01") => {name: "Oct-2024", ltfu_since_date: "31-Oct-2023"},
-      Period.new(type: :month, value: "2024-11-01") => {name: "Nov-2024", ltfu_since_date: "30-Nov-2023"}
-    }
+    total_registrations_data.keys.map do |date|
+      period = Period.new(type: :month, value: date)
+      ltfu_since_date = Date.parse(date).prev_year.end_of_month.strftime("%d-%b-%Y")
+      [period, {name: Date.parse(date).strftime("%b-%Y"), ltfu_since_date: ltfu_since_date}]
+    end.to_h
   end
   let(:diagnosis) { "diabetes" }
 
@@ -51,23 +53,16 @@ RSpec.describe Reports::ProgressTotalRegistrationsComponent, type: :component do
 
   it "passes the correct data to the data bar graph partial" do
     expect(subject).to have_selector('div[data-graph-type="bar-chart"]')
-    expect(subject).to have_text("42")
-    expect(subject).to have_text("44")
-    expect(subject).to have_text("49")
-    expect(subject).to have_text("56")
-    expect(subject).to have_text("61")
-    expect(subject).to have_text("62")
-    expect(subject).to have_text("Jun-2024")
-    expect(subject).to have_text("Jul-2024")
-    expect(subject).to have_text("Aug-2024")
-    expect(subject).to have_text("Sep-2024")
-    expect(subject).to have_text("Oct-2024")
-    expect(subject).to have_text("Nov-2024")
+
+    expectations = [
+      "42", "44", "49", "56", "61", "62",
+      "Jun-2024", "Jul-2024", "Aug-2024", "Sep-2024", "Oct-2024", "Nov-2024"
+    ]
+    expectations.each { |expectation| expect(subject).to have_text(expectation) }
   end
 
   it "displays the correct number of total registrations" do
-    total_values = total_registrations.values
-    total_values.each do |value|
+    total_registrations_data.values.each do |value|
       expect(subject).to have_text(value.to_s)
     end
   end

--- a/spec/components/reports/progress_total_registrations_component_spec.rb
+++ b/spec/components/reports/progress_total_registrations_component_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe Reports::ProgressTotalRegistrationsComponent, type: :component do
+  let(:region) { double("Region", name: "Region 1") }
+  let(:total_registrations) do
+    {
+      Period.new(type: :month, value: "2024-06-01") => 42,
+      Period.new(type: :month, value: "2024-07-01") => 44,
+      Period.new(type: :month, value: "2024-08-01") => 49,
+      Period.new(type: :month, value: "2024-09-01") => 56,
+      Period.new(type: :month, value: "2024-10-01") => 61,
+      Period.new(type: :month, value: "2024-11-01") => 62
+    }
+  end
+  let(:period_info) do
+    {
+      Period.new(type: :month, value: "2024-06-01") => {name: "Jun-2024", ltfu_since_date: "30-Jun-2023"},
+      Period.new(type: :month, value: "2024-07-01") => {name: "Jul-2024", ltfu_since_date: "31-Jul-2023"},
+      Period.new(type: :month, value: "2024-08-01") => {name: "Aug-2024", ltfu_since_date: "31-Aug-2023"},
+      Period.new(type: :month, value: "2024-09-01") => {name: "Sep-2024", ltfu_since_date: "30-Sep-2023"},
+      Period.new(type: :month, value: "2024-10-01") => {name: "Oct-2024", ltfu_since_date: "31-Oct-2023"},
+      Period.new(type: :month, value: "2024-11-01") => {name: "Nov-2024", ltfu_since_date: "30-Nov-2023"}
+    }
+  end
+  let(:diagnosis) { "diabetes" }
+
+  subject do
+    render_inline(described_class.new(
+      total_registrations: total_registrations,
+      period_info: period_info,
+      region: region,
+      diagnosis: diagnosis
+    ))
+  end
+
+  it "renders the component wrapper div" do
+    expect(subject).to have_css("div.mb-8px.p-16px.bgc-white.bs-card")
+  end
+
+  it "renders the title with correct translation" do
+    expect(subject).to have_text(I18n.t("progress_tab.diagnosis_report.total_registered_patients.title"))
+  end
+
+  it "renders the subtitle with the region name and diagnosis" do
+    expect(subject).to have_text(I18n.t("progress_tab.diagnosis_report.total_registered_patients.subtitle", facility_name: region.name, diagnosis: diagnosis))
+  end
+
+  it "renders the user analytics data bar graph partial" do
+    expect(subject).to have_selector('div[data-graph-type="bar-chart"]')
+  end
+
+  it "passes the correct data to the data bar graph partial" do
+    expect(subject).to have_selector('div[data-graph-type="bar-chart"]')
+    expect(subject).to have_text("42")
+    expect(subject).to have_text("44")
+    expect(subject).to have_text("49")
+    expect(subject).to have_text("56")
+    expect(subject).to have_text("61")
+    expect(subject).to have_text("62")
+    expect(subject).to have_text("Jun-2024")
+    expect(subject).to have_text("Jul-2024")
+    expect(subject).to have_text("Aug-2024")
+    expect(subject).to have_text("Sep-2024")
+    expect(subject).to have_text("Oct-2024")
+    expect(subject).to have_text("Nov-2024")
+  end
+
+  it "displays the correct number of total registrations" do
+    total_values = total_registrations.values
+    total_values.each do |value|
+      expect(subject).to have_text(value.to_s)
+    end
+  end
+end

--- a/spec/services/reports/facility_progress_service_spec.rb
+++ b/spec/services/reports/facility_progress_service_spec.rb
@@ -120,8 +120,6 @@ RSpec.describe Reports::FacilityProgressService, type: :model do
       refresh_views
       service = described_class.new(facility, Period.current)
       result = service.diabetes_reports_data
-
-      # Check if result includes the necessary keys
       expect(result).to include(:assigned_patients, :period_info, :region, :total_registrations)
       expect(result[:assigned_patients]).to eq(dm_patients.count)
 
@@ -151,8 +149,6 @@ RSpec.describe Reports::FacilityProgressService, type: :model do
           name: "Nov-2024"
         }
       }
-
-      # Assert that the period_info matches the expected structure
       expect(result[:period_info]).to eq(expected_period_info)
     end
   end

--- a/spec/services/reports/facility_progress_service_spec.rb
+++ b/spec/services/reports/facility_progress_service_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Reports::FacilityProgressService, type: :model do
   let(:two_days_ago) { 2.days.ago }
   let(:one_day_ago) { 1.day.ago }
   let(:two_minutes_ago) { 2.minutes.ago }
+  let(:region) { double("Region", name: "Region 1") }
 
   context "daily registrations" do
     it "returns counts for HTN or DM patients if diabetes is enabled" do
@@ -108,6 +109,55 @@ RSpec.describe Reports::FacilityProgressService, type: :model do
         service = described_class.new(facility, Period.current)
 
         expect(service.daily_follow_ups(Date.current)).to eq(3)
+      end
+    end
+
+    it "includes the region, assigned patients, total registration and period info" do
+      Timecop.freeze(Date.today.at_noon) do
+        facility = create(:facility, enable_diabetes_management: true)
+        dm_patient1 = create(:patient, :diabetes, registration_facility: facility, registration_user: user, recorded_at: 2.months.ago)
+        dm_patient2 = create(:patient, :diabetes, registration_facility: facility, registration_user: user, recorded_at: 2.months.ago)
+        undiagnosed_patient = create(:patient, :without_hypertension, registration_facility: facility, registration_user: user, recorded_at: 2.months.ago)
+        dm_patient3 = create(:patient, :diabetes, registration_facility: facility, registration_user: user, recorded_at: 2.months.ago)
+
+        create(:appointment, recorded_at: seven_days_ago, patient: dm_patient1, facility: facility, user: user)
+        create(:appointment, recorded_at: two_minutes_ago, patient: dm_patient1, facility: facility, user: user)
+        create(:blood_pressure, recorded_at: two_minutes_ago, patient: dm_patient2, facility: facility, user: user)
+        create(:blood_pressure, recorded_at: two_minutes_ago, patient: undiagnosed_patient, facility: facility, user: user)
+        create(:blood_sugar, recorded_at: two_minutes_ago, patient: dm_patient3, facility: facility, user: user)
+        create(:blood_pressure, recorded_at: two_minutes_ago, patient: dm_patient3, facility: facility, user: user)
+
+        refresh_views
+        service = described_class.new(facility, Period.current)
+        result = service.diabetes_reports_data
+        expect(result).to include(:assigned_patients, :period_info, :region, :total_registrations)
+        expected_period_info = {
+          Period.new(type: :month, value: '2024-09-01') => {
+            :bp_control_end_date => "30-Sep-2024", 
+            :bp_control_registration_date => "30-Jun-2024", 
+            :bp_control_start_date => "1-Jul-2024", 
+            :ltfu_end_date => "30-Sep-2024", 
+            :ltfu_since_date => "30-Sep-2023", 
+            :name => "Sep-2024"
+          },
+          Period.new(type: :month, value: '2024-10-01') => {
+            :bp_control_end_date => "31-Oct-2024", 
+            :bp_control_registration_date => "31-Jul-2024", 
+            :bp_control_start_date => "1-Aug-2024", 
+            :ltfu_end_date => "31-Oct-2024", 
+            :ltfu_since_date => "31-Oct-2023", 
+            :name => "Oct-2024"
+          },
+          Period.new(type: :month, value: '2024-11-01') => {
+            :bp_control_end_date => "30-Nov-2024", 
+            :bp_control_registration_date => "31-Aug-2024", 
+            :bp_control_start_date => "1-Sep-2024", 
+            :ltfu_end_date => "30-Nov-2024", 
+            :ltfu_since_date => "30-Nov-2023", 
+            :name => "Nov-2024"
+          }
+        }
+        expect(result[:period_info]).to eq(expected_period_info)
       end
     end
   end


### PR DESCRIPTION
**Story card:** [sc-14020](https://app.shortcut.com/simpledotorg/story/14020/add-diabetes-report-section-total-registered-patients)
## Because

To add 2 more sections i.e. Diabetes report section and total registered patient

## This addresses

In this PR we will add 2 sections Diabetes report section (1st section from figma) and total registered patient(3rd patient from figma).

<img width="1512" alt="Screenshot 2024-11-13 at 10 59 24 PM" src="https://github.com/user-attachments/assets/83432c79-b0b8-49ec-98b8-4cdaa9fd0ec0">

## Test instructions

Enable this flipper flag :diabetes_progress_report_tab to check the functionality.