### PR TITLE
chore: clean test output by removing deprecation on rendered_component

### DIFF
--- a/spec/components/progress_tab/diabetes/blood_sugar200_to299_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/blood_sugar200_to299_component_spec.rb
@@ -63,24 +63,24 @@ RSpec.describe ProgressTab::Diabetes::BloodSugar200To299Component, type: :compon
     end
 
     it "renders the correct uncontrolled threshold long text for Sri Lanka" do
-      expect(rendered_component).to have_text(I18n.t("bs_over_200_copy.reports_card_title_dm_fbs"))
+      expect(page).to have_text(I18n.t("bs_over_200_copy.reports_card_title_dm_fbs"))
     end
 
     it "renders the correct uncontrolled threshold short text for Sri Lanka" do
-      expect(rendered_component).to have_text(I18n.t("bs_over_200_copy.bs_200_to_299.title_dm_fbs"))
+      expect(page).to have_text(I18n.t("bs_over_200_copy.bs_200_to_299.title_dm_fbs"))
     end
 
     it "renders the correct denominator text for Sri Lanka" do
-      expect(rendered_component).to have_text(I18n.t("progress_tab.diagnosis_report.patient_treatment_outcomes.uncontrolled_card.help_tooltip.denominator", facility_name: "Region 1", diagnosis: "Diabetes"))
+      expect(page).to have_text(I18n.t("progress_tab.diagnosis_report.patient_treatment_outcomes.uncontrolled_card.help_tooltip.denominator", facility_name: "Region 1", diagnosis: "Diabetes"))
     end
 
     it "renders the bar chart with correct data" do
-      expect(rendered_component).to have_selector('.d-flex[data-graph-type="bar-chart"]')
-      expect(rendered_component).to have_selector(".w-32px.bgc-yellow")
+      expect(page).to have_selector('.d-flex[data-graph-type="bar-chart"]')
+      expect(page).to have_selector(".w-32px.bgc-yellow")
     end
 
     it "renders the correct uncontrolled bar text for Sri Lanka" do
-      expect(rendered_component).to have_text(I18n.t("bs_over_200_copy.bs_200_to_299.title_dm_fbs"))
+      expect(page).to have_text(I18n.t("bs_over_200_copy.bs_200_to_299.title_dm_fbs"))
     end
   end
 
@@ -90,24 +90,24 @@ RSpec.describe ProgressTab::Diabetes::BloodSugar200To299Component, type: :compon
     end
 
     it "renders the correct uncontrolled threshold long text for non-Sri Lanka countries" do
-      expect(rendered_component).to have_text(I18n.t("bs_over_200_copy.reports_card_title_dm"))
+      expect(page).to have_text(I18n.t("bs_over_200_copy.reports_card_title_dm"))
     end
 
     it "renders the correct uncontrolled threshold short text for non-Sri Lanka countries" do
-      expect(rendered_component).to have_text(I18n.t("bs_over_200_copy.bs_200_to_299.title_dm_bs"))
+      expect(page).to have_text(I18n.t("bs_over_200_copy.bs_200_to_299.title_dm_bs"))
     end
 
     it "renders the correct denominator text for non-Sri Lanka countries" do
-      expect(rendered_component).to have_text(I18n.t("progress_tab.diagnosis_report.patient_treatment_outcomes.uncontrolled_card.help_tooltip.denominator", facility_name: "Region 1", diagnosis: "Diabetes"))
+      expect(page).to have_text(I18n.t("progress_tab.diagnosis_report.patient_treatment_outcomes.uncontrolled_card.help_tooltip.denominator", facility_name: "Region 1", diagnosis: "Diabetes"))
     end
 
     it "renders the bar chart with correct data for non-Sri Lanka countries" do
-      expect(rendered_component).to have_selector('.d-flex[data-graph-type="bar-chart"]')
-      expect(rendered_component).to have_selector(".w-32px.bgc-yellow")
+      expect(page).to have_selector('.d-flex[data-graph-type="bar-chart"]')
+      expect(page).to have_selector(".w-32px.bgc-yellow")
     end
 
     it "renders the correct uncontrolled bar text for non-Sri Lanka countries" do
-      expect(rendered_component).to have_text(I18n.t("bs_over_200_copy.bs_200_to_299.title_dm"))
+      expect(page).to have_text(I18n.t("bs_over_200_copy.bs_200_to_299.title_dm"))
     end
   end
 end

--- a/spec/components/progress_tab/diabetes/blood_sugar300_and_above_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/blood_sugar300_and_above_component_spec.rb
@@ -64,15 +64,15 @@ RSpec.describe ProgressTab::Diabetes::BloodSugar300AndAboveComponent, type: :com
       end
 
       it "displays the correct uncontrolled threshold long text" do
-        expect(rendered_component).to have_text(I18n.t("bs_over_200_copy.bs_over_300.numerator_dm_fbs"))
+        expect(page).to have_text(I18n.t("bs_over_200_copy.bs_over_300.numerator_dm_fbs"))
       end
 
       it "displays the correct uncontrolled threshold short text" do
-        expect(rendered_component).to have_text(I18n.t("bs_over_200_copy.bs_over_300.title_dm_fbs"))
+        expect(page).to have_text(I18n.t("bs_over_200_copy.bs_over_300.title_dm_fbs"))
       end
 
       it "displays the correct denominator text" do
-        expect(rendered_component).to have_text(
+        expect(page).to have_text(
           I18n.t(
             "progress_tab.diagnosis_report.patient_treatment_outcomes.controlled_card.help_tooltip.denominator",
             facility_name: region.name,
@@ -82,8 +82,8 @@ RSpec.describe ProgressTab::Diabetes::BloodSugar300AndAboveComponent, type: :com
       end
 
       it "renders the bar chart with correct styling and tooltip enabled" do
-        expect(rendered_component).to have_selector('.d-flex[data-graph-type="bar-chart"]')
-        expect(rendered_component).to have_selector(".w-32px.bgc-yellow-dark-new")
+        expect(page).to have_selector('.d-flex[data-graph-type="bar-chart"]')
+        expect(page).to have_selector(".w-32px.bgc-yellow-dark-new")
       end
     end
 
@@ -93,11 +93,11 @@ RSpec.describe ProgressTab::Diabetes::BloodSugar300AndAboveComponent, type: :com
       end
 
       it "displays the correct uncontrolled threshold short text" do
-        expect(rendered_component).to have_text(I18n.t("bs_over_200_copy.bs_over_300.title"))
+        expect(page).to have_text(I18n.t("bs_over_200_copy.bs_over_300.title"))
       end
 
       it "displays the correct denominator text" do
-        expect(rendered_component).to have_text(
+        expect(page).to have_text(
           I18n.t(
             "progress_tab.diagnosis_report.patient_treatment_outcomes.controlled_card.help_tooltip.denominator",
             facility_name: region.name,
@@ -107,8 +107,8 @@ RSpec.describe ProgressTab::Diabetes::BloodSugar300AndAboveComponent, type: :com
       end
 
       it "renders the bar chart with correct styling and tooltip enabled" do
-        expect(rendered_component).to have_selector('.d-flex[data-graph-type="bar-chart"]')
-        expect(rendered_component).to have_selector(".w-32px.bgc-yellow-dark-new")
+        expect(page).to have_selector('.d-flex[data-graph-type="bar-chart"]')
+        expect(page).to have_selector(".w-32px.bgc-yellow-dark-new")
       end
     end
   end

--- a/spec/components/progress_tab/diabetes/control_component_spec.rb
+++ b/spec/components/progress_tab/diabetes/control_component_spec.rb
@@ -61,15 +61,15 @@ RSpec.describe ProgressTab::Diabetes::ControlComponent, type: :component do
     end
 
     it "renders the controlled threshold long text for WHO standard" do
-      expect(rendered_component).to have_text("Numerator: Patients with FBS <126mg/dL or HbA1c <7% at their last visit in the last 3 months")
+      expect(page).to have_text("Numerator: Patients with FBS <126mg/dL or HbA1c <7% at their last visit in the last 3 months")
     end
 
     it "renders the controlled threshold short text for WHO standard" do
-      expect(rendered_component).to have_text(I18n.t("bs_below_200_copy.reports_card_title_dm_fbs"))
+      expect(page).to have_text(I18n.t("bs_below_200_copy.reports_card_title_dm_fbs"))
     end
 
     it "renders the correct subtitle for WHO standard" do
-      expect(rendered_component).to have_text(I18n.t(
+      expect(page).to have_text(I18n.t(
         "bs_below_200_copy.reports_card_subtitle_dm_fbs",
         region_name: "Region 1",
         diagnosis: "Diabetes",
@@ -78,8 +78,8 @@ RSpec.describe ProgressTab::Diabetes::ControlComponent, type: :component do
     end
 
     it "renders the bar chart with correct data" do
-      expect(rendered_component).to have_selector('.d-flex[data-graph-type="bar-chart"]')
-      expect(rendered_component).to have_selector(".w-32px.bgc-green-dark-new", count: 3)
+      expect(page).to have_selector('.d-flex[data-graph-type="bar-chart"]')
+      expect(page).to have_selector(".w-32px.bgc-green-dark-new", count: 3)
     end
   end
 
@@ -89,15 +89,15 @@ RSpec.describe ProgressTab::Diabetes::ControlComponent, type: :component do
     end
 
     it "renders the controlled threshold long text for non-WHO standard" do
-      expect(rendered_component).to have_text(I18n.t("bs_below_200_copy.numerator"))
+      expect(page).to have_text(I18n.t("bs_below_200_copy.numerator"))
     end
 
     it "renders the controlled threshold short text for non-WHO standard" do
-      expect(rendered_component).to have_text(I18n.t("bs_below_200_copy.reports_card_title_dm_bs"))
+      expect(page).to have_text(I18n.t("bs_below_200_copy.reports_card_title_dm_bs"))
     end
 
     it "renders the correct subtitle for non-WHO standard" do
-      expect(rendered_component).to have_text(I18n.t(
+      expect(page).to have_text(I18n.t(
         "bs_below_200_copy.reports_card_subtitle_dm",
         region_name: "Region 1",
         diagnosis: "Diabetes",
@@ -106,8 +106,8 @@ RSpec.describe ProgressTab::Diabetes::ControlComponent, type: :component do
     end
 
     it "renders the bar chart with correct data" do
-      expect(rendered_component).to have_selector('.d-flex[data-graph-type="bar-chart"]')
-      expect(rendered_component).to have_selector(".w-32px.bgc-green-dark-new", count: 3)
+      expect(page).to have_selector('.d-flex[data-graph-type="bar-chart"]')
+      expect(page).to have_selector(".w-32px.bgc-green-dark-new", count: 3)
     end
   end
 end

--- a/spec/components/progress_tab/hypertension/control_component_spec.rb
+++ b/spec/components/progress_tab/hypertension/control_component_spec.rb
@@ -58,18 +58,18 @@ RSpec.describe ProgressTab::Hypertension::ControlComponent, type: :component do
     before { render_component }
 
     it "renders the controlled threshold long text" do
-      expect(rendered_component).to have_text(I18n.t(
+      expect(page).to have_text(I18n.t(
         "progress_tab.diagnosis_report.patient_treatment_outcomes.controlled_card.help_tooltip.numerator",
         controlled_threshold: I18n.t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_controlled_long")
       ))
     end
 
     it "renders the controlled threshold short text" do
-      expect(rendered_component).to have_text(I18n.t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_controlled_short"))
+      expect(page).to have_text(I18n.t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_controlled_short"))
     end
 
     it "renders the correct subtitle" do
-      expect(rendered_component).to have_text(I18n.t(
+      expect(page).to have_text(I18n.t(
         "progress_tab.diagnosis_report.patient_treatment_outcomes.controlled_card.subtitle",
         facility_name: "Region 1",
         diagnosis: "Hypertension",
@@ -78,8 +78,8 @@ RSpec.describe ProgressTab::Hypertension::ControlComponent, type: :component do
     end
 
     it "renders the bar chart with correct data" do
-      expect(rendered_component).to have_selector('.d-flex[data-graph-type="bar-chart"]')
-      expect(rendered_component).to have_selector(".w-32px.bgc-green-dark-new", count: 3)
+      expect(page).to have_selector('.d-flex[data-graph-type="bar-chart"]')
+      expect(page).to have_selector(".w-32px.bgc-green-dark-new", count: 3)
     end
   end
 end

--- a/spec/components/progress_tab/hypertension/uncontrolled_component_spec.rb
+++ b/spec/components/progress_tab/hypertension/uncontrolled_component_spec.rb
@@ -60,28 +60,28 @@ RSpec.describe ProgressTab::Hypertension::UncontrolledComponent, type: :componen
     end
 
     it "renders the correct title text" do
-      expect(rendered_component).to have_text(I18n.t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_short"))
+      expect(page).to have_text(I18n.t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_short"))
     end
 
     it "renders the correct subtitle text" do
-      expect(rendered_component).to have_text(I18n.t("progress_tab.diagnosis_report.patient_treatment_outcomes.uncontrolled_card.subtitle",
+      expect(page).to have_text(I18n.t("progress_tab.diagnosis_report.patient_treatment_outcomes.uncontrolled_card.subtitle",
         facility_name: "Region 1", diagnosis: "Hypertension",
         uncontrolled_threshold: I18n.t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_long")))
     end
 
     it "renders the tooltip with correct numerator and denominator text" do
-      expect(rendered_component).to have_text(I18n.t("progress_tab.diagnosis_report.patient_treatment_outcomes.uncontrolled_card.help_tooltip.numerator",
+      expect(page).to have_text(I18n.t("progress_tab.diagnosis_report.patient_treatment_outcomes.uncontrolled_card.help_tooltip.numerator",
         uncontrolled_threshold: I18n.t("progress_tab.diagnosis_report.diagnosis_thresholds.hypertension_uncontrolled_long")))
-      expect(rendered_component).to have_text(I18n.t("progress_tab.diagnosis_report.patient_treatment_outcomes.uncontrolled_card.help_tooltip.denominator",
+      expect(page).to have_text(I18n.t("progress_tab.diagnosis_report.patient_treatment_outcomes.uncontrolled_card.help_tooltip.denominator",
         facility_name: "Region 1", diagnosis: "Hypertension"))
     end
 
     it "renders the bar chart with correct data" do
-      expect(rendered_component).to have_selector("[data-graph-type='bar-chart']")
+      expect(page).to have_selector("[data-graph-type='bar-chart']")
     end
 
     it "includes the correct graph colors" do
-      expect(rendered_component).to have_selector(".bgc-yellow-dark-new")
+      expect(page).to have_selector(".bgc-yellow-dark-new")
     end
   end
 end

--- a/spec/components/reports/progress_monthly_follow_ups_component_spec.rb
+++ b/spec/components/reports/progress_monthly_follow_ups_component_spec.rb
@@ -44,25 +44,25 @@ RSpec.describe Reports::ProgressMonthlyFollowUpsComponent, type: :component do
 
   describe "rendering the component" do
     it "renders the title correctly" do
-      expect(rendered_component).to have_css("h2", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.title"))
+      expect(page).to have_css("h2", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.title"))
     end
 
     it "renders the subtitle with correct facility name and diagnosis" do
-      expect(rendered_component).to have_selector("p", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle_dm", facility_name: region.name, diagnosis: diagnosis))
+      expect(page).to have_selector("p", text: I18n.t("progress_tab.diagnosis_report.monthly_follow_up_patients.subtitle_dm", facility_name: region.name, diagnosis: diagnosis))
     end
 
     it "displays the correct number of total registrations" do
       monthly_follow_ups_data.values.each do |value|
-        expect(rendered_component).to have_text(value.to_s)
+        expect(page).to have_text(value.to_s)
       end
     end
 
     it "passes the correct data to the data bar graph partial" do
-      expect(rendered_component).to have_selector('div[data-graph-type="bar-chart"]')
+      expect(page).to have_selector('div[data-graph-type="bar-chart"]')
       monthly_follow_ups_data.keys.each do |date_str|
-        expect(rendered_component).to have_text(period_info_data[date_str][:name])
+        expect(page).to have_text(period_info_data[date_str][:name])
       end
-      monthly_follow_ups_data.values.each { |value| expect(rendered_component).to have_text(value.to_s) }
+      monthly_follow_ups_data.values.each { |value| expect(page).to have_text(value.to_s) }
     end
   end
 


### PR DESCRIPTION
**Story card:** [sc-15268](https://app.shortcut.com/simpledotorg/story/15268/versioning-adopt-semantic-versioning)

## Because

Building in Github surfaces the noise Semaphore hides

## This addresses

```
DEPRECATION WARNING: `rendered_component` is deprecated and will be removed in v3.0.0. Use `page` instead. (called from block (3 levels) in <top (required)> at /home/runner/work/simple-server/simple-server/spec/components/which/uses/rendered_component_spec.rb:##)
```

## Test instructions

suite tests
