### PR TITLE
Added Systolic BP reading report in quick links

### DIFF
--- a/.env.BD
+++ b/.env.BD
@@ -8,3 +8,4 @@ DISTRICT_FACILITY_TREND_REPORT_URL = "https://api.bd.simple.org/my_facilities/bp
 DISTRICT_DRUG_STOCK_REPORT_URL = "https://api.bd.simple.org/my_facilities/drug_stocks?facility_group="
 DISTRICT_METABASE_TITRATION_URL = "https://metabase.bd.simple.org/question/997-district-titration-trend?months=past9months&district_name="
 DISTRICT_METABASE_BP_FUDGING_URL = "https://metabase.bd.simple.org/question/1000-01-district-report?state_name="
+DISTRICT_METABASE_SYSTOLIC_BP_URL = "https://metabase.bd.simple.org/question/1005-histogram-systolic-reading-for-all-bp-measures-in-past-3-months?district="

--- a/.env.test
+++ b/.env.test
@@ -70,3 +70,4 @@ DISTRICT_DRUG_STOCK_REPORT_URL = "https://api.example.com/my_facilities/drug_sto
 DISTRICT_FACILITY_TREND_REPORT_URL = "https://api.example.com/my_facilities/bp_controlled?facility_group="
 DISTRICT_METABASE_TITRATION_URL = "https://metabase.example.com/titration?district_name="
 DISTRICT_METABASE_BP_FUDGING_URL = "https://metabase.example.com/bp_fudging?state_name="
+DISTRICT_METABASE_SYSTOLIC_BP_URL = "https://metabase.example.com/systolic?district_name="

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -37,6 +37,9 @@
       <div>⚡ <a href="<%= ENV.fetch('DISTRICT_METABASE_BP_FUDGING_URL', '') %><%= @region.parent.name %>&district_name=<%= @region.name %>" target="_blank">
         Metabase: BP fudging report
       </a></div>
+      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_METABASE_SYSTOLIC_BP_URL', '') %><%= @region.name %>" target="_blank">
+        Metabase: Systolic BP reading report
+      </a></div>
     </div>
   <% end %>
 <% end %>

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -92,10 +92,12 @@ RSpec.describe Reports::RegionsController, type: :controller do
           expect(response.body).to include("Drug stock")
           expect(response.body).to include("Metabase: Titration report")
           expect(response.body).to include("Metabase: BP fudging report")
+          expect(response.body).to include("Metabase: Systolic BP reading report")
           expect(response.body).to include("https://api.example.com/my_facilities/drug_stocks?facility_group=")
           expect(response.body).to include("https://api.example.com/my_facilities/bp_controlled?facility_group=")
           expect(response.body).to include("https://metabase.example.com/titration?district_name=")
           expect(response.body).to include("https://metabase.example.com/bp_fudging?state_name=")
+          expect(response.body).to include("https://metabase.example.com/systolic?district_name=")
         end
       end
       context "and the feature flag is disabled" do
@@ -106,10 +108,12 @@ RSpec.describe Reports::RegionsController, type: :controller do
           expect(response.body).to_not include("District Drug sto_notck report")
           expect(response.body).to_not include("Metabase: Titration report")
           expect(response.body).to_not include("Metabase: BP fudging report")
+          expect(response.body).to_not include("Metabase: Systolic BP reading report")
           expect(response.body).to_not include("https://api.example.com/my_facilities/drug_stocks?facility_group=")
           expect(response.body).to_not include("https://api.example.com/my_facilities/bp_controlled?facility_group=")
           expect(response.body).to_not include("https://metabase.example.com/titration?district_name=")
           expect(response.body).to_not include("https://metabase.example.com/bp_fudging?state_name=")
+          expect(response.body).to_not include("https://metabase.example.com/systolic?district_name=")
         end
       end
     end


### PR DESCRIPTION
**Story card:** [sc-15060](https://app.shortcut.com/simpledotorg/story/15060/update-systolic-bp-readings-query-report-layout)

Because
At district level, quick links will open the corresponding metabase report for that district

This Addresses
Will open the quick links for the respective district

Test Instructions
Enable the flipper "quick_link_for_metabase"