### PR TITLE
Cancel upcoming BD SMSs

### DIFF
--- a/db/data/20250204101724_cancel_bangladesh_stale_experiments.rb
+++ b/db/data/20250204101724_cancel_bangladesh_stale_experiments.rb
@@ -2,8 +2,9 @@
 
 class CancelBangladeshStaleExperiments < ActiveRecord::Migration[6.1]
   def up
-    Experimentation::Experiment.upcoming.where(experiment_type: 'stale_patients').each do |experiment|
-      experiment.destroy  # ...because we need the associated notifications gone too
+    return unless CountryConfig.current_country?("Bangladesh") && SimpleServer.env.production?
+    Experimentation::Experiment.upcoming.where(experiment_type: "stale_patients").each do |experiment|
+      experiment.destroy # ...because we need the associated notifications gone too
     end
   end
 

--- a/db/data/20250204101724_cancel_bangladesh_stale_experiments.rb
+++ b/db/data/20250204101724_cancel_bangladesh_stale_experiments.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CancelBangladeshStaleExperiments < ActiveRecord::Migration[6.1]
+  def up
+    Experimentation::Experiment.upcoming.where(experiment_type: 'stale_patients').each do |experiment|
+      experiment.destroy  # ...because we need the associated notifications gone too
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240902213036)
+DataMigrate::Data.define(version: 20250204101724)


### PR DESCRIPTION
**Story card:** [sc-14668](https://app.shortcut.com/simpledotorg/story/14668/delete-all-upcoming-bd-notifications-for-stale-patients)

## Because

Stale patient experiments use up credit meant for current patients

## This addresses

Cancelling the experiments for stale patients

## Test instructions

1. Ran the underlying SQL in metabase to confirm the set
1. Ran the query (without the `destroy`) in prod to match (1)
