### PR TITLE
sc-14945 updated rexml gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,7 +508,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.5)
+    rexml (3.4.1)
     rgeo (2.4.0)
     rgeo-geojson (2.1.1)
       rgeo (>= 1.0.0)


### PR DESCRIPTION
**Story card:** [sc-14945](https://app.shortcut.com/simpledotorg/story/14945/upgrade-libs-that-contain-cve)

## Because

We are updgrading the gem version one by one(upgraded rexml (3.2.5) ----> rexml (3.4.1)

## This addresses

This address the depandabot issue on our repository

## Test instructions

Enter detailed instructions for how to test this PR...