### PR TITLE
sc-14945 updated sidekiq-unique-jobs gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,8 @@ gem "doorkeeper", "~> 5.6"
 gem "prometheus_exporter"
 gem "zip_kit"
 gem "device_detector"
-gem 'sanitize', '~> 6.0', '>= 6.0.2'
+gem "sanitize", "~> 6.0", ">= 6.0.2"
+gem "globalid", "~> 1.0", ">= 1.0.1"
 
 group :development, :test do
   gem "active_record_query_trace", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ gem "sentry-sidekiq"
 gem "sidekiq-statsd"
 gem "sidekiq-throttled"
 gem "sidekiq"
-gem "sidekiq-unique-jobs"
+gem "sidekiq-unique-jobs", "~> 7.1", ">= 7.1.33"
 gem "slack-notifier"
 gem "squid"
 gem "stackprof", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,7 @@ gem "doorkeeper", "~> 5.6"
 gem "prometheus_exporter"
 gem "zip_kit"
 gem "device_detector"
+gem 'sanitize', '~> 6.0', '>= 6.0.2'
 
 group :development, :test do
   gem "active_record_query_trace", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,8 +276,8 @@ GEM
       ffi (~> 1.0)
     github-ds (0.5.2)
       activerecord (>= 3.2)
-    globalid (1.0.0)
-      activesupport (>= 5.0)
+    globalid (1.2.1)
+      activesupport (>= 6.1)
     google-protobuf (3.25.6)
     google-protobuf (3.25.6-x86_64-darwin)
     google-protobuf (3.25.6-x86_64-linux)
@@ -757,6 +757,7 @@ DEPENDENCIES
   friendly_id (~> 5.4.2)
   generator_spec
   github-ds
+  globalid (~> 1.0, >= 1.0.1)
   google-protobuf (~> 3.25, >= 3.25.5)
   groupdate
   guard-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -570,7 +570,7 @@ GEM
     ruby-statistics (3.0.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    sanitize (6.0.0)
+    sanitize (6.1.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     sassc (2.4.0)
@@ -807,6 +807,7 @@ DEPENDENCIES
   rswag-ui
   ruby-progressbar
   rubyzip
+  sanitize (~> 6.0, >= 6.0.2)
   sassc-rails
   scenic
   scientist

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,9 +95,9 @@ GEM
     bootstrap_form (4.5.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
-    brpoplpush-redis_script (0.1.2)
+    brpoplpush-redis_script (0.1.3)
       concurrent-ruby (~> 1.0, >= 1.0.5)
-      redis (>= 1.0, <= 5.0)
+      redis (>= 1.0, < 6)
     builder (3.2.4)
     byebug (11.1.3)
     capistrano (3.17.1)
@@ -612,10 +612,11 @@ GEM
       concurrent-ruby
       redis-prescription
       sidekiq
-    sidekiq-unique-jobs (7.1.27)
+    sidekiq-unique-jobs (7.1.33)
       brpoplpush-redis_script (> 0.1.1, <= 2.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.5)
-      sidekiq (>= 5.0, < 8.0)
+      redis (< 5.0)
+      sidekiq (>= 5.0, < 7.0)
       thor (>= 0.20, < 3.0)
     simplecov (0.21.2)
       docile (~> 1.1)
@@ -816,7 +817,7 @@ DEPENDENCIES
   sidekiq
   sidekiq-statsd
   sidekiq-throttled
-  sidekiq-unique-jobs
+  sidekiq-unique-jobs (~> 7.1, >= 7.1.33)
   simplecov
   slack-notifier
   spring (= 3.1.1)


### PR DESCRIPTION
**Story card:** [sc-14945](https://app.shortcut.com/simpledotorg/story/14945/upgrade-libs-that-contain-cve)

## Because

We are updgrading the gem version one by one(upgraded sidekiq-unique-jobs (7.1.27) ----> sidekiq-unique-jobs (7.1.33)

## This addresses

This address the depandabot issue on our repository

## Test instructions

Enter detailed instructions for how to test this PR...