### PR TITLE
Sc 15055

### DIFF
--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -34,7 +34,7 @@
       <div>⚡ <a href="<%= ENV.fetch('DISTRICT_METABASE_TITRATION_URL', '') %><%= @region.name %>" target="_blank">
         Metabase: Titration report
       </a></div>
-      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_METABASE_BP_FUDGING_URL', '') %><%= @region.parent.name %>&district_name= <%= @region.name %>" target="_blank">
+      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_METABASE_BP_FUDGING_URL', '') %><%= @region.parent.name %>&district_name=<%= @region.name %>" target="_blank">
         Metabase: BP fudging report
       </a></div>
     </div>


### PR DESCRIPTION
**Story card:** [sc-15055](https://app.shortcut.com/simpledotorg/story/15055/additional-reports-for-district-dashboards-bp-fudging)

Because
At district level, quick links will open the corresponding metabase report for that district

This Addresses
Will open the quick links for the respective district

Test Instructions
Enable the flipper "quick_link_for_metabase"