### PR TITLE
fix: Force ActionPlan to implement the Calculatable interface

### DIFF
--- a/app/models/dr_rai/action_plan.rb
+++ b/app/models/dr_rai/action_plan.rb
@@ -1,4 +1,6 @@
 class DrRai::ActionPlan < ApplicationRecord
+  include DrRai::Calculatable
+
   belongs_to :dr_rai_indicator, class_name: "DrRai::Indicator"
   belongs_to :dr_rai_target, class_name: "DrRai::Target"
   belongs_to :region


### PR DESCRIPTION
**Story card:** [sc-15941](https://app.shortcut.com/simpledotorg/story/15941/actionplan-should-implement-calculatable)

## Because

Things should be formal even if the language allows little formality

## This addresses

Adding the `Calculatable` interface to `ActionPlan`

## Test instructions

n/a
