### PR TITLE
Fix date format in diagnosis component spec

### DIFF
--- a/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/diagnosis_report_component_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe ProgressTab::Diabetes::DiagnosisReportComponent, type: :component
   end
 
   it "displays the last updated date and time" do
-    formatted_date_time = last_updated_at.strftime("%d-%b-%Y at %I:%M %p")
+    formatted_date_time = last_updated_at.strftime("%-d-%b-%Y at %I:%M %p")
     expect(subject).to have_text("Data last updated on #{formatted_date_time}")
   end
 


### PR DESCRIPTION
**Story card:** [sc-14257](https://app.shortcut.com/simpledotorg/story/14257/fix-failure-in-the-diabetes-component-spec)

## Because

Deploying to production is broken with the failing test

## This addresses

Fixing the failing date format for the expectation

## Test instructions

- Existing test suite
