### PR TITLE
chore: Index cvd_risks on risk_score

### DIFF
--- a/db/migrate/20250327172921_index_cvd_risk_on_risk_score.rb
+++ b/db/migrate/20250327172921_index_cvd_risk_on_risk_score.rb
@@ -1,0 +1,5 @@
+class IndexCvdRiskOnRiskScore < ActiveRecord::Migration[6.1]
+  def change
+    add_index :cvd_risks, :risk_score
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6299,6 +6299,13 @@ CREATE INDEX index_cvd_risks_on_patient_id ON public.cvd_risks USING btree (pati
 
 
 --
+-- Name: index_cvd_risks_on_risk_score; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_cvd_risks_on_risk_score ON public.cvd_risks USING btree (risk_score);
+
+
+--
 -- Name: index_deduplication_logs_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7862,6 +7869,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241129212725'),
 ('20241204155510'),
 ('20241210092449'),
-('20250120104431');
+('20250120104431'),
+('20250327172921');
 
 


### PR DESCRIPTION
**Story card:** [sc-14082](https://app.shortcut.com/simpledotorg/story/14082/add-statins-analytics-to-metabase)

## Because

We would be asking questions on the risk score more frequently in reports

## This addresses

Adding an index to `cvd_risks` on `risk_score`

## Test instructions

n.a
