### PR TITLE
Sc-14111 Add Monthly follow-up patients

### DIFF
--- a/app/components/progress_tab/diabetes/diagnosis_report_component.html.erb
+++ b/app/components/progress_tab/diabetes/diagnosis_report_component.html.erb
@@ -31,4 +31,10 @@
     region: diabetes_reports_data[:region],
     diagnosis: "diabetes"
   )) %>
+  <%= render(Reports::ProgressMonthlyFollowUpsComponent.new(
+    monthly_follow_ups: diabetes_reports_data[:monthly_follow_ups],
+    period_info: diabetes_reports_data[:period_info],
+    region: diabetes_reports_data[:region],
+    diagnosis: "Diabetes"
+  )) %>
 </div>

--- a/app/components/reports/progress_monthly_follow_ups_component.html.erb
+++ b/app/components/reports/progress_monthly_follow_ups_component.html.erb
@@ -5,7 +5,7 @@
     </h2>
   </div>
   <p class="m-0px mb-24px p-0px ta-left fw-normal fs-16px lh-150 c-grey-dark">
-    <%= t("progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle", facility_name: @region.name, diagnosis: "Hypertension") %>
+    <%= t("progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle", facility_name: @region.name, diagnosis: @diagnosis) %>
   </p>
   <%= render partial: "api/v3/analytics/user_analytics/data_bar_graph",
              locals: {

--- a/app/components/reports/progress_monthly_follow_ups_component.rb
+++ b/app/components/reports/progress_monthly_follow_ups_component.rb
@@ -4,11 +4,12 @@ class Reports::ProgressMonthlyFollowUpsComponent < ViewComponent::Base
   include AssetsHelper
   include ActionView::Helpers::NumberHelper
 
-  attr_reader :monthly_follow_ups, :period_info, :region
+  attr_reader :monthly_follow_ups, :period_info, :region, :diagnosis
 
-  def initialize(monthly_follow_ups:, period_info:, region:)
+  def initialize(monthly_follow_ups:, period_info:, region:, diagnosis: nil)
     @monthly_follow_ups = monthly_follow_ups
     @period_info = period_info
     @region = region
+    @diagnosis = diagnosis || "Hypertension"
   end
 end

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -90,6 +90,7 @@ module Reports
 
     def diabetes_reports_data
       {
+        monthly_follow_ups: repository.diabetes_follow_ups[@region.slug],
         total_registrations: repository.cumulative_diabetes_registrations[@region.slug],
         assigned_patients: repository.cumulative_assigned_diabetic_patients[@region.slug][@period],
         period_info: repository.period_info(@region),

--- a/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
@@ -55,8 +55,6 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
     }
   end
 
-  let(:last_updated_at) { Time.current }
-
   before do
     allow(repository).to receive(:cumulative_diabetes_registrations).and_return(total_registrations)
     allow(repository).to receive(:cumulative_assigned_diabetic_patients).and_return(diabetes_reports_data[:assigned_patients])

--- a/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
@@ -32,12 +32,25 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
     end.to_h
   end
 
+  let(:monthly_follow_ups_data) do
+    {
+      "2024-06-01" => 20,
+      "2024-07-01" => 25,
+      "2024-08-01" => 30
+    }
+  end
+
+  let(:monthly_follow_ups) do
+    monthly_follow_ups_data.map { |date_str, value| [Period.new(type: :month, value: date_str), value] }.to_h
+  end
+
   let(:diabetes_reports_data) do
     {
       total_registrations: total_registrations,
       period_info: period_info,
       region: region,
       assigned_patients: 100,
+      monthly_follow_ups: monthly_follow_ups,
       diagnosis: "diabetes"
     }
   end
@@ -45,10 +58,10 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
   let(:last_updated_at) { Time.current }
 
   before do
-    allow(repository).to receive(:cumulative_diabetes_registrations).and_return(diabetes_reports_data[:total_registrations])
+    allow(repository).to receive(:cumulative_diabetes_registrations).and_return(total_registrations)
     allow(repository).to receive(:cumulative_assigned_diabetic_patients).and_return(diabetes_reports_data[:assigned_patients])
-    allow(repository).to receive(:period_info).and_return(diabetes_reports_data[:period_info])
-    allow(repository).to receive(:monthly_follow_ups).and_return(diabetes_reports_data[:monthly_follow_ups])
+    allow(repository).to receive(:period_info).and_return(period_info)
+    allow(repository).to receive(:monthly_follow_ups).and_return(monthly_follow_ups)
     allow(region).to receive(:slug).and_return("region_slug")
   end
 
@@ -84,5 +97,11 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
   it "renders the Reports::ProgressTotalRegistrationsComponent" do
     expect(subject).to have_text(region.name)
     expect(subject).to have_text("49")
+  end
+
+  it "renders the Reports::ProgressMonthlyFollowUpsComponent" do
+    monthly_follow_ups.values.each do |value|
+      expect(subject).to have_text(value.to_s)
+    end
   end
 end

--- a/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
@@ -42,10 +42,13 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
     }
   end
 
+  let(:last_updated_at) { Time.current }
+
   before do
-    allow(repository).to receive(:cumulative_diabetes_registrations).and_return(total_registrations)
+    allow(repository).to receive(:cumulative_diabetes_registrations).and_return(diabetes_reports_data[:total_registrations])
     allow(repository).to receive(:cumulative_assigned_diabetic_patients).and_return(diabetes_reports_data[:assigned_patients])
-    allow(repository).to receive(:period_info).and_return(period_info)
+    allow(repository).to receive(:period_info).and_return(diabetes_reports_data[:period_info])
+    allow(repository).to receive(:monthly_follow_ups).and_return(diabetes_reports_data[:monthly_follow_ups])
     allow(region).to receive(:slug).and_return("region_slug")
   end
 

--- a/spec/components/reports/progress_monthly_follow_ups_component_spec.rb
+++ b/spec/components/reports/progress_monthly_follow_ups_component_spec.rb
@@ -1,0 +1,103 @@
+require "rails_helper"
+
+RSpec.describe Reports::ProgressMonthlyFollowUpsComponent, type: :component do
+  let(:region) { double("Region", name: "Region 1") }
+  let(:diagnosis) { "Diabetes" }
+  let(:period_info) do
+    {
+      Period.new(type: :month, value: "2024-06-01") => {name: "Jun-2024", ltfu_since_date: "30-Jun-2023"},
+      Period.new(type: :month, value: "2024-07-01") => {name: "Jul-2024", ltfu_since_date: "31-Jul-2023"},
+      Period.new(type: :month, value: "2024-08-01") => {name: "Aug-2024", ltfu_since_date: "31-Aug-2023"},
+      Period.new(type: :month, value: "2024-09-01") => {name: "Sep-2024", ltfu_since_date: "30-Sep-2023"},
+      Period.new(type: :month, value: "2024-10-01") => {name: "Oct-2024", ltfu_since_date: "31-Oct-2023"},
+      Period.new(type: :month, value: "2024-11-01") => {name: "Nov-2024", ltfu_since_date: "30-Nov-2023"}
+    }
+  end
+  let(:monthly_follow_ups) do
+    {
+      Period.new(type: :month, value: "2024-06-01") => 5,
+      Period.new(type: :month, value: "2024-07-01") => 4,
+      Period.new(type: :month, value: "2024-08-01") => 3,
+      Period.new(type: :month, value: "2024-09-01") => 4,
+      Period.new(type: :month, value: "2024-10-01") => 11,
+      Period.new(type: :month, value: "2024-11-01") => 2
+    }
+  end
+
+  subject do
+    render_inline(described_class.new(
+      monthly_follow_ups: monthly_follow_ups,
+      period_info: period_info,
+      region: region,
+      diagnosis: diagnosis
+    ))
+  end
+
+  describe "rendering the component" do
+    it "renders the title correctly" do
+      expect(subject).to have_css("h2", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.title"))
+    end
+
+    it "renders the subtitle with correct facility name and diagnosis" do
+      expect(subject).to have_selector("p", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle", facility_name: region.name, diagnosis: diagnosis))
+    end
+
+    it "displays the correct number of total registrations" do
+      total_values = monthly_follow_ups.values
+      total_values.each do |value|
+        expect(subject).to have_text(value.to_s)
+      end
+    end
+
+    it "passes the correct data to the data bar graph partial" do
+      expect(subject).to have_selector('div[data-graph-type="bar-chart"]')
+      expect(subject).to have_text("5")
+      expect(subject).to have_text("4")
+      expect(subject).to have_text("3")
+      expect(subject).to have_text("4")
+      expect(subject).to have_text("11")
+      expect(subject).to have_text("2")
+      expect(subject).to have_text("Jun-2024")
+      expect(subject).to have_text("Jul-2024")
+      expect(subject).to have_text("Aug-2024")
+      expect(subject).to have_text("Sep-2024")
+      expect(subject).to have_text("Oct-2024")
+      expect(subject).to have_text("Nov-2024")
+    end
+  end
+
+  describe "when diagnosis is not passed" do
+    it 'defaults to "Hypertension" as diagnosis' do
+      component = render_inline(described_class.new(
+        monthly_follow_ups: monthly_follow_ups,
+        period_info: period_info,
+        region: region
+      ))
+      expect(component).to have_selector("p", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle", facility_name: region.name, diagnosis: "Hypertension"))
+    end
+  end
+
+  describe "handling empty data" do
+    let(:empty_data) { {} }
+
+    it "renders nothing if monthly_follow_ups is empty" do
+      component_with_empty_data = render_inline(described_class.new(
+        monthly_follow_ups: empty_data,
+        period_info: period_info,
+        region: region,
+        diagnosis: diagnosis
+      ))
+      expect(component_with_empty_data).to have_no_text("monthly_follow_ups")
+    end
+
+    it "renders nothing if period_info is empty" do
+      component_with_empty_period_info = render_inline(described_class.new(
+        monthly_follow_ups: monthly_follow_ups,
+        period_info: empty_data,
+        region: region,
+        diagnosis: diagnosis
+      ))
+      expect(component_with_empty_period_info).to have_no_text("period_info")
+    end
+  end
+end

--- a/spec/components/reports/progress_monthly_follow_ups_component_spec.rb
+++ b/spec/components/reports/progress_monthly_follow_ups_component_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe Reports::ProgressMonthlyFollowUpsComponent, type: :component do
 
   let(:period_info_data) do
     {
-      "2024-06-01" => { name: "Jun-2024", ltfu_since_date: "30-Jun-2023" },
-      "2024-07-01" => { name: "Jul-2024", ltfu_since_date: "31-Jul-2023" },
-      "2024-08-01" => { name: "Aug-2024", ltfu_since_date: "31-Aug-2023" },
-      "2024-09-01" => { name: "Sep-2024", ltfu_since_date: "30-Sep-2023" },
-      "2024-10-01" => { name: "Oct-2024", ltfu_since_date: "31-Oct-2023" },
-      "2024-11-01" => { name: "Nov-2024", ltfu_since_date: "30-Nov-2023" }
+      "2024-06-01" => {name: "Jun-2024", ltfu_since_date: "30-Jun-2023"},
+      "2024-07-01" => {name: "Jul-2024", ltfu_since_date: "31-Jul-2023"},
+      "2024-08-01" => {name: "Aug-2024", ltfu_since_date: "31-Aug-2023"},
+      "2024-09-01" => {name: "Sep-2024", ltfu_since_date: "30-Sep-2023"},
+      "2024-10-01" => {name: "Oct-2024", ltfu_since_date: "31-Oct-2023"},
+      "2024-11-01" => {name: "Nov-2024", ltfu_since_date: "30-Nov-2023"}
     }
   end
 

--- a/spec/components/reports/progress_monthly_follow_ups_component_spec.rb
+++ b/spec/components/reports/progress_monthly_follow_ups_component_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Reports::ProgressMonthlyFollowUpsComponent, type: :component do
     (6..11).each_with_object({}) do |month, hash|
       date = Date.new(2024, month, 1).beginning_of_month
       date_str = date.to_s
-      ltfu_since_date = date.prev_month.end_of_month.strftime('%d-%b-%Y')
-      name = date.strftime('%b-%Y')
-      hash[date_str] = { name: name, ltfu_since_date: ltfu_since_date }
+      ltfu_since_date = date.prev_month.end_of_month.strftime("%d-%b-%Y")
+      name = date.strftime("%b-%Y")
+      hash[date_str] = {name: name, ltfu_since_date: ltfu_since_date}
     end
   end
 

--- a/spec/components/reports/progress_monthly_follow_ups_component_spec.rb
+++ b/spec/components/reports/progress_monthly_follow_ups_component_spec.rb
@@ -5,14 +5,13 @@ RSpec.describe Reports::ProgressMonthlyFollowUpsComponent, type: :component do
   let(:diagnosis) { "Diabetes" }
 
   let(:period_info_data) do
-    {
-      "2024-06-01" => {name: "Jun-2024", ltfu_since_date: "30-Jun-2023"},
-      "2024-07-01" => {name: "Jul-2024", ltfu_since_date: "31-Jul-2023"},
-      "2024-08-01" => {name: "Aug-2024", ltfu_since_date: "31-Aug-2023"},
-      "2024-09-01" => {name: "Sep-2024", ltfu_since_date: "30-Sep-2023"},
-      "2024-10-01" => {name: "Oct-2024", ltfu_since_date: "31-Oct-2023"},
-      "2024-11-01" => {name: "Nov-2024", ltfu_since_date: "30-Nov-2023"}
-    }
+    (6..11).each_with_object({}) do |month, hash|
+      date = Date.new(2024, month, 1).beginning_of_month
+      date_str = date.to_s
+      ltfu_since_date = date.prev_month.end_of_month.strftime('%d-%b-%Y')
+      name = date.strftime('%b-%Y')
+      hash[date_str] = { name: name, ltfu_since_date: ltfu_since_date }
+    end
   end
 
   let(:period_info) do

--- a/spec/components/reports/progress_monthly_follow_ups_component_spec.rb
+++ b/spec/components/reports/progress_monthly_follow_ups_component_spec.rb
@@ -3,28 +3,38 @@ require "rails_helper"
 RSpec.describe Reports::ProgressMonthlyFollowUpsComponent, type: :component do
   let(:region) { double("Region", name: "Region 1") }
   let(:diagnosis) { "Diabetes" }
-  let(:period_info) do
+
+  let(:period_info_data) do
     {
-      Period.new(type: :month, value: "2024-06-01") => {name: "Jun-2024", ltfu_since_date: "30-Jun-2023"},
-      Period.new(type: :month, value: "2024-07-01") => {name: "Jul-2024", ltfu_since_date: "31-Jul-2023"},
-      Period.new(type: :month, value: "2024-08-01") => {name: "Aug-2024", ltfu_since_date: "31-Aug-2023"},
-      Period.new(type: :month, value: "2024-09-01") => {name: "Sep-2024", ltfu_since_date: "30-Sep-2023"},
-      Period.new(type: :month, value: "2024-10-01") => {name: "Oct-2024", ltfu_since_date: "31-Oct-2023"},
-      Period.new(type: :month, value: "2024-11-01") => {name: "Nov-2024", ltfu_since_date: "30-Nov-2023"}
-    }
-  end
-  let(:monthly_follow_ups) do
-    {
-      Period.new(type: :month, value: "2024-06-01") => 5,
-      Period.new(type: :month, value: "2024-07-01") => 4,
-      Period.new(type: :month, value: "2024-08-01") => 3,
-      Period.new(type: :month, value: "2024-09-01") => 4,
-      Period.new(type: :month, value: "2024-10-01") => 11,
-      Period.new(type: :month, value: "2024-11-01") => 2
+      "2024-06-01" => { name: "Jun-2024", ltfu_since_date: "30-Jun-2023" },
+      "2024-07-01" => { name: "Jul-2024", ltfu_since_date: "31-Jul-2023" },
+      "2024-08-01" => { name: "Aug-2024", ltfu_since_date: "31-Aug-2023" },
+      "2024-09-01" => { name: "Sep-2024", ltfu_since_date: "30-Sep-2023" },
+      "2024-10-01" => { name: "Oct-2024", ltfu_since_date: "31-Oct-2023" },
+      "2024-11-01" => { name: "Nov-2024", ltfu_since_date: "30-Nov-2023" }
     }
   end
 
-  subject do
+  let(:period_info) do
+    period_info_data.map { |date_str, data| [Period.new(type: :month, value: date_str), data] }.to_h
+  end
+
+  let(:monthly_follow_ups_data) do
+    {
+      "2024-06-01" => 5,
+      "2024-07-01" => 4,
+      "2024-08-01" => 3,
+      "2024-09-01" => 4,
+      "2024-10-01" => 11,
+      "2024-11-01" => 2
+    }
+  end
+
+  let(:monthly_follow_ups) do
+    monthly_follow_ups_data.map { |date_str, value| [Period.new(type: :month, value: date_str), value] }.to_h
+  end
+
+  let(:rendered_component) do
     render_inline(described_class.new(
       monthly_follow_ups: monthly_follow_ups,
       period_info: period_info,
@@ -35,69 +45,58 @@ RSpec.describe Reports::ProgressMonthlyFollowUpsComponent, type: :component do
 
   describe "rendering the component" do
     it "renders the title correctly" do
-      expect(subject).to have_css("h2", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.title"))
+      expect(rendered_component).to have_css("h2", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.title"))
     end
 
     it "renders the subtitle with correct facility name and diagnosis" do
-      expect(subject).to have_selector("p", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle", facility_name: region.name, diagnosis: diagnosis))
+      expect(rendered_component).to have_selector("p", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle", facility_name: region.name, diagnosis: diagnosis))
     end
 
     it "displays the correct number of total registrations" do
-      total_values = monthly_follow_ups.values
-      total_values.each do |value|
-        expect(subject).to have_text(value.to_s)
+      monthly_follow_ups_data.values.each do |value|
+        expect(rendered_component).to have_text(value.to_s)
       end
     end
 
     it "passes the correct data to the data bar graph partial" do
-      expect(subject).to have_selector('div[data-graph-type="bar-chart"]')
-      expect(subject).to have_text("5")
-      expect(subject).to have_text("4")
-      expect(subject).to have_text("3")
-      expect(subject).to have_text("4")
-      expect(subject).to have_text("11")
-      expect(subject).to have_text("2")
-      expect(subject).to have_text("Jun-2024")
-      expect(subject).to have_text("Jul-2024")
-      expect(subject).to have_text("Aug-2024")
-      expect(subject).to have_text("Sep-2024")
-      expect(subject).to have_text("Oct-2024")
-      expect(subject).to have_text("Nov-2024")
+      expect(rendered_component).to have_selector('div[data-graph-type="bar-chart"]')
+      monthly_follow_ups_data.keys.each do |date_str|
+        expect(rendered_component).to have_text(period_info_data[date_str][:name])
+      end
+      monthly_follow_ups_data.values.each { |value| expect(rendered_component).to have_text(value.to_s) }
     end
   end
 
   describe "when diagnosis is not passed" do
-    it 'defaults to "Hypertension" as diagnosis' do
-      component = render_inline(described_class.new(
+    let(:component_without_diagnosis) do
+      render_inline(described_class.new(
         monthly_follow_ups: monthly_follow_ups,
         period_info: period_info,
         region: region
       ))
-      expect(component).to have_selector("p", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle", facility_name: region.name, diagnosis: "Hypertension"))
+    end
+
+    it 'defaults to "Hypertension" as diagnosis' do
+      expect(component_without_diagnosis).to have_selector("p", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle", facility_name: region.name, diagnosis: "Hypertension"))
     end
   end
 
   describe "handling empty data" do
     let(:empty_data) { {} }
 
-    it "renders nothing if monthly_follow_ups is empty" do
-      component_with_empty_data = render_inline(described_class.new(
-        monthly_follow_ups: empty_data,
-        period_info: period_info,
-        region: region,
-        diagnosis: diagnosis
-      ))
-      expect(component_with_empty_data).to have_no_text("monthly_follow_ups")
+    shared_examples "renders nothing if empty" do |data_key|
+      it "renders nothing if #{data_key} is empty" do
+        component_with_empty_data = render_inline(described_class.new(
+          monthly_follow_ups: data_key == :monthly_follow_ups ? empty_data : monthly_follow_ups,
+          period_info: data_key == :period_info ? empty_data : period_info,
+          region: region,
+          diagnosis: diagnosis
+        ))
+        expect(component_with_empty_data).to have_no_text(data_key.to_s)
+      end
     end
 
-    it "renders nothing if period_info is empty" do
-      component_with_empty_period_info = render_inline(described_class.new(
-        monthly_follow_ups: monthly_follow_ups,
-        period_info: empty_data,
-        region: region,
-        diagnosis: diagnosis
-      ))
-      expect(component_with_empty_period_info).to have_no_text("period_info")
-    end
+    include_examples "renders nothing if empty", :monthly_follow_ups
+    include_examples "renders nothing if empty", :period_info
   end
 end

--- a/spec/components/reports/progress_total_registrations_component_spec.rb
+++ b/spec/components/reports/progress_total_registrations_component_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Reports::ProgressTotalRegistrationsComponent, type: :component do
 
   it "passes the correct data to the data bar graph partial" do
     expect(subject).to have_selector('div[data-graph-type="bar-chart"]')
+
     expectations = [
       "42", "44", "49", "56", "61", "62",
       "Jun-2024", "Jul-2024", "Aug-2024", "Sep-2024", "Oct-2024", "Nov-2024"

--- a/spec/components/reports/progress_total_registrations_component_spec.rb
+++ b/spec/components/reports/progress_total_registrations_component_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe Reports::ProgressTotalRegistrationsComponent, type: :component do
 
   it "passes the correct data to the data bar graph partial" do
     expect(subject).to have_selector('div[data-graph-type="bar-chart"]')
-
     expectations = [
       "42", "44", "49", "56", "61", "62",
       "Jun-2024", "Jul-2024", "Aug-2024", "Sep-2024", "Oct-2024", "Nov-2024"


### PR DESCRIPTION
**Story card:** [sc-14111] (https://app.shortcut.com/simpledotorg/story/14111/add-monthly-follow-up-patients)

## Because

To add 1 more section i.e. Monthly follow-up patients

## This addresses

In this PR we will add 1 more section Monthly follow-up patients (4th section from figma).
It will be shown something like this: 

<img width="1512" alt="Screenshot 2024-11-18 at 4 31 39 PM" src="https://github.com/user-attachments/assets/c2ec9ad8-8135-4b7c-86fa-a039b9a3f08d">


## Test instructions

Enable this flipper flag :diabetes_progress_report_tab to check the functionality.