### PR TITLE
sc-14101 added organization to breadcrum

### DIFF
--- a/app/controllers/regions_search_controller.rb
+++ b/app/controllers/regions_search_controller.rb
@@ -7,7 +7,6 @@ class RegionsSearchController < AdminController
     regions = []
     benchmark("retrieving all accessible regions for search") do
       authorize do
-        regions.concat current_admin.user_access.accessible_organization_regions(:view_reports)
         regions.concat current_admin.user_access.accessible_state_regions(:view_reports)
         regions.concat current_admin.user_access.accessible_district_regions(:view_reports)
         regions.concat current_admin.user_access.accessible_block_regions(:view_reports)

--- a/app/controllers/regions_search_controller.rb
+++ b/app/controllers/regions_search_controller.rb
@@ -7,6 +7,7 @@ class RegionsSearchController < AdminController
     regions = []
     benchmark("retrieving all accessible regions for search") do
       authorize do
+        regions.concat current_admin.user_access.accessible_organization_regions(:view_reports)
         regions.concat current_admin.user_access.accessible_state_regions(:view_reports)
         regions.concat current_admin.user_access.accessible_district_regions(:view_reports)
         regions.concat current_admin.user_access.accessible_block_regions(:view_reports)

--- a/app/models/user_access.rb
+++ b/app/models/user_access.rb
@@ -75,6 +75,10 @@ class UserAccess
       .includes(facility_groups: :facilities)
   end
 
+  def accessible_organization_regions(action)
+    accessible_organizations(action)
+  end
+
   # Users can view reports for a state if they can manage any district within the state.
   # Any other access requests (ie manage, view_pii, etc) for a state receive an error and are not supported.
   #

--- a/app/views/reports/regions/_header.html.erb
+++ b/app/views/reports/regions/_header.html.erb
@@ -5,7 +5,8 @@
   <nav class="breadcrumb mb-0px pb-16px">
     <%= link_to "All reports", dashboard_districts_path %>
 
-    <% @region.ancestors.where(region_type: %w[state district block facility]).order(:path).each do |region| %>
+    <% region_types = current_admin.feature_enabled?(:organization_reports) ? %w[organization state district block facility] :  %w[state district block facility] %>
+    <% @region.ancestors.where(region_type: region_types).order(:path).each do |region| %>
       <i class="fas fa-chevron-right"></i>
       <%= link_to_if(accessible_region?(region, :view_reports), region.name, reports_region_path(region.slug, report_scope: region.region_type)) %>
     <% end %>

--- a/config/initializers/country_config.rb
+++ b/config/initializers/country_config.rb
@@ -67,7 +67,7 @@ class CountryConfig
     LK: {
       abbreviation: "LK",
       name: "Sri Lanka",
-      extended_region_reports: false,
+      extended_region_reports: true,
       states: COUNTRYWISE_STATES["Sri Lanka"],
       dashboard_locale: ENV["DEFAULT_PREFERRED_DASHBOARD_LOCALE"] || "en-LK",
       faker_locale: "en-IND",

--- a/spec/views/reports/regions/_header.html.erb_spec.rb
+++ b/spec/views/reports/regions/_header.html.erb_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe "reports/regions/_header.html.erb", type: :view do
+  let(:organization) { create(:organization) }
+  let(:current_admin) { create(:admin, :manager) }
+  let(:organization_region) { create(:region, name: "Organization", region_type: "organization", path: "organization") }
+  let(:current_period) { Period.current }
+  let(:sub_region) { create(:region, name: "State Subregion", region_type: "state", path: "organization.state") }
+
+  helper do
+    def accessible_region?(*args)
+      true
+    end
+
+    def active_action?(*args)
+      false
+    end
+  end
+
+  before do
+    allow(view).to receive(:accessible_region?).and_return(true)
+    assign(:period, current_period)
+    assign(:region, organization_region)
+
+    allow(view).to receive(:params).and_return({report_scope: "organization", id: organization_region.slug})
+    allow(view).to receive(:action_name).and_return("diabetes")
+    allow(current_admin).to receive(:feature_enabled?).with(:organization_reports).and_return(true)
+  end
+
+  describe "when the feature flag for organization_reports is enabled" do
+    context "and we are on the organization-level report" do
+      it "renders the organization name in the breadcrumb without a hyperlink" do
+        render partial: "reports/regions/header", locals: {current_admin: current_admin}
+        expect(rendered).to have_link("All reports", href: "/dashboard/districts")
+        expect(rendered).not_to have_link("Organization", href: "/reports/regions/organization/organization")
+        expect(rendered).to have_content(/Organization/)
+      end
+    end
+
+    context "when the feature flag for organization_reports is enabled and we are on a sub-level report (e.g., state or facility)" do
+      before do
+        assign(:region, sub_region)
+        assign(:organization, organization)
+        allow(view).to receive(:params).and_return({report_scope: "state", id: sub_region.slug})
+        allow(current_admin).to receive(:feature_enabled?).with(:monthly_state_data_download).and_return(true)
+      end
+
+      it "renders the organization name as a hyperlink in the breadcrumb" do
+        render partial: "reports/regions/header", locals: {current_admin: current_admin}
+        expect(rendered).to have_link("All reports", href: "/dashboard/districts")
+        expect(rendered).to have_link("Organization", href: "/reports/regions/organization/organization")
+        expect(rendered).to have_content(/State Subregion/)
+      end
+    end
+  end
+
+  context "when the feature flag for organization_reports is disabled" do
+    before do
+      allow(current_admin).to receive(:feature_enabled?).with(:organization_reports).and_return(false)
+      allow(current_admin).to receive(:feature_enabled?).with(:monthly_state_data_download).and_return(true)
+      allow(view).to receive(:params).and_return({report_scope: "state", id: sub_region.slug})
+      assign(:region, sub_region)
+    end
+
+    it "does not render the organization name in the breadcrumb" do
+      render partial: "reports/regions/header", locals: {current_admin: current_admin}
+      expect(rendered).to have_link("All reports", href: "/dashboard/districts")
+      expect(rendered).not_to have_content("Organization")
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-14101](https://app.shortcut.com/simpledotorg/story/13777/add-national-dashboard-link-in-the-top-navigation-bar-in-the-dashboard)

## Because

So that we could see the organization in the breadcrumb 

## This addresses

Can see the organization on the navigational breadcrumb where organization_reports are enabled

## Test instructions

Enable the organization_reports flipper