### PR TITLE
Remove capistrano-multiconfig

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,4 +1,3 @@
-require "capistrano/multiconfig"
 require "capistrano/deploy"
 require "capistrano/bundler"
 require "capistrano/rails/console"

--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,6 @@ group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "capistrano", "~> 3.17"
   gem "capistrano-db-tasks", require: false
-  gem "capistrano-multiconfig", require: true
   gem "capistrano-passenger", "0.2.1"
   gem "capistrano-rails"
   gem "capistrano-rails-console", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,8 +109,6 @@ GEM
       capistrano (~> 3.1)
     capistrano-db-tasks (0.6)
       capistrano (>= 3.0.0)
-    capistrano-multiconfig (3.1.0)
-      capistrano (>= 3.7.0)
     capistrano-passenger (0.2.1)
       capistrano (~> 3.0)
     capistrano-rails (1.6.2)
@@ -722,7 +720,6 @@ DEPENDENCIES
   byebug
   capistrano (~> 3.17)
   capistrano-db-tasks
-  capistrano-multiconfig
   capistrano-passenger (= 0.2.1)
   capistrano-rails
   capistrano-rails-console


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

## Because

This breaks for development and test when running with a docker image, is not
used in production (far as I can tell), and is not used when the server is
launched with `rails s`; yet it doesn't work. This impedes the work we're doing
to prepare the server for other components which may need it for CI.

## This addresses

- Failing server setup because of capistrano-multiconfig

## Test instructions

- n/a
