### PR TITLE
chore: Make tests faster

### DIFF
--- a/spec/queries/patient_states/diabetes/bs_over200_patients_query_spec.rb
+++ b/spec/queries/patient_states/diabetes/bs_over200_patients_query_spec.rb
@@ -16,7 +16,15 @@ describe PatientStates::Diabetes::BsOver200PatientsQuery do
       facility_2_bs_below_200_patients = create_list(:patient, 1, :bs_below_200, assigned_facility: regions[:facility_2])
       facility_2_bs_200_to_300_patients = create_list(:patient, 1, :bs_200_to_300, assigned_facility: regions[:facility_2])
       facility_2_bs_over_300_patients = create_list(:patient, 1, :bs_over_300, assigned_facility: regions[:facility_2])
-      refresh_views views: ["Reports::PatientState"]
+      refresh_views views: %w[
+        Reports::Month
+        Reports::Facility
+        Reports::PatientBloodPressure
+        Reports::PatientBloodSugar
+        Reports::PatientVisit
+        Reports::Prescriptions
+        Reports::PatientState
+      ]
 
       expect(PatientStates::Diabetes::BsOver200PatientsQuery.new(regions[:facility_1].region, period)
                                                    .call

--- a/spec/queries/patient_states/diabetes/bs_over200_patients_query_spec.rb
+++ b/spec/queries/patient_states/diabetes/bs_over200_patients_query_spec.rb
@@ -16,7 +16,7 @@ describe PatientStates::Diabetes::BsOver200PatientsQuery do
       facility_2_bs_below_200_patients = create_list(:patient, 1, :bs_below_200, assigned_facility: regions[:facility_2])
       facility_2_bs_200_to_300_patients = create_list(:patient, 1, :bs_200_to_300, assigned_facility: regions[:facility_2])
       facility_2_bs_over_300_patients = create_list(:patient, 1, :bs_over_300, assigned_facility: regions[:facility_2])
-      refresh_views
+      refresh_views views: ['Reports::PatientStates']
 
       expect(PatientStates::Diabetes::BsOver200PatientsQuery.new(regions[:facility_1].region, period)
                                                    .call

--- a/spec/queries/patient_states/diabetes/bs_over200_patients_query_spec.rb
+++ b/spec/queries/patient_states/diabetes/bs_over200_patients_query_spec.rb
@@ -16,7 +16,7 @@ describe PatientStates::Diabetes::BsOver200PatientsQuery do
       facility_2_bs_below_200_patients = create_list(:patient, 1, :bs_below_200, assigned_facility: regions[:facility_2])
       facility_2_bs_200_to_300_patients = create_list(:patient, 1, :bs_200_to_300, assigned_facility: regions[:facility_2])
       facility_2_bs_over_300_patients = create_list(:patient, 1, :bs_over_300, assigned_facility: regions[:facility_2])
-      refresh_views views: ['Reports::PatientStates']
+      refresh_views views: ["Reports::PatientStates"]
 
       expect(PatientStates::Diabetes::BsOver200PatientsQuery.new(regions[:facility_1].region, period)
                                                    .call

--- a/spec/queries/patient_states/diabetes/bs_over200_patients_query_spec.rb
+++ b/spec/queries/patient_states/diabetes/bs_over200_patients_query_spec.rb
@@ -16,7 +16,7 @@ describe PatientStates::Diabetes::BsOver200PatientsQuery do
       facility_2_bs_below_200_patients = create_list(:patient, 1, :bs_below_200, assigned_facility: regions[:facility_2])
       facility_2_bs_200_to_300_patients = create_list(:patient, 1, :bs_200_to_300, assigned_facility: regions[:facility_2])
       facility_2_bs_over_300_patients = create_list(:patient, 1, :bs_over_300, assigned_facility: regions[:facility_2])
-      refresh_views views: ["Reports::PatientStates"]
+      refresh_views views: ["Reports::PatientState"]
 
       expect(PatientStates::Diabetes::BsOver200PatientsQuery.new(regions[:facility_1].region, period)
                                                    .call

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,8 +53,8 @@ RSpec.configure do |config|
     end
   end
 
-  def refresh_views
-    RefreshReportingViews.call
+  def refresh_views(views: :all)
+    RefreshReportingViews.call(views: views)
   end
 
   config.before(:each) do


### PR DESCRIPTION
**Story card:** [sc-15268](https://app.shortcut.com/simpledotorg/story/15268/versioning-adopt-semantic-versioning)

## Because

CI takes 1 hour to build

## This addresses

Optimizing matview refreshes during unit tests

Ensure `refresh_views` can refresh specific views.

Originally, this refreshed all the mat views which — for some tests
— may be a recipe for wasting time. It's this query that's in focus for
this change. There are other places where `refresh_views` is used, but
those do not seem to run slow.

## Test instructions

suite tests
