### PR TITLE
sc-14776 added target at html

### DIFF
--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -9,19 +9,18 @@
     <% size = @region.source.facility_size.present? ? @region.source.facility_size : '' %>
     <% zone = @region.source.zone %>
     <% last_month = Date.today.last_month.strftime("%b-%Y") %>
-    <div>⚡ <a href="<%= ENV.fetch('DRUG_STOCK_REPORT_URL', '') %><%= district %>&zone=<%= zone %>&for_end_of_month=<%= last_month %>&size=<%= size %> ">
+    <div>⚡ <a href="<%= ENV.fetch('DRUG_STOCK_REPORT_URL', '') %><%= district %>&zone=<%= zone %>&for_end_of_month=<%= last_month %>&size=<%= size %> " target="_blank">
       Drug stock report
     </a></div>
-
-    <div>⚡ <a href="<%= ENV.fetch('METABASE_TITRATION_URL', '') %><%= @region.name %>">
+    <div>⚡ <a href="<%= ENV.fetch('METABASE_TITRATION_URL', '') %><%= @region.name %>" target="_blank">
       Metabase: Titration report
     </a></div>
-
-    <div>⚡ <a href="<%= ENV.fetch('METABASE_BP_FUDGING_URL', '') %><%= @region.name %>">
+    <div>⚡ <a href="<%= ENV.fetch('METABASE_BP_FUDGING_URL', '') %><%= @region.name %>" target="_blank">
       Metabase: BP fudging report
     </a></div>
   </div>
 <% end %>
+
 
 
 <%= render "header" %>


### PR DESCRIPTION
**Story card:** [sc-14776](https://app.shortcut.com/simpledotorg/story/14776/open-links-in-a-new-tab-on-the-simple-dashboard)

Because
To enable quick links to open in a new tab for a seamless user experience.

This Addresses
This change allows users to compare the Metabase reports with the Simple dashboard simultaneously, improving usability and workflow efficiency.

Test Instructions
Ensuring that when a user clicks a link from the Simple dashboard, it opens in a new tab, allowing them to view both the dashboard and external reports (e.g., Metabase) side by side.

