### PR TITLE
sc-14455 change text for progress tab DM

### DIFF
--- a/app/components/reports/progress_monthly_follow_ups_component.html.erb
+++ b/app/components/reports/progress_monthly_follow_ups_component.html.erb
@@ -5,7 +5,7 @@
     </h2>
   </div>
   <p class="m-0px mb-24px p-0px ta-left fw-normal fs-16px lh-150 c-grey-dark">
-    <%= t("progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle", facility_name: @region.name, diagnosis: @diagnosis) %>
+    <%= t(@diagnosis_subtitle_key, facility_name: @region.name, diagnosis: @diagnosis) %>
   </p>
   <%= render partial: "api/v3/analytics/user_analytics/data_bar_graph",
              locals: {

--- a/app/components/reports/progress_monthly_follow_ups_component.rb
+++ b/app/components/reports/progress_monthly_follow_ups_component.rb
@@ -4,12 +4,24 @@ class Reports::ProgressMonthlyFollowUpsComponent < ViewComponent::Base
   include AssetsHelper
   include ActionView::Helpers::NumberHelper
 
-  attr_reader :monthly_follow_ups, :period_info, :region, :diagnosis
+  attr_reader :monthly_follow_ups, :period_info, :region, :diagnosis, :diagnosis_subtitle_key
 
   def initialize(monthly_follow_ups:, period_info:, region:, diagnosis: nil)
     @monthly_follow_ups = monthly_follow_ups
     @period_info = period_info
     @region = region
     @diagnosis = diagnosis || "Hypertension"
+    @diagnosis_subtitle_key = determine_subtitle_key
+  end
+
+  private
+
+  def determine_subtitle_key
+    if @diagnosis == "Hypertension"
+      "progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle"
+    else
+      "progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle_dm"
+    end
   end
 end
+

--- a/app/components/reports/progress_monthly_follow_ups_component.rb
+++ b/app/components/reports/progress_monthly_follow_ups_component.rb
@@ -24,4 +24,3 @@ class Reports::ProgressMonthlyFollowUpsComponent < ViewComponent::Base
     end
   end
 end
-

--- a/config/locales/api/en.yml
+++ b/config/locales/api/en.yml
@@ -412,6 +412,7 @@ en:
       monthly_follow_up_patients:
         title: "Monthly follow-up patients"
         subtitle: "%{diagnosis} patients with a BP taken, a blood sugar taken, an appointment scheduled, or a medication updated at %{facility_name} during a month."
+        subtitle_dm: "%{diagnosis} patients with a blood sugar taken, a BP taken, an appointment scheduled, or a medication updated at %{facility_name} during a month."
       patient_treatment_outcomes:
         section_title: "Patient treatment status"
         chart_tooltip: "%{number_of_patients} %{number_of_patient_or_patients} with %{threshold} between %{start_period} and %{end_period} of %{number_of_registered_patients} %{number_of_registered_patient_or_patients} registered till %{registration_period}."

--- a/spec/components/reports/progress_monthly_follow_ups_component_spec.rb
+++ b/spec/components/reports/progress_monthly_follow_ups_component_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Reports::ProgressMonthlyFollowUpsComponent, type: :component do
     end
 
     it "renders the subtitle with correct facility name and diagnosis" do
-      expect(rendered_component).to have_selector("p", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle", facility_name: region.name, diagnosis: diagnosis))
+      expect(rendered_component).to have_selector("p", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle_dm", facility_name: region.name, diagnosis: diagnosis))
     end
 
     it "displays the correct number of total registrations" do


### PR DESCRIPTION
**Story card:** [sc-14455](https://app.shortcut.com/simpledotorg/story/14455/change-text-for-lk-progress-tab)

## Because

To change the text for DM progress tab
## This addresses

DM progress tab

## Test instructions

Enable this flipper flag :diabetes_progress_report_tab to check the functionality.