### PR TITLE
sc-14946 added gems for all env

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -44,7 +44,7 @@ ENV RAILS_SERVE_STATIC_FILES true
 
 # Build
 RUN gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
-RUN bundle install --without development test
+RUN bundle config --delete without && bundle install
 RUN yarn install
 RUN set -a && source .env.development && set +a && bundle exec rake assets:precompile
 RUN chown -R app:app /home/app


### PR DESCRIPTION
**Story card:** [sc-14946](https://app.shortcut.com/simpledotorg/story/14946/make-sure-that-the-image-on-dockerhub-contains-all-the-gems-required-to-start-the-server-in-development-or-test-without-having)

## Because

Changed docker(prod) file so that we can have gems for all env 

## This addresses

Image can be used for dev env also

## Test instructions

Enter detailed instructions for how to test this PR...