### PR TITLE
No CSP for review environment

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -5,7 +5,7 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 # See https://app.clubhouse.io/simpledotorg/story/1616/why-do-heroku-deployments-intermittently-fail
-unless SimpleServer.env.review? && Rake.application.top_level_tasks.any? { |task| task.include?("assets") }
+unless SimpleServer.env.review?
   if Rails.env.production?
     Rails.application.config.content_security_policy do |policy|
       policy.default_src(:self, :https)


### PR DESCRIPTION
**Story card:** [sc-13775](https://app.shortcut.com/simpledotorg/story/13775/fix-integration-tests-on-android-ci-checks)

## Because

Review apps don't communicate over HTTPS

## This addresses

Coupling to Heroku

## Test instructions

- Spin up docker image
- Connect to it without SSL
