### PR TITLE
fix(OpenSRP Exporter): Handle missing patient addresses

### DIFF
--- a/app/services/one_off/opensrp/patient_exporter.rb
+++ b/app/services/one_off/opensrp/patient_exporter.rb
@@ -36,17 +36,7 @@ module OneOff
               use: "mobile"
             )
           end,
-          address: FHIR::Address.new(
-            line: [patient.address.street_address],
-            city: patient.address.village_or_colony,
-            district: patient.address.district,
-            state: patient.address.state,
-            country: patient.address.country,
-            postalCode: patient.address.pin,
-            use: "home",
-            type: "physical",
-            text: address_text
-          ),
+          address: fhir_patient_address,
           generalPractitioner: [
             FHIR::Reference.new(reference: "Practitioner/#{opensrp_ids[:practitioner_id]}")
           ],
@@ -66,7 +56,25 @@ module OneOff
         )
       end
 
+      def fhir_patient_address
+        return {} if patient.address.nil?
+
+        FHIR::Address.new(
+          line: [patient.address.street_address],
+          city: patient.address.village_or_colony,
+          district: patient.address.district,
+          state: patient.address.state,
+          country: patient.address.country,
+          postalCode: patient.address.pin,
+          use: "home",
+          type: "physical",
+          text: address_text
+        ) if patient.address
+      end
+
       def address_text
+        return "" if patient.address.nil?
+
         "#{patient.address.street_address} (#{patient.address.village_or_colony}), [No GND Registered]"
       end
 

--- a/app/services/one_off/opensrp/patient_exporter.rb
+++ b/app/services/one_off/opensrp/patient_exporter.rb
@@ -59,17 +59,19 @@ module OneOff
       def fhir_patient_address
         return {} if patient.address.nil?
 
-        FHIR::Address.new(
-          line: [patient.address.street_address],
-          city: patient.address.village_or_colony,
-          district: patient.address.district,
-          state: patient.address.state,
-          country: patient.address.country,
-          postalCode: patient.address.pin,
-          use: "home",
-          type: "physical",
-          text: address_text
-        ) if patient.address
+        if patient.address
+          FHIR::Address.new(
+            line: [patient.address.street_address],
+            city: patient.address.village_or_colony,
+            district: patient.address.district,
+            state: patient.address.state,
+            country: patient.address.country,
+            postalCode: patient.address.pin,
+            use: "home",
+            type: "physical",
+            text: address_text
+          )
+        end
       end
 
       def address_text

--- a/lib/tasks/opensrp.rake
+++ b/lib/tasks/opensrp.rake
@@ -187,7 +187,7 @@ namespace :opensrp do
       patient_name: patient.full_name,
       patient_gender: patient.gender,
       patient_date_of_birth: patient.date_of_birth || patient.age_updated_at - patient.age.years,
-      patient_address: patient.address.street_address,
+      patient_address: patient.address ? patient.address.street_address : "",
       patient_telephone: patient.phone_numbers.pluck(:number).join(";"),
       patient_facility: facilities[patient.assigned_facility_id][:name],
       patient_preferred_language: "Sinhala",

--- a/spec/services/one_off/opensrp/patient_exporter_spec.rb
+++ b/spec/services/one_off/opensrp/patient_exporter_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe OneOff::Opensrp::PatientExporter do
+  describe "#fhir_patient_address" do
+    it "is {} when the patient has no address" do
+      patient = create(:patient, address: nil)
+
+      expect(patient.address).to be_nil
+
+      exporter = OneOff::Opensrp::PatientExporter.new(patient, {})
+
+      expect(exporter.fhir_patient_address).to eq({})
+    end
+  end
+
+  describe "#address_text" do
+    it "is empty string when patient has no address" do
+      patient = create(:patient, address: nil)
+
+      expect(patient.address).to be_nil
+
+      exporter = OneOff::Opensrp::PatientExporter.new(patient, {})
+
+      expect(exporter.address_text).to eq("")
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-15562](https://app.shortcut.com/simpledotorg/story/15562/fix-address-issue-in-opensrp-exporter-then-re-dump-katugahahena)

## Because

Patients without addresses break the export process

## This addresses

Handling null cases for `patient.address`

## Test instructions

suite tests
