### PR TITLE
sc-14313 added current user for flipper

### DIFF
--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -72,7 +72,7 @@
               <%= t("progress_tab.hypertension_report_title") %>
             </p>
           </a>
-          <% if Flipper.enabled?(:diabetes_progress_report_tab, current_admin)%>
+          <% if Flipper.enabled?(:diabetes_progress_report_tab, current_user)%>
             <a
               class=" f-1 d-flex fd-column ai-center jc-center h-96px ml-8px p-12px td-none bgc-purple-light bs-purple-light-button br-8px"
               href="#"

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -72,7 +72,7 @@
               <%= t("progress_tab.hypertension_report_title") %>
             </p>
           </a>
-          <% if Flipper.enabled?(:diabetes_progress_report_tab)%>
+          <% if Flipper.enabled?(:diabetes_progress_report_tab, current_admin)%>
             <a
               class=" f-1 d-flex fd-column ai-center jc-center h-96px ml-8px p-12px td-none bgc-purple-light bs-purple-light-button br-8px"
               href="#"


### PR DESCRIPTION
**Story card:** [sc-14313](https://app.shortcut.com/simpledotorg/story/14313/create-flipper-flag-for-users)

## Because

added current_user role with flipper flag

## This addresses

When will the current user, whose ID is assigned in the Flipper flag, be identified?

<img width="1512" alt="Screenshot 2024-12-10 at 7 17 47 PM" src="https://github.com/user-attachments/assets/1eae9a61-a2b7-4231-bae0-2756e3ecf139">


When will the current user, whose ID is assigned in the Flipper flag, not identified?

<img width="1511" alt="Screenshot 2024-12-10 at 7 17 16 PM" src="https://github.com/user-attachments/assets/e5afc266-ba4f-4446-9d1d-66ace9432d26">


## Test instructions

Enable this flipper flag :diabetes_progress_report_tab with current_user