### PR TITLE
fix: Fix the progress calculation

### DIFF
--- a/app/models/dr_rai/action_plan.rb
+++ b/app/models/dr_rai/action_plan.rb
@@ -24,6 +24,6 @@ class DrRai::ActionPlan < ApplicationRecord
   def progress
     return 0 unless denominator.positive?
 
-    numerator / denominator
+    (numerator.to_f / denominator * 100).round(2)
   end
 end

--- a/spec/models/dr_rai/action_plan_spec.rb
+++ b/spec/models/dr_rai/action_plan_spec.rb
@@ -17,4 +17,23 @@ RSpec.describe DrRai::ActionPlan, type: :model do
       end
     end
   end
+
+  describe "#progress" do
+    let(:indicator) { DrRai::ContactOverduePatientsIndicator.create }
+    let(:target) { DrRai::NumericTarget.create(indicator: indicator, numeric_value: 20, period: "Q1-2025") }
+    let(:district_with_facilities) { setup_district_with_facilities }
+    let(:region) { district_with_facilities[:region] }
+
+    before do
+      allow_any_instance_of(DrRai::ContactOverduePatientsIndicator).to receive(:numerator).with(anything).and_return(9)
+    end
+
+    it "calculates pecentage to 2 decimal places" do
+      action_plan = DrRai::ActionPlan.new(dr_rai_target: target,
+        dr_rai_indicator: indicator,
+        region: region,
+        statement: "TODO")
+      expect(action_plan.progress).to eq((9.to_f / 20 * 100).round(2))
+    end
+  end
 end


### PR DESCRIPTION
**Story card:** [sc-15939](https://app.shortcut.com/simpledotorg/story/15939/ensure-the-progress-bar-fills-up-with-actions-taken)

## Because

Everything was setup correctly, but the calculation for the `action_plan#progress` was wrong.

## This addresses

Changing the divition from `int / int` — which would always return 0 if the numerator is less than the denominator — to a proper percentage calculation.

## Test instructions

n/a
