### PR TITLE
fix(OpenSRP Exporter): Patient Export, Syntax, et al

### DIFF
--- a/app/services/one_off/opensrp/encounter_generator.rb
+++ b/app/services/one_off/opensrp/encounter_generator.rb
@@ -19,7 +19,7 @@ module OneOff
           service_provider = first_child_encounter.serviceProvider
           child_encounters.pluck(:child_encounter).append(
             FHIR::Encounter.new(
-              meta: meta(opensrp_ids),
+              meta: meta(opensrp_ids.symbolize_keys),
               status: "finished",
               id: parent_id,
               identifier: [

--- a/config/opensrp-export.sample.yml
+++ b/config/opensrp-export.sample.yml
@@ -4,13 +4,7 @@ time_boundaries:
 facilities:
   d1dbd3c6-26bb-48e7-aa89-bc8a0b2bf75b:
     name: Health Facility 1
-    opensrp_practitioner_id: 0c375fe8-b38f-484e-aa64-c02750ee183b
-    opensrp_organization_id: d3363aea-66ad-4370-809a-8e4436a4218f
-    opensrp_care_team_id: 1c8100b5-222b-4815-ba4d-3ebde537c6ce
-    opensrp_location_id: ABC01230123
-  b100eb1a-18b3-424f-a2bf-c2e6b1655b1b:
-    name: Health Facility 2
-    opensrp_practitioner_id: 34a9da76-e18c-4fd6-a696-dee7a8454fb4
-    opensrp_organization_id: 5466dfd9-b10b-4bd8-8692-5732340de7f1
-    opensrp_care_team_id: f91c89c9-6790-4a94-b877-5feb578e0af8
-    opensrp_location_id: DEF01230123
+    practitioner_id: 0c375fe8-b38f-484e-aa64-c02750ee183b
+    organization_id: d3363aea-66ad-4370-809a-8e4436a4218f
+    care_team_id: 1c8100b5-222b-4815-ba4d-3ebde537c6ce
+    location_id: ABC01230123

--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -38,10 +38,12 @@ namespace :opensrp do
     logger.info "Preparing data for #{patients.size} patients"
     patients.each do |patient|
       logger.debug "Preparing data for Patient[##{patient.id}]"
-      patient_exporter = OneOff::Opensrp::PatientExporter.new(patient, facilities_to_export)
-      resources << patient_exporter.export
-      resources << patient_exporter.export_registration_questionnaire_response
-      encounters << patient_exporter.export_registration_encounter
+      if time_window.cover?(patient.recorded_at)
+        patient_exporter = OneOff::Opensrp::PatientExporter.new(patient, facilities_to_export)
+        resources << patient_exporter.export
+        resources << patient_exporter.export_registration_questionnaire_response
+        encounters << patient_exporter.export_registration_encounter
+      end
 
       blood_pressures = patient.blood_pressures
       blood_pressures = blood_pressures.where(recorded_at: time_window).or(blood_pressures.where(updated_at: time_window)) if using_time_boundaries

--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -113,11 +113,11 @@ namespace :opensrp do
   end
 
   def has_report_start?(config)
-    using_time_boundaries?(config) && time_boundaries.has_key?("report_start")
+    using_time_boundaries?(config) && config["time_boundaries"].has_key?("report_start")
   end
 
   def has_report_end?(config)
-    using_time_boundaries?(config) && time_boundaries.has_key?("report_end")
+    using_time_boundaries?(config) && config["time_boundaries"].has_key?("report_end")
   end
 
   def create_audit_record(facilities, patient)

--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -25,8 +25,8 @@ namespace :opensrp do
     facilities_to_export = config["facilities"]
     time_boundaries = config["time_boundaries"]
     using_time_boundaries = using_time_boundaries? config
-    report_start = DateTime.parse(time_boundaries["report_start"]) if has_report_start?(config)
-    report_end = DateTime.parse(time_boundaries["report_end"]) if has_report_end?(config)
+    report_start = time_boundaries["report_start"] if has_report_start?(config)
+    report_end = time_boundaries["report_end"] if has_report_end?(config)
 
     logger.info "Time Boundaries: [#{report_start}..#{report_end}]"
 

--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -27,6 +27,7 @@ namespace :opensrp do
     using_time_boundaries = using_time_boundaries? config
     report_start = time_boundaries["report_start"] if has_report_start?(config)
     report_end = time_boundaries["report_end"] if has_report_end?(config)
+    time_window = report_start..report_end
 
     logger.info "Time Boundaries: [#{report_start}..#{report_end}]"
 


### PR DESCRIPTION
**Story card:** [sc-14814](https://app.shortcut.com/simpledotorg/story/14814/opensrp-exports-export-a-specific-time-window)

## Because

Running the exporter failed for a few reasons

## This addresses

All the reason the exporter fails per commit

- YAML parses dates directly into datetime
- declare `time_window` in local functions
- change hash to active_record#relation + add exporters
- use `time_window` definition in helper function
- ensure config data fits the `meta` function call
- return original keys; code is dependent on them
- only add the patient encounter if recorded within `time_window`

## Test instructions

- build a new image
- run an export
- ensure all `lastUpdatedBy` for resource types which are not `Condition` happen within the time window specified
