### PR TITLE
chore(OpenSRP Exporter): Add logs to the process

### DIFF
--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -22,7 +22,6 @@ namespace :opensrp do
     report_start = DateTime.parse(time_boundaries["report_start"]) if has_report_start?(config)
     report_end = DateTime.parse(time_boundaries["report_end"]) if has_report_end?(config)
     time_window = report_start..report_end
-
     resources = []
     encounters = []
     patients = Patient.where(assigned_facility_id: facilities_to_export.keys)
@@ -35,7 +34,6 @@ namespace :opensrp do
       blood_pressures = patient.blood_pressures
       blood_pressures = blood_pressures.where(recorded_at: time_window).or(updated_at: time_window) if using_time_boundaries
       blood_pressures.each do |bp|
-        bp_exporter = OneOff::Opensrp::BloodPressureExporter.new(bp, facilities_to_export)
         resources << bp_exporter.export
         encounters << bp_exporter.export_encounter
       end
@@ -43,7 +41,6 @@ namespace :opensrp do
       blood_sugars = patient.blood_sugars
       blood_sugars = blood_sugars.where(recorded_at: time_window).or(updated_at: time_window) if using_time_boundaries
       blood_sugars.each do |bp|
-        bs_exporter = OneOff::Opensrp::BloodSugarExporter.new(bs, facilities_to_export)
         if patient.medical_history.diabetes_no?
           resources << bs_exporter.export_no_diabetes_observation
         end
@@ -54,7 +51,6 @@ namespace :opensrp do
       prescription_drugs = patient.prescription_drugs
       prescription_drugs = prescription_drugs.where(created_at: time_window).or(updated_at: time_window) if using_time_boundaries
       prescription_drugs.each do |bp|
-        drug_exporter = OneOff::Opensrp::PrescriptionDrugExporter.new(drug, facilities_to_export)
         resources << drug_exporter.export_dosage_flag
         encounters << drug_exporter.export_encounter
       end
@@ -67,7 +63,6 @@ namespace :opensrp do
       appointments = patient.appointments
       appointments = appointments.where(created_at: time_window).or(updated_at: time_window) if using_time_boundaries
       appointments.each do |bp|
-        next unless appointment.status_scheduled?
         appointment_exporter = OneOff::Opensrp::AppointmentExporter.new(appointment, facilities_to_export)
         resources << appointment_exporter.export
         if appointment.call_results.present?

--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -1,6 +1,10 @@
 require "faker"
 require "yaml"
 
+logfile = Rails.root.join("log", "#{Rails.env}.log")
+logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(logfile))
+logger.extend(ActiveSupport::Logger.broadcast(ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT))))
+
 namespace :opensrp do
   desc "Export simple patient-related data as opensrp fhir resources"
   task :export, [:config_file, :output_file] => :environment do |_task, args|
@@ -14,6 +18,8 @@ namespace :opensrp do
     raise "Output file should be JSON" unless output_file.split(".").last == "json"
     config = YAML.load_file(config_file)
 
+    logger.tagged("opensrp:export") { logger.info "Exporting data using config at #{config_file}" }
+
     report_start = DateTime.parse("2020-01-01")
     report_end = DateTime.now
     facilities_to_export = config["facilities"]
@@ -21,11 +27,16 @@ namespace :opensrp do
     using_time_boundaries = using_time_boundaries? config
     report_start = DateTime.parse(time_boundaries["report_start"]) if has_report_start?(config)
     report_end = DateTime.parse(time_boundaries["report_end"]) if has_report_end?(config)
-    time_window = report_start..report_end
+
+    logger.tagged("opensrp:export") { logger.info "Time Boundaries: [#{report_start}..#{report_end}]" }
+
     resources = []
     encounters = []
     patients = Patient.where(assigned_facility_id: facilities_to_export.keys)
+
+    logger.tagged("opensrp:export") { logger.info "Preparing data for #{patients.size} patients" }
     patients.each do |patient|
+      logger.tagged("opensrp:export") { logger.debug "Preparing data for Patient[##{patient.id}]" }
       patient_exporter = OneOff::Opensrp::PatientExporter.new(patient, facilities_to_export)
       resources << patient_exporter.export
       resources << patient_exporter.export_registration_questionnaire_response
@@ -33,6 +44,7 @@ namespace :opensrp do
 
       blood_pressures = patient.blood_pressures
       blood_pressures = blood_pressures.where(recorded_at: time_window).or(updated_at: time_window) if using_time_boundaries
+      logger.tagged("opensrp:export") { logger.debug "Patient[##{patient.id}] has #{blood_pressures.size} blood pressure readings." }
       blood_pressures.each do |bp|
         resources << bp_exporter.export
         encounters << bp_exporter.export_encounter
@@ -40,6 +52,7 @@ namespace :opensrp do
 
       blood_sugars = patient.blood_sugars
       blood_sugars = blood_sugars.where(recorded_at: time_window).or(updated_at: time_window) if using_time_boundaries
+      logger.tagged("opensrp:export") { logger.debug "Patient[##{patient.id}] has #{blood_sugars.size} blood sugar readings." }
       blood_sugars.each do |bp|
         if patient.medical_history.diabetes_no?
           resources << bs_exporter.export_no_diabetes_observation
@@ -50,6 +63,7 @@ namespace :opensrp do
 
       prescription_drugs = patient.prescription_drugs
       prescription_drugs = prescription_drugs.where(created_at: time_window).or(updated_at: time_window) if using_time_boundaries
+      logger.tagged("opensrp:export") { logger.debug "Patient[##{patient.id}] has #{prescription_drugs.size} drugs prescribed." }
       prescription_drugs.each do |bp|
         resources << drug_exporter.export_dosage_flag
         encounters << drug_exporter.export_encounter
@@ -62,6 +76,7 @@ namespace :opensrp do
 
       appointments = patient.appointments
       appointments = appointments.where(created_at: time_window).or(updated_at: time_window) if using_time_boundaries
+      logger.tagged("opensrp:export") { logger.debug "Patient[##{patient.id}] has #{appointments.size} appointments." }
       appointments.each do |bp|
         appointment_exporter = OneOff::Opensrp::AppointmentExporter.new(appointment, facilities_to_export)
         resources << appointment_exporter.export

--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -3,7 +3,7 @@ require "yaml"
 
 logfile = Rails.root.join("log", "#{Rails.env}.log")
 logger = ActiveSupport::Logger.new(logfile)
-logger.extend(ActiveSupport::Logger.broadcast(ActiveSupport::Logger.new(STDOUT)))
+logger.extend(ActiveSupport::Logger.broadcast(ActiveSupport::Logger.new($stdout)))
 
 namespace :opensrp do
   desc "Export simple patient-related data as opensrp fhir resources"


### PR DESCRIPTION
**Story card:** [sc-14814](https://app.shortcut.com/simpledotorg/story/14814/opensrp-exports-export-a-specific-time-window)

## Because

When these rake tasks run, we are practically blind

## This addresses

The need to have some logs for monitoring in Loki/Grafana

## Test instructions

- run the script, see the logs
