### PR TITLE
fix: Remove duplicate states

### DIFF
--- a/config/data/canonical_states.yml
+++ b/config/data/canonical_states.yml
@@ -73,6 +73,3 @@ Sri Lanka:
   - Southern Province
   - Uva Province
   - Western Province
-  - Uva Province
-  - Northern Province
-  - Sabaragamuwa Province


### PR DESCRIPTION
**Story card:** [sc-15047](https://app.shortcut.com/simpledotorg/story/15047/create-new-sl-provinces)

## Because

After #5543 deployed, we realized that the states which were added already existed in the config, but did not exist in the DB. — this is a weird problem we need to solve, but is outside the scope of this current work.

## This addresses

Removing the newly added entries to canonical states which forced a re-creation of the non-existing regions.

## Test instructions

n/a
