### PR TITLE
feature(OpenSRP Exporter): Time Boundaries

### DIFF
--- a/config/opensrp-export.sample.yml
+++ b/config/opensrp-export.sample.yml
@@ -1,3 +1,6 @@
+time_boundaries:
+  report_start: 2001-01-01
+  report_end: 2002-02-02
 facilities:
   d1dbd3c6-26bb-48e7-aa89-bc8a0b2bf75b:
     name: Health Facility 1

--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -33,7 +33,7 @@ namespace :opensrp do
       encounters << patient_exporter.export_registration_encounter
 
       blood_pressures = patient.blood_pressures
-      blood_pressures = blood_pressures.where(recorded_at: time_window) if using_time_boundaries
+      blood_pressures = blood_pressures.where(recorded_at: time_window).or(updated_at: time_window) if using_time_boundaries
       blood_pressures.each do |bp|
         bp_exporter = OneOff::Opensrp::BloodPressureExporter.new(bp, facilities_to_export)
         resources << bp_exporter.export
@@ -41,7 +41,7 @@ namespace :opensrp do
       end
 
       blood_sugars = patient.blood_sugars
-      blood_sugars = blood_sugars.where(recorded_at: time_window) if using_time_boundaries
+      blood_sugars = blood_sugars.where(recorded_at: time_window).or(updated_at: time_window) if using_time_boundaries
       blood_sugars.each do |bp|
         bs_exporter = OneOff::Opensrp::BloodSugarExporter.new(bs, facilities_to_export)
         if patient.medical_history.diabetes_no?

--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -14,7 +14,13 @@ namespace :opensrp do
     raise "Output file should be JSON" unless output_file.split(".").last == "json"
     config = YAML.load_file(config_file)
 
+    report_start = DateTime.parse('2020-01-01')
+    report_end = DateTime.now
     facilities_to_export = config["facilities"]
+    time_boundaries = config["time_boundaries"]
+    using_time_boundaries = using_time_boundaries? config
+    report_start = DateTime.parse(time_boundaries["report_start"]) if has_report_start?(config)
+    report_end = DateTime.parse(time_boundaries["report_end"]) if has_report_end?(config)
 
     resources = []
     encounters = []
@@ -25,13 +31,17 @@ namespace :opensrp do
       resources << patient_exporter.export_registration_questionnaire_response
       encounters << patient_exporter.export_registration_encounter
 
-      patient.blood_pressures.each do |bp|
+      blood_pressures = patient.blood_pressures
+      blood_pressures = blood_pressures.where(recorded_at: report_start..report_end) if using_time_boundaries
+      blood_pressures.each do |bp|
         bp_exporter = OneOff::Opensrp::BloodPressureExporter.new(bp, facilities_to_export)
         resources << bp_exporter.export
         encounters << bp_exporter.export_encounter
       end
 
-      patient.blood_sugars.each do |bs|
+      blood_sugars = patient.blood_sugars
+      blood_sugars = blood_sugars.where(recorded_at: report_start..report_end) if using_time_boundaries
+      blood_sugars.each do |bp|
         bs_exporter = OneOff::Opensrp::BloodSugarExporter.new(bs, facilities_to_export)
         if patient.medical_history.diabetes_no?
           resources << bs_exporter.export_no_diabetes_observation
@@ -40,16 +50,22 @@ namespace :opensrp do
         encounters << bs_exporter.export_encounter
       end
 
-      patient.prescription_drugs.each do |drug|
+      prescription_drugs = patient.prescription_drugs
+      prescription_drugs = prescription_drugs.where(created_at: report_start..report_end) if using_time_boundaries
+      prescription_drugs.each do |bp|
         drug_exporter = OneOff::Opensrp::PrescriptionDrugExporter.new(drug, facilities_to_export)
         resources << drug_exporter.export_dosage_flag
         encounters << drug_exporter.export_encounter
       end
+
       OneOff::Opensrp::MedicalHistoryExporter.new(patient.medical_history, facilities_to_export).then do |medical_history_exporter|
         resources << medical_history_exporter.export
         encounters << medical_history_exporter.export_encounter
       end
-      patient.appointments.each do |appointment|
+
+      appointments = patient.appointments
+      appointments = appointments.where(created_at: report_start..report_end) if using_time_boundaries
+      appointments.each do |bp|
         next unless appointment.status_scheduled?
         appointment_exporter = OneOff::Opensrp::AppointmentExporter.new(appointment, facilities_to_export)
         resources << appointment_exporter.export
@@ -60,6 +76,7 @@ namespace :opensrp do
         encounters << appointment_exporter.export_encounter
       end
     end
+
     resources << OneOff::Opensrp::EncounterGenerator.new(encounters).generate
 
     CSV.open("audit_trail.csv", "w") do |csv|
@@ -74,6 +91,18 @@ namespace :opensrp do
         f.puts(resource.as_json.to_json)
       end
     end
+  end
+
+  def using_time_boundaries?(config)
+    config.has_key? "time_boundaries"
+  end
+
+  def has_report_start?(config)
+    using_time_boundaries?(config) && time_boundaries.has_key?("report_start")
+  end
+
+  def has_report_end?(config)
+    using_time_boundaries?(config) && time_boundaries.has_key?("report_end")
   end
 
   def create_audit_record(facilities, patient)

--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -14,7 +14,7 @@ namespace :opensrp do
     raise "Output file should be JSON" unless output_file.split(".").last == "json"
     config = YAML.load_file(config_file)
 
-    report_start = DateTime.parse('2020-01-01')
+    report_start = DateTime.parse("2020-01-01")
     report_end = DateTime.now
     facilities_to_export = config["facilities"]
     time_boundaries = config["time_boundaries"]


### PR DESCRIPTION
**Story card:** [sc-14814](https://app.shortcut.com/simpledotorg/story/14814/opensrp-exports-export-a-specific-time-window)

## Because

Our stakeholders have asked for reports which are deltas from when they received the last report.

## This addresses

Adding some time boundaries to the report's config so operators can define for how long they want this report.

## Test instructions

- Did an export
- Inspected the JSON
