### PR TITLE
fix: Singleton Indicators

### DIFF
--- a/app/models/dr_rai/indicator.rb
+++ b/app/models/dr_rai/indicator.rb
@@ -14,6 +14,9 @@ class DrRai::Indicator < ApplicationRecord
   # best we can do technique-wise
   include DrRai::Calculatable
 
+  # There should only ever be one instance of any indicator in the db
+  validates :type, uniqueness: true
+
   has_one :target, class_name: "DrRai::Target", dependent: :destroy, foreign_key: "dr_rai_indicators_id"
   accepts_nested_attributes_for :target
 

--- a/spec/models/dr_rai/indicator_spec.rb
+++ b/spec/models/dr_rai/indicator_spec.rb
@@ -1,4 +1,12 @@
 require "rails_helper"
 
 RSpec.describe DrRai::Indicator, type: :model do
+  describe "validations" do
+    it "should be singleton" do
+      existing_indicator = DrRai::ContactOverduePatientsIndicator.create
+      new_same_indicator = DrRai::ContactOverduePatientsIndicator.new
+      expect(new_same_indicator).not_to be_valid
+      expect(new_same_indicator.errors.of_kind?(:type, :taken)).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
**Story card:** [sc-15944](https://app.shortcut.com/simpledotorg/story/15944/indicators-should-be-singleton)

## Because

An indicator is a blueprint for an action. Singleton is the way to go here.

## This addresses

Ensuring we keep only one instance of an indicator in the database

## Test instructions

- model tests
