### PR TITLE
fix: Do not sync discarded facilities

### DIFF
--- a/app/controllers/api/v3/facilities_controller.rb
+++ b/app/controllers/api/v3/facilities_controller.rb
@@ -14,7 +14,6 @@ class Api::V3::FacilitiesController < Api::V3::SyncController
 
   def other_facility_records
     Facility
-      .with_discarded
       .updated_on_server_since(other_facilities_processed_since, limit)
   end
 


### PR DESCRIPTION
**Story card:** [sc-15392](https://app.shortcut.com/simpledotorg/story/15392/do-not-sync-discarded-facilities)

## Because

Deleting a facility with its district causes onboarding to break

## This addresses

Not syncing discarded facilities

## Test instructions

- 
