### PR TITLE
Facilities Controller for proper querying

### DIFF
--- a/app/services/facility_service.rb
+++ b/app/services/facility_service.rb
@@ -1,0 +1,13 @@
+class FacilityService
+  def initialize(current_admin)
+    @current_admin = current_admin
+  end
+
+  def facilities_by_district(district)
+    if district == "All"
+      @current_admin.accessible_facilities(:manage)
+    else
+      @current_admin.accessible_facilities(:manage).where(district: district)
+    end
+  end
+end


### PR DESCRIPTION

**Overview**

In the Admin module, the user controller handles both users and facilities. The mixing of concepts is a violation of bounded context. The controller should focus solely on users, and the interaction with facilities should handled separately. The index action retrieves facilities based on the @district variable, selecting all accessible facilities or filtering by the district. It then queries users based on these facilities creating a dependency on users and facilities within the same action.

Regarding aggregate usage, the controller deals with facilities and users that should block different aggregates. Users should not be able to manage facilities directly; these operations should be mediated through application services. The current implementation crosses these boundaries by combining the management of users and facilities in the same controller, which can cause confusion in the domain.

**Creating Facility Service**

Beginning the refactoring, we need a service to handle the admin’s calls for the facilities specifically. This service was added as a class FacilityService within a new facility_service.rb file. 

In the initialization of the service, we use an admin's permissions to initiate the query for the facilities, so the currently logged-in admin is stored as the admin requesting the facilities. 

The function handling the query for the facilities uses the admin’s profile and credentials to query the database for all queries. Depending on the district search term, only facilities within the district will be returned. Searching for district “All” will return all districts.

**Refactor User Controller**

We wanted to make changes to the User Controller so it would no longer violate Domain-Driven Design Principles, which it would handle both users and facilities rather than just users.

To fix this, we needed to add a new before_action and refactor the index method among the public functions in this class. Below is the new before_action and the refactored index method:

The before_action will make a call to set_facility_service, which then allows the Users Controller to begin using the new FacilityService prior to executing the index method. Here is the set_facility_service method the before_action calls and executes before the index method:

With this change, The Users Controller will now only focus on users and has the management of facilities removed and handled by the FacilityService class. This will then separate the bounded contexts as they are supposed to and comply with DDD principles.
