### PR TITLE
Fix: Daily experiments task failing due to method missing from MobitelDeliveryDetails

### DIFF
--- a/app/models/mobitel_delivery_detail.rb
+++ b/app/models/mobitel_delivery_detail.rb
@@ -13,6 +13,10 @@ class MobitelDeliveryDetail < DeliveryDetail
     false
   end
 
+  def result
+    "sent"
+  end
+
   def self.create_with_communication!(message:, recipient_number:)
     ActiveRecord::Base.transaction do
       delivery_detail = create!(

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -847,11 +847,58 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
 
   describe "#notification_result" do
     let(:notification) { create(:notification, status: "sent", communications: [communication]) }
+    let(:communication) { create(:communication, detailable_type: detailable_type, detailable_id: detailable.id) }
 
     subject { described_class.new.send(:notification_result, notification.id) }
-    context "with mobitel as sms vendor" do
+
+    context "with Mobitel as sms vendor" do
       let(:detailable) { create(:mobitel_delivery_detail) }
-      let(:communication) { create(:communication, detailable_type: "MobitelDeliveryDetail", detailable_id: detailable.id) }
+      let(:detailable_type) { "MobitelDeliveryDetail" }
+
+      it "returns successful result" do
+        expect { subject }.not_to raise_error
+        actual_result = subject
+        expect(actual_result[:notification_status]).to eq(notification.status)
+        expect(actual_result[:successful_communication_id]).to eq(communication.id)
+        expect(actual_result[:successful_communication_type]).to eq(communication.communication_type)
+        expect(actual_result[:successful_delivery_status]).to eq(communication.detailable.result)
+        expect(actual_result[:notification_status_updated_at].to_date).to eq(notification.updated_at.to_date)
+      end
+    end
+
+    context "with AlphaSMS as vendor" do
+      let(:detailable) { create(:alpha_sms_delivery_detail, request_status: "Sent") }
+      let(:detailable_type) { "AlphaSmsDeliveryDetail" }
+
+      it "returns successful result" do
+        expect { subject }.not_to raise_error
+        actual_result = subject
+        expect(actual_result[:notification_status]).to eq(notification.status)
+        expect(actual_result[:successful_communication_id]).to eq(communication.id)
+        expect(actual_result[:successful_communication_type]).to eq(communication.communication_type)
+        expect(actual_result[:successful_delivery_status]).to eq(communication.detailable.result)
+        expect(actual_result[:notification_status_updated_at].to_date).to eq(notification.updated_at.to_date)
+      end
+    end
+
+    context "with BSNL as vendor" do
+      let(:detailable) { create(:bsnl_delivery_detail, message_status: "7") }
+      let(:detailable_type) { "BsnlDeliveryDetail" }
+
+      it "returns successful result" do
+        expect { subject }.not_to raise_error
+        actual_result = subject
+        expect(actual_result[:notification_status]).to eq(notification.status)
+        expect(actual_result[:successful_communication_id]).to eq(communication.id)
+        expect(actual_result[:successful_communication_type]).to eq(communication.communication_type)
+        expect(actual_result[:successful_delivery_status]).to eq(communication.detailable.result)
+        expect(actual_result[:notification_status_updated_at].to_date).to eq(notification.updated_at.to_date)
+      end
+    end
+
+   context "with Twilio as vendor" do
+      let(:detailable) { create(:twilio_sms_delivery_detail, result: "sent") }
+      let(:detailable_type) { "TwilioSmsDeliveryDetail" }
 
       it "returns successful result" do
         expect { subject }.not_to raise_error

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -844,4 +844,28 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
       described_class.first.monitor
     end
   end
+
+  describe "#notification_result" do
+    let(:notification) { create(:notification, status: "sent", communications: [communication]) }
+
+    subject { described_class.new.send(:notification_result, notification.id) }
+    context "with mobitel as sms vendor" do
+      let(:detailable) { create(:mobitel_delivery_detail) }
+      let(:communication) { create(:communication, detailable_type: "MobitelDeliveryDetail", detailable_id: detailable.id) }
+      
+      it "returns successful result" do
+        expected_result = {
+          notification_status: notification.status,
+          notification_status_updated_at: notification.updated_at,
+          result: :success,
+          successful_communication_id: communication.id,
+          successful_communication_type: communication.communication_type,
+          successful_communication_created_at: communication.created_at.to_s,
+          successful_delivery_status: communication.detailable.result
+        }
+        expect { subject }.not_to raise_error
+        expect(subject).to eq(expected_result)
+      end
+    end
+  end
 end

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -852,19 +852,15 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
     context "with mobitel as sms vendor" do
       let(:detailable) { create(:mobitel_delivery_detail) }
       let(:communication) { create(:communication, detailable_type: "MobitelDeliveryDetail", detailable_id: detailable.id) }
-      
+
       it "returns successful result" do
-        expected_result = {
-          notification_status: notification.status,
-          notification_status_updated_at: notification.updated_at,
-          result: :success,
-          successful_communication_id: communication.id,
-          successful_communication_type: communication.communication_type,
-          successful_communication_created_at: communication.created_at.to_s,
-          successful_delivery_status: communication.detailable.result
-        }
         expect { subject }.not_to raise_error
-        expect(subject).to eq(expected_result)
+        actual_result = subject
+        expect(actual_result[:notification_status]).to eq(notification.status)
+        expect(actual_result[:successful_communication_id]).to eq(communication.id)
+        expect(actual_result[:successful_communication_type]).to eq(communication.communication_type)
+        expect(actual_result[:successful_delivery_status]).to eq(communication.detailable.result)
+        expect(actual_result[:notification_status_updated_at].to_date).to eq(notification.updated_at.to_date)
       end
     end
   end

--- a/spec/models/experimentation/notifications_experiment_spec.rb
+++ b/spec/models/experimentation/notifications_experiment_spec.rb
@@ -896,7 +896,7 @@ RSpec.describe Experimentation::NotificationsExperiment, type: :model do
       end
     end
 
-   context "with Twilio as vendor" do
+    context "with Twilio as vendor" do
       let(:detailable) { create(:twilio_sms_delivery_detail, result: "sent") }
       let(:detailable_type) { "TwilioSmsDeliveryDetail" }
 

--- a/spec/models/mobitel_delivery_detail_spec.rb
+++ b/spec/models/mobitel_delivery_detail_spec.rb
@@ -36,4 +36,10 @@ RSpec.describe MobitelDeliveryDetail, type: :model do
       expect(communication.detailable.message).to eq message
     end
   end
+
+  describe "#result" do
+    it "returns successful state because messages are either successful or fails at API validation" do
+      expect(described_class.new.result).to eq("sent")
+    end
+  end
 end


### PR DESCRIPTION
**Story card:** [sc-13928](https://app.shortcut.com/simpledotorg/story/13928/investigate-sms-issue-in-sri-lanka)

## Because

The monitoring stage in the experimentation daily rake task is failing to send experiment notifications. Hence, the actual SMS sending part, which happens after monitoring, was not triggered. 
The error was from a missing method "result" in MobitelDeliveryDetail class.

## This addresses

We are adding the "result" method, which is used to determine the status of the notification. Since Mobitel does not give back the actual state of the notification, this is being hardcoded to "sent," assuming the API call to Mobitel is successful and the message was sent.

## Test instructions

If we are using Mobitel as an SMS vendor, then `rake "experiments:conduct_daily" should complete without errors, and we should see SMSes being sent out.
