### PR TITLE
build: push tagged image to Docker Hub

### DIFF
--- a/.semaphore/docker.yml
+++ b/.semaphore/docker.yml
@@ -16,6 +16,7 @@ blocks:
           - docker images
           - docker push $tag_latest
           - docker push $tag_git_sha
+          - docker push "$image_name:${SEMAPHORE_WORKFLOW_ID}"
       secrets:
       - name: docker-hub
 queue:


### PR DESCRIPTION
**Story card:** [sc-15268](https://app.shortcut.com/simpledotorg/story/15268/versioning-adopt-semantic-versioning)

## Because

The image wasn't getting pushed to the docker hub

## This addresses

Adding the necessary comment

## Test instructions

check that the image is pushed with sha and workflow_id on docker-hub after deploy
