### PR TITLE
Sc 15055

### DIFF
--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -34,7 +34,7 @@
       <div>⚡ <a href="<%= ENV.fetch('DISTRICT_METABASE_TITRATION_URL', '') %><%= @region.name %>" target="_blank">
         Metabase: Titration report
       </a></div>
-      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_METABASE_BP_FUDGING_URL', '') %><%= @region.parent.name %>&district_name= <%= @region.source.slug %>" target="_blank">
+      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_METABASE_BP_FUDGING_URL', '') %><%= @region.parent.name %>&district_name= <%= @region.name %>" target="_blank">
         Metabase: BP fudging report
       </a></div>
     </div>

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -106,6 +106,10 @@ RSpec.describe Reports::RegionsController, type: :controller do
           expect(response.body).to_not include("District Drug sto_notck report")
           expect(response.body).to_not include("Metabase: Titration report")
           expect(response.body).to_not include("Metabase: BP fudging report")
+          expect(response.body).to_not include("https://api.example.com/my_facilities/drug_stocks?facility_group=")
+          expect(response.body).to_not include("https://api.example.com/my_facilities/bp_controlled?facility_group=")
+          expect(response.body).to_not include("https://metabase.example.com/titration?district_name=")
+          expect(response.body).to_not include("https://metabase.example.com/bp_fudging?state_name=")
         end
       end
     end


### PR DESCRIPTION
**Story card:** [sc-15055](https://app.shortcut.com/simpledotorg/story/15055/additional-reports-for-district-dashboards-bp-fudging)

Because
At district level, quick links will open the corresponding metabase report for that district

This Addresses
Will open the quick links for the respective district

Test Instructions
Enable the flipper "quick_link_for_metabase"