### PR TITLE
Fixing export bug in dhis2 export for ethiopia

### DIFF
--- a/app/jobs/dhis2/ethiopia_exporter_job.rb
+++ b/app/jobs/dhis2/ethiopia_exporter_job.rb
@@ -90,13 +90,11 @@ module Dhis2
     # DHIS2 library we use works for old versions of DHIS2. Since Ethiopia is on much advanced version, this is a hack to prevent
     # false errors being raised from the client.
     def export(data_values)
-      begin
-        @client.data_value_sets.bulk_create(data_values: data_values)
-      rescue Dhis2::BulkCreationError => error
-        response = JSON.parse(error.import_summary.to_json)["hash"]
-        raise error if response["http_status_code"] != 200
-        Rails.logger.info("Exported to Dhis2 with response: ", response)
-      end
+      @client.data_value_sets.bulk_create(data_values: data_values)
+    rescue Dhis2::BulkCreationError => error
+      response = JSON.parse(error.import_summary.to_json)["hash"]
+      raise error if response["http_status_code"] != 200
+      Rails.logger.info("Exported to Dhis2 with response: ", response)
     end
   end
 end

--- a/app/jobs/dhis2/ethiopia_exporter_job.rb
+++ b/app/jobs/dhis2/ethiopia_exporter_job.rb
@@ -86,5 +86,17 @@ module Dhis2
     def format_cohort_registered_data(registered_patients)
       {"default" => registered_patients.count}
     end
+
+    # DHIS2 library we use works for old versions of DHIS2. Since Ethiopia is on much advanced version, this is a hack to prevent
+    # false errors being raised from the client.
+    def export(data_values)
+      begin
+        @client.data_value_sets.bulk_create(data_values: data_values)
+      rescue Dhis2::BulkCreationError => error
+        response = JSON.parse(error.import_summary.to_json)["hash"]
+        raise error if response["http_status_code"] != 200
+        Rails.logger.info("Exported to Dhis2 with response: ", response)
+      end
+    end
   end
 end


### PR DESCRIPTION
**Story card:** [sc-14094](https://app.shortcut.com/simpledotorg/story/14094/fix-dhis2-export-job-bug-ethiopia)

## Because

DHIS2 ruby client that we use works for old version of DHIS2 (2.28). The newer versions of DHIS2 has there API response structure changed. Because of this it was raising error, even though import was successful, and sidekiq job was going to retry queue. 

## This addresses

Changing the export method for ethiopia to handle the response correctly, and not raise error when the response is 200. Since Bangladesh still is using older version of DHIS2, this change will only affect Ethiopia.

## Test instructions

Run `rake "dhis2:ethiopia_export"` and monitor the response. After successful DHIS2 import, it should not raise an error.