### PR TITLE
chore: Update manifest.json

### DIFF
--- a/public/manifest/qa.json
+++ b/public/manifest/qa.json
@@ -1,76 +1,53 @@
 {
-  "v1": [
+  "version": "3",
+  "countries": [
     {
       "country_code": "IN",
-      "endpoint": "https://api-qa.simple.org/api/",
       "display_name": "India",
-      "isd_code": "91"
+      "isd_code": "91",
+      "deployments": [
+        {
+          "display_name": "India",
+          "endpoint": "https://api-qa.simple.org/api/"
+        },
+        {
+          "display_name": "India test deployment",
+          "endpoint": "https://api-qa.simple.org/api/"
+        }
+      ]
     },
     {
       "country_code": "BD",
-      "endpoint": "https://api-qa.simple.org/api/",
       "display_name": "Bangladesh",
-      "isd_code": "880"
+      "isd_code": "880",
+      "deployments": [
+        {
+          "display_name": "Bangladesh",
+          "endpoint": "https://api-qa.simple.org/api/"
+        }
+      ]
     },
     {
       "country_code": "ET",
-      "endpoint": "https://api-qa.simple.org/api/",
       "display_name": "Ethiopia",
-      "isd_code": "251"
+      "isd_code": "251",
+      "deployments": [
+        {
+          "display_name": "Ethiopia",
+          "endpoint": "https://api-qa.simple.org/api/"
+        }
+      ]
     },
     {
       "country_code": "LK",
-      "endpoint": "https://api-qa.simple.org/api/",
       "display_name": "Sri Lanka",
-      "isd_code": "94"
+      "isd_code": "94",
+      "deployments": [
+        {
+          "display_name": "Sri Lanka",
+          "endpoint": "https://api-qa.simple.org/api/"
+        }
+      ]
     }
-  ],
-  "v2": {
-    "countries": [
-      {
-        "country_code": "IN",
-        "display_name": "India",
-        "isd_code": "91",
-        "deployments": [
-          {
-            "display_name": "India",
-            "endpoint": "https://api-qa.simple.org/api/"
-          }
-        ]
-      },
-      {
-        "country_code": "BD",
-        "display_name": "Bangladesh",
-        "isd_code": "880",
-        "deployments": [
-          {
-            "display_name": "Bangladesh",
-            "endpoint": "https://api-qa.simple.org/api/"
-          }
-        ]
-      },
-      {
-        "country_code": "ET",
-        "display_name": "Ethiopia",
-        "isd_code": "251",
-        "deployments": [
-          {
-            "display_name": "Ethiopia",
-            "endpoint": "https://api-qa.simple.org/api/"
-          }
-        ]
-      },
-      {
-        "country_code": "LK",
-        "display_name": "Sri Lanka",
-        "isd_code": "94",
-        "deployments": [
-          {
-            "display_name": "Sri Lanka",
-            "endpoint": "https://api-qa.simple.org/api/"
-          }
-        ]
-      }
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
**Story card:** [sc-15331](https://app.shortcut.com/simpledotorg/story/15331/update-the-manifest-payload-to-remove-versioning-and-directly-have-countries-at-the-top-level)

## Because

Some CI uses the QA manifest in this repository while other environments would be served from `simple-manifests`

## This addresses

Updating the structure of the QA manifest to match the version 3

## Test instructions

n/a
