### PR TITLE
fix: Remove Serialization

### DIFF
--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -3,7 +3,6 @@ class Period
 
   include Comparable
   include ActiveModel::Model
-  include ActiveModel::Serialization
   validates :type, presence: true, inclusion: {in: [:month, :quarter], message: "must be month or quarter"}
   validates :value, presence: true
 


### PR DESCRIPTION
**Story card:** [sc-15946](https://app.shortcut.com/simpledotorg/story/15946/remove-period-serialization)

## Because

Serializing a period came out inconsistent, and it was impossible to recreate a quarter period from its serialized form. So we decided to work with string periods in the target and remove serialization completely.

## This addresses

Removing serizalization from the Period value object

## Test instructions

n/a
