### PR TITLE
sc-15091 added division level report

### DIFF
--- a/.env.BD
+++ b/.env.BD
@@ -9,3 +9,5 @@ DISTRICT_DRUG_STOCK_REPORT_URL = "https://api.bd.simple.org/my_facilities/drug_s
 DISTRICT_METABASE_TITRATION_URL = "https://metabase.bd.simple.org/question/997-district-titration-trend?months=past9months&district_name="
 DISTRICT_METABASE_BP_FUDGING_URL = "https://metabase.bd.simple.org/question/1000-01-district-report?state_name="
 DISTRICT_METABASE_SYSTOLIC_BP_URL = "https://metabase.bd.simple.org/question/1005-histogram-systolic-reading-for-all-bp-measures-in-past-3-months?district_name="
+DIVISION_METABASE_TITRATION_URL = "https://metabase.bd.simple.org/question/998-division-titration-trend?months=past9months&state_name="
+DIVISION_METABASE_SYSTOLIC_BP_URL = "https://metabase.bd.simple.org/question/1010-histogram-systolic-reading-for-all-bp-measures-in-past-3-months-division?state_name="

--- a/.env.test
+++ b/.env.test
@@ -71,3 +71,5 @@ DISTRICT_FACILITY_TREND_REPORT_URL = "https://api.example.com/my_facilities/bp_c
 DISTRICT_METABASE_TITRATION_URL = "https://metabase.example.com/titration?district_name="
 DISTRICT_METABASE_BP_FUDGING_URL = "https://metabase.example.com/bp_fudging?state_name="
 DISTRICT_METABASE_SYSTOLIC_BP_URL = "https://metabase.example.com/systolic?district_name="
+DIVISION_METABASE_TITRATION_URL = "https://metabase.example.com/titration?state_name="
+DIVISION_METABASE_SYSTOLIC_BP_URL = "https://metabase.example.com/systolic?state_name="

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -41,6 +41,16 @@
         Metabase: Systolic BP reading report
       </a></div>
     </div>
+  <% elsif @region.state_region? %>
+    <div class="float-right desktop">
+      <h4 class="mb-0px">Quick links</h4>
+      <div>⚡ <a href="<%= ENV.fetch('DIVISION_METABASE_TITRATION_URL', '') %><%= @region.name %>" target="_blank">
+        Metabase: Titration report
+      </a></div>
+      <div>⚡ <a href="<%= ENV.fetch('DIVISION_METABASE_SYSTOLIC_BP_URL', '') %><%= @region.name %>" target="_blank">
+        Metabase: Systolic BP reading report
+      </a></div>
+    </div>
   <% end %>
 <% end %>
 

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -118,30 +118,28 @@ RSpec.describe Reports::RegionsController, type: :controller do
       end
     end
 
-  context "when the region is a division region" do
-    let(:facility_group) { create(:facility_group, organization: organization) }
-    let(:state) { create(:facility, facility_group: facility_group) }
-    let(:region) { state.region }
-    before do
-      state.region.update(region_type: "state")
-      allow(region).to receive(:state_region?).and_return(true)
-      allow(DeviceDetector).to receive(:new).and_return(double(device_type: "desktop"))
-    end
+    context "when the region is a division region" do
+      let(:facility_group) { create(:facility_group, organization: organization) }
+      let(:state) { create(:facility, facility_group: facility_group) }
+      let(:region) { state.region }
+      before do
+        state.region.update(region_type: "state")
+        allow(region).to receive(:state_region?).and_return(true)
+        allow(DeviceDetector).to receive(:new).and_return(double(device_type: "desktop"))
+      end
 
-    context "and the feature flag is disabled" do
-      it "does not display the quick links section" do
-        sign_in(cvho.email_authentication)
-        get :show, params: { id: facility_group.slug, report_scope: "state" }
+      context "and the feature flag is disabled" do
+        it "does not display the quick links section" do
+          sign_in(cvho.email_authentication)
+          get :show, params: {id: facility_group.slug, report_scope: "state"}
 
-        expect(response.body).to_not include("Metabase: Titration report")
-        expect(response.body).to_not include("Metabase: Systolic BP reading report")
-        expect(response.body).to_not include("https://metabase.example.com/titration?state_name=")
-        expect(response.body).to_not include("https://metabase.example.com/systolic?state_name=")
+          expect(response.body).to_not include("Metabase: Titration report")
+          expect(response.body).to_not include("Metabase: Systolic BP reading report")
+          expect(response.body).to_not include("https://metabase.example.com/titration?state_name=")
+          expect(response.body).to_not include("https://metabase.example.com/systolic?state_name=")
+        end
       end
     end
-  end
-
-
 
     it "redirects if matching region slug not found" do
       sign_in(cvho.email_authentication)

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
       end
     end
 
-    context "when the region is a facility region" do
+    context "when the region is a district region" do
       let(:facility_group) { create(:facility_group, organization: organization) }
       let(:district) { create(:facility, facility_group: facility_group) }
       let(:region) { district.region }
@@ -117,6 +117,31 @@ RSpec.describe Reports::RegionsController, type: :controller do
         end
       end
     end
+
+  context "when the region is a division region" do
+    let(:facility_group) { create(:facility_group, organization: organization) }
+    let(:state) { create(:facility, facility_group: facility_group) }
+    let(:region) { state.region }
+    before do
+      state.region.update(region_type: "state")
+      allow(region).to receive(:state_region?).and_return(true)
+      allow(DeviceDetector).to receive(:new).and_return(double(device_type: "desktop"))
+    end
+
+    context "and the feature flag is disabled" do
+      it "does not display the quick links section" do
+        sign_in(cvho.email_authentication)
+        get :show, params: { id: facility_group.slug, report_scope: "state" }
+
+        expect(response.body).to_not include("Metabase: Titration report")
+        expect(response.body).to_not include("Metabase: Systolic BP reading report")
+        expect(response.body).to_not include("https://metabase.example.com/titration?state_name=")
+        expect(response.body).to_not include("https://metabase.example.com/systolic?state_name=")
+      end
+    end
+  end
+
+
 
     it "redirects if matching region slug not found" do
       sign_in(cvho.email_authentication)


### PR DESCRIPTION
**Story card:** [sc-15091](https://app.shortcut.com/simpledotorg/story/15091/quick-links-at-division-level-reports)

Because
At division level, quick links will open the corresponding metabase report for that division

This Addresses
Will open the quick links for the respective division

Test Instructions
Enable the flipper "quick_link_for_metabase"