### PR TITLE
the change

### DIFF
--- a/app/models/dr_rai/target.rb
+++ b/app/models/dr_rai/target.rb
@@ -1,5 +1,5 @@
 class DrRai::Target < ApplicationRecord
   belongs_to :indicator, class_name: "DrRai::Indicator", foreign_key: "dr_rai_indicators_id"
 
-  validates :period, presence: true
+  validates :period, presence: true, format: { with: /\AQ\d-\d{4}\Z/ }
 end

--- a/spec/models/dr_rai/target_spec.rb
+++ b/spec/models/dr_rai/target_spec.rb
@@ -2,10 +2,33 @@ require "rails_helper"
 
 RSpec.describe DrRai::Target, type: :model do
   describe "validations:" do
+    INVALID_PERIODS = %w[
+      01_2025
+      1_2025
+      Q1_23
+      01-2025
+      1-2025
+      Q1-23
+    ]
+
     it "periods must exist" do
       new_target = DrRai::Target.new
       expect(new_target).not_to be_valid
       expect(new_target.errors.added?(:period, :blank)).to be_truthy
+    end
+
+    INVALID_PERIODS.each do |period|
+      it "#{period} is not a valid period format" do
+        target = DrRai::Target.new period: "01-2025"
+        expect(target).not_to be_valid
+        expect(target.errors.of_kind?(:period, :invalid)).to be_truthy
+      end
+    end
+
+    it "Q1-2023 is a valid period format" do
+      target = DrRai::Target.new period: "Q1-2025"
+      expect(target).not_to be_valid
+      expect(target.errors.include?(:period)).to be_falsey
     end
   end
 end


### PR DESCRIPTION
**Story card:** [sc-15494](https://app.shortcut.com/simpledotorg/story/15943/validate-format-of-target-period)

## Because

Targets must be in a specific format since they should be readily translatable to the Period value object we currently have for Dr. Rai purposes.

## This addresses

Validating `DrRai::Target#period` is in the correct format

## Test instructions

model tests