### PR TITLE
Actually allow disabling Datadog

### DIFF
--- a/config/initializers/00_datadog.rb
+++ b/config/initializers/00_datadog.rb
@@ -4,7 +4,7 @@ require "datadog/statsd"
 
 # Allow running via an ENV var (for development usage, for example) ...otherwise
 # exclude some envs by default
-DATADOG_ENABLED = ENV["DATADOG_ENABLED"] || !(Rails.env.development? || Rails.env.test? || Rails.env.profiling? || SimpleServer.env.review? || SimpleServer.env.android_review?)
+DATADOG_ENABLED = ActiveModel::Type::Boolean.new.cast(ENV["DATADOG_ENABLED"]) || !(Rails.env.development? || Rails.env.test? || Rails.env.profiling? || SimpleServer.env.review? || SimpleServer.env.android_review?)
 
 Datadog.configure do |c|
   c.tracing.enabled = DATADOG_ENABLED


### PR DESCRIPTION
It is impossible to disable Datadog because we don't coerce the environment variable that toggles Datadog to boolean. This change coerces the value into a Boolean.

This bug has led to a lot of log noise in environments where Datadog is disabled because of the server attempting to connect to a Datadog instances that do not exist.

"false" is true. And `nil` is short-circuited by the OR operator.