### PR TITLE
fix: keep save button invisible through reset

### DIFF
--- a/app/components/dashboard/dr_rai_report.html.erb
+++ b/app/components/dashboard/dr_rai_report.html.erb
@@ -352,7 +352,7 @@
       // Reset UI
       toHide.forEach((el) => el.addClass('d-none'))
       toReveal.forEach((el) => el.removeClass('d-none'))
-      $('.action-buttons-block .save-button').addClass('d-none')
+      $('.action-buttons-block .save-button').addClass('invisible')
       $('.sidepanel input').val('')
       $('.active .activity-promise').addClass('invisible')
       $('.sidepanel textarea').val('')


### PR DESCRIPTION
**Story card:** [sc-15985](https://app.shortcut.com/simpledotorg/story/15985/jf-bugs)

## Because

There are some inconsistencies in the Dr. Rai UI across resets

## This addresses

Ensuring the right classes are kept through the reset process

## Test instructions

- visual
