### PR TITLE
sc-15060 modified env bd

### DIFF
--- a/.env.BD
+++ b/.env.BD
@@ -8,4 +8,4 @@ DISTRICT_FACILITY_TREND_REPORT_URL = "https://api.bd.simple.org/my_facilities/bp
 DISTRICT_DRUG_STOCK_REPORT_URL = "https://api.bd.simple.org/my_facilities/drug_stocks?facility_group="
 DISTRICT_METABASE_TITRATION_URL = "https://metabase.bd.simple.org/question/997-district-titration-trend?months=past9months&district_name="
 DISTRICT_METABASE_BP_FUDGING_URL = "https://metabase.bd.simple.org/question/1000-01-district-report?state_name="
-DISTRICT_METABASE_SYSTOLIC_BP_URL = "https://metabase.bd.simple.org/question/1005-histogram-systolic-reading-for-all-bp-measures-in-past-3-months?district="
+DISTRICT_METABASE_SYSTOLIC_BP_URL = "https://metabase.bd.simple.org/question/1005-histogram-systolic-reading-for-all-bp-measures-in-past-3-months?district_name="


### PR DESCRIPTION
**Story card:** [sc-14920](https://app.shortcut.com/simpledotorg/story/14920/quick-links-at-district-level-reports)

Because
At district level, quick links will open the corresponding metabase report for that district

This Addresses
Will open the quick links for the respective district

Test Instructions
Enable the flipper "quick_link_for_metabase"