### PR TITLE
Sc 15091

### DIFF
--- a/.env.BD
+++ b/.env.BD
@@ -11,4 +11,4 @@ DISTRICT_METABASE_BP_FUDGING_URL = "https://metabase.bd.simple.org/question/1000
 DISTRICT_METABASE_SYSTOLIC_BP_URL = "https://metabase.bd.simple.org/question/1005-histogram-systolic-reading-for-all-bp-measures-in-past-3-months?district_name="
 DIVISION_METABASE_TITRATION_URL = "https://metabase.bd.simple.org/question/998-division-titration-trend?months=past9months&state_name="
 DIVISION_METABASE_SYSTOLIC_BP_URL = "https://metabase.bd.simple.org/question/1010-histogram-systolic-reading-for-all-bp-measures-in-past-3-months-division?state_name="
-DISTRICT_METABASE_BP_FUDGING_URL = "https://metabase.bd.simple.org/question/1011-division-report?state_name="
+DIVISION_METABASE_BP_FUDGING_URL = "https://metabase.bd.simple.org/question/1011-division-report?state_name="

--- a/.env.BD
+++ b/.env.BD
@@ -11,3 +11,4 @@ DISTRICT_METABASE_BP_FUDGING_URL = "https://metabase.bd.simple.org/question/1000
 DISTRICT_METABASE_SYSTOLIC_BP_URL = "https://metabase.bd.simple.org/question/1005-histogram-systolic-reading-for-all-bp-measures-in-past-3-months?district_name="
 DIVISION_METABASE_TITRATION_URL = "https://metabase.bd.simple.org/question/998-division-titration-trend?months=past9months&state_name="
 DIVISION_METABASE_SYSTOLIC_BP_URL = "https://metabase.bd.simple.org/question/1010-histogram-systolic-reading-for-all-bp-measures-in-past-3-months-division?state_name="
+DISTRICT_METABASE_BP_FUDGING_URL = "https://metabase.bd.simple.org/question/1011-division-report?state_name="

--- a/.env.test
+++ b/.env.test
@@ -73,3 +73,4 @@ DISTRICT_METABASE_BP_FUDGING_URL = "https://metabase.example.com/bp_fudging?stat
 DISTRICT_METABASE_SYSTOLIC_BP_URL = "https://metabase.example.com/systolic?district_name="
 DIVISION_METABASE_TITRATION_URL = "https://metabase.example.com/titration?state_name="
 DIVISION_METABASE_SYSTOLIC_BP_URL = "https://metabase.example.com/systolic?state_name="
+DIVISION_METABASE_SYSTOLIC_BP_URL = "https://metabase.example.com/bp_fudging_division?state_name="

--- a/.env.test
+++ b/.env.test
@@ -73,4 +73,4 @@ DISTRICT_METABASE_BP_FUDGING_URL = "https://metabase.example.com/bp_fudging?stat
 DISTRICT_METABASE_SYSTOLIC_BP_URL = "https://metabase.example.com/systolic?district_name="
 DIVISION_METABASE_TITRATION_URL = "https://metabase.example.com/titration?state_name="
 DIVISION_METABASE_SYSTOLIC_BP_URL = "https://metabase.example.com/systolic?state_name="
-DIVISION_METABASE_SYSTOLIC_BP_URL = "https://metabase.example.com/bp_fudging_division?state_name="
+DIVISION_METABASE_BP_FUDGING_URL = "https://metabase.example.com/bp_fudging_division?state_name="

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -50,7 +50,7 @@
       <div>⚡ <a href="<%= ENV.fetch('DIVISION_METABASE_SYSTOLIC_BP_URL', '') %><%= @region.name %>" target="_blank">
         Metabase: Systolic BP reading report
       </a></div>
-      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_METABASE_BP_FUDGING_URL', '') %><%= @region.name %>" target="_blank">
+      <div>⚡ <a href="<%= ENV.fetch('DIVISION_METABASE_BP_FUDGING_URL', '') %><%= @region.name %>" target="_blank">
         Metabase: BP fudging report
       </a></div>
     </div>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -50,6 +50,9 @@
       <div>⚡ <a href="<%= ENV.fetch('DIVISION_METABASE_SYSTOLIC_BP_URL', '') %><%= @region.name %>" target="_blank">
         Metabase: Systolic BP reading report
       </a></div>
+      <div>⚡ <a href="<%= ENV.fetch('DISTRICT_METABASE_BP_FUDGING_URL', '') %><%= @region.name %>" target="_blank">
+        Metabase: BP fudging report
+      </a></div>
     </div>
   <% end %>
 <% end %>

--- a/spec/controllers/reports/regions_controller_spec.rb
+++ b/spec/controllers/reports/regions_controller_spec.rb
@@ -137,6 +137,7 @@ RSpec.describe Reports::RegionsController, type: :controller do
           expect(response.body).to_not include("Metabase: Systolic BP reading report")
           expect(response.body).to_not include("https://metabase.example.com/titration?state_name=")
           expect(response.body).to_not include("https://metabase.example.com/systolic?state_name=")
+          expect(response.body).to_not include("https://metabase.example.com/bp_fudging_division?state_name=")
         end
       end
     end


### PR DESCRIPTION
**Story card:** [sc-15091](https://app.shortcut.com/simpledotorg/story/15091/quick-links-at-division-level-reports)

Because
At division level, quick links will open the corresponding metabase report for that division

This Addresses
Will open the quick links for the respective division

Test Instructions
Enable the flipper "quick_link_for_metabase"