### PR TITLE
Prefer numeric interface for numeric fields

### DIFF
--- a/app/schema/api/v4/models.rb
+++ b/app/schema/api/v4/models.rb
@@ -108,8 +108,8 @@ class Api::V4::Models
          id: {"$ref" => "#/definitions/uuid"},
          user_id: {"$ref" => "#/definitions/uuid"},
          patient_id: {"$ref" => "#/definitions/uuid"},
-         height: {"$ref" => "#/definitions/non_empty_string"},
-         weight: {"$ref" => "#/definitions/non_empty_string"},
+         height: {type: :number},
+         weight: {type: :number},
          deleted_at: {"$ref" => "#/definitions/nullable_timestamp"},
          created_at: {"$ref" => "#/definitions/timestamp"},
          updated_at: {"$ref" => "#/definitions/timestamp"}

--- a/app/transformers/api/v4/patient_attribute_transformer.rb
+++ b/app/transformers/api/v4/patient_attribute_transformer.rb
@@ -1,7 +1,11 @@
 class Api::V4::PatientAttributeTransformer < Api::V4::Transformer
   class << self
-    def to_response(patient_attribute)
-      super(patient_attribute)
+    def to_response(payload)
+      super(payload)
+        .merge({
+          "height" => payload["height"].to_f,
+          "weight" => payload["weight"].to_f
+        })
     end
 
     def from_request(payload)

--- a/spec/controllers/api/v4/patient_attributes_controller_spec.rb
+++ b/spec/controllers/api/v4/patient_attributes_controller_spec.rb
@@ -9,7 +9,7 @@ describe Api::V4::PatientAttributesController, type: :controller do
   let(:build_invalid_payload) { -> { build_invalid_patient_attribute_payload } }
   let(:invalid_record) { build_invalid_payload.call }
   let(:number_of_schema_errors_in_invalid_payload) { 2 }
-  let(:update_payload) { ->(patient_attribute) { patient_attribute.attributes.with_payload_keys.merge(updated_at: 5.days.from_now) } }
+  let(:update_payload) { ->(patient_attribute) { updated_patient_attributes_payload(patient_attribute) } }
 
   def create_record(options = {})
     facility = create(:facility, facility_group: request_facility_group)
@@ -28,7 +28,63 @@ describe Api::V4::PatientAttributesController, type: :controller do
 
   describe "POST sync: send data from device to server;" do
     it_behaves_like "a working sync controller creating records"
-    it_behaves_like "a working sync controller updating records"
+
+    describe "a working sync controller updating records" do
+      let(:request_key) { model.to_s.underscore.pluralize }
+      let(:existing_records) { create_record_list(10) }
+      let(:updated_records) { existing_records.map(&update_payload) }
+      let(:updated_payload) { {request_key => updated_records} }
+
+      before :each do
+        set_authentication_headers
+      end
+
+      describe "updates records" do
+        it "no-ops the discarded records" do
+          existing_records.map(&:discard)
+          post :sync_from_user, params: updated_payload, as: :json
+
+          updated_records.each do |record|
+            db_record = model.with_discarded.find(record["id"])
+
+            expect(db_record).to be_discarded
+
+            expected_hash = db_record
+              .attributes
+              .to_json_and_back
+              .except("user_id")
+              .with_payload_keys.with_int_timestamps
+            actual_hash = record
+              .to_json_and_back
+              .except("user_id")
+              .with_int_timestamps
+            expect(expected_hash).not_to eq(actual_hash)
+          end
+        end
+
+        it "with updated record attributes" do
+          post :sync_from_user, params: updated_payload, as: :json
+
+          updated_records.each do |record|
+            db_record = model.find(record["id"])
+            expected = db_record
+              .attributes
+              .with_payload_keys
+              .with_int_timestamps
+              .except("user_id")
+              .merge(
+                "height" => db_record["height"].to_f,
+                "weight" => db_record["weight"].to_f
+              )
+            actual = record
+              .to_json_and_back
+              .with_int_timestamps
+              .except("user_id")
+            expect(expected).to eq(actual)
+          end
+        end
+      end
+    end
   end
 
   describe "GET sync: send data from server to device;" do

--- a/spec/factories/patient_attributes.rb
+++ b/spec/factories/patient_attributes.rb
@@ -16,9 +16,19 @@ FactoryBot.define do
 end
 
 def build_patient_attribute_payload(patient_attribute = FactoryBot.build(:patient_attribute))
-  patient_attribute.attributes.with_payload_keys
+  Api::V4::PatientAttributeTransformer.to_response(patient_attribute).with_indifferent_access
 end
 
 def build_invalid_patient_attribute_payload
-  FactoryBot.build(:patient_attribute, :invalid)
+  build_patient_attribute_payload.merge(
+    "created_at" => nil,
+    "height" => "invalid"
+  )
+end
+
+def updated_patient_attributes_payload(payload)
+  update_time = 5.days.from_now
+  build_patient_attribute_payload(payload).merge(
+    "updated_at" => update_time
+  )
 end

--- a/spec/transformers/api/v4/patient_attribute_transformer_spec.rb
+++ b/spec/transformers/api/v4/patient_attribute_transformer_spec.rb
@@ -5,8 +5,8 @@ describe Api::V4::PatientAttributeTransformer do
     {
       id: SecureRandom.uuid,
       patient_id: SecureRandom.uuid,
-      height: "123.4",
-      weight: "67.8"
+      height: 123.4,
+      weight: 67.8
     }
   end
 

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -2882,10 +2882,10 @@
           "$ref": "#/definitions/uuid"
         },
         "height": {
-          "$ref": "#/definitions/non_empty_string"
+          "type": "number"
         },
         "weight": {
-          "$ref": "#/definitions/non_empty_string"
+          "type": "number"
         },
         "deleted_at": {
           "$ref": "#/definitions/nullable_timestamp"


### PR DESCRIPTION
**Story card:** [sc-14400](https://app.shortcut.com/simpledotorg/story/14400/prefer-numerics-in-schema-for-number-fields)

## Because

Leaving the interface for a numeric as a String would mean that whenever this is to be calculated on the client side, they would have to convert this to a float.

## This addresses

BMI attributes

## Test instructions

- suite tests
