### PR TITLE
fix: Change "PHN" to "Simple Clinic Number"

### DIFF
--- a/app/services/one_off/opensrp/patient_exporter.rb
+++ b/app/services/one_off/opensrp/patient_exporter.rb
@@ -113,8 +113,8 @@ module OneOff
               coding: [
                 FHIR::Coding.new(
                   system: "https://smartregister.org/",
-                  code: "PHN",
-                  display: "PHN"
+                  code: "clinic_number",
+                  display: "Simple Clinic Number"
                 )
               ]
             )


### PR DESCRIPTION
**Story card:** [sc-15420](https://app.shortcut.com/simpledotorg/story/15420/update-phn-tag-on-opensrp-dumps)

## Because

The OpenSRP team in SL prefers `clinic_number` to `phn` for the official identifier.

## This addresses

A text change bug in the OpenSRP exporter

## Test instructions

suite tests
