### PR TITLE
fix: Use correct Ruby for Nginx

### DIFF
--- a/.docker/config/nginx/webapp.conf
+++ b/.docker/config/nginx/webapp.conf
@@ -8,7 +8,7 @@ server {
   gzip_types text/html text/plain application/json;
 
   passenger_user app;
-  passenger_ruby /usr/bin/ruby2.7;
+  passenger_ruby /usr/local/bin/ruby;
   passenger_app_root /home/app;
   passenger_enabled on;
   passenger_app_env production;

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,7 +27,14 @@ blocks:
             - cache store
   - name: Tests
     skip:
-      when: change_in(['/doc', '/swagger', '**/*.md', '/public', '/script'])
+      when: change_in([
+        '**/*.md',
+        '/.*'
+        '/doc',
+        '/public',
+        '/script',
+        '/swagger',
+      ])
     task:
       env_vars:
         - name: RAILS_ENV


### PR DESCRIPTION
**Story card:** [sc-15637](https://app.shortcut.com/simpledotorg/story/15637)

## Because

Nginx pointing to a now non-existent Ruby — because of the Ruby upgrades going on — causes SBX to 503

## This addresses

Using the right Ruby version in Nginx

## Test instructions

a healthy SBX
