### PR TITLE
Sc 14920 added source slug

### DIFF
--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -28,7 +28,7 @@
       <div>⚡ <a href="<%= ENV.fetch('DISTRICT_FACILITY_TREND_REPORT_URL', '') %><%= @region.slug %>&for_end_of_month=" target="_blank">
         District facility trend report
       </a></div>
-      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_DRUG_STOCK_REPORT_URL', '') %><%= @region.name %>&for_end_of_month=<%= last_month %>" target="_blank">
+      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_DRUG_STOCK_REPORT_URL', '') %><%= @region.slug %>&for_end_of_month=<%= last_month %>" target="_blank">
         District Drug stock report
       </a></div>
       <div>⚡ <a href="<%= ENV.fetch('DISTRICT_METABASE_TITRATION_URL', '') %><%= @region.name %>" target="_blank">

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -28,7 +28,7 @@
       <div>⚡ <a href="<%= ENV.fetch('DISTRICT_FACILITY_TREND_REPORT_URL', '') %><%= @region.slug %>&for_end_of_month=" target="_blank">
         District facility trend report
       </a></div>
-      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_DRUG_STOCK_REPORT_URL', '') %><%= @region.slug %>&for_end_of_month=<%= last_month %>" target="_blank">
+      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_DRUG_STOCK_REPORT_URL', '') %><%= @region.name %>&for_end_of_month=<%= last_month %>" target="_blank">
         District Drug stock report
       </a></div>
       <div>⚡ <a href="<%= ENV.fetch('DISTRICT_METABASE_TITRATION_URL', '') %><%= @region.name %>" target="_blank">

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -25,10 +25,10 @@
   <% elsif @region.district_region? %>
     <div class="float-right desktop">
       <h4 class="mb-0px">Quick links</h4>
-      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_FACILITY_TREND_REPORT_URL', '') %><%= @region.slug %>&for_end_of_month=" target="_blank">
+      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_FACILITY_TREND_REPORT_URL', '') %><%= @region.source.slug %>&for_end_of_month=" target="_blank">
         District facility trend report
       </a></div>
-      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_DRUG_STOCK_REPORT_URL', '') %><%= @region.slug %>&for_end_of_month=<%= last_month %>" target="_blank">
+      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_DRUG_STOCK_REPORT_URL', '') %><%= @region.source.slug %>&for_end_of_month=<%= last_month %>" target="_blank">
         District Drug stock report
       </a></div>
       <div>⚡ <a href="<%= ENV.fetch('DISTRICT_METABASE_TITRATION_URL', '') %><%= @region.name %>" target="_blank">


### PR DESCRIPTION
**Story card:** [sc-14920](https://app.shortcut.com/simpledotorg/story/14920/quick-links-at-district-level-reports)

Because
At district level, quick links will open the corresponding metabase report for that district

This Addresses
Will open the quick links for the respective district

Test Instructions
Enable the flipper "quick_link_for_metabase"