### PR TITLE
Log on error for patient line list

### DIFF
--- a/app/controllers/reports/patient_lists_controller.rb
+++ b/app/controllers/reports/patient_lists_controller.rb
@@ -6,6 +6,8 @@ class Reports::PatientListsController < AdminController
   before_action :set_region, only: [:show, :diabetes]
   before_action :set_download_params, only: [:show, :diabetes]
 
+  rescue_from Exception, with: :show_error
+
   def show
     case region_class
     when "facility"
@@ -27,6 +29,11 @@ class Reports::PatientListsController < AdminController
         end
       end
     end
+  end
+
+  def show_error e
+    logger.error (["#{self.class} - #{e.class}: #{e.message}"]+e.backtrace).join("\n")
+    raise e
   end
 
   private


### PR DESCRIPTION
**Story card:** [sc-13796](https://app.shortcut.com/simpledotorg/story/13796/patient-line-list-returning-no-data-in-simple-dashboard-ethiopia)

## Because

We don't know what's going on during an exception in this method. And when an exception is raised, it bypasses the logs.

## This addresses

Exception logs within the Patient Line List controller.
