### PR TITLE
sc-14333 added specs for HTN progress tab

### DIFF
--- a/spec/components/progress_tab/hypertension/control_component_spec.rb
+++ b/spec/components/progress_tab/hypertension/control_component_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe ProgressTab::Hypertension::ControlComponent, type: :component do
+  let(:region) { double("Region", name: "Region 1") }
+
+  let(:control_data) do
+    {
+      "2024-08-01" => 85,
+      "2024-09-01" => 88,
+      "2024-10-01" => 90
+    }
+  end
+
+  let(:adjusted_patients_data) do
+    {
+      "2024-08-01" => 140,
+      "2024-09-01" => 150,
+      "2024-10-01" => 160
+    }
+  end
+
+  let(:control_rates_data) do
+    {
+      "2024-08-01" => 0.61,
+      "2024-09-01" => 0.59,
+      "2024-10-01" => 0.57
+    }
+  end
+
+  let(:period_info_data) do
+    {
+      "2024-08-01" => {name: "Aug-2024"},
+      "2024-09-01" => {name: "Sep-2024"},
+      "2024-10-01" => {name: "Oct-2024"}
+    }
+  end
+
+  let(:controlled) { map_data(control_data) }
+  let(:adjusted_patients) { map_data(adjusted_patients_data) }
+  let(:controlled_rates) { map_data(control_rates_data) }
+  let(:period_info) { map_data(period_info_data) }
+
+  def map_data(data)
+    data.map { |date_str, value| [Period.new(type: :month, value: date_str), value] }.to_h
+  end
+
+  def render_component
+    render_inline(ProgressTab::Hypertension::ControlComponent.new(
+      controlled_rates: controlled_rates,
+      controlled: controlled,
+      adjusted_patients: adjusted_patients,
+      period_info: period_info,
+      region: region
+    ))
+  end
+
+  context "when rendering the component" do
+    before { render_component }
+
+    it "renders the controlled threshold long text" do
+      expect(rendered_component).to have_text(I18n.t(
+        "progress_tab.diagnosis_report.patient_treatment_outcomes.controlled_card.help_tooltip.numerator",
+        controlled_threshold: I18n.t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_controlled_long")
+      ))
+    end
+
+    it "renders the controlled threshold short text" do
+      expect(rendered_component).to have_text(I18n.t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_controlled_short"))
+    end
+
+    it "renders the correct subtitle" do
+      expect(rendered_component).to have_text(I18n.t(
+        "progress_tab.diagnosis_report.patient_treatment_outcomes.controlled_card.subtitle",
+        facility_name: "Region 1",
+        diagnosis: "Hypertension",
+        controlled_threshold: I18n.t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_controlled_long")
+      ))
+    end
+
+    it "renders the bar chart with correct data" do
+      expect(rendered_component).to have_selector('.d-flex[data-graph-type="bar-chart"]')
+      expect(rendered_component).to have_selector(".w-32px.bgc-green-dark-new", count: 3)
+    end
+  end
+end

--- a/spec/components/progress_tab/hypertension/missed_visits_component_spec.rb
+++ b/spec/components/progress_tab/hypertension/missed_visits_component_spec.rb
@@ -1,7 +1,6 @@
-# spec/components/progress_tab/diabetes/missed_visits_component_spec.rb
 require "rails_helper"
 
-RSpec.describe ProgressTab::Diabetes::MissedVisitsComponent, type: :component do
+RSpec.describe ProgressTab::Hypertension::MissedVisitsComponent, type: :component do
   let(:region) { double("Region", name: "Region 1") }
   let(:missed_visits_data) do
     {
@@ -73,11 +72,11 @@ RSpec.describe ProgressTab::Diabetes::MissedVisitsComponent, type: :component do
   end
 
   it "renders the title correctly" do
-    expect(subject).to have_text("Diabetes")
+    expect(subject).to have_text("Missed visits")
   end
 
   it "renders the title correctly" do
-    expect(subject).to have_text("Missed visits")
+    expect(subject).to have_text("Hypertension")
   end
 
   it "displays the region name" do

--- a/spec/components/progress_tab/hypertension/uncontrolled_component_spec.rb
+++ b/spec/components/progress_tab/hypertension/uncontrolled_component_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe ProgressTab::Hypertension::UncontrolledComponent, type: :component do
+  let(:region) { double("Region", name: "Region 1") }
+
+  let(:uncontrolled_data) do
+    {
+      "2024-08-01" => 20,
+      "2024-09-01" => 25,
+      "2024-10-01" => 30
+    }
+  end
+
+  let(:adjusted_patients_data) do
+    {
+      "2024-08-01" => 140,
+      "2024-09-01" => 150,
+      "2024-10-01" => 160
+    }
+  end
+
+  let(:uncontrolled_rates_data) do
+    {
+      "2024-08-01" => 0.14,
+      "2024-09-01" => 0.17,
+      "2024-10-01" => 0.19
+    }
+  end
+
+  let(:period_info_data) do
+    {
+      "2024-08-01" => {name: "Aug-2024"},
+      "2024-09-01" => {name: "Sep-2024"},
+      "2024-10-01" => {name: "Oct-2024"}
+    }
+  end
+
+  let(:uncontrolled) { map_data(uncontrolled_data) }
+  let(:adjusted_patients) { map_data(adjusted_patients_data) }
+  let(:uncontrolled_rates) { map_data(uncontrolled_rates_data) }
+  let(:period_info) { map_data(period_info_data) }
+
+  def map_data(data)
+    data.map { |date_str, value| [Period.new(type: :month, value: date_str), value] }.to_h
+  end
+
+  def render_component
+    render_inline(ProgressTab::Hypertension::UncontrolledComponent.new(
+      uncontrolled_rates: uncontrolled_rates,
+      uncontrolled: uncontrolled,
+      adjusted_patients: adjusted_patients,
+      period_info: period_info,
+      region: region
+    ))
+  end
+
+  context "when rendering the component" do
+    before do
+      render_component
+    end
+
+    it "renders the correct title text" do
+      expect(rendered_component).to have_text(I18n.t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_short"))
+    end
+
+    it "renders the correct subtitle text" do
+      expect(rendered_component).to have_text(I18n.t("progress_tab.diagnosis_report.patient_treatment_outcomes.uncontrolled_card.subtitle", 
+                                                     facility_name: "Region 1", diagnosis: "Hypertension", 
+                                                     uncontrolled_threshold: I18n.t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_long")))
+    end
+
+    it "renders the tooltip with correct numerator and denominator text" do
+      expect(rendered_component).to have_text(I18n.t("progress_tab.diagnosis_report.patient_treatment_outcomes.uncontrolled_card.help_tooltip.numerator", 
+                                                     uncontrolled_threshold: I18n.t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_long")))
+      expect(rendered_component).to have_text(I18n.t("progress_tab.diagnosis_report.patient_treatment_outcomes.uncontrolled_card.help_tooltip.denominator", 
+                                                     facility_name: "Region 1", diagnosis: "Hypertension"))
+    end
+
+    it "renders the bar chart with correct data" do
+      expect(rendered_component).to have_selector("[data-graph-type='bar-chart']")
+    end
+
+    it "includes the correct graph colors" do
+      expect(rendered_component).to have_selector(".bgc-yellow-dark-new")
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-sc-14333](https://app.shortcut.com/simpledotorg/story/14333/htn-progress-tab-test-cases-rspecs)

## Because

As test cases are not present for HTM Progress tab

## This addresses

Will Cover test cases for HTN progress tab

## Test instructions

You can run rspecs into your local by running `bundle exec rsepc <file_name>`