### PR TITLE
refactor(OpenSRP Exporter): External Config

### DIFF
--- a/config/opensrp-export.sample.yml
+++ b/config/opensrp-export.sample.yml
@@ -1,0 +1,13 @@
+facilities:
+  d1dbd3c6-26bb-48e7-aa89-bc8a0b2bf75b:
+    name: Health Facility 1
+    opensrp_practitioner_id: 0c375fe8-b38f-484e-aa64-c02750ee183b
+    opensrp_organization_id: d3363aea-66ad-4370-809a-8e4436a4218f
+    opensrp_care_team_id: 1c8100b5-222b-4815-ba4d-3ebde537c6ce
+    opensrp_location_id: ABC01230123
+  b100eb1a-18b3-424f-a2bf-c2e6b1655b1b:
+    name: Health Facility 2
+    opensrp_practitioner_id: 34a9da76-e18c-4fd6-a696-dee7a8454fb4
+    opensrp_organization_id: 5466dfd9-b10b-4bd8-8692-5732340de7f1
+    opensrp_care_team_id: f91c89c9-6790-4a94-b877-5feb578e0af8
+    opensrp_location_id: DEF01230123

--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -1,24 +1,17 @@
 require "faker"
 require "yaml"
 
-# facilities_to_export = {
-#   "d1dbd3c6-26bb-48e7-aa89-bc8a0b2bf75b" => {
-#     name: "Test Health Center",
-#     practitioner_id: "0c375fe8-b38f-484e-aa64-c02750ee183b",
-#     organization_id: "d3363aea-66ad-4370-809a-8e4436a4218f",
-#     care_team_id: "1c8100b5-222b-4815-ba4d-3ebde537c6ce",
-#     location_id: "PKT0010397"
-#   }
-# }
-
 namespace :opensrp do
   desc "Export simple patient-related data as opensrp fhir resources"
   task :export, [:config_file, :output_file] => :environment do |_task, args|
+    raise "Usage: ./bin/rake 'opensrp:export[path/to/config.yml, name-of-output.json]'" unless args.to_a.size == 2
     # For now we are leaving in the PII.
     # patients = remove_pii(patients)
     output_file = args[:output_file]
     config_file = args[:config_file]
 
+    raise "Config file should be YAML" unless %w[ yaml yml ].include?(config_file.split('.').last)
+    raise "Output file should be JSON" unless output_file.split('.').last == 'json'
     config = YAML.load_file(config_file)
 
     facilities_to_export = config['facilities']

--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -10,11 +10,11 @@ namespace :opensrp do
     output_file = args[:output_file]
     config_file = args[:config_file]
 
-    raise "Config file should be YAML" unless %w[ yaml yml ].include?(config_file.split('.').last)
-    raise "Output file should be JSON" unless output_file.split('.').last == 'json'
+    raise "Config file should be YAML" unless %w[yaml yml].include?(config_file.split(".").last)
+    raise "Output file should be JSON" unless output_file.split(".").last == "json"
     config = YAML.load_file(config_file)
 
-    facilities_to_export = config['facilities']
+    facilities_to_export = config["facilities"]
 
     resources = []
     encounters = []

--- a/spec/lib/tasks/opensrp_spec.rb
+++ b/spec/lib/tasks/opensrp_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 describe "opensrp:export" do
   include_context "rake"
 
-  TEST_CONFIG = "spec/support/fixtures/test-export-config.yml"
+  let(:test_config_file) { "spec/support/fixtures/test-export-config.yml" }
 
   it "should reqiure a config file" do
-    expect(YAML).to receive(:load_file).with(TEST_CONFIG).and_call_original
-    subject.invoke(TEST_CONFIG, "output.json")
+    expect(YAML).to receive(:load_file).with(test_config_file).and_call_original
+    subject.invoke(test_config_file, "output.json")
   end
 end

--- a/spec/lib/tasks/opensrp_spec.rb
+++ b/spec/lib/tasks/opensrp_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe "opensrp:export" do
+  include_context "rake"
+
+  TEST_CONFIG = 'spec/support/fixtures/test-export-config.yml'
+
+  it "should reqiure a config file" do
+    expect(YAML).to receive(:load_file).with(TEST_CONFIG).and_call_original
+    subject.invoke(TEST_CONFIG, 'output.json')
+  end
+end

--- a/spec/lib/tasks/opensrp_spec.rb
+++ b/spec/lib/tasks/opensrp_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 describe "opensrp:export" do
   include_context "rake"
 
-  TEST_CONFIG = 'spec/support/fixtures/test-export-config.yml'
+  TEST_CONFIG = "spec/support/fixtures/test-export-config.yml"
 
   it "should reqiure a config file" do
     expect(YAML).to receive(:load_file).with(TEST_CONFIG).and_call_original
-    subject.invoke(TEST_CONFIG, 'output.json')
+    subject.invoke(TEST_CONFIG, "output.json")
   end
 end

--- a/spec/support/fixtures/test-export-config.yml
+++ b/spec/support/fixtures/test-export-config.yml
@@ -1,0 +1,7 @@
+facilities:
+  d1dbd3c6-26bb-48e7-aa89-bc8a0b2bf75b:
+    name: Test Health Center
+    opensrp_practitioner_id: 0c375fe8-b38f-484e-aa64-c02750ee183b
+    opensrp_organization_id: d3363aea-66ad-4370-809a-8e4436a4218f
+    opensrp_care_team_id: 1c8100b5-222b-4815-ba4d-3ebde537c6ce
+    opensrp_location_id: ABC01230123

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,0 +1,20 @@
+require "rake"
+
+shared_context "rake" do
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { "lib/tasks/#{ task_name.split(':').first}" }
+  subject         { rake[task_name] }
+
+  def all_but_rake_file
+    $".reject do |file|
+      file == Rails.root.join("#{task_path}.rake").to_s
+    end
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [Rails.root.to_s], all_but_rake_file)
+    Rake::Task.define_task(:environment)
+  end
+end

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,10 +1,10 @@
 require "rake"
 
 shared_context "rake" do
-  let(:rake)      { Rake::Application.new }
+  let(:rake) { Rake::Application.new }
   let(:task_name) { self.class.top_level_description }
-  let(:task_path) { "lib/tasks/#{ task_name.split(':').first}" }
-  subject         { rake[task_name] }
+  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+  subject { rake[task_name] }
 
   def all_but_rake_file
     $".reject do |file|


### PR DESCRIPTION
**Story card:** [sc-14814](https://app.shortcut.com/simpledotorg/story/14814/opensrp-exports-export-a-specific-time-window)

## Because

Whenever we want to do an export, we have to update the rake file in the running instance with the information per export. This is technically configuration within the script, and doesn't scale as much

## This addresses

Enabling people bring their external configuration for the export. This change does not alter the functionality in the exports. 

## Test instructions

- suite tests
