### PR TITLE
fix: Use Passenger Ruby alias

### DIFF
--- a/.docker/config/nginx/webapp.conf
+++ b/.docker/config/nginx/webapp.conf
@@ -8,7 +8,7 @@ server {
   gzip_types text/html text/plain application/json;
 
   passenger_user app;
-  passenger_ruby /usr/local/bin/ruby;
+  passenger_ruby /usr/bin/passenger_free_ruby;
   passenger_app_root /home/app;
   passenger_enabled on;
   passenger_app_env production;


### PR DESCRIPTION
**Story card:** [sc-15637](https://app.shortcut.com/simpledotorg/story/15637)

## Because

Deploys are failing with the hard-coded ruby path

## This addresses

Using the passenger alias in case the path changes

## Test instructions

n/a
