### PR TITLE
Bump manifest workflow actions

### DIFF
--- a/.github/workflows/deploy-manifest.yml
+++ b/.github/workflows/deploy-manifest.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'public/manifest'
       - name: Deploy to GitHub Pages

--- a/.github/workflows/deploy-manifest.yml
+++ b/.github/workflows/deploy-manifest.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create manifest.json file from production.json
         run: cp public/manifest/production.json public/manifest/manifest.json
       - name: Setup Pages

--- a/.github/workflows/deploy-manifest.yml
+++ b/.github/workflows/deploy-manifest.yml
@@ -33,11 +33,11 @@ jobs:
       - name: Create manifest.json file from production.json
         run: cp public/manifest/production.json public/manifest/manifest.json
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: 'public/manifest'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
**Story card:** [sc-14689](https://app.shortcut.com/simpledotorg/story/14689/upgrade-actions-upload-artifact-from-v3-to-v4)

## Because

Our documentation no longer deploys because the action fails

## This addresses

Bumping the versions of actions tooling away from deprecated and old versions

## Test instructions

n/a
