### PR TITLE
[WIP] Refreshable: set local work_mem for before refresh

### DIFF
--- a/app/models/reports/refreshable.rb
+++ b/app/models/reports/refreshable.rb
@@ -6,11 +6,19 @@ module Reports
     def refresh(transaction: true)
       return refresh_view unless transaction
       ActiveRecord::Base.transaction do
+        set_work_mem if Flipper.enabled?(:optimize_work_mem)
         refresh_view
       end
     end
 
     private
+
+    def set_work_mem
+      work_mem = ENV.fetch("REFRESH_WORK_MEM", nil)
+      return Rails.logger.warn("REFRESH_WORK_MEM is not set, falling back to default value") if work_mem.nil?
+
+      ActiveRecord::Base.connection.execute("SET LOCAL work_mem TO '#{work_mem}'")
+    end
 
     def refresh_view
       ActiveRecord::Base.connection.execute("SET LOCAL TIME ZONE '#{Period::REPORTING_TIME_ZONE}'")

--- a/doc/wiki/feature-flags.md
+++ b/doc/wiki/feature-flags.md
@@ -38,3 +38,4 @@ to facility the launch of a new feature, and may reference the Simple team's int
 | patients_protected_htn_cascade            | Yes                          | To selectively launch the HTN cascade subsection of the [patients protected](https://app.shortcut.com/simpledotorg/epic/11405) feature on the HTN dashboard.
 | diabetes_who_standard_indicator           | Yes                          | When enabled, only FBS and HBA1c measurements are considered for calculating diabetes controlled and uncontrolled rate
 | diabetes_progress_report_tab              | Yes                          | When the progress tab is activated, the diabetes section will be displayed as enabled, followed by a comprehensive listing of all associated key indicators.
+| optimize_work_mem                         | Yes                          | When enabled, the work_mem setting will be set to the value of the REFRESH_WORK_MEM environment variable for materialized views refreshes.

--- a/spec/models/reports/refreshable_spec.rb
+++ b/spec/models/reports/refreshable_spec.rb
@@ -31,5 +31,23 @@ RSpec.describe Reports::Refreshable do
       expect(Scenic.database).to receive(:refresh_materialized_view).with("fake_mat_view", concurrently: false, cascade: false)
       Reports::FakeMatView.refresh
     end
+
+    it "sets work mem when the env var is set and the Flipper flag is enabled" do
+      Flipper.enable(:optimize_work_mem)
+      ENV["REFRESH_WORK_MEM"] = "1GB"
+      allow(Scenic.database).to receive(:refresh_materialized_view).with("fake_mat_view", concurrently: true, cascade: false)
+
+      Reports::FakeMatView.refresh
+      expect(ActiveRecord::Base.connection.execute("SHOW work_mem").first["work_mem"]).to eq("1GB")
+    end
+
+    it "does not set work mem when the env var is not set" do
+      Flipper.enable(:optimize_work_mem)
+      ENV.delete("REFRESH_WORK_MEM")
+      allow(Scenic.database).to receive(:refresh_materialized_view).with("fake_mat_view", concurrently: true, cascade: false)
+
+      expect(ActiveRecord::Base.connection).not_to receive(:execute).with("SET LOCAL work_mem TO '1GB'")
+      Reports::FakeMatView.refresh
+    end
   end
 end


### PR DESCRIPTION
This is an optimization to speed up our matviews. The `work_mem` will be set to a value configured in our environment variables.

For more on this optimisation, read [this doc](https://docs.google.com/document/d/1uqJIggt7RmnP069-GfEHHI3WYmvNkR3gd4c5inhTL0s/edit?tab=t.0)

**Story card:** [sc-XXXX](URL)

## Because

Enter the reason for raising this PR...

## This addresses

Enter the details of what all this covers...

## Test instructions

Enter detailed instructions for how to test this PR...