### PR TITLE
fix(OpenSRP Exporter): Key Format

### DIFF
--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -16,7 +16,7 @@ namespace :opensrp do
 
     raise "Config file should be YAML" unless %w[yaml yml].include?(config_file.split(".").last)
     raise "Output file should be JSON" unless output_file.split(".").last == "json"
-    config = YAML.load_file(config_file)
+    config = YAML.load_file(config_file).deep_symbolize_keys.with_indifferent_access
 
     logger.info "Exporting data using config at #{config_file}"
 


### PR DESCRIPTION
**Story card:** [sc-14967](https://app.shortcut.com/simpledotorg/story/14967/opensrp-export-fix-null-practitioner-uuid)

## Because

Practitioner IDs were not being filled in.

## This addresses

Making the keys in the config accessible in any form

## Test instructions

- build the image
- configure an export
  - find a seeded facility with data for the time-window you're concerned about
  - get the ID of said facility
  - Modify a copy of config/opensrp-export.sample.yml
    - use the ID of said facility as the ID of the test Facility
    - remember to set the time boundaries accordingly
- run the export task with the configuration file
- copy the generated json out of your docker container
- group the json export with `jq -sc '.' [file] > [output]`
- grep `[output]` for practitioner references with UUIDs
