### PR TITLE
Sc 14137 Added Missed Visit Section to DM progress Tab

### DIFF
--- a/app/components/progress_tab/diabetes/diagnosis_report_component.html.erb
+++ b/app/components/progress_tab/diabetes/diagnosis_report_component.html.erb
@@ -37,4 +37,11 @@
     region: diabetes_reports_data[:region],
     diagnosis: "Diabetes"
   )) %>
+  <%= render(ProgressTab::Diabetes::MissedVisitsComponent.new(
+    missed_visits_rates: diabetes_reports_data[:missed_visits_rates],
+    missed_visits: diabetes_reports_data[:missed_visits],
+    adjusted_patients: diabetes_reports_data[:adjusted_patients],
+    period_info: diabetes_reports_data[:period_info],
+    region: diabetes_reports_data[:region]
+  )) %>
 </div>

--- a/app/components/progress_tab/diabetes/missed_visits_component.html.erb
+++ b/app/components/progress_tab/diabetes/missed_visits_component.html.erb
@@ -1,0 +1,49 @@
+<div class="mb-8px p-16px bgc-white bs-card">
+  <div class="p-relative d-flex ai-center mb-8px" data-element-type="header">
+    <div class="d-flex ai-center" data-element-type="header-title">
+      <h2 class="m-0px mr-8px p-0px ta-left fw-medium fs-18px c-black pe-none">
+        <%= t("progress_tab.diagnosis_report.diagnosis_thresholds.missed_visits_short") %>
+      </h2>
+      <div class="d-flex ai-center w-16px h-16px pe-none" data-element-type="help-circle">
+        <%= inline_file("help-circle.svg") %>
+      </div>
+    </div>
+    <div
+      class="o-0 pe-none p-absolute l-0 zi-100 d-flex fd-column w-100 bs-tooltip ttf-ease-in-out td-0_25s tp-opacity" 
+      data-element-type="tooltip"
+    >
+      <div class="p-8px bgc-black br-4px">
+        <% missed_visits_threshold_long = t("progress_tab.diagnosis_report.diagnosis_thresholds.missed_visits_long") %>
+        <p class="m-0px mb-4px p-0px ta-left fw-regular fs-14px lh-150 c-white">
+          <span class="fw-bold">Numerator:</span> <%= t("progress_tab.diagnosis_report.patient_treatment_outcomes.missed_visits_card.help_tooltip.numerator", diagnosis: "Diabetes") %>
+        </p>
+        <p class="m-0px p-0px ta-left fw-regular fs-14px lh-150 c-white">
+          <span class="fw-bold">Denominator:</span> <%= t("progress_tab.diagnosis_report.patient_treatment_outcomes.missed_visits_card.help_tooltip.denominator", facility_name: @region.name, diagnosis: "Diabetes") %>
+        </p>
+      </div>
+      <div
+        class="p-absolute b--8px w-0px h-0px br-8px-transparent bl-8px-transparent bt-8px-black"
+        data-element-type="tip"
+      >
+      </div>
+    </div>
+  </div>
+  <% missed_visits_threshold_subtitle = t("progress_tab.diagnosis_report.diagnosis_thresholds.missed_visits_long") %>
+  <p class="m-0px mb-24px p-0px ta-left fw-normal fs-16px lh-150 c-grey-dark">
+    <%= t("progress_tab.diagnosis_report.patient_treatment_outcomes.missed_visits_card.subtitle", facility_name: @region.name, diagnosis: "Diabetes") %>
+  </p>
+  <% missed_visits_tooltip_threshold = t("progress_tab.diagnosis_report.diagnosis_thresholds.missed_visits_long") %>
+  <%= render partial: "api/v3/analytics/user_analytics/data_bar_graph",
+             locals: {
+               data: {
+                 "numerators" => missed_visits.values.last(6),
+                 "denominators" => adjusted_patients.values.last(6),
+                 "rates" => missed_visits_rates.values.last(6),
+                 "period_info" => period_info.values.last(6)
+               },
+               data_type: "percentage",
+               graph_css_color: "bgc-red-dark-new",
+               show_tooltip: true,
+               threshold: missed_visits_tooltip_threshold }
+  %>
+</div>

--- a/app/components/progress_tab/diabetes/missed_visits_component.rb
+++ b/app/components/progress_tab/diabetes/missed_visits_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ProgressTab::Diabetes::MissedVisitsComponent < ApplicationComponent
+  include AssetsHelper
+  # include ActionView::Helpers::NumberHelper
+
+  attr_reader :missed_visits_rates, :missed_visits, :adjusted_patients, :period_info, :region
+
+  def initialize(missed_visits_rates:, missed_visits:, adjusted_patients:, period_info:, region:)
+    @missed_visits_rates = missed_visits_rates
+    @missed_visits = missed_visits
+    @adjusted_patients = adjusted_patients
+    @period_info = period_info
+    @region = region
+  end
+end

--- a/app/components/progress_tab/diabetes/missed_visits_component.rb
+++ b/app/components/progress_tab/diabetes/missed_visits_component.rb
@@ -2,8 +2,6 @@
 
 class ProgressTab::Diabetes::MissedVisitsComponent < ApplicationComponent
   include AssetsHelper
-  # include ActionView::Helpers::NumberHelper
-
   attr_reader :missed_visits_rates, :missed_visits, :adjusted_patients, :period_info, :region
 
   def initialize(missed_visits_rates:, missed_visits:, adjusted_patients:, period_info:, region:)

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -90,10 +90,14 @@ module Reports
 
     def diabetes_reports_data
       {
+
         monthly_follow_ups: repository.diabetes_follow_ups[@region.slug],
         total_registrations: repository.cumulative_diabetes_registrations[@region.slug],
         assigned_patients: repository.cumulative_assigned_diabetic_patients[@region.slug][@period],
         period_info: repository.period_info(@region),
+        missed_visits_rates: repository.diabetes_missed_visits_rates[@region.slug],
+        missed_visits: repository.diabetes_missed_visits[@region.slug],
+        adjusted_patients: repository.adjusted_diabetes_patients[@region.slug],
         region: @region
       }
     end

--- a/app/services/reports/facility_progress_service.rb
+++ b/app/services/reports/facility_progress_service.rb
@@ -90,7 +90,6 @@ module Reports
 
     def diabetes_reports_data
       {
-
         monthly_follow_ups: repository.diabetes_follow_ups[@region.slug],
         total_registrations: repository.cumulative_diabetes_registrations[@region.slug],
         assigned_patients: repository.cumulative_assigned_diabetic_patients[@region.slug][@period],

--- a/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
@@ -44,6 +44,42 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
     monthly_follow_ups_data.map { |date_str, value| [Period.new(type: :month, value: date_str), value] }.to_h
   end
 
+  let(:missed_visits_data) do
+    {
+      "2024-06-01" => 10,
+      "2024-07-01" => 12,
+      "2024-08-01" => 15
+    }
+  end
+
+  let(:missed_visits) do
+    missed_visits_data.map { |date_str, value| [Period.new(type: :month, value: date_str), value] }.to_h
+  end
+
+  let(:missed_visits_rates_data) do
+    {
+      "2024-06-01" => 0.5,
+      "2024-07-01" => 0.55,
+      "2024-08-01" => 0.6
+    }
+  end
+
+  let(:missed_visits_rates) do
+    missed_visits_rates_data.map { |date_str, value| [Period.new(type: :month, value: date_str), value] }.to_h
+  end
+
+  let(:adjusted_patients_data) do
+    {
+      "2024-06-01" => 120,
+      "2024-07-01" => 130,
+      "2024-08-01" => 140
+    }
+  end
+
+  let(:adjusted_patients) do
+    adjusted_patients_data.map { |date_str, value| [Period.new(type: :month, value: date_str), value] }.to_h
+  end
+
   let(:diabetes_reports_data) do
     {
       total_registrations: total_registrations,
@@ -51,6 +87,9 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
       region: region,
       assigned_patients: 100,
       monthly_follow_ups: monthly_follow_ups,
+      missed_visits: missed_visits,
+      missed_visits_rates: missed_visits_rates,
+      adjusted_patients: adjusted_patients,
       diagnosis: "diabetes"
     }
   end
@@ -60,6 +99,9 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
     allow(repository).to receive(:cumulative_assigned_diabetic_patients).and_return(diabetes_reports_data[:assigned_patients])
     allow(repository).to receive(:period_info).and_return(period_info)
     allow(repository).to receive(:monthly_follow_ups).and_return(monthly_follow_ups)
+    allow(repository).to receive(:missed_visits).and_return(missed_visits)
+    allow(repository).to receive(:missed_visits_rates).and_return(missed_visits_rates)
+    allow(repository).to receive(:adjusted_patients).and_return(diabetes_reports_data[:adjusted_patients])
     allow(region).to receive(:slug).and_return("region_slug")
   end
 
@@ -99,6 +141,12 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
 
   it "renders the Reports::ProgressMonthlyFollowUpsComponent" do
     monthly_follow_ups.values.each do |value|
+      expect(subject).to have_text(value.to_s)
+    end
+  end
+
+  it "renders the missed visits data correctly" do
+    missed_visits.values.each do |value|
       expect(subject).to have_text(value.to_s)
     end
   end

--- a/spec/components/progress_tab/diabetes/missed_visits_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/missed_visits_component_spec.rb
@@ -1,0 +1,109 @@
+# spec/components/progress_tab/diabetes/missed_visits_component_spec.rb
+require "rails_helper"
+
+RSpec.describe ProgressTab::Diabetes::MissedVisitsComponent, type: :component do
+  let(:region) { double("Region", name: "Region 1") }
+  let(:missed_visits_data) do
+    {
+      "2024-06-01" => 10,
+      "2024-07-01" => 12,
+      "2024-08-01" => 15
+    }
+  end
+  let(:adjusted_patients_data) do
+    {
+      "2024-06-01" => 120,
+      "2024-07-01" => 130,
+      "2024-08-01" => 140
+    }
+  end
+  let(:missed_visits_rates_data) do
+    {
+      "2024-06-01" => 0.5,
+      "2024-07-01" => 0.55,
+      "2024-08-01" => 0.6
+    }
+  end
+  let(:period_info_data) do
+    {
+      "2024-06-01" => {name: "Jun-2024"},
+      "2024-07-01" => {name: "Jul-2024"},
+      "2024-08-01" => {name: "Aug-2024"}
+    }
+  end
+
+  let(:missed_visits) do
+    missed_visits_data.map { |date_str, value| [Period.new(type: :month, value: date_str), value] }.to_h
+  end
+
+  let(:adjusted_patients) do
+    adjusted_patients_data.map { |date_str, value| [Period.new(type: :month, value: date_str), value] }.to_h
+  end
+
+  let(:missed_visits_rates) do
+    missed_visits_rates_data.map { |date_str, value| [Period.new(type: :month, value: date_str), value] }.to_h
+  end
+
+  let(:period_info) do
+    period_info_data.map { |date_str, value| [Period.new(type: :month, value: date_str), value] }.to_h
+  end
+
+  let(:missed_visits_report_data) do
+    {
+      missed_visits_rates: missed_visits_rates,
+      missed_visits: missed_visits,
+      adjusted_patients: adjusted_patients,
+      period_info: period_info,
+      region: region
+    }
+  end
+
+  subject do
+    render_inline(described_class.new(
+      missed_visits_rates: missed_visits_rates,
+      missed_visits: missed_visits,
+      adjusted_patients: adjusted_patients,
+      period_info: period_info,
+      region: region
+    ))
+  end
+
+  it "renders the missed visits section" do
+    expect(subject).to have_css("div.mb-8px.p-16px.bgc-white.bs-card")
+  end
+
+  it "renders the title correctly" do
+    expect(subject).to have_text("Missed visits")
+  end
+
+  it "displays the region name" do
+    expect(subject).to have_text(region.name)
+  end
+
+  it "renders the help circle and tooltip correctly" do
+    expect(subject).to have_css("div[data-element-type='help-circle']")
+    expect(subject).to have_css("div[data-element-type='tooltip']")
+  end
+
+  it "renders the bar graph with the correct data" do
+    expect(subject).to have_css("div[data-element-type='bar']")
+  end
+
+  it "displays the missed visits data correctly" do
+    missed_visits_data.each do |date, value|
+      expect(subject).to have_text(value.to_s)
+    end
+  end
+
+  it "displays the adjusted patients data correctly" do
+    adjusted_patients_data.each do |date, value|
+      expect(subject).to have_text(value.to_s)
+    end
+  end
+
+  it "displays the missed visits rates correctly" do
+    missed_visits_rates_data.each do |date, value|
+      expect(subject).to have_text(value.to_s)
+    end
+  end
+end

--- a/spec/services/reports/facility_progress_service_spec.rb
+++ b/spec/services/reports/facility_progress_service_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Reports::FacilityProgressService, type: :model do
           Period.month(previous_month) => dm_patients.count,
           Period.month(current_month) => dm_patients.count
         }
-        expect(result).to include(:assigned_patients, :period_info, :region, :total_registrations, :monthly_follow_ups)
+        expect(result).to include(:assigned_patients, :period_info, :region, :total_registrations, :monthly_follow_ups, :missed_visits, :missed_visits_rates, :adjusted_patients)
         expect(result[:assigned_patients]).to eq(dm_patients.count)
         expect(result[:period_info]).to eq(expected_period_info)
         expect(result[:monthly_follow_ups]).to eq(expected_follow_ups)


### PR DESCRIPTION
**Story card:** [sc-14137](https://app.shortcut.com/simpledotorg/story/14137/add-missed-visit-section)

## Because

Need to add missed visit section for progress tab

## This addresses

This section should display the Missed visit % on the bar graph with the months

<img width="1510" alt="Screenshot 2024-11-28 at 11 06 46 AM" src="https://github.com/user-attachments/assets/2213f398-2d2d-473f-912f-249d3b94dfa7">

**Missed Visit Card Tool Tip**
<img width="1512" alt="Screenshot 2024-11-28 at 11 10 26 AM" src="https://github.com/user-attachments/assets/242d4514-d69f-4f91-80b9-948e346e9cd3">

**Missed Visit Chart Tool Tip**
<img width="1512" alt="Screenshot 2024-11-28 at 11 10 44 AM" src="https://github.com/user-attachments/assets/fa56facc-4cfa-40f8-9587-7ec6e163a9d7">

## Test instructions

Enable this flipper flag :diabetes_progress_report_tab to check the functionality.