### PR TITLE
Add Cholesterol to API

### DIFF
--- a/app/schema/api/v3/models.rb
+++ b/app/schema/api/v3/models.rb
@@ -308,6 +308,7 @@ class Api::V3::Models
          hypertension: {type: :string, enum: MedicalHistory::MEDICAL_HISTORY_ANSWERS.keys},
          diagnosed_with_hypertension: {type: :string, enum: MedicalHistory::MEDICAL_HISTORY_ANSWERS.keys},
          smoking: {type: :string, enum: MedicalHistory::MEDICAL_HISTORY_ANSWERS.keys},
+         cholesterol_value: {type: :number},
          deleted_at: {"$ref" => "#/definitions/nullable_timestamp"},
          created_at: {"$ref" => "#/definitions/timestamp"},
          updated_at: {"$ref" => "#/definitions/timestamp"}

--- a/app/schema/api/v4/models.rb
+++ b/app/schema/api/v4/models.rb
@@ -163,6 +163,8 @@ class Api::V4::Models
       {
         type: :object,
         properties: {
+          cholesterol_value: {type: :number},
+          smoking: {type: :string, enum: MedicalHistory::MEDICAL_HISTORY_ANSWERS.keys},
           chronic_kidney_disease: {type: :string, enum: MedicalHistory::MEDICAL_HISTORY_ANSWERS.keys},
           diabetes: {type: :string, enum: MedicalHistory::MEDICAL_HISTORY_ANSWERS.keys},
           hypertension: {type: :string, enum: MedicalHistory::MEDICAL_HISTORY_ANSWERS.keys},

--- a/swagger/v3/swagger.json
+++ b/swagger/v3/swagger.json
@@ -2489,6 +2489,9 @@
             "unknown"
           ]
         },
+        "cholesterol_value": {
+          "type": "number"
+        },
         "deleted_at": {
           "$ref": "#/definitions/nullable_timestamp"
         },

--- a/swagger/v4/swagger.json
+++ b/swagger/v4/swagger.json
@@ -2268,6 +2268,9 @@
             "unknown"
           ]
         },
+        "cholesterol_value": {
+          "type": "number"
+        },
         "deleted_at": {
           "$ref": "#/definitions/nullable_timestamp"
         },
@@ -2592,6 +2595,17 @@
         "medical_history": {
           "type": "object",
           "properties": {
+            "cholesterol_value": {
+              "type": "number"
+            },
+            "smoking": {
+              "type": "string",
+              "enum": [
+                "yes",
+                "no",
+                "unknown"
+              ]
+            },
             "chronic_kidney_disease": {
               "type": "string",
               "enum": [


### PR DESCRIPTION
**Story card:** [sc-14690](https://app.shortcut.com/simpledotorg/story/14690/expose-cholesterol-to-the-api)

## Because

Clients need to know how to specify cholesterol to the server

## This addresses

Adding cholesterol to the API

## Test instructions

Check the documentation at /api-docs that

- `cholesterol` is part of `medical_histories` in V3, and
- `cholesterol` is part of `patient.medical_histories` in V4
