### PR TITLE
Whitelabeling around resources tab

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -84,3 +84,7 @@ HELP_EMAIL_ID="help_email@test.org"
 CVHO_EMAIL_ID="cvho_email@test.org"
 ENG_EMAIL_ID="eng-backend@test.org"
 FAVICON_URL="https://simple.org/images/favicon.png"
+WHITELABEL_APP=TRUE
+DEPLOYMENT_CHECKLIST_LINK="https://docs.google.com/document/d/1qLoXo3dIw7A2WIRqsJ5Zx77DJDYnNnfu76vm8PVobxU/edit?usp=sharing"
+PRIVACY_LINK="https://www.simple.org/privacy"
+LICENSE_LINK="https://www.simple.org/license/"

--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -1,5 +1,5 @@
 module ExternalLinksHelper
-  DEPLOYMENT_CHECKLIST_LINK = "https://docs.google.com/document/d/1cleJkm09VRGUAafkpzC9U2ao9r4r8ewZjLPwfTTj57Q/edit?usp=sharing"
+  DEPLOYMENT_CHECKLIST_LINK = Rails.application.config.deployment_checklist_link
   BP_PASSPORT_CREATOR_LINK = "https://drive.google.com/file/d/1fB9RFdrFC4NaU1CQUfEodC6IyXdQcs_A/view?usp=sharing"
 
   INDIA_SIMPLE_TRAINING_GUIDE_LINK = "https://docs.google.com/presentation/d/1YKlZfXpnX0tGk6NMO6JLuZY0l9O3P3zOxKXsWNJh7W0/edit#slide=id.g25f6af9dd6_0_0"

--- a/app/views/api/v3/help/show.html.erb
+++ b/app/views/api/v3/help/show.html.erb
@@ -17,28 +17,32 @@
     <div id="help-section" class="help-body">
       <div class="help-contents">
         <nav class="help-nav">
-          <a href="#" onclick="goToPage('help-section', 'help-videos'); return false">
-          <%= t("help.menu.videos_html") %>
-          <%= inline_svg('icon_chevron_right.svg') %>
-          </a>
-          <a href="#" onclick="goToPage('help-section', 'help-start'); return false">
-          <%= t("help.menu.start_html") %>
-          <%= inline_svg('icon_chevron_right.svg') %>
-          </a>
+          <% if !Rails.application.config.whitelabel_app %>
+            <a href="#" onclick="goToPage('help-section', 'help-videos'); return false">
+            <%= t("help.menu.videos_html") %>
+            <%= inline_svg('icon_chevron_right.svg') %>
+            </a>
+          <% end %>
+          <% if !Rails.application.config.whitelabel_app %>
+            <a href="#" onclick="goToPage('help-section', 'help-start'); return false">
+            <%= t("help.menu.start_html") %>
+            <%= inline_svg('icon_chevron_right.svg') %>
+            </a>
+          <% end %>
           <a href="#" onclick="goToPage('help-section', 'help-register'); return false">
-          <%= t("help.menu.register_html") %>
+          <%= t("help.menu.register_html", list_order_number: Rails.application.config.whitelabel_app ? "1" : "2") %>
           <%= inline_svg('icon_chevron_right.svg') %>
           </a>
           <a href="#" onclick="goToPage('help-section', 'help-search'); return false">
-          <%= t("help.menu.search_html") %>
+          <%= t("help.menu.search_html", list_order_number: Rails.application.config.whitelabel_app ? "2" : "3") %>
           <%= inline_svg('icon_chevron_right.svg') %>
           </a>
           <a href="#" onclick="goToPage('help-section', 'help-record'); return false">
-          <%= t("help.menu.record_html") %>
+          <%= t("help.menu.record_html", list_order_number: Rails.application.config.whitelabel_app ? "3" : "4") %>
           <%= inline_svg('icon_chevron_right.svg') %>
           </a>
           <a href="#" onclick="goToPage('help-section', 'help-overdue'); return false">
-          <%= t("help.menu.overdue_html") %>
+          <%= t("help.menu.overdue_html", list_order_number: Rails.application.config.whitelabel_app ? "4" : "5") %>
           <%= inline_svg('icon_chevron_right.svg') %>
           </a>
           <a href="#" onclick="goToPage('help-section', 'help-faq'); return false">
@@ -67,150 +71,152 @@
           <p><%= t("help.bp_passport_app_summary.contents_2_html") %></p>
           <p class="card-footer-button"><a href="#" onclick="goToPage('help-section', 'help-bp-passport-app'); return false"><%= t("help.bp_passport_app_summary.learn_more_html") %></a></p>
         </div>
-        <p class="tos"><a href="https://simple.org/simple-privacy"><%= t("help.privacy_policy_html") %></a> <span class="divider">&nbsp;|&nbsp;</span> <a href="https://simple.org/terms"><%= t("help.terms_of_service_html") %></a></p>
+        <% if !Rails.application.config.whitelabel_app %>
+          <p class="tos"><a href="https://simple.org/simple-privacy"><%= t("help.privacy_policy_html") %></a> <span class="divider">&nbsp;|&nbsp;</span> <a href="https://simple.org/terms"><%= t("help.terms_of_service_html") %></a></p>
+        <% end %>
       </div>
     </div>
+    <% if !Rails.application.config.whitelabel_app %>
+      <!-----  Videos Page ------>
 
-    <!-----  Videos Page ------>
-
-    <div id="help-videos" class="help-body" style="display: none;">
-      <div class="help-contents">
-        <a href="#" onclick="goToPage('help-videos', 'help-section'); return false" class="help-back">
-          <%= inline_svg('icon_back.svg') %>
-        </a>
-        <h2><%= t("help.videos.heading_html") %></h2>
-        <div class="card">
-          <h3><%= t("help.videos.class.heading_html") %></h3>
-          <p><%= t("help.videos.class.contents_html", app_brand_name: Rails.application.config.application_brand_name) %></p>
-          <a href="<%= ENV['HELP_SCREEN_YOUTUBE_TRAINING_URL'] %>" class="video">
-          <%= inline_svg('thumb_training.svg') %>
+      <div id="help-videos" class="help-body" style="display: none;">
+        <div class="help-contents">
+          <a href="#" onclick="goToPage('help-videos', 'help-section'); return false" class="help-back">
+            <%= inline_svg('icon_back.svg') %>
           </a>
-          <p>
-            <a href="<%= ENV['HELP_SCREEN_YOUTUBE_TRAINING_URL'] %>"><%= t("help.videos.class.training_videos_link_html") %></a>
-            <br>
-            <%= t("help.videos.class.training_videos_subtitle_html") %>
-          </p>
-        </div>
-        <div class="card">
-          <h3><%= t("help.videos.chapters.heading_html") %></h3>
-          <div class="video-small">
-            <a href="https://youtu.be/r0mbu1s0l7A"><%= t("help.videos.chapters.chapter_1_html") %></a>
+          <h2><%= t("help.videos.heading_html") %></h2>
+          <div class="card">
+            <h3><%= t("help.videos.class.heading_html") %></h3>
+            <p><%= t("help.videos.class.contents_html", app_brand_name: Rails.application.config.application_brand_name) %></p>
+            <a href="<%= ENV['HELP_SCREEN_YOUTUBE_TRAINING_URL'] %>" class="video">
+            <%= inline_svg('thumb_training.svg') %>
+            </a>
+            <p>
+              <a href="<%= ENV['HELP_SCREEN_YOUTUBE_TRAINING_URL'] %>"><%= t("help.videos.class.training_videos_link_html") %></a>
+              <br>
+              <%= t("help.videos.class.training_videos_subtitle_html") %>
+            </p>
           </div>
-          <div class="video-small">
-            <a href="https://youtu.be/YPySS9sL-EU"><%= t("help.videos.chapters.chapter_2_html") %></a>
+          <div class="card">
+            <h3><%= t("help.videos.chapters.heading_html") %></h3>
+            <div class="video-small">
+              <a href="https://youtu.be/r0mbu1s0l7A"><%= t("help.videos.chapters.chapter_1_html") %></a>
+            </div>
+            <div class="video-small">
+              <a href="https://youtu.be/YPySS9sL-EU"><%= t("help.videos.chapters.chapter_2_html") %></a>
+            </div>
+            <div class="video-small">
+              <a href="https://youtu.be/5P5mGQVQFOU"><%= t("help.videos.chapters.chapter_3_html") %></a>
+            </div>
+            <div class="video-small">
+              <a href="https://youtu.be/6hR1vQ8hoTU"><%= t("help.videos.chapters.chapter_4_html") %></a>
+            </div>
+            <div class="video-small">
+              <a href="https://youtu.be/o3klwHrMEi0"><%= t("help.videos.chapters.chapter_5_html") %></a>
+            </div>
+            <div class="video-small">
+              <a href="https://youtu.be/PuM29XINOn4"><%= t("help.videos.chapters.chapter_6_html") %></a>
+            </div>
+            <div class="video-small">
+              <a href="https://youtu.be/elCBnApJLIM"><%= t("help.videos.chapters.chapter_7_html") %></a>
+            </div>
+            <div class="video-small">
+              <a href="https://youtu.be/Aj-dKn_kmlw"><%= t("help.videos.chapters.chapter_8_html") %></a>
+            </div>
+            <div class="video-small">
+              <a href="https://youtu.be/wF4t_pFuugY"><%= t("help.videos.chapters.chapter_9_html") %></a>
+            </div>
+            <div class="video-small">
+              <a href="https://youtu.be/kls4QnWz1Nw"><%= t("help.videos.chapters.chapter_10_html", app_brand_name: Rails.application.config.application_brand_name) %></a>
+            </div>
           </div>
-          <div class="video-small">
-            <a href="https://youtu.be/5P5mGQVQFOU"><%= t("help.videos.chapters.chapter_3_html") %></a>
+          <div class="card">
+            <h3><%= t("help.videos.teleconsultation.heading_html") %></h3>
+            <p><%= t("help.videos.teleconsultation.contents_html", app_brand_name: Rails.application.config.application_brand_name) %></p>
+            <div class="video-small">
+              <a href="<%= ExternalLinksHelper::TELEMEDICINE_TRAINING_ENGLISH_YOUTUBE_LINK %>"><%= t("help.videos.teleconsultation.english_video_link_html", app_brand_name: Rails.application.config.application_brand_name) %><span><%= t("help.videos.teleconsultation.english_video_link_language_html") %></span></a>
+            </div>
+            <div class="video-small">
+              <a href="<%= ExternalLinksHelper::TELEMEDICINE_TRAINING_HINDI_YOUTUBE_LINK %>"><%= t("help.videos.teleconsultation.hindi_video_link_html") %><span><%= t("help.videos.teleconsultation.hindi_video_link_language_html") %></span></a>
+            </div>
           </div>
-          <div class="video-small">
-            <a href="https://youtu.be/6hR1vQ8hoTU"><%= t("help.videos.chapters.chapter_4_html") %></a>
+          <div class="card">
+            <h3><%= t("help.videos.bp_passports.heading_html") %></h3>
+            <p><%= t("help.videos.bp_passports.contents_html") %></p>
+            <div class="video-small">
+              <a href="https://www.youtube.com/watch?v=aktZ1yTdDOA&t=52s"><%= t("help.videos.bp_passports.video_link_html") %><span><%= t("help.videos.bp_passports.video_link_subtitle_html") %></span></a>
+            </div>
           </div>
-          <div class="video-small">
-            <a href="https://youtu.be/o3klwHrMEi0"><%= t("help.videos.chapters.chapter_5_html") %></a>
+          <div class="card">
+            <h3><%= t("help.videos.film.heading_html", app_brand_name: Rails.application.config.application_brand_name) %></h3>
+            <a href="https://www.youtube.com/watch?v=C26CoyeExmU" class="video">
+            <%= inline_svg('thumb_documentary.svg') %>
+            </a>
+            <p>
+              <%= t("help.videos.film.link_html", app_brand_name: Rails.application.config.application_brand_name) %>
+            </p>
           </div>
-          <div class="video-small">
-            <a href="https://youtu.be/PuM29XINOn4"><%= t("help.videos.chapters.chapter_6_html") %></a>
-          </div>
-          <div class="video-small">
-            <a href="https://youtu.be/elCBnApJLIM"><%= t("help.videos.chapters.chapter_7_html") %></a>
-          </div>
-          <div class="video-small">
-            <a href="https://youtu.be/Aj-dKn_kmlw"><%= t("help.videos.chapters.chapter_8_html") %></a>
-          </div>
-          <div class="video-small">
-            <a href="https://youtu.be/wF4t_pFuugY"><%= t("help.videos.chapters.chapter_9_html") %></a>
-          </div>
-          <div class="video-small">
-            <a href="https://youtu.be/kls4QnWz1Nw"><%= t("help.videos.chapters.chapter_10_html", app_brand_name: Rails.application.config.application_brand_name) %></a>
-          </div>
-        </div>
-        <div class="card">
-          <h3><%= t("help.videos.teleconsultation.heading_html") %></h3>
-          <p><%= t("help.videos.teleconsultation.contents_html", app_brand_name: Rails.application.config.application_brand_name) %></p>
-          <div class="video-small">
-            <a href="<%= ExternalLinksHelper::TELEMEDICINE_TRAINING_ENGLISH_YOUTUBE_LINK %>"><%= t("help.videos.teleconsultation.english_video_link_html", app_brand_name: Rails.application.config.application_brand_name) %><span><%= t("help.videos.teleconsultation.english_video_link_language_html") %></span></a>
-          </div>
-          <div class="video-small">
-            <a href="<%= ExternalLinksHelper::TELEMEDICINE_TRAINING_HINDI_YOUTUBE_LINK %>"><%= t("help.videos.teleconsultation.hindi_video_link_html") %><span><%= t("help.videos.teleconsultation.hindi_video_link_language_html") %></span></a>
-          </div>
-        </div>
-        <div class="card">
-          <h3><%= t("help.videos.bp_passports.heading_html") %></h3>
-          <p><%= t("help.videos.bp_passports.contents_html") %></p>
-          <div class="video-small">
-            <a href="https://www.youtube.com/watch?v=aktZ1yTdDOA&t=52s"><%= t("help.videos.bp_passports.video_link_html") %><span><%= t("help.videos.bp_passports.video_link_subtitle_html") %></span></a>
-          </div>
-        </div>
-        <div class="card">
-          <h3><%= t("help.videos.film.heading_html", app_brand_name: Rails.application.config.application_brand_name) %></h3>
-          <a href="https://www.youtube.com/watch?v=C26CoyeExmU" class="video">
-          <%= inline_svg('thumb_documentary.svg') %>
-          </a>
-          <p>
-            <%= t("help.videos.film.link_html", app_brand_name: Rails.application.config.application_brand_name) %>
-          </p>
         </div>
       </div>
-    </div>
 
-    <!-----  Getting Started Page ------>
+      <!-----  Getting Started Page ------>
 
-    <div id="help-start" class="help-body" style="display: none;">
-      <div class="help-contents">
-        <a href="#" onclick="goToPage('help-start', 'help-section'); return false" class="help-back">
-          <%= inline_svg('icon_back.svg') %>
-        </a>
-        <h2><%= t("help.start.heading_html") %></h2>
-        <div class="card">
-          <h3><%= t("help.start.getting_started_video.heading_html") %></h3>
-          <a href="<%= ENV['HELP_SCREEN_YOUTUBE_VIDEO_URL'] %>" class="video">
-            <%= inline_svg('thumb_demo.svg') %>
+      <div id="help-start" class="help-body" style="display: none;">
+        <div class="help-contents">
+          <a href="#" onclick="goToPage('help-start', 'help-section'); return false" class="help-back">
+            <%= inline_svg('icon_back.svg') %>
           </a>
-          <p><%= t("help.start.getting_started_video.contents_html", app_brand_name: Rails.application.config.application_brand_name) %></p>
-        </div>
-        <div class="card">
-          <h3><%= t("help.start.who_to_record.heading_html", app_brand_name: Rails.application.config.application_brand_name) %></h3>
-          <p><%= t("help.start.who_to_record.contents_1_html", app_brand_name: Rails.application.config.application_brand_name) %></p>
-          <p><%= t("help.start.who_to_record.contents_2_html") %></p>
-        </div>
-        <div class="card">
-          <h3><span class="header-label"><span><%= t("help.start.step_1.label_html") %></span></span><%= t("help.start.step_1.heading_html") %></h3>
-          <p><%= t("help.start.step_1.contents_html") %></p>
-        </div>
-        <div class="card">
-          <h3><span class="header-label"><span><%= t("help.start.step_2.label_html") %></span></span><%= t("help.start.step_2.heading_html") %></h3>
-          <p><%= t("help.start.step_2.contents_html", app_brand_name: Rails.application.config.application_brand_name) %></p>
-        </div>
-        <div class="card">
-          <h3><span class="header-label"><span><%= t("help.start.step_3.label_html") %></span></span><%= t("help.start.step_3.heading_html") %></h3>
-          <p><%= t("help.start.step_3.contents_html") %></p>
-        </div>
-        <div class="card">
-          <h3><span class="header-label"><span><%= t("help.start.step_4.label_html") %></span></span><%= t("help.start.step_4.heading_html", app_brand_name: Rails.application.config.application_brand_name) %></h3>
-          <p><%= t("help.start.step_4.contents_html") %></p>
-        </div>
-        <div class="card">
-          <h3><span class="header-label"><span><%= t("help.start.step_5.label_html") %></span></span><%= t("help.start.step_5.heading_html") %></h3>
-          <p><%= t("help.start.step_5.contents_html") %></p>
-        </div>
-        <div class="card">
-          <h3><span class="header-label"><span><%= t("help.start.step_6.label_html") %></span></span><%= t("help.start.step_6.heading_html") %></h3>
-          <p><%= t("help.start.step_6.contents_html") %></p>
-        </div>
-        <hr>
-        <div class="card">
-          <h3><span class="header-label"><span><%= t("help.start.missed_visit.label_html") %></span></span><%= t("help.start.missed_visit.heading_html") %></h3>
-          <p><%= t("help.start.missed_visit.contents_html", app_brand_name: Rails.application.config.application_brand_name) %></p>
-        </div>
-        <hr>
-        <div class="card card-tip">
-          <%= inline_svg('help/tip.svg') %>
-          <h3><%= t("help.start.tip.heading_html") %></h3>
-          <p><%= t("help.start.tip.contents_html") %></p>
+          <h2><%= t("help.start.heading_html") %></h2>
+          <div class="card">
+            <h3><%= t("help.start.getting_started_video.heading_html") %></h3>
+            <a href="<%= ENV['HELP_SCREEN_YOUTUBE_VIDEO_URL'] %>" class="video">
+              <%= inline_svg('thumb_demo.svg') %>
+            </a>
+            <p><%= t("help.start.getting_started_video.contents_html", app_brand_name: Rails.application.config.application_brand_name) %></p>
+          </div>
+          <div class="card">
+            <h3><%= t("help.start.who_to_record.heading_html", app_brand_name: Rails.application.config.application_brand_name) %></h3>
+            <p><%= t("help.start.who_to_record.contents_1_html", app_brand_name: Rails.application.config.application_brand_name) %></p>
+            <p><%= t("help.start.who_to_record.contents_2_html") %></p>
+          </div>
+          <div class="card">
+            <h3><span class="header-label"><span><%= t("help.start.step_1.label_html") %></span></span><%= t("help.start.step_1.heading_html") %></h3>
+            <p><%= t("help.start.step_1.contents_html") %></p>
+          </div>
+          <div class="card">
+            <h3><span class="header-label"><span><%= t("help.start.step_2.label_html") %></span></span><%= t("help.start.step_2.heading_html") %></h3>
+            <p><%= t("help.start.step_2.contents_html", app_brand_name: Rails.application.config.application_brand_name) %></p>
+          </div>
+          <div class="card">
+            <h3><span class="header-label"><span><%= t("help.start.step_3.label_html") %></span></span><%= t("help.start.step_3.heading_html") %></h3>
+            <p><%= t("help.start.step_3.contents_html") %></p>
+          </div>
+          <div class="card">
+            <h3><span class="header-label"><span><%= t("help.start.step_4.label_html") %></span></span><%= t("help.start.step_4.heading_html", app_brand_name: Rails.application.config.application_brand_name) %></h3>
+            <p><%= t("help.start.step_4.contents_html") %></p>
+          </div>
+          <div class="card">
+            <h3><span class="header-label"><span><%= t("help.start.step_5.label_html") %></span></span><%= t("help.start.step_5.heading_html") %></h3>
+            <p><%= t("help.start.step_5.contents_html") %></p>
+          </div>
+          <div class="card">
+            <h3><span class="header-label"><span><%= t("help.start.step_6.label_html") %></span></span><%= t("help.start.step_6.heading_html") %></h3>
+            <p><%= t("help.start.step_6.contents_html") %></p>
+          </div>
+          <hr>
+          <div class="card">
+            <h3><span class="header-label"><span><%= t("help.start.missed_visit.label_html") %></span></span><%= t("help.start.missed_visit.heading_html") %></h3>
+            <p><%= t("help.start.missed_visit.contents_html", app_brand_name: Rails.application.config.application_brand_name) %></p>
+          </div>
+          <hr>
+          <div class="card card-tip">
+            <%= inline_svg('help/tip.svg') %>
+            <h3><%= t("help.start.tip.heading_html") %></h3>
+            <p><%= t("help.start.tip.contents_html") %></p>
+          </div>
         </div>
       </div>
-    </div>
-
+    <% end %>
     <!-----  Register a Patient Page ------>
 
     <div id="help-register" class="help-body" style="display: none;">

--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -18,12 +18,14 @@
           <a href="#card-checklist" class="nav-link">
             Deployment checklist
           </a>
-          <a href="#card-presentations" class="nav-link">
-            Training presentations
-          </a>
-          <a href="#card-videos" class="nav-link">
-            Training videos
-          </a>
+          <% if !Rails.application.config.whitelabel_app %>
+            <a href="#card-presentations" class="nav-link">
+              Training presentations
+            </a>
+            <a href="#card-videos" class="nav-link">
+              Training videos
+            </a>
+          <% end %>
           <a href="#card-1pager" class="nav-link">
             1-pager about <%= Rails.application.config.application_brand_name %>
           </a>
@@ -98,463 +100,465 @@
             </a>
           </div>
         </div>
-        <div class="card" id="card-presentations">
-          <h2>
-            Training presentations
-          </h2>
-          <% if CountryConfig.current[:name] == "Ethiopia" %>
-            <%= render "shared/simple_training_guide_ethiopia" %>
-          <% elsif CountryConfig.current[:name] == "India" %>
-            <%= render "shared/simple_training_guide_india" %>
-            <%= render "shared/simple_training_guide_telemedicine" %>
-          <% elsif CountryConfig.current[:name] == "Bangladesh" %>
-            <%= render "shared/simple_training_guide_bangladesh" %>
-          <% elsif CountryConfig.current[:name] == "Sri Lanka" %>
-            <%= render "shared/simple_training_guide_sri_lanka" %>
-          <% end %>
-        </div>
-        <div class="card" id="card-videos">
-          <h2>
-            Training videos
-          </h2>
-          <div class="row">
-            <div class="col-sm-3 col-video">
-              <%= image_tag 'resources/video-chapter-all.jpg', style: 'width: 100%;' %>
-              <strong>
-                Training video: All Chapters
-              </strong>
-              <span>
-                36 min
-              </span>
-              <a href="<%= ExternalLinksHelper::TRAINING_VIDEO_ALL_CHAPTERS_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> English YouTube
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::TRAINING_VIDEO_ALL_CHAPTERS_AMHARIC_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Amharic YouTube
-                </a>
-                <a href="<%= ExternalLinksHelper::TRAINING_VIDEO_ALL_CHAPTERS_OROMO_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Oromo YouTube
-                </a>
-              <% end %>
-              <a href="<%= ExternalLinksHelper::TRAINING_VIDEO_ALL_CHAPTERS_DOWNLOAD_LINK %>">
-                <i class="fas fa-arrow-circle-down"></i> Download English: 515 <small>MB</small>
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::TRAINING_VIDEO_ALL_CHAPTERS_AMHARIC_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Amharic: 892 <small>MB</small>
-                </a>
-                <a href="<%= ExternalLinksHelper::TRAINING_VIDEO_ALL_CHAPTERS_OROMO_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Oromo: 857 <small>MB</small>
-                </a>
-              <% end %>
-            </div>
-            <div class="col-sm-3 col-video">
-              <%= image_tag 'resources/video-trainers.jpg', style: 'width: 100%;' %>
-              <strong>
-                How to conduct a training
-              </strong>
-              <span>
-                5 min 42 sec
-              </span>
-              <a href="<%= ExternalLinksHelper::HOW_TO_CONDUCT_A_TRAINING_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> English YouTube
-              </a>
-              <a href="<%= ExternalLinksHelper::HOW_TO_CONDUCT_A_TRAINING_DOWNLOAD_LINK %>">
-                <i class="fas fa-arrow-circle-down"></i> Download English: 87 <small>MB</small>
-              </a>
-            </div>
+        <% if !Rails.application.config.whitelabel_app %>
+          <div class="card" id="card-presentations">
+            <h2>
+              Training presentations
+            </h2>
+            <% if CountryConfig.current[:name] == "Ethiopia" %>
+              <%= render "shared/simple_training_guide_ethiopia" %>
+            <% elsif CountryConfig.current[:name] == "India" %>
+              <%= render "shared/simple_training_guide_india" %>
+              <%= render "shared/simple_training_guide_telemedicine" %>
+            <% elsif CountryConfig.current[:name] == "Bangladesh" %>
+              <%= render "shared/simple_training_guide_bangladesh" %>
+            <% elsif CountryConfig.current[:name] == "Sri Lanka" %>
+              <%= render "shared/simple_training_guide_sri_lanka" %>
+            <% end %>
           </div>
-          <h4 class="mt-5">
-            Training chapters
-          </h4>
-          <div class="row">
-            <div class="col-sm-3 col-video mb-3">
-              <%= image_tag 'resources/video-chapter-1.jpg', style: 'width: 100%;' %>
-              <strong>
-                1: Install the app
-              </strong>
-              <span>
-                4 min
-              </span>
-              <a href="<%= ExternalLinksHelper::INSTALL_THE_APP_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> English YouTube
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::INSTALL_THE_APP_AMHARIC_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Amharic YouTube
-                </a>
-                <a href="<%= ExternalLinksHelper::INSTALL_THE_APP_OROMO_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Oromo YouTube
-                </a>
-              <% end %>
-              <a href="<%= ExternalLinksHelper::INSTALL_THE_APP_DOWNLOAD_LINK %>">
-                <i class="fas fa-arrow-circle-down"></i> Download English: 48 <small>MB</small>
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::INSTALL_THE_APP_AMHARIC_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Amharic: 89 <small>MB</small>
-                </a>
-                <a href="<%= ExternalLinksHelper::INSTALL_THE_APP_OROMO_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Oromo: 75 <small>MB</small>
-                </a>
-              <% end %>
-            </div>
-            <div class="col-sm-3 col-video mb-3">
-              <%= image_tag 'resources/video-chapter-2.jpg', style: 'width: 100%;' %>
-              <strong>
-                2: Introduction
-              </strong>
-              <span>
-                4 min
-              </span>
-              <a href="<%= ExternalLinksHelper::INTRODUCTION_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> English YouTube
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::INTRODUCTION_AMHARIC_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Amharic YouTube
-                </a>
-                <a href="<%= ExternalLinksHelper::INTRODUCTION_OROMO_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Oromo YouTube
-                </a>
-              <% end %>
-              <a href="<%= ExternalLinksHelper::INTRODUCTION_DOWNLOAD_LINK %>">
-                <i class="fas fa-arrow-circle-down"></i> Download English: 59 <small>MB</small>
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::INTRODUCTION_AMHARIC_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Amharic: 83 <small>MB</small>
-                </a>
-                <a href="<%= ExternalLinksHelper::INTRODUCTION_OROMO_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Oromo: 78 <small>MB</small>
-                </a>
-              <% end %>
-            </div>
-            <div class="col-sm-3 col-video mb-3">
-              <%= image_tag 'resources/video-chapter-3.jpg', style: 'width: 100%;' %>
-              <strong>
-                3: Register a patient
-              </strong>
-              <span>
-                8 min
-              </span>
-              <a href="<%= ExternalLinksHelper::REGISTER_A_PATIENT_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> English YouTube
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::REGISTER_A_PATIENT_AMHARIC_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Amharic YouTube
-                </a>
-                <a href="<%= ExternalLinksHelper::REGISTER_A_PATIENT_OROMO_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Oromo YouTube
-                </a>
-              <% end %>
-              <a href="<%= ExternalLinksHelper::REGISTER_A_PATIENT_DOWNLOAD_LINK %>">
-                <i class="fas fa-arrow-circle-down"></i> Download English: 86 <small>MB</small>
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::REGISTER_A_PATIENT_AMHARIC_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Amharic: 179 <small>MB</small>
-                </a>
-                <a href="<%= ExternalLinksHelper::REGISTER_A_PATIENT_OROMO_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Oromo: 160 <small>MB</small>
-                </a>
-              <% end %>
-            </div>
-            <div class="col-sm-3 col-video mb-3">
-              <%= image_tag 'resources/video-chapter-4.jpg', style: 'width: 100%;' %>
-              <strong>
-                4: Search for a follow-up patient
-              </strong>
+          <div class="card" id="card-videos">
+            <h2>
+              Training videos
+            </h2>
+            <div class="row">
+              <div class="col-sm-3 col-video">
+                <%= image_tag 'resources/video-chapter-all.jpg', style: 'width: 100%;' %>
+                <strong>
+                  Training video: All Chapters
+                </strong>
                 <span>
-                  4 min
+                  36 min
                 </span>
-                <a href="<%= ExternalLinksHelper::SEARCH_FOR_PATIENT_YOUTUBE_LINK %>">
+                <a href="<%= ExternalLinksHelper::TRAINING_VIDEO_ALL_CHAPTERS_YOUTUBE_LINK %>">
                   <i class="fab fa-youtube"></i> English YouTube
                 </a>
                 <% if CountryConfig.current[:name] == "Ethiopia" %>
-                  <a href="<%= ExternalLinksHelper::SEARCH_FOR_PATIENT_AMHARIC_YOUTUBE_LINK %>">
+                  <a href="<%= ExternalLinksHelper::TRAINING_VIDEO_ALL_CHAPTERS_AMHARIC_YOUTUBE_LINK %>">
                     <i class="fab fa-youtube"></i> Amharic YouTube
                   </a>
-                  <a href="<%= ExternalLinksHelper::SEARCH_FOR_PATIENT_OROMO_YOUTUBE_LINK %>">
+                  <a href="<%= ExternalLinksHelper::TRAINING_VIDEO_ALL_CHAPTERS_OROMO_YOUTUBE_LINK %>">
                     <i class="fab fa-youtube"></i> Oromo YouTube
                   </a>
                 <% end %>
-                <a href="<%= ExternalLinksHelper::SEARCH_FOR_PATIENT_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download English: 64 <small>MB</small>
+                <a href="<%= ExternalLinksHelper::TRAINING_VIDEO_ALL_CHAPTERS_DOWNLOAD_LINK %>">
+                  <i class="fas fa-arrow-circle-down"></i> Download English: 515 <small>MB</small>
                 </a>
                 <% if CountryConfig.current[:name] == "Ethiopia" %>
-                  <a href="<%= ExternalLinksHelper::SEARCH_FOR_PATIENT_AMHARIC_DOWNLOAD_LINK %>">
-                    <i class="fas fa-arrow-circle-down"></i> Download Amharic: 96 <small>MB</small>
+                  <a href="<%= ExternalLinksHelper::TRAINING_VIDEO_ALL_CHAPTERS_AMHARIC_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Amharic: 892 <small>MB</small>
                   </a>
-                  <a href="<%= ExternalLinksHelper::SEARCH_FOR_PATIENT_OROMO_DOWNLOAD_LINK %>">
-                    <i class="fas fa-arrow-circle-down"></i> Download Oromo: 106 <small>MB</small>
+                  <a href="<%= ExternalLinksHelper::TRAINING_VIDEO_ALL_CHAPTERS_OROMO_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Oromo: 857 <small>MB</small>
                   </a>
                 <% end %>
+              </div>
+              <div class="col-sm-3 col-video">
+                <%= image_tag 'resources/video-trainers.jpg', style: 'width: 100%;' %>
+                <strong>
+                  How to conduct a training
+                </strong>
+                <span>
+                  5 min 42 sec
+                </span>
+                <a href="<%= ExternalLinksHelper::HOW_TO_CONDUCT_A_TRAINING_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> English YouTube
+                </a>
+                <a href="<%= ExternalLinksHelper::HOW_TO_CONDUCT_A_TRAINING_DOWNLOAD_LINK %>">
+                  <i class="fas fa-arrow-circle-down"></i> Download English: 87 <small>MB</small>
+                </a>
+              </div>
             </div>
-            <div class="col-sm-3 col-video mb-3">
-              <%= image_tag 'resources/video-chapter-5.jpg', style: 'width: 100%;' %>
-              <strong>
-                5: Find the right patient
-              </strong>
-              <span>
-                3 min
-              </span>
-              <a href="<%= ExternalLinksHelper::FIND_PATIENT_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> English YouTube
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::FIND_PATIENT_AMHARIC_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Amharic YouTube
+            <h4 class="mt-5">
+              Training chapters
+            </h4>
+            <div class="row">
+              <div class="col-sm-3 col-video mb-3">
+                <%= image_tag 'resources/video-chapter-1.jpg', style: 'width: 100%;' %>
+                <strong>
+                  1: Install the app
+                </strong>
+                <span>
+                  4 min
+                </span>
+                <a href="<%= ExternalLinksHelper::INSTALL_THE_APP_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> English YouTube
                 </a>
-                <a href="<%= ExternalLinksHelper::FIND_PATIENT_OROMO_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Oromo YouTube
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::INSTALL_THE_APP_AMHARIC_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Amharic YouTube
+                  </a>
+                  <a href="<%= ExternalLinksHelper::INSTALL_THE_APP_OROMO_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Oromo YouTube
+                  </a>
+                <% end %>
+                <a href="<%= ExternalLinksHelper::INSTALL_THE_APP_DOWNLOAD_LINK %>">
+                  <i class="fas fa-arrow-circle-down"></i> Download English: 48 <small>MB</small>
                 </a>
-              <% end %>
-              <a href="<%= ExternalLinksHelper::FIND_PATIENT_DOWNLOAD_LINK %>">
-                <i class="fas fa-arrow-circle-down"></i> Download English: 33 <small>MB</small>
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::FIND_PATIENT_AMHARIC_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Amharic: 43 <small>MB</small>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::INSTALL_THE_APP_AMHARIC_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Amharic: 89 <small>MB</small>
+                  </a>
+                  <a href="<%= ExternalLinksHelper::INSTALL_THE_APP_OROMO_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Oromo: 75 <small>MB</small>
+                  </a>
+                <% end %>
+              </div>
+              <div class="col-sm-3 col-video mb-3">
+                <%= image_tag 'resources/video-chapter-2.jpg', style: 'width: 100%;' %>
+                <strong>
+                  2: Introduction
+                </strong>
+                <span>
+                  4 min
+                </span>
+                <a href="<%= ExternalLinksHelper::INTRODUCTION_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> English YouTube
                 </a>
-                <a href="<%= ExternalLinksHelper::FIND_PATIENT_OROMO_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Oromo: 30 <small>MB</small>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::INTRODUCTION_AMHARIC_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Amharic YouTube
+                  </a>
+                  <a href="<%= ExternalLinksHelper::INTRODUCTION_OROMO_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Oromo YouTube
+                  </a>
+                <% end %>
+                <a href="<%= ExternalLinksHelper::INTRODUCTION_DOWNLOAD_LINK %>">
+                  <i class="fas fa-arrow-circle-down"></i> Download English: 59 <small>MB</small>
                 </a>
-              <% end %>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::INTRODUCTION_AMHARIC_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Amharic: 83 <small>MB</small>
+                  </a>
+                  <a href="<%= ExternalLinksHelper::INTRODUCTION_OROMO_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Oromo: 78 <small>MB</small>
+                  </a>
+                <% end %>
+              </div>
+              <div class="col-sm-3 col-video mb-3">
+                <%= image_tag 'resources/video-chapter-3.jpg', style: 'width: 100%;' %>
+                <strong>
+                  3: Register a patient
+                </strong>
+                <span>
+                  8 min
+                </span>
+                <a href="<%= ExternalLinksHelper::REGISTER_A_PATIENT_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> English YouTube
+                </a>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::REGISTER_A_PATIENT_AMHARIC_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Amharic YouTube
+                  </a>
+                  <a href="<%= ExternalLinksHelper::REGISTER_A_PATIENT_OROMO_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Oromo YouTube
+                  </a>
+                <% end %>
+                <a href="<%= ExternalLinksHelper::REGISTER_A_PATIENT_DOWNLOAD_LINK %>">
+                  <i class="fas fa-arrow-circle-down"></i> Download English: 86 <small>MB</small>
+                </a>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::REGISTER_A_PATIENT_AMHARIC_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Amharic: 179 <small>MB</small>
+                  </a>
+                  <a href="<%= ExternalLinksHelper::REGISTER_A_PATIENT_OROMO_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Oromo: 160 <small>MB</small>
+                  </a>
+                <% end %>
+              </div>
+              <div class="col-sm-3 col-video mb-3">
+                <%= image_tag 'resources/video-chapter-4.jpg', style: 'width: 100%;' %>
+                <strong>
+                  4: Search for a follow-up patient
+                </strong>
+                  <span>
+                    4 min
+                  </span>
+                  <a href="<%= ExternalLinksHelper::SEARCH_FOR_PATIENT_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> English YouTube
+                  </a>
+                  <% if CountryConfig.current[:name] == "Ethiopia" %>
+                    <a href="<%= ExternalLinksHelper::SEARCH_FOR_PATIENT_AMHARIC_YOUTUBE_LINK %>">
+                      <i class="fab fa-youtube"></i> Amharic YouTube
+                    </a>
+                    <a href="<%= ExternalLinksHelper::SEARCH_FOR_PATIENT_OROMO_YOUTUBE_LINK %>">
+                      <i class="fab fa-youtube"></i> Oromo YouTube
+                    </a>
+                  <% end %>
+                  <a href="<%= ExternalLinksHelper::SEARCH_FOR_PATIENT_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download English: 64 <small>MB</small>
+                  </a>
+                  <% if CountryConfig.current[:name] == "Ethiopia" %>
+                    <a href="<%= ExternalLinksHelper::SEARCH_FOR_PATIENT_AMHARIC_DOWNLOAD_LINK %>">
+                      <i class="fas fa-arrow-circle-down"></i> Download Amharic: 96 <small>MB</small>
+                    </a>
+                    <a href="<%= ExternalLinksHelper::SEARCH_FOR_PATIENT_OROMO_DOWNLOAD_LINK %>">
+                      <i class="fas fa-arrow-circle-down"></i> Download Oromo: 106 <small>MB</small>
+                    </a>
+                  <% end %>
+              </div>
+              <div class="col-sm-3 col-video mb-3">
+                <%= image_tag 'resources/video-chapter-5.jpg', style: 'width: 100%;' %>
+                <strong>
+                  5: Find the right patient
+                </strong>
+                <span>
+                  3 min
+                </span>
+                <a href="<%= ExternalLinksHelper::FIND_PATIENT_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> English YouTube
+                </a>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::FIND_PATIENT_AMHARIC_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Amharic YouTube
+                  </a>
+                  <a href="<%= ExternalLinksHelper::FIND_PATIENT_OROMO_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Oromo YouTube
+                  </a>
+                <% end %>
+                <a href="<%= ExternalLinksHelper::FIND_PATIENT_DOWNLOAD_LINK %>">
+                  <i class="fas fa-arrow-circle-down"></i> Download English: 33 <small>MB</small>
+                </a>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::FIND_PATIENT_AMHARIC_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Amharic: 43 <small>MB</small>
+                  </a>
+                  <a href="<%= ExternalLinksHelper::FIND_PATIENT_OROMO_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Oromo: 30 <small>MB</small>
+                  </a>
+                <% end %>
+              </div>
+              <div class="col-sm-3 col-video mb-3">
+                <%= image_tag 'resources/video-chapter-6.jpg', style: 'width: 100%;' %>
+                <strong>
+                  6: Call overdue patients
+                </strong>
+                <span>
+                  3 min
+                </span>
+                <a href="<%= ExternalLinksHelper::CALL_OVERDUE_PATIENTS_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> English YouTube
+                </a>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::CALL_OVERDUE_PATIENTS_AMHARIC_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Amharic YouTube
+                  </a>
+                  <a href="<%= ExternalLinksHelper::CALL_OVERDUE_PATIENTS_OROMO_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Oromo YouTube
+                  </a>
+                <% end %>
+                <a href="<%= ExternalLinksHelper::CALL_OVERDUE_PATIENTS_DOWNLOAD_LINK %>">
+                  <i class="fas fa-arrow-circle-down"></i> Download English: 35 <small>MB</small>
+                </a>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::CALL_OVERDUE_PATIENTS_AMHARIC_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Amharic: 68 <small>MB</small>
+                  </a>
+                  <a href="<%= ExternalLinksHelper::CALL_OVERDUE_PATIENTS_OROMO_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Oromo: 63 <small>MB</small>
+                  </a>
+                <% end %>
+              </div>
+              <div class="col-sm-3 col-video mb-3">
+                <%= image_tag 'resources/video-chapter-7.jpg', style: 'width: 100%;' %>
+                <strong>
+                  7: Important features
+                </strong>
+                <span>
+                  4 min
+                </span>
+                <a href="<%= ExternalLinksHelper::IMPORTANT_FEATURES_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> English YouTube
+                </a>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::IMPORTANT_FEATURES_AMHARIC_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Amharic YouTube
+                  </a>
+                  <a href="<%= ExternalLinksHelper::IMPORTANT_FEATURES_OROMO_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Oromo YouTube
+                  </a>
+                <% end %>
+                <a href="<%= ExternalLinksHelper::IMPORTANT_FEATURES_DOWNLOAD_LINK %>">
+                  <i class="fas fa-arrow-circle-down"></i> Download English: 52 <small>MB</small>
+                </a>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::IMPORTANT_FEATURES_AMHARIC_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Amharic: 84 <small>MB</small>
+                  </a>
+                  <a href="<%= ExternalLinksHelper::IMPORTANT_FEATURES_OROMO_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Oromo: 64 <small>MB</small>
+                  </a>
+                <% end %>
+              </div>
+              <div class="col-sm-3 col-video mb-3">
+                <%= image_tag 'resources/video-chapter-8.jpg', style: 'width: 100%;' %>
+                <strong>
+                  8: FAQ
+                </strong>
+                <span>
+                  3 min 35 sec
+                </span>
+                <a href="<%= ExternalLinksHelper::FAQ_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> English YouTube
+                </a>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::FAQ_AMHARIC_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Amharic YouTube
+                  </a>
+                  <a href="<%= ExternalLinksHelper::FAQ_OROMO_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Oromo YouTube
+                  </a>
+                <% end %>
+                <a href="<%= ExternalLinksHelper::FAQ_DOWNLOAD_LINK %>">
+                  <i class="fas fa-arrow-circle-down"></i> Download English: 39 <small>MB</small>
+                </a>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::FAQ_AMHARIC_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Amharic: 72 <small>MB</small>
+                  </a>
+                  <a href="<%= ExternalLinksHelper::FAQ_OROMO_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Oromo: 73 <small>MB</small>
+                  </a>
+                <% end %>
+              </div>
+              <div class="col-sm-3 col-video mb-3">
+                <%= image_tag 'resources/video-chapter-9.jpg', style: 'width: 100%;' %>
+                <strong>
+                  9: How to get help
+                </strong>
+                <span>
+                  1 min 22 sec
+                </span>
+                <a href="<%= ExternalLinksHelper::HOW_TO_GET_HELP_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> English YouTube
+                </a>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::HOW_TO_GET_HELP_AMHARIC_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Amharic YouTube
+                  </a>
+                  <a href="<%= ExternalLinksHelper::HOW_TO_GET_HELP_OROMO_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Oromo YouTube
+                  </a>
+                <% end %>
+                <a href="<%= ExternalLinksHelper::HOW_TO_GET_HELP_DOWNLOAD_LINK %>">
+                  <i class="fas fa-arrow-circle-down"></i> Download English: 20 <small>MB</small>
+                </a>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::HOW_TO_GET_HELP_AMHARIC_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Amharic: 31 <small>MB</small>
+                  </a>
+                  <a href="<%= ExternalLinksHelper::HOW_TO_GET_HELP_OROMO_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Oromo: 37 <small>MB</small>
+                  </a>
+                <% end %>
+              </div>
+              <div class="col-sm-3 col-video mb-3">
+                <%= image_tag 'resources/video-chapter-10.jpg', style: 'width: 100%;' %>
+                <strong>
+                  10: Start using <%= Rails.application.config.application_brand_name %>
+                </strong>
+                <span>
+                  2 min
+                </span>
+                <a href="<%= ExternalLinksHelper::START_USING_SIMPLE_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> English YouTube
+                </a>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::START_USING_SIMPLE_AMHARIC_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Amharic YouTube
+                  </a>
+                  <a href="<%= ExternalLinksHelper::START_USING_SIMPLE_OROMO_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Oromo YouTube
+                  </a>
+                <% end %>
+                <a href="<%= ExternalLinksHelper::START_USING_SIMPLE_DOWNLOAD_LINK %>">
+                  <i class="fas fa-arrow-circle-down"></i> Download English: 30 <small>MB</small>
+                </a>
+                <% if CountryConfig.current[:name] == "Ethiopia" %>
+                  <a href="<%= ExternalLinksHelper::START_USING_SIMPLE_AMHARIC_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Amharic: 48 <small>MB</small>
+                  </a>
+                  <a href="<%= ExternalLinksHelper::START_USING_SIMPLE_OROMO_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Oromo: 55 <small>MB</small>
+                  </a>
+                <% end %>
+              </div>
             </div>
-            <div class="col-sm-3 col-video mb-3">
-              <%= image_tag 'resources/video-chapter-6.jpg', style: 'width: 100%;' %>
-              <strong>
-                6: Call overdue patients
-              </strong>
-              <span>
-                3 min
-              </span>
-              <a href="<%= ExternalLinksHelper::CALL_OVERDUE_PATIENTS_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> English YouTube
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::CALL_OVERDUE_PATIENTS_AMHARIC_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Amharic YouTube
+            <h4 class="mt-5">
+              Other videos
+            </h4>
+            <div class="row">
+              <div class="col-sm-3 col-video">
+                <%= image_tag 'resources/video-telemedicine.jpg', style: 'width: 100%;' %>
+                <strong>
+                  Telemedicine Training
+                </strong>
+                <span>
+                  5 min
+                </span>
+                <a href="<%= ExternalLinksHelper::TELEMEDICINE_TRAINING_ENGLISH_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> English YouTube
                 </a>
-                <a href="<%= ExternalLinksHelper::CALL_OVERDUE_PATIENTS_OROMO_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Oromo YouTube
+                <% if CountryConfig.current[:name] == "India" %>
+                  <a href="<%= ExternalLinksHelper::TELEMEDICINE_TRAINING_HINDI_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Hindi YouTube
+                  </a>
+                <% end %>
+                <a href="<%= ExternalLinksHelper::TELEMEDICINE_TRAINING_ENGLISH_DOWNLOAD_LINK %>">
+                  <i class="fas fa-arrow-circle-down"></i> Download English: 82 <small>MB</small>
                 </a>
-              <% end %>
-              <a href="<%= ExternalLinksHelper::CALL_OVERDUE_PATIENTS_DOWNLOAD_LINK %>">
-                <i class="fas fa-arrow-circle-down"></i> Download English: 35 <small>MB</small>
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::CALL_OVERDUE_PATIENTS_AMHARIC_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Amharic: 68 <small>MB</small>
+                <% if CountryConfig.current[:name] == "India" %>
+                  <a href="<%= ExternalLinksHelper::TELEMEDICINE_TRAINING_HINDI_DOWNLOAD_LINK %>">
+                    <i class="fas fa-arrow-circle-down"></i> Download Hindi: 88 <small>MB</small>
+                  </a>
+                <% end %>
+              </div>
+              <div class="col-sm-3 col-video">
+                <%= image_tag 'resources/video-how.jpg', style: 'width: 100%;' %>
+                <strong>
+                  Quick <%= Rails.application.config.application_brand_name %> Training
+                </strong>
+                <span>
+                  5 min
+                </span>
+                <a href="<%= ExternalLinksHelper::QUICK_SIMPLE_TRAINING_ENGLISH_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> English YouTube
                 </a>
-                <a href="<%= ExternalLinksHelper::CALL_OVERDUE_PATIENTS_OROMO_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Oromo: 63 <small>MB</small>
+                <% if CountryConfig.current[:name] == "India" %>
+                  <a href="<%= ExternalLinksHelper::QUICK_SIMPLE_TRAINING_HINDI_YOUTUBE_LINK %>">
+                    <i class="fab fa-youtube"></i> Hindi YouTube
+                  </a>
+                <% end %>
+              </div>
+              <div class="col-sm-3 col-video">
+                <%= image_tag 'resources/video-passport.jpg', style: 'width: 100%;' %>
+                <strong>
+                  How to use a BP Passport
+                </strong>
+                <span>
+                  3 min 21 sec
+                </span>
+                <a href="<%= ExternalLinksHelper::HOW_TO_USE_BP_PASSPORT_HINDI_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> Hindi (English subtitles)
                 </a>
-              <% end %>
-            </div>
-            <div class="col-sm-3 col-video mb-3">
-              <%= image_tag 'resources/video-chapter-7.jpg', style: 'width: 100%;' %>
-              <strong>
-                7: Important features
-              </strong>
-              <span>
-                4 min
-              </span>
-              <a href="<%= ExternalLinksHelper::IMPORTANT_FEATURES_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> English YouTube
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::IMPORTANT_FEATURES_AMHARIC_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Amharic YouTube
+              </div>
+              <div class="col-sm-3 col-video">
+                <%= image_tag 'resources/video-doc.jpg', style: 'width: 100%;' %>
+                <strong>
+                  <%= Rails.application.config.application_brand_name %> Documentary
+                </strong>
+                <span>
+                  3 min / 5 min 30 sec
+                </span>
+                <a href="<%= ExternalLinksHelper::SIMPLE_DOCUMENTARY_SHORT_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> Short version
                 </a>
-                <a href="<%= ExternalLinksHelper::IMPORTANT_FEATURES_OROMO_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Oromo YouTube
+                <a href="<%= ExternalLinksHelper::SIMPLE_DOCUMENTARY_LONG_YOUTUBE_LINK %>">
+                  <i class="fab fa-youtube"></i> Long version
                 </a>
-              <% end %>
-              <a href="<%= ExternalLinksHelper::IMPORTANT_FEATURES_DOWNLOAD_LINK %>">
-                <i class="fas fa-arrow-circle-down"></i> Download English: 52 <small>MB</small>
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::IMPORTANT_FEATURES_AMHARIC_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Amharic: 84 <small>MB</small>
-                </a>
-                <a href="<%= ExternalLinksHelper::IMPORTANT_FEATURES_OROMO_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Oromo: 64 <small>MB</small>
-                </a>
-              <% end %>
-            </div>
-            <div class="col-sm-3 col-video mb-3">
-              <%= image_tag 'resources/video-chapter-8.jpg', style: 'width: 100%;' %>
-              <strong>
-                8: FAQ
-              </strong>
-              <span>
-                3 min 35 sec
-              </span>
-              <a href="<%= ExternalLinksHelper::FAQ_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> English YouTube
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::FAQ_AMHARIC_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Amharic YouTube
-                </a>
-                <a href="<%= ExternalLinksHelper::FAQ_OROMO_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Oromo YouTube
-                </a>
-              <% end %>
-              <a href="<%= ExternalLinksHelper::FAQ_DOWNLOAD_LINK %>">
-                <i class="fas fa-arrow-circle-down"></i> Download English: 39 <small>MB</small>
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::FAQ_AMHARIC_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Amharic: 72 <small>MB</small>
-                </a>
-                <a href="<%= ExternalLinksHelper::FAQ_OROMO_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Oromo: 73 <small>MB</small>
-                </a>
-              <% end %>
-            </div>
-            <div class="col-sm-3 col-video mb-3">
-              <%= image_tag 'resources/video-chapter-9.jpg', style: 'width: 100%;' %>
-              <strong>
-                9: How to get help
-              </strong>
-              <span>
-                1 min 22 sec
-              </span>
-              <a href="<%= ExternalLinksHelper::HOW_TO_GET_HELP_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> English YouTube
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::HOW_TO_GET_HELP_AMHARIC_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Amharic YouTube
-                </a>
-                <a href="<%= ExternalLinksHelper::HOW_TO_GET_HELP_OROMO_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Oromo YouTube
-                </a>
-              <% end %>
-              <a href="<%= ExternalLinksHelper::HOW_TO_GET_HELP_DOWNLOAD_LINK %>">
-                <i class="fas fa-arrow-circle-down"></i> Download English: 20 <small>MB</small>
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::HOW_TO_GET_HELP_AMHARIC_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Amharic: 31 <small>MB</small>
-                </a>
-                <a href="<%= ExternalLinksHelper::HOW_TO_GET_HELP_OROMO_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Oromo: 37 <small>MB</small>
-                </a>
-              <% end %>
-            </div>
-            <div class="col-sm-3 col-video mb-3">
-              <%= image_tag 'resources/video-chapter-10.jpg', style: 'width: 100%;' %>
-              <strong>
-                10: Start using <%= Rails.application.config.application_brand_name %>
-              </strong>
-              <span>
-                2 min
-              </span>
-              <a href="<%= ExternalLinksHelper::START_USING_SIMPLE_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> English YouTube
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::START_USING_SIMPLE_AMHARIC_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Amharic YouTube
-                </a>
-                <a href="<%= ExternalLinksHelper::START_USING_SIMPLE_OROMO_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Oromo YouTube
-                </a>
-              <% end %>
-              <a href="<%= ExternalLinksHelper::START_USING_SIMPLE_DOWNLOAD_LINK %>">
-                <i class="fas fa-arrow-circle-down"></i> Download English: 30 <small>MB</small>
-              </a>
-              <% if CountryConfig.current[:name] == "Ethiopia" %>
-                <a href="<%= ExternalLinksHelper::START_USING_SIMPLE_AMHARIC_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Amharic: 48 <small>MB</small>
-                </a>
-                <a href="<%= ExternalLinksHelper::START_USING_SIMPLE_OROMO_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Oromo: 55 <small>MB</small>
-                </a>
-              <% end %>
+              </div>
             </div>
           </div>
-          <h4 class="mt-5">
-            Other videos
-          </h4>
-          <div class="row">
-            <div class="col-sm-3 col-video">
-              <%= image_tag 'resources/video-telemedicine.jpg', style: 'width: 100%;' %>
-              <strong>
-                Telemedicine Training
-              </strong>
-              <span>
-                5 min
-              </span>
-              <a href="<%= ExternalLinksHelper::TELEMEDICINE_TRAINING_ENGLISH_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> English YouTube
-              </a>
-              <% if CountryConfig.current[:name] == "India" %>
-                <a href="<%= ExternalLinksHelper::TELEMEDICINE_TRAINING_HINDI_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Hindi YouTube
-                </a>
-              <% end %>
-              <a href="<%= ExternalLinksHelper::TELEMEDICINE_TRAINING_ENGLISH_DOWNLOAD_LINK %>">
-                <i class="fas fa-arrow-circle-down"></i> Download English: 82 <small>MB</small>
-              </a>
-              <% if CountryConfig.current[:name] == "India" %>
-                <a href="<%= ExternalLinksHelper::TELEMEDICINE_TRAINING_HINDI_DOWNLOAD_LINK %>">
-                  <i class="fas fa-arrow-circle-down"></i> Download Hindi: 88 <small>MB</small>
-                </a>
-              <% end %>
-            </div>
-            <div class="col-sm-3 col-video">
-              <%= image_tag 'resources/video-how.jpg', style: 'width: 100%;' %>
-              <strong>
-                Quick <%= Rails.application.config.application_brand_name %> Training
-              </strong>
-              <span>
-                5 min
-              </span>
-              <a href="<%= ExternalLinksHelper::QUICK_SIMPLE_TRAINING_ENGLISH_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> English YouTube
-              </a>
-              <% if CountryConfig.current[:name] == "India" %>
-                <a href="<%= ExternalLinksHelper::QUICK_SIMPLE_TRAINING_HINDI_YOUTUBE_LINK %>">
-                  <i class="fab fa-youtube"></i> Hindi YouTube
-                </a>
-              <% end %>
-            </div>
-            <div class="col-sm-3 col-video">
-              <%= image_tag 'resources/video-passport.jpg', style: 'width: 100%;' %>
-              <strong>
-                How to use a BP Passport
-              </strong>
-              <span>
-                3 min 21 sec
-              </span>
-              <a href="<%= ExternalLinksHelper::HOW_TO_USE_BP_PASSPORT_HINDI_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> Hindi (English subtitles)
-              </a>
-            </div>
-            <div class="col-sm-3 col-video">
-              <%= image_tag 'resources/video-doc.jpg', style: 'width: 100%;' %>
-              <strong>
-                <%= Rails.application.config.application_brand_name %> Documentary
-              </strong>
-              <span>
-                3 min / 5 min 30 sec
-              </span>
-              <a href="<%= ExternalLinksHelper::SIMPLE_DOCUMENTARY_SHORT_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> Short version
-              </a>
-              <a href="<%= ExternalLinksHelper::SIMPLE_DOCUMENTARY_LONG_YOUTUBE_LINK %>">
-                <i class="fab fa-youtube"></i> Long version
-              </a>
-            </div>
-          </div>
-        </div>
+        <% end %>
         <div class="card" id="card-1pager">
           <h2>
             1-pagers about <%= Rails.application.config.application_brand_name %>
@@ -569,54 +573,56 @@
             Print material
           </h2>
           <div class="row">
-            <div class="col-sm-3 col-video mt-3 mb-0px">
-              <%= image_tag 'resources/user-handbook.jpg', style: 'width: 100%;' %>
-              <strong class="mt-2 d-block">
-                App Users Guidebook
-              </strong>
-              <div class="mt-2">
-                <% if CountryConfig.current[:name] == "India" %>
-                  <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_BENGALI_DOWNLOAD_LINK %>" class="doc-download">
-                    <i class="fas fa-arrow-circle-down"></i> Download Bengali PDF
+            <% if !Rails.application.config.whitelabel_app %>
+              <div class="col-sm-3 col-video mt-3 mb-0px">
+                <%= image_tag 'resources/user-handbook.jpg', style: 'width: 100%;' %>
+                <strong class="mt-2 d-block">
+                  App Users Guidebook
+                </strong>
+                <div class="mt-2">
+                  <% if CountryConfig.current[:name] == "India" %>
+                    <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_BENGALI_DOWNLOAD_LINK %>" class="doc-download">
+                      <i class="fas fa-arrow-circle-down"></i> Download Bengali PDF
+                    </a>
+                    <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_HINDI_DOWNLOAD_LINK %>" class="doc-download">
+                      <i class="fas fa-arrow-circle-down"></i> Download Hindi PDF
+                    </a>
+                    <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_MARATHI_DOWNLOAD_LINK %>" class="doc-download">
+                      <i class="fas fa-arrow-circle-down"></i> Download Marathi PDF
+                    </a>
+                    <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_PUNJABI_DOWNLOAD_LINK %>" class="doc-download">
+                      <i class="fas fa-arrow-circle-down"></i> Download Punjabi PDF
+                    </a>
+                    <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_TAMIL_DOWNLOAD_LINK %>" class="doc-download">
+                      <i class="fas fa-arrow-circle-down"></i> Download Tamil PDF
+                    </a>
+                    <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_TELUGU_DOWNLOAD_LINK %>" class="doc-download">
+                      <i class="fas fa-arrow-circle-down"></i> Download Telugu PDF
+                    </a>
+                  <% elsif CountryConfig.current[:name] == "Bangladesh" %>
+                    <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_BENGALI_DOWNLOAD_LINK %>" class="doc-download">
+                      <i class="fas fa-arrow-circle-down"></i> Download Bengali PDF
+                    </a>
+                    <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_HINDI_DOWNLOAD_LINK %>" class="doc-download">
+                      <i class="fas fa-arrow-circle-down"></i> Download Hindi PDF
+                    </a>
+                  <% elsif CountryConfig.current[:name] == "Ethiopia" %>
+                    <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_AMHARIC_DOWNLOAD_LINK %>" class="doc-download">
+                      <i class="fas fa-arrow-circle-down"></i> Download Amharic PDF
+                    </a>
+                    <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_OROMO_DOWNLOAD_LINK %>" class="doc-download">
+                      <i class="fas fa-arrow-circle-down"></i> Download Oromo PDF
+                    </a>
+                    <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_TIGRINYA_DOWNLOAD_LINK %>" class="doc-download">
+                      <i class="fas fa-arrow-circle-down"></i> Download Tigrinya PDF
+                    </a>
+                  <% end %>
+                  <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_ENGLISH_DOWNLOAD_LINK %>" class="doc-download">
+                    <i class="fas fa-arrow-circle-down"></i> Download English PDF
                   </a>
-                  <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_HINDI_DOWNLOAD_LINK %>" class="doc-download">
-                    <i class="fas fa-arrow-circle-down"></i> Download Hindi PDF
-                  </a>
-                  <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_MARATHI_DOWNLOAD_LINK %>" class="doc-download">
-                    <i class="fas fa-arrow-circle-down"></i> Download Marathi PDF
-                  </a>
-                  <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_PUNJABI_DOWNLOAD_LINK %>" class="doc-download">
-                    <i class="fas fa-arrow-circle-down"></i> Download Punjabi PDF
-                  </a>
-                  <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_TAMIL_DOWNLOAD_LINK %>" class="doc-download">
-                    <i class="fas fa-arrow-circle-down"></i> Download Tamil PDF
-                  </a>
-                  <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_TELUGU_DOWNLOAD_LINK %>" class="doc-download">
-                    <i class="fas fa-arrow-circle-down"></i> Download Telugu PDF
-                  </a>
-                <% elsif CountryConfig.current[:name] == "Bangladesh" %>
-                  <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_BENGALI_DOWNLOAD_LINK %>" class="doc-download">
-                    <i class="fas fa-arrow-circle-down"></i> Download Bengali PDF
-                  </a>
-                  <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_HINDI_DOWNLOAD_LINK %>" class="doc-download">
-                    <i class="fas fa-arrow-circle-down"></i> Download Hindi PDF
-                  </a>
-                <% elsif CountryConfig.current[:name] == "Ethiopia" %>
-                  <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_AMHARIC_DOWNLOAD_LINK %>" class="doc-download">
-                    <i class="fas fa-arrow-circle-down"></i> Download Amharic PDF
-                  </a>
-                  <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_OROMO_DOWNLOAD_LINK %>" class="doc-download">
-                    <i class="fas fa-arrow-circle-down"></i> Download Oromo PDF
-                  </a>
-                  <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_TIGRINYA_DOWNLOAD_LINK %>" class="doc-download">
-                    <i class="fas fa-arrow-circle-down"></i> Download Tigrinya PDF
-                  </a>
-                <% end %>
-                <a href="<%= ExternalLinksHelper::APP_USERS_GUIDE_ENGLISH_DOWNLOAD_LINK %>" class="doc-download">
-                  <i class="fas fa-arrow-circle-down"></i> Download English PDF
-                </a>
+                </div>
               </div>
-            </div>
+            <% end %>
             <div class="col-sm-3 col-video mt-3">
               <%= image_tag 'resources/bp-poster.jpg', style: 'width: 100%' %>
               <strong class="mt-2 d-block">
@@ -629,18 +635,6 @@
                   </a>
                   <a class="doc-download" href="<%= ExternalLinksHelper::HOW_TO_TAKE_A_BP_POSTER_HINDI_DOWNLOAD_LINK %>">
                     <i class="fas fa-arrow-circle-down"></i> Download Hindi PDF
-                  </a>
-                  <a class="doc-download" href="<%= ExternalLinksHelper::HOW_TO_TAKE_A_BP_POSTER_MARATHI_DOWNLOAD_LINK %>">
-                    <i class="fas fa-arrow-circle-down"></i> Download Marathi PDF
-                  </a>
-                  <a class="doc-download" href="<%= ExternalLinksHelper::HOW_TO_TAKE_A_BP_POSTER_PUNJABI_DOWNLOAD_LINK %>">
-                    <i class="fas fa-arrow-circle-down"></i> Download Punjabi PDF
-                  </a>
-                  <a class="doc-download" href="<%= ExternalLinksHelper::HOW_TO_TAKE_A_BP_POSTER_TAMIL_DOWNLOAD_LINK %>">
-                    <i class="fas fa-arrow-circle-down"></i> Download Tamil PDF
-                  </a>
-                  <a class="doc-download" href="<%= ExternalLinksHelper::HOW_TO_TAKE_A_BP_POSTER_TELUGU_DOWNLOAD_LINK %>">
-                    <i class="fas fa-arrow-circle-down"></i> Download Telugu PDF
                   </a>
                 <% elsif CountryConfig.current[:name] == "Bangladesh" %>
                   <a class="doc-download" href="<%= ExternalLinksHelper::HOW_TO_TAKE_A_BP_POSTER_BENGALI_DOWNLOAD_LINK %>">

--- a/app/views/shared/_nav_bar.html.erb
+++ b/app/views/shared/_nav_bar.html.erb
@@ -117,7 +117,7 @@
             Error traces
           <% end %>
         <% end %>
-        <% if current_admin.power_user? %>
+        <% if current_admin.power_user? && !Rails.application.config.whitelabel_app %>
           <%= link_to admin_cphc_migration_path, class: "sub-nav-link #{active_controller?("admin/cphc_migration")}" do %>
             CPHC Migration
           <% end %>
@@ -126,10 +126,10 @@
 
       <div class="nav-divider"></div>
 
-      <a href="https://www.simple.org/privacy/" class="sub-nav-link" target="_blank">
+      <a href="<%= Rails.application.config.privacy_link %>" class="sub-nav-link" target="_blank">
         Privacy policy
       </a>
-      <a href="https://www.simple.org/license/" class="sub-nav-link" target="_blank">
+      <a href="<%= Rails.application.config.license_link %>" class="sub-nav-link" target="_blank">
         License
       </a>
 

--- a/app/views/shared/_nav_bar_v2.html.erb
+++ b/app/views/shared/_nav_bar_v2.html.erb
@@ -203,7 +203,7 @@
     </a>
   </div>
   <div class="mb-1 px-2">
-    <a class="block" href="https://www.simple.org/privacy">
+    <a class="block" href="<%= Rails.application.config.privacy_link %>">
       <div class="flex py-2 px-3 bg-white rounded-md transition-bg duration-250 ease-in-expo">
         <div class="relative top-1 mr-2">
           <svg class="stroke-current text-grey-300" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -217,7 +217,7 @@
     </a>
   </div>
   <div class="mb-3 px-2">
-    <a class="block" href="https://www.simple.org/privacy">
+    <a class="block" href="<%= Rails.application.config.privacy_link %>">
       <div class="flex py-2 px-3 bg-white rounded-md transition-bg duration-250 ease-in-expo">
         <div class="relative top-1 mr-2">
           <svg class="stroke-current text-grey-300" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">

--- a/config/initializers/whitelabel.rb
+++ b/config/initializers/whitelabel.rb
@@ -5,4 +5,8 @@ Rails.application.configure do
   config.cvho_email_id = ENV.fetch("CVHO_EMAIL_ID", "cvho@simple.org")
   config.eng_email_id = ENV.fetch("ENG_EMAIL_ID", "eng-backend@resolvetosavelives.org")
   config.favicon_url = ENV.fetch("FAVICON_URL", "https://simple.org/images/favicon.png")
+  config.whitelabel_app = ENV["WHITELABEL_APP"] ? ActiveModel::Type::Boolean.new.cast(ENV["WHITELABEL_APP"].downcase) : false
+  config.deployment_checklist_link = ENV.fetch("DEPLOYMENT_CHECKLIST_LINK", "https://docs.google.com/document/d/1cleJkm09VRGUAafkpzC9U2ao9r4r8ewZjLPwfTTj57Q/edit?usp=sharing")
+  config.privacy_link = ENV.fetch("PRIVACY_LINK", "https://www.simple.org/privacy")
+  config.license_link = ENV.fetch("LICENSE_LINK", "https://www.simple.org/license/")
 end

--- a/config/locales/api/am_ET.yml
+++ b/config/locales/api/am_ET.yml
@@ -79,10 +79,10 @@ am-ET:
     menu:
       videos_html: ቪዲዮዎች
       start_html: 1. ጀምር
-      register_html: 2. ታካሚ መዝግብ
-      search_html: 3. ትክክለኛውን ታካሚ ፈልግ
-      record_html: 4. የታካሚ ጉብኝት መዝግብ
-      overdue_html: 5. የዘገዩ ታካሚዎችን ይጥሩ
+      register_html: "%{list_order_number}. ታካሚ መዝግብ"
+      search_html: "%{list_order_number}. ትክክለኛውን ታካሚ ፈልግ"
+      record_html: "%{list_order_number}. የታካሚ ጉብኝት መዝግብ"
+      overdue_html: "%{list_order_number}. የዘገዩ ታካሚዎችን ይጥሩ"
       faq_html: የተለመዱ ጥያቄዎች
     support:
       heading_html: እገዛ ይጠይቁ

--- a/config/locales/api/bn_BD.yml
+++ b/config/locales/api/bn_BD.yml
@@ -79,10 +79,10 @@ bn-BD:
     menu:
       videos_html: ভিডিওগুলি
       start_html: 1. শুরু করা হচ্ছে
-      register_html: 2. রোগীকে নিবন্ধন করুন
-      search_html: 3. সঠিক রোগীকে খুঁজুন
-      record_html: 4. একজন রোগীর ভিজিট রেকর্ড করুন
-      overdue_html: 5. ভিজিটের সময় পেরিয়ে যাওয়া রোগীদের ফোন করা
+      register_html: "%{list_order_number}. রোগীকে নিবন্ধন করুন"
+      search_html: "%{list_order_number}. সঠিক রোগীকে খুঁজুন"
+      record_html: "%{list_order_number}. একজন রোগীর ভিজিট রেকর্ড করুন"
+      overdue_html: "%{list_order_number}. ভিজিটের সময় পেরিয়ে যাওয়া রোগীদের ফোন করা"
       faq_html: সাধারণ প্রশ্নাবলী
     support:
       heading_html: সহায়্তা চান

--- a/config/locales/api/bn_IN.yml
+++ b/config/locales/api/bn_IN.yml
@@ -79,10 +79,10 @@ bn-IN:
     menu:
       videos_html: ভিডিওগুলি
       start_html: 1. শুরু করা হচ্ছে
-      register_html: 2. রোগীকে নিবন্ধন করুন
-      search_html: 3. সঠিক রোগীকে খুঁজুন
-      record_html: 4. একজন রোগীর ভিজিট রেকর্ড করুন
-      overdue_html: 5. ভিজিটের সময় পেরিয়ে যাওয়া রোগীদের ফোন করুন
+      register_html: "%{list_order_number}. রোগীকে নিবন্ধন করুন"
+      search_html: "%{list_order_number}. সঠিক রোগীকে খুঁজুন"
+      record_html: "%{list_order_number}. একজন রোগীর ভিজিট রেকর্ড করুন"
+      overdue_html: "%{list_order_number}. ভিজিটের সময় পেরিয়ে যাওয়া রোগীদের ফোন করুন"
       faq_html: প্রচলিত প্রশ্নাবলী
     support:
       heading_html: সহায়্তার জন্য প্রশ্ন করুন

--- a/config/locales/api/en.yml
+++ b/config/locales/api/en.yml
@@ -79,10 +79,10 @@ en:
     menu:
       videos_html: Videos
       start_html: 1. Getting started
-      register_html: 2. Register a patient
-      search_html: 3. Find the correct patient
-      record_html: 4. Record a patient’s visit
-      overdue_html: 5. Call overdue patients
+      register_html: "%{list_order_number}. Register a patient"
+      search_html: "%{list_order_number}. Find the correct patient"
+      record_html: "%{list_order_number}. Record a patient’s visit"
+      overdue_html: "%{list_order_number}. Call overdue patients"
       faq_html: Common questions
     support:
       heading_html: Ask for help

--- a/config/locales/api/es.yml
+++ b/config/locales/api/es.yml
@@ -80,10 +80,10 @@ es:
     menu:
       videos_html: Videos
       start_html: 1. Cómo empezar
-      register_html: 2. Registrar un paciente
-      search_html: 3. Encontrar al paciente correcto
-      record_html: 4. Registrar la visita del paciente
-      overdue_html: 5. Llamar a pacientes atrasados
+      register_html: "%{list_order_number}. Registrar un paciente"
+      search_html: "%{list_order_number}. Encontrar al paciente correcto"
+      record_html: "%{list_order_number}. Registrar la visita del paciente"
+      overdue_html: "%{list_order_number}. Llamar a pacientes atrasados"
       faq_html: Preguntas comunes
     support:
       heading_html: Pedir ayuda

--- a/config/locales/api/hi_IN.yml
+++ b/config/locales/api/hi_IN.yml
@@ -79,10 +79,10 @@ hi-IN:
     menu:
       videos_html: वीडियो
       start_html: 1. आरंभ करना
-      register_html: 2. रोगी को पंजीकृत करें
-      search_html: 3. सही रोगी को खोजें
-      record_html: 4. रोगी की विज़िट को रिकॉर्ड करें
-      overdue_html: 5. निर्धारित दिन पर नहीं आए रोगियों को कॉल करें
+      register_html: "%{list_order_number}. रोगी को पंजीकृत करें"
+      search_html: "%{list_order_number}. सही रोगी को खोजें"
+      record_html: "%{list_order_number}. रोगी की विज़िट को रिकॉर्ड करें"
+      overdue_html: "%{list_order_number}. निर्धारित दिन पर नहीं आए रोगियों को कॉल करें"
       faq_html: सामान्य सवाल
     support:
       heading_html: मदद पाने के लिए पूछें

--- a/config/locales/api/kn_IN.yml
+++ b/config/locales/api/kn_IN.yml
@@ -79,10 +79,10 @@ kn-IN:
     menu:
       videos_html: ವೀಡಿಯೊಗಳು
       start_html: 1. ಆರಂಭಿಸುವುದು
-      register_html: 2. ರೋಗಿಯನ್ನು ನೋಂದಣಿ ಮಾಡಿ
-      search_html: 3. ಸರಿಯಾದ ರೋಗಿಯನ್ನು ಹುಡುಕಿ
-      record_html: 4. ರೋಗಿಯ ಭೇಟಿಯನ್ನು ದಾಖಲಿಸಿ
-      overdue_html: 5. ಓವರ್‌ಡ್ಯೂ ಇರುವ ರೋಗಿಗಳಿಗೆ ಕರೆ ಮಾಡಿ
+      register_html: "%{list_order_number}. ರೋಗಿಯನ್ನು ನೋಂದಣಿ ಮಾಡಿ"
+      search_html: "%{list_order_number}. ಸರಿಯಾದ ರೋಗಿಯನ್ನು ಹುಡುಕಿ"
+      record_html: "%{list_order_number}. ರೋಗಿಯ ಭೇಟಿಯನ್ನು ದಾಖಲಿಸಿ"
+      overdue_html: "%{list_order_number}. ಓವರ್‌ಡ್ಯೂ ಇರುವ ರೋಗಿಗಳಿಗೆ ಕರೆ ಮಾಡಿ"
       faq_html: ಸಾಮಾನ್ಯ ಪ್ರಶ್ನೆಗಳು
     support:
       heading_html: ಸಹಾಯ ಕೇಳಿ

--- a/config/locales/api/mr_IN.yml
+++ b/config/locales/api/mr_IN.yml
@@ -79,10 +79,10 @@ mr-IN:
     menu:
       videos_html: व्हिडिओ
       start_html: 1. सुरुवात करत आहे
-      register_html: 2. रुग्णाची नोंदणी करा
-      search_html: 3. योग्य रूग्ण शोधा
-      record_html: 4. रुग्णाच्या भेटीचा रेकॉर्ड ठेवा
-      overdue_html: 5. ओव्हरड्यू रुग्णांना कॉल करा
+      register_html: "%{list_order_number}. रुग्णाची नोंदणी करा"
+      search_html: "%{list_order_number}. योग्य रूग्ण शोधा"
+      record_html: "%{list_order_number}. रुग्णाच्या भेटीचा रेकॉर्ड ठेवा"
+      overdue_html: "%{list_order_number}. ओव्हरड्यू रुग्णांना कॉल करा"
       faq_html: सामान्&zwj;य प्रश्&zwj;न
     support:
       heading_html: मदत घ्या

--- a/config/locales/api/om_ET.yml
+++ b/config/locales/api/om_ET.yml
@@ -79,10 +79,10 @@ om-ET:
     menu:
       videos_html: Suursagalee
       start_html: 1. Jalqabuu
-      register_html: 2. Dhukkubsataa galmeessi
-      search_html: 3. Dhukkubsataa sirrii barbaadi
-      record_html: 4. Daawwannaa dhukkubsataa galmeessi
-      overdue_html: 5. Dhukkubsatoota yeroon irra darbe waami
+      register_html: "%{list_order_number}. Dhukkubsataa galmeessi"
+      search_html: "%{list_order_number}. Dhukkubsataa sirrii barbaadi"
+      record_html: "%{list_order_number}. Daawwannaa dhukkubsataa galmeessi"
+      overdue_html: "%{list_order_number}. Dhukkubsatoota yeroon irra darbe waami"
       faq_html: Gaaffiiwwan baraman
     support:
       heading_html: Gargaarsaaf gaafadhu

--- a/config/locales/api/pa_Guru_IN.yml
+++ b/config/locales/api/pa_Guru_IN.yml
@@ -79,10 +79,10 @@ pa-Guru-IN:
     menu:
       videos_html: ਵੀਡੀਓ
       start_html: 1. ਸ਼ੁਰੂ ਕਰੋ
-      register_html: 2. ਮਰੀਜ਼ ਨੂੰ ਰਜਿਸਟਰ ਕਰੋ
-      search_html: 3. ਸਹੀ ਮਰੀਜ਼ ਲੱਭੋ
-      record_html: 4. ਮਰੀਜ਼ ਦੀ ਮੁਲਾਕਾਤ ਰਿਕਾਰਡ ਕਰੋ
-      overdue_html: 5. ਓਵਰਡਿਊ ਮਰੀਜ਼ਾਂ ਨੂੰ ਕਾਲ ਕਰੋ
+      register_html: "%{list_order_number}. ਮਰੀਜ਼ ਨੂੰ ਰਜਿਸਟਰ ਕਰੋ"
+      search_html: "%{list_order_number}. ਸਹੀ ਮਰੀਜ਼ ਲੱਭੋ"
+      record_html: "%{list_order_number}. ਮਰੀਜ਼ ਦੀ ਮੁਲਾਕਾਤ ਰਿਕਾਰਡ ਕਰੋ"
+      overdue_html: "%{list_order_number}. ਓਵਰਡਿਊ ਮਰੀਜ਼ਾਂ ਨੂੰ ਕਾਲ ਕਰੋ"
       faq_html: ਆਮ ਸਵਾਲ
     support:
       heading_html: ਮਦਦ ਮੰਗੋ

--- a/config/locales/api/si_LK.yml
+++ b/config/locales/api/si_LK.yml
@@ -79,10 +79,10 @@ si-LK:
     menu:
       videos_html: වීඩියෝ
       start_html: 1. ආරම්භ කිරීම
-      register_html: 2. රෝගියකු ලියාපදිංචි කිරීම
-      search_html: 3. නිවැරදි රෝගියාව සොයා ගන්න
-      record_html: 4. රෝගියෙකුගේ හමුවීම වාර්තා කරන්න
-      overdue_html: 5. කල් ඉක්මුණු රෝගීන්ව අමතන්න
+      register_html: "%{list_order_number}. රෝගියකු ලියාපදිංචි කිරීම"
+      search_html: "%{list_order_number}. නිවැරදි රෝගියාව සොයා ගන්න"
+      record_html: "%{list_order_number}. රෝගියෙකුගේ හමුවීම වාර්තා කරන්න"
+      overdue_html: "%{list_order_number}. කල් ඉක්මුණු රෝගීන්ව අමතන්න"
       faq_html: පොදු ප්‍රශ්න
     support:
       heading_html: සහාය ඉල්ලන්න

--- a/config/locales/api/sid_ET.yml
+++ b/config/locales/api/sid_ET.yml
@@ -13,7 +13,7 @@ sid-ET:
       invalid_password: "Sa”ate Qaali Dixxaadino. Wirro Wo’nnaala?"
       account_locked: "Harunseewo %{minutes} Geeshsha Xawwishshiki Cufamino. Agarte Wirro Wo’naali."
   communications:
-    request_otp: "<#> %{otp} Tini Simple Huwatate Code/Fojote Borro/kiiro atete %{app_signature}\n"
+    request_otp: "<#> %{otp} Tini %{app_brand_name} Huwatate Code/Fojote Borro/kiiro atete %{app_signature}\n"
     appointment_reminders:
       sms: "Ninke Borro mini %{facility_name} nni yaa ki’neranna ki’ne wodani keeri daafira hedanno yaate. Ballo! Mundeete xiiwo xagga harunse. Mulekki leeltawo Cinaanchu uurrinshini xaggichokki gamba assiri. "
       whatsapp: "Ninke Borro mini %{facility_name} nni yaa ki’neranna ki’ne wodani keeri daafira hedanno yaate. Ballo! Mundeete xiiwo xagga harunse. Mulekki leeltawo Cinaanchu uurrinshini xaggichokki gamba assiri. "
@@ -79,10 +79,10 @@ sid-ET:
     menu:
       videos_html: Viidio
       start_html: 1. Hanafa
-      register_html: 2. Xagisiraano borreesse
-      search_html: 3. Garu/addu Xagisiraancho afiri
-      record_html: 4. Xagisiraanchu  daa’ante borreessi
-      overdue_html: 5. Yanna sa’inonsa xagisiraanora bilbille/woshshe
+      register_html: "%{list_order_number}. Xagisiraano borreesse"
+      search_html: "%{list_order_number}. Garu/addu Xagisiraancho afiri"
+      record_html: "%{list_order_number}. Xagisiraanchu  daa’ante borreessi"
+      overdue_html: "%{list_order_number}. Yanna sa’inonsa xagisiraanora bilbille/woshshe"
       faq_html: Rosantino xa’muwa
     support:
       heading_html: Kaa’lo xa’mi
@@ -97,7 +97,7 @@ sid-ET:
       heading_html: Qajeelshu viidio
       class:
         heading_html: Kifile adhi
-        contents_html: Simple horonsirate rosate mitte Kifile lai
+        contents_html: "%{app_brand_name} horonsirate rosate mitte Kifile lai"
         training_videos_link_html: "Qajeelle: Wo’manta fooliishsho"
         training_videos_subtitle_html: "Ingilezete afoo Hindete afiinni cinaancho handaara 36:15"
       chapters:
@@ -125,16 +125,16 @@ sid-ET:
         video_link_html: Hiittoonni horonsi’nayiro Mundeete xiiwo passporte
         video_link_subtitle_html: Hindete afoo Ingilezete afiinni cinaancho handaara
       film:
-        heading_html: Simple filme
-        link_html: '<a href="https://www.youtube.com/watch?v=C26CoyeExmU">"Simple heeshsho giddo mitto barra"</a> hindete Punjab, India giddo noo nersite Mundeete xiiwo noonsa xiwamaasine xagisate shotuyi hiitoonni horonsidhannoro leellishanno filme'
+        heading_html: "%{app_brand_name} filme"
+        link_html: '<a href="https://www.youtube.com/watch?v=C26CoyeExmU">"%{app_brand_name} heeshsho giddo mitto barra"</a> hindete Punjab, India giddo noo nersite Mundeete xiiwo noonsa xiwamaasine xagisate shotuyi hiitoonni horonsidhannoro leellishanno filme'
     start:
       heading_html: Hanafa
       getting_started_video:
         heading_html: Viidio lai
-        contents_html: Ontu/5 dhiqqeessi giddo Simple qara coyibba affe
+        contents_html: Ontu/5 dhiqqeessi giddo %{app_brand_name} qara coyibba affe
       who_to_record:
-        heading_html: "Simple ayi hinkiili?"
-        contents_1_html: Borreessate Simple Horonsiri <i>mittu mittunku Jawa Mundeete xiiwo noonsarira</i> woyi jawa Mundeete xiiwora xagga adhitayi noorira.
+        heading_html: "%{app_brand_name} ayi hinkiili?"
+        contents_1_html: Borreessate %{app_brand_name} Horonsiri <i>mittu mittunku Jawa Mundeete xiiwo noonsarira</i> woyi jawa Mundeete xiiwora xagga adhitayi noorira.
         contents_2_html: Xagisiraanchu layirara higiro mittu gari xiwamaancho hasi nna haaro Mundeete xiiwo eessi.
       step_1:
         label_html: Deerra 1
@@ -143,14 +143,14 @@ sid-ET:
       step_2:
         label_html: Deerra 2
         heading_html: Mundeete xiiwo passporte giddo borreessi
-        contents_html: "Mundeete xiiwo passporte nooheha ikkiro, xagisiraanchu su’ma borreessi. Hakuyi gedensaanni, Simple app horonsiratenni daa”ati (scan) assi."
+        contents_html: "Mundeete xiiwo passporte nooheha ikkiro, xagisiraanchu su’ma borreessi. Hakuyi gedensaanni, %{app_brand_name} app horonsiratenni daa”ati (scan) assi."
       step_3:
         label_html: Deerra 3
         heading_html: Xagisiraancho borreesi
         contents_html: "Haaro ikkituro, xagisiraancho borreesi"
       step_4:
         label_html: Deerra 4
-        heading_html: Simple Mundeete xiiwo eessi
+        heading_html: "%{app_brand_name} Mundeete xiiwo eessi"
         contents_html: <i>doyitooti</i> Mundeete xiiwo xiinxallo.
       step_5:
         label_html: Deerra 5
@@ -163,7 +163,7 @@ sid-ET:
       missed_visit:
         label_html: Xea koyinya/lao
         heading_html: "Harunse maikanno?"
-        contents_html: Xagisiraanchu koyinyisi/laomasi yannasi sa’usiro Simple ikkitewoti qole higawo gede qaagisitawisi borro sokka sooyanno.
+        contents_html: Xagisiraanchu koyinyisi/laomasi yannasi sa’usiro %{app_brand_name} ikkitewoti qole higawo gede qaagisitawisi borro sokka sooyanno.
       tip:
         heading_html: Horo uyitawo (dancha) amaale
         contents_html: "Wo’ma woyite Xiwamaasine garu uurrinshi giddo borreessaki buuxi. Hanafote qooli iskiriine (screen) aana, wo’ma woyite aleenni guracho widoonni noo uurrinsha buuxi"
@@ -211,7 +211,7 @@ sid-ET:
         contents_2_html: "Xiwamaanchu hasatote giddo nooro mittu xagisiraanchi ledono xaadawokiha ikkiro, hato haaru xagisiraanchi gede assitine borreesse"
       tip:
         heading_html: Horo uyitawo (dancha) amaale
-        contents_html: "BP (Mundeete xiiwo) passporte iskaane (scan) loosawokiha ikkiro, daa'atinayi (Scan) mittu gari iskiriine (screen) qooli aana xano ledine BP (Mundeete xiiwo) kiiro hakka Simple widira type assa dandiitinanni."
+        contents_html: "BP (Mundeete xiiwo) passporte iskaane (scan) loosawokiha ikkiro, daa'atinayi (Scan) mittu gari iskiriine (screen) qooli aana xano ledine BP (Mundeete xiiwo) kiiro hakka %{app_brand_name} widira type assa dandiitinanni."
     record:
       heading_html: Borreesi xagisiraanchu daa"atata.
       find_patient:
@@ -264,11 +264,11 @@ sid-ET:
     faq:
       heading_html: Rosantino xa’muwa
       app_crash_question_html: "Ane app loosa gibburo maa assa nooe?"
-      app_crash_answer_html: Umo computereki uduunnichi wirro hanafisiisate wo’naali Simple ba”ayi noohanna iso biddi assate dandaamahekiha ikkiro haka <span class="help">kaa’lo</span> iasikiriinete (screen) qoolira haratenni qorqoraasine woyi gaamonke hasaawisse.
+      app_crash_answer_html: Umo computereki uduunnichi wirro hanafisiisate wo’naali %{app_brand_name} ba”ayi noohanna iso biddi assate dandaamahekiha ikkiro haka <span class="help">kaa’lo</span> iasikiriinete (screen) qoolira haratenni qorqoraasine woyi gaamonke hasaawisse.
       scan_not_working_question_html: "Iskaane(scan) loosayi dino Maa assa nooe?"
       scan_not_working_answer_html: "Isikiriinete (screen) qoolira woroonni BP (Mundeete xiiwo) passporte kiiro eesse. Qarru harunsiro, bilbilaki wirro hanafisi Xano loosa hooguro, hasaawisi qorqoraanchoki."
       udpate_app_question_html: "App/e hiittoonni yannannita/woyyaabinota assa dandeemo/ma?"
-      udpate_app_answer_html: "Qinnibirete ayikone (icon) kisatenni nna <span class=\"code\">woyyeesse</span> kisatenni app yannannita asse/woyyeesse Bilbiliki uduunichi aana yannannita Simple ittime afira hasiissanno"
+      udpate_app_answer_html: "Qinnibirete ayikone (icon) kisatenni nna <span class=\"code\">woyyeesse</span> kisatenni app yannannita asse/woyyeesse Bilbiliki uduunichi aana yannannita %{app_brand_name} ittime afira hasiissanno"
       cant_find_followup_question_html: Harunsiranno xagisiraancho afira didandoomo/ma
       cant_find_followup_answer_html: "BP (Mundeete xiiwo) passporte heedhawonsakki woyite, mite mite yanna harunsitanno xagisiraanno afira qarrissanno 5 dhiqqeessi gedensaanni, xagisiraancho afira dandaa hooginiro, haaru xiwamaanchi gede assitine borreessensa. Albilliteeta xagisiraanchu borreesammete dabitara karsiisa/mitto assa dandiinanni"
       two_bp_passports_question_html: Mittu xagisiraanchira 2 BP (Mundeete xiiwo) passporte heedhasira dandiitanno.
@@ -277,10 +277,10 @@ sid-ET:
       no_more_bp_passports_answer_html: "Goofasira albaanni, qorqoraanchokki ledote Mundeete xiiwo passporte amadawo gede xa’mi Wodanchi, ayi gari BP (Mundeete xiiwo) passporte hooguhero nafa xano xiwamaasine borreessa dandiitinanni&#8212; BP (Mundeete xiiwo) gaama dandiitinanni."
       what_is_sync_question_html: "\"Sync\" maati?"
       what_is_sync_answer_html: "\"Sync\" Taje mereerima serverera ofoshiishshano. Tajekki ajayi ajeena mitte hige barrunni duunamase buuxi. Danchu internetete xaadi hoogiro, tajekki \"sync\" assate shiima dhiqqeessa adhitara dandiitano"
-      data_usage_question_html: "Simple Mageeshiha mashallaqqe horonsirato/ta?"
-      data_usage_answer_html: Simple lowo Geeshsha shiima taje horonsidhanno. Mereerimuyi aganu giddo 20 MB looso aana hosssanno.
-      access_my_info_question_html: "Mashallaqqe’ya Simple afira dandaanno?"
-      access_my_info_answer_html: Simple bilbilu woyi tabiletete aana ayitano hallanshu mashallaqqe diafiranno.
+      data_usage_question_html: "%{app_brand_name} Mageeshiha mashallaqqe horonsirato/ta?"
+      data_usage_answer_html: "%{app_brand_name} lowo Geeshsha shiima taje horonsidhanno. Mereerimuyi aganu giddo 20 MB looso aana hosssanno."
+      access_my_info_question_html: "Mashallaqqe’ya %{app_brand_name} afira dandaanno?"
+      access_my_info_answer_html: "%{app_brand_name} bilbilu woyi tabiletete aana ayitano hallanshu mashallaqqe diafiranno."
     bp_passport_app:
       heading_html: Mundeete xiiwo passporte app
       features:
@@ -379,7 +379,7 @@ sid-ET:
         subtitle: "%{facility_name}. ra maareekkinoonni harunso assinanni toyanyubba. xissamaanote Jawa mundeete xiiwo haa'niro, mundeete sukkaare haa'niro, dinye qineessiniro, woy xagichonsa haroonsidhuro harunso toyaanyo ikkitanno. "
       patients_initiated_on_treatment_card:
         title: 'Taje "xissamaano xagisirate hasato leellishshinoti" mama no?'
-        main_text: '"Borreessantino xissamaano" horoonsiri, ayee woyteno "xagisirate hasatto leellishshino xissamaano" nna Simple giddo borrreessantino xissamaano taaloho.'
+        main_text: '"Borreessantino xissamaano" horoonsiri, ayee woyteno "xagisirate hasatto leellishshino xissamaano" nna %{app_brand_name} giddo borrreessantino xissamaano taaloho.'
       more_patient_data_coming_soon_card:
         title: "Roore xissamaanote taje mulenni dagganno. "
         main_text: "Barru baali boreessonna harunso taje, xissote daninninna koo/tee tenni babbande mulenni lendanni  "

--- a/config/locales/api/so_ET.yml
+++ b/config/locales/api/so_ET.yml
@@ -79,10 +79,10 @@ so-ET:
     menu:
       videos_html: Fiidyawyo
       start_html: 1. Bilawga
-      register_html: 2. Duwaan gelinta bukaanka
-      search_html: 3. Hel bukaanka saxda ah
-      record_html: 4. Duwaanka booqashada bukaanka
-      overdue_html: 5. La hadal bukaanka mudadu ka dhaaftay
+      register_html: "%{list_order_number}. Duwaan gelinta bukaanka"
+      search_html: "%{list_order_number}. Hel bukaanka saxda ah"
+      record_html: "%{list_order_number}. Duwaanka booqashada bukaanka"
+      overdue_html: "%{list_order_number}. La hadal bukaanka mudadu ka dhaaftay"
       faq_html: Su'aalaha caamka ah
     support:
       heading_html: Dalbo kaalmo

--- a/config/locales/api/ta_IN.yml
+++ b/config/locales/api/ta_IN.yml
@@ -79,10 +79,10 @@ ta-IN:
     menu:
       videos_html: வீடியோக்கள்
       start_html: 1. தொடங்குதல்
-      register_html: 2. நோயாளியைப் பதிவு செய்தல்
-      search_html: 3. சரியான நோயாளியைக் கண்டுபிடித்தல்
-      record_html: 4. நோயாளியின் வருகையைப் பதிவு செய்தல்
-      overdue_html: 5. வரத் தவறிய நோயாளிகளை அழைத்தல்
+      register_html: "%{list_order_number}. நோயாளியைப் பதிவு செய்தல்"
+      search_html: "%{list_order_number}. சரியான நோயாளியைக் கண்டுபிடித்தல்"
+      record_html: "%{list_order_number}. நோயாளியின் வருகையைப் பதிவு செய்தல்"
+      overdue_html: "%{list_order_number}. வரத் தவறிய நோயாளிகளை அழைத்தல்"
       faq_html: பொதுவான கேள்விகள்
     support:
       heading_html: உதவி கேட்கவும்

--- a/config/locales/api/ta_LK.yml
+++ b/config/locales/api/ta_LK.yml
@@ -79,10 +79,10 @@ ta-LK:
     menu:
       videos_html: வீடியோக்கள்
       start_html: 1. தொடங்குதல்
-      register_html: 2. நோயாளரைப் பதிவு செய்யவும்
-      search_html: 3. சரியான நோயாளரைக் கண்டுபிடிக்கவும்
-      record_html: 4. நோயாளரின் வருகையைப் பதிவுசெய்யவும்
-      overdue_html: 5. தாமதமான நோயாளர்களை அழைக்கவும்
+      register_html: "%{list_order_number}. நோயாளரைப் பதிவு செய்யவும்"
+      search_html: "%{list_order_number}. சரியான நோயாளரைக் கண்டுபிடிக்கவும்"
+      record_html: "%{list_order_number}. நோயாளரின் வருகையைப் பதிவுசெய்யவும்"
+      overdue_html: "%{list_order_number}. தாமதமான நோயாளர்களை அழைக்கவும்"
       faq_html: பொதுவான கேள்விகள்
     support:
       heading_html: உதவிக் கேட்கவும்

--- a/config/locales/api/te_IN.yml
+++ b/config/locales/api/te_IN.yml
@@ -79,10 +79,10 @@ te-IN:
     menu:
       videos_html: వీడియోలు
       start_html: 1. ప్రారంభించడం
-      register_html: 2. రోగిని రిజిస్టర్ చేయండి
-      search_html: 3. సరైన రోగిని కనుగొనండి
-      record_html: 4. రోగి సందర్శనను రికార్డ్ చేయండి
-      overdue_html: 5. గడువు తేదీ దాటిన రోగులకు కాల్ చేయండి
+      register_html: "%{list_order_number}. రోగిని రిజిస్టర్ చేయండి"
+      search_html: "%{list_order_number}. సరైన రోగిని కనుగొనండి"
+      record_html: "%{list_order_number}. రోగి సందర్శనను రికార్డ్ చేయండి"
+      overdue_html: "%{list_order_number}. గడువు తేదీ దాటిన రోగులకు కాల్ చేయండి"
       faq_html: సాధారణ ప్రశ్నలు
     support:
       heading_html: సహాయం కోసం అడగండి

--- a/config/locales/api/ti_ET.yml
+++ b/config/locales/api/ti_ET.yml
@@ -79,10 +79,10 @@ ti-ET:
     menu:
       videos_html: ቪዲዮታት
       start_html: 1. ኣብ ምጅማር
-      register_html: 2. ተሓካሚ መዝግብ
-      search_html: 3. ንእትደልዮ ተሓካሚ ብልክዕ ርኸቦ
-      record_html: 4. ናይ ተሓካማይ ምብፃሕ ምምዝጋብ
-      overdue_html: 5. ጊዚኦም ዝሓለፎም ተሓከምቲ ጸዉዕዎም
+      register_html: "%{list_order_number}. ተሓካሚ መዝግብ"
+      search_html: "%{list_order_number}. ንእትደልዮ ተሓካሚ ብልክዕ ርኸቦ"
+      record_html: "%{list_order_number}. ናይ ተሓካማይ ምብፃሕ ምምዝጋብ"
+      overdue_html: "%{list_order_number}. ጊዚኦም ዝሓለፎም ተሓከምቲ ጸዉዕዎም"
       faq_html: ብኣብዝሓ ዝሕተቱ ሕቶታት
     support:
       heading_html: ሓገዝ ሕተት

--- a/doc/howto/whitelabel.md
+++ b/doc/howto/whitelabel.md
@@ -10,6 +10,10 @@ Set the following environment variables according to your desired branding:
 - `CVHO_EMAIL_ID` – Email address for your CVHO team.
 - `ENG_EMAIL_ID` – Contact email for the engineering team.
 - `FAVICON_URL` - Public URL for accessing the favicon.
+- `WHITELABEL_APP` - Set to TRUE/FALSE to deteremine whether you are using a whitelabelled version of the app or not. Look and feel of the dashboard will change based on this flag
+- `DEPLOYMENT_CHECKLIST_LINK` - Link to the deployment checklist document, which would appear under Resources tab in the dashboard
+- `PRIVACY_LINK` - Link to the privacy policy adhereing to the new brand
+- `LICENSE_LINK` - Link to the license information adhereing to the new brand
 
 ### Example Configuration
 
@@ -20,6 +24,10 @@ HELP_EMAIL_ID="help_email@test.org"
 CVHO_EMAIL_ID="cvho_email@test.org"
 ENG_EMAIL_ID="eng-backend@test.org"
 FAVICON_URL="https://www.google.com/favicon.ico"
+DEPLOYMENT_CHECKLIST_LINK="https://docs.google.com/document/d/1qLoXo3dIw7A2WIRqsJ5Zx77DJDYnNnfu76vm8PVobxU/edit?usp=sharing"
+WHITELABEL_APP="TRUE"
+PRIVACY_LINK="https://www.simple.org/privacy"
+LICENSE_LINK="https://www.simple.org/license/"
 ```
 
 Make sure these environment variables are set in your environment, `.env` file, or your deployment configuration system.


### PR DESCRIPTION
**Story card:** [sc-15243](https://app.shortcut.com/simpledotorg/story/15243/the-name-of-the-application-simple-should-come-from-the-configuration)

## Because

We need to remove some links in under Resources tab in dashboard, and Help section in Android app.

## This addresses

Introducing a new "WHITELABEL_APP" flag in the environment variable, which will control this.
When set to TRUE, it entails that we are whitelabeling the server app, and hence will remove the simple branded video links from the resources section.

## Test instructions

Set up following environment vars
WHITELABEL_APP
DEPLOYMENT_CHECKLIST_LINK
PRIVACY_LINK
LICENSE_LINK
Check the links under Resources & Training section. All "Simple" branded videos should not be available.