### PR TITLE
Further UI improvements

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -963,8 +963,8 @@ span.inactive {
       text-align: right;
       margin: 12px 0 6px;
       font-weight: 500;
-    font-size: 16px;
-    font-weight: 500;
+      font-size: 16px;
+      font-weight: 600;
       font-family: $font-condensed;
     }
 
@@ -1003,32 +1003,27 @@ span.inactive {
   }
 }
 
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  margin-bottom: 13px;
+// ================================================
+// ================================================
+
+// Side panel
 
 .sidepanel {
-  display: flex;
-  position: fixed;
-  // top: 0;
-  // left: 100px;
-  width: 550px;
-  // height: 100%;
-  background: white;
+  // position: fixed;
   z-index: 1000;
+  display: flex;
   flex-direction: column;
   font-family: "Roboto", sans-serif;
   font-size: 16px;
   box-shadow: -8px 0 0 0 rgba(0, 0, 0, 0.08), -4px 0 8px rgba(0, 0, 0, 0.05);
   overflow-y: scroll;
+  background: #ffffff;
 }
 
 @scope (.sidepanel) {
   .header {
     background-color: white;
     display: flex;
-    flex-direction: row;
     justify-content: space-between;
     align-items: center;
     padding: 12px 20px;
@@ -1041,7 +1036,6 @@ span.inactive {
     p {
       font-weight: semi-bold;
       margin: 0 !important;
-      font-size: 18px;
     }
 
     button {
@@ -1053,12 +1047,19 @@ span.inactive {
       align-items: center;
       border-radius: 6px;
       transition: 200ms ease-out;
-      font-size: medium;
+      font-size: 18px;
+
       &:hover {
-        background-color: #00000012;
-        background-color: (0 0 0 / 0.08);
+        background-color: rgba(0, 0, 0, 0.16);
       }
     }
+  }
+
+  .content {
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
   }
 
   h1 {
@@ -1081,25 +1082,14 @@ span.inactive {
     letter-spacing: 0;
   }
 
-
   p {
     margin-bottom: 0;
-  }
-
-  .content {
-    padding: 20px;
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
   }
 
   .step-block {
     background-color: #eff8ff;
     border: 1px solid #d5e6ff !important;
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-    padding-left: 20px;
-    padding-right: 20px;
+    padding: 16px 20px;
     border-radius: 0.375rem;
     position: relative;
   }
@@ -1110,12 +1100,25 @@ span.inactive {
     color: #007eff;
     cursor: pointer;
     font-size: 16px;
-    padding: 6px 0px;
+    padding: 5px 0px;
     text-align: left;
 
     &:hover {
       text-decoration: underline;
       text-underline-offset: 3px;
+    }
+  }
+
+  .step-statement {
+    margin-top: 8px;
+  }
+
+  .activity-statement {
+    font-family: $font-condensed;
+    color: grey;
+    margin-top: 8px;
+    .highlight {
+      font-weight: 800;
     }
   }
 
@@ -1127,8 +1130,8 @@ span.inactive {
   }
 
   ul {
-    margin: 6px 0 0;
-    padding-inline-start: 5px;
+    margin: 3px 0 0;
+    padding-inline-start: 0px;
     list-style-type: none;
   }
 
@@ -1139,25 +1142,25 @@ span.inactive {
     margin: 0 -2px;
   }
 
-  .activity-statement {
-    margin: 16px 0 0;
-    font-size: 17px;
-    display: block;
-    font-family: $font-condensed;
-    color: grey;
-    .highlight {
-      font-weight: 800;
+  .goal-input-block {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 16px 0 8px;
+
+    p {
+      margin: 0;
     }
   }
 
-  .goal-input-block {
+  .goal-label-block {
     display: flex;
     border: 1px solid #cad0d7;
     background: #fff;
     border-radius: 0.375rem;
     width: 7em; // 28 * 0.25rem = 7rem
-    margin: 16px 0 8px;
     padding: 2px;
+    margin: 0;
 
     input {
       display: block;
@@ -1170,16 +1173,11 @@ span.inactive {
       font-size: 1rem;
       width: 100%;
       font-weight: 400;
-      margin-bottom: 2px;
       border: 0;
     }
     input::placeholder {
       font-weight: 400;
     }
-
-    // input.patient {
-    //   width: 100%;
-    // }
 
     span {
       background-color: #f0f0f0;
@@ -1194,8 +1192,15 @@ span.inactive {
     }
   }
 
-  .goal-input-block.patients {
+  .goal-label-block.patients {
     width: 11rem;
+  }
+
+  .missing-input-warning {
+    color: #d10000;
+    margin-top: 4px;
+    margin-bottom: 8px;
+    font-weight: 500;
   }
 
   .next-button {
@@ -1208,6 +1213,7 @@ span.inactive {
     color: #007eff;
     border-radius: 0.375rem;
     margin-top: 1rem;
+    margin-bottom: 4px;
 
     &:hover {
       background-color: #b2d9ff;
@@ -1237,27 +1243,25 @@ span.inactive {
 
   .action-buttons-block {
     display: flex;
-    justify-content: flex-end;
-    gap: 36px;
+    gap: 28px;
 
     button {
       border: none;
+      font-family: $font-condensed;
+      padding: 10px;
+      border-radius: 4px;
+      background: none;
+      transition: background-color 150ms ease-out;
     }
 
     .save-button {
       background-color: #0275eb;
-      font-family: $font-condensed;
       color: #fff;
-      padding: 0.625rem;
       width: 100%;
-      border-radius: 0.375rem;
-      grid-column: span 3;
-      transition: background-color 200ms ease-out;
-      flex-grow: 1;
       display: flex;
+      flex-grow: 1;
       justify-content: center;
       align-items: center;
-      gap: 12px;
 
       &:hover {
         background-color: #025bbf;
@@ -1266,53 +1270,55 @@ span.inactive {
 
     // Cancel button styles
     .cancel-button {
-      text-align: left;
-      font-family: $font-condensed;
-      padding: 0.625rem;
-      border-radius: 0.375rem;
       display: inline;
-      color: #6b7280; // Tailwind's gray-500
+      color: #6b7280;
+      border: 1px solid #d0d2d7; // Tailwind's gray-500
       cursor: pointer;
       width: auto;
       min-width: 0;
       flex-shrink: 0;
-    }
-
-    .loading-animation {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 8px;
-    }
-
-    .dot {
-      width: 6px;
-      height: 6px;
-      border-radius: 50%;
-      background: #fff;
-      animation: pulse 1.2s infinite ease-in-out;
-    }
-
-    .dot:nth-child(2) {
-      animation-delay: 0.2s;
-    }
-
-    .dot:nth-child(3) {
-      animation-delay: 0.4s;
-    }
-
-    @keyframes pulse {
-      0%,
-      80%,
-      100% {
-        transform: scale(1);
-        opacity: 0.6;
-      }
-      40% {
-        transform: scale(1.6);
-        opacity: 1;
+      padding: 10px 16px;
+      &:hover {
+        background-color: #ededed;
+        border: 1px solid #ededed; // Tailwind's gray-500
       }
     }
+
+    //   .loading-animation {
+    //     display: flex;
+    //     align-items: center;
+    //     justify-content: center;
+    //     gap: 8px;
+    //   }
+
+    //   .dot {
+    //     width: 6px;
+    //     height: 6px;
+    //     border-radius: 50%;
+    //     background: #fff;
+    //     animation: pulse 1.2s infinite ease-in-out;
+    //   }
+
+    //   .dot:nth-child(2) {
+    //     animation-delay: 0.2s;
+    //   }
+
+    //   .dot:nth-child(3) {
+    //     animation-delay: 0.4s;
+    //   }
+
+    //   @keyframes pulse {
+    //     0%,
+    //     80%,
+    //     100% {
+    //       transform: scale(1);
+    //       opacity: 0.6;
+    //     }
+    //     40% {
+    //       transform: scale(1.6);
+    //       opacity: 1;
+    //     }
+    //   }
   }
 }
 
@@ -1343,8 +1349,8 @@ span.inactive {
 }
 
 .bs-canvas-anim {
-   transition: all .4s ease-out;
-   -webkit-transition: all .4s ease-out;
-   -moz-transition: all .4s ease-out;
-   -ms-transition: all .4s ease-out;
+  transition: all 0.4s ease-out;
+  -webkit-transition: all 0.4s ease-out;
+  -moz-transition: all 0.4s ease-out;
+  -ms-transition: all 0.4s ease-out;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -801,9 +801,86 @@ span.inactive {
 
 .no-card-gap-filler p {
   color: #A0A0A0;
+// Action plan
+
+.actions-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  margin-bottom: 16px;
+  min-height: 152px;
+  &.empty {
+    background: #e9ecef;
+    border: 2px dashed rgba(0, 0, 0, 0.15);
+    border-radius: 4px;
+    box-shadow: inset 0 2px 8px 0 rgba(0, 0, 0, 0.04);
+
+    & .empty-message {
+      font-family: $font-condensed;
+      margin-top: 0;
+      margin-bottom: 0.5rem;
+      font-size: 1.125rem; // 18px
+      color: rgba(0, 0, 0, 0.6);
+    }
+  }
 }
 
-.action-progress-block {
+.actions-periods-navigation {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: 6px;
+  height: 34px;
+
+  & .period-button {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    font-weight: 600;
+    color: #6c737a;
+    &:hover {
+      color: #2f363d;
+      text-decoration: none;
+    }
+  }
+
+  & .selected {
+    color: #ff3355;
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 6px;
+    &:hover {
+      color: #ff3355;
+      text-decoration: underline;
+      text-decoration: underline;
+      text-decoration-thickness: 2px;
+      text-underline-offset: 6px;
+    }
+  }
+}
+
+.add-action-button {
+  background: #d4e4fd !important;
+  color: #016de4;
+  border-radius: 4px;
+  padding: 6px 20px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  font-size: 13px;
+  display: inline-block;
+  text-align: center;
+  cursor: pointer;
+  border: none;
+  &:hover {
+    background: #b8d4ff !important;
+  }
+}
+
+// action card
+.action-card {
   width: 100%;
   background: #feffd8;
   display: grid;
@@ -812,9 +889,11 @@ span.inactive {
   padding: 20px;
   border-radius: 4px;
   position: relative;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  min-height: 152px;
 }
 
-@scope (.action-progress-block) {
+@scope (.action-card) {
   h3 {
     font-size: 20px;
     font-weight: bold;
@@ -834,230 +913,100 @@ span.inactive {
     font-size: 16px;
   }
 
-  .progress-options {
+  .options {
     position: absolute;
-    top: 4px;
-    right: 4px;
+    top: 3px;
+    right: 3px;
     font-size: 20px;
 
-    .dots-button {
-      cursor: pointer;
-      border: 2px solid #eceeb1;
-      border-radius: 3px;
-      height: 24px;
-      width: 30px;
-      overflow: hidden;
+    button {
       display: flex;
       align-items: center;
-      justify-content: center;
-      gap: 3px;
-    }
-    .dots-button:focus {
-      background: #eceeb1;
-    }
-  }
-  .progress-options-inner {
-    position: relative;
-  }
+      justify-items: center;
+      cursor: pointer;
+      border: 1px solid #eceeb1;
+      border-radius: 3px;
+      height: 24px;
+      width: 32px;
+      background: none;
 
-  .popover {
-    width: 112px;
-    border: 4px solid #d5d5d550;
-    border-radius: 8px;
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    overflow: hidden;
-    padding: 4px 0;
-
-    ul {
-      list-style-type: none;
-      padding: 0;
-      margin: 0;
+      &:hover {
+        background: #f2f4b9;
+      }
+      &:focus {
+        background: #e2e4a7;
+      }
     }
-
-    hr {
-      margin: 2px 8px;
-    }
-
-    button {
+    & .dropdown-item {
       padding: 8px 16px;
-      font: "Roboto", sans-serif;
-      width: 100%;
-      text-align: left;
+      font-size: 15px;
+      font-family: "Roboto", sans-serif;
+      &.edit:hover {
+        background: #ecf2fe !important;
+        color: #007eff;
+      }
+      &.delete:hover {
+        background: #feecec !important;
+        color: #d10000;
+      }
     }
 
-    button.edit:hover {
-      background: #ecf2fe !important;
-      color: #007eff;
-    }
-
-    button.delete:hover {
-      background: #feecec !important;
-      color: #d10000;
+    & .dropdown-divider {
+      margin: 4px 8px;
     }
   }
 
-  // @scope (.popover) {
-  //   .edit {
-  //     background-color: #c4e2ff;
-  //     padding: 0.5rem;
-  //     width: 100%;
-  //     text-align: center;
-  //     font-size: 1rem;
-
-  //     border-radius: 0.375rem;
-
-  //     &:hover {
-  //       background-color: #b2d9ff;
-  //     }
-  //   }
-  // }
-
-  .progress-right-col {
+  .action-progress {
     padding-right: 20px;
-  }
 
-  .progress-statement {
-    text-align: right;
-    margin: 12px 0 6px;
-    font-weight: 500;
+    & .statement {
+      text-align: right;
+      margin: 12px 0 6px;
+      font-weight: 500;
     font-size: 16px;
     font-weight: 500;
-    font-family: $font-condensed;
-  }
-
-  .progress-bar {
-    background: #eceeb1;
-    width: 100%;
-    height: 36px;
-    border-radius: 0.375rem;
-    overflow: hidden;
-    position: relative;
-
-    .progress-bar-fill {
-      background: #d7cd06;
-      height: 100%;
-      position: relative;
-      display: block;
+      font-family: $font-condensed;
     }
 
-    .progress-number {
-      position: absolute;
-      top: 1px;
-      color: #6a6500;
+    & .bar {
+      background: #eceeb1;
+      width: 100%;
+      height: 36px;
+    border-radius: 0.375rem;
+      overflow: hidden;
+      position: relative;
+
+      .bar-fill {
+        background: #d7cd06;
+        height: 100%;
+        position: relative;
+        display: block;
+      }
+
+      .bar-number {
+        position: absolute;
+        top: 1px;
+        color: #6a6500;
       font-size: 1.5rem;
       font-weight: bold;
       display: inline-block;
       right: 0;
       transform: translateX(100%);
-      transform: translateX(calc(100% + 8px));
-    }
+        transform: translateX(calc(100% + 8px));
+      }
 
-    .progress-number-over-88-percent {
-      transform: translateX(-8px);
-      text-align: right;
+      .over-88-percent {
+        transform: translateX(-8px);
+        text-align: right;
+      }
     }
   }
 }
 
-.action-block {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  margin-top: 16px;
-}
-
-.actions-block button {
-  border: 0;
-  background-color: inherit;
-}
-
-.actions-header {
   display: flex;
   align-items: center;
   gap: 16px;
   margin-bottom: 13px;
-}
-
-.actions-header h4 {
-  margin-right: 16px;
-  margin-bottom: 0;
-  padding: 0;
-}
-
-.actions-header-button {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  font-weight: 600;
-  color: black;
-}
-
-.action-header-selected {
-  color: #ff3355;
-  text-decoration: underline;
-  text-decoration-thickness: 4px;
-  text-underline-offset: 6px;
-}
-
-.actions-header-add-action {
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  font-weight: 600;
-  font-family: $font-condensed;
-  font-size: 14px;
-  color: #016de4;
-  margin-left: 12px;
-
-  &:hover {
-    text-decoration: underline;
-    text-decoration-thickness: 4px;
-    text-underline-offset: 6px;
-  }
-}
-
-.empty-goals-block {
-  background: #ebebeb;
-  border: 2px dashed rgba(0, 0, 0, 0.15);
-  border-radius: 0.75rem;
-  box-shadow: inset 0 2px 8px 0 rgba(0, 0, 0, 0.04);
-  height: 180px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  gap: 8px;
-}
-
-.empty-goals-message {
-  font-family: $font-condensed;
-  margin-top: 0;
-  margin-bottom: 0.5rem;
-  font-size: 1.125rem; // 18px
-  color: rgba(0, 0, 0, 0.6);
-}
-
-.empty-goals-add-button {
-  background: #c5def8;
-  color: #016de4;
-  border-radius: 4px;
-  padding: 6px 0;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 600;
-  font-size: 14px;
-  min-width: 208px;
-  display: inline-block;
-  text-align: center;
-  cursor: pointer;
-
-  &:hover {
-    background: #b2d9ff;
-    color: #0156b2;
-  }
-}
 
 .sidepanel {
   display: flex;

--- a/app/components/dashboard/dr_rai_report.html.erb
+++ b/app/components/dashboard/dr_rai_report.html.erb
@@ -71,17 +71,20 @@
         </div>
         <div class='inactive d-none'>
           <h2>Which indicator to improve?</h2>
-          <p class="step-statement mt-3"></p>
+          <p class="step-statement"></p>
         </div>
       </div>
       <div class="step-block d-none" id="step-2-percent">
         <div class='active'>
           <h2>What is the goal?</h2>
           <%# <button class="link-button edit">Edit</button> %>
-          <label class="goal-input-block">
-            <input type="text" placeholder="Q2 goal">
-            <span class="">%</span>
-          </label>
+          <div class="goal-input-block">
+            <label class="goal-label-block">
+              <input type="text" placeholder="Q2 goal">
+              <span class="">%</span>
+            </label>
+            <p class="missing-input-warning">Enter a goal value</p>
+          </div>
           <p class="activity-promise d-none">Contact <span class="highlight target-number">500</span> overdue patients by <%= end_of(selected_period) %></p>
           <p class="activity-statement"><span class="highlight"><span class="previous-percentage">6</span>%</span> <span class='indicator-action'></span> (<span class='indicator-previous-numerator'></span> of <span class='indicator-denominator'></span>) in <%= human_readable(selected_period.previous) %></p>
           <button class="next-button">Next</button>
@@ -89,17 +92,20 @@
         <div class="inactive d-none">
           <h2>What is the goal?</h2>
           <button class="link-button edit">Edit</button>
-          <p class="step-statement mt-3"></p>
+          <p class="step-statement"></p>
         </div>
       </div>
       <div class="step-block d-none" id="step-2-numeric">
         <div class='active'>
           <h2>What is the goal?</h2>
           <%# <button class="link-button edit">Edit</button> %>
-          <label class="goal-input-block">
-            <input type="text" placeholder="Q2 goal">
-            <span class="">patients</span>
-          </label>
+          <div class="goal-input-block">
+            <label class="goal-label-block patients">
+              <input type="text" placeholder="Q2 goal">
+              <span class="">patients</span>
+            </label>
+            <p class="missing-input-warning">Enter a goal value</p>
+          </div>
           <p class="activity-promise d-none">Contact <span class="highlight target-number">500</span> overdue patients by <%= end_of(selected_period) %></p>
           <p class="activity-statement"><span class="highlight"><span class="indicator-previous-numerator">6</span></span> <span class='indicator-action'></span> (<span class='indicator-previous-numerator'></span> of <span class='indicator-denominator'></span>) in <%= human_readable(selected_period.previous) %></p>
           <p class="activity-statement"><span class="highlight">6%</span> overdue patients called (600 of 10,000) in <%= human_readable(selected_period.previous) %></p>
@@ -108,7 +114,7 @@
         <div class="inactive d-none">
           <h2>What is the goal?</h2>
           <button class="link-button edit">Edit</button>
-          <p class="step-statement mt-3"></p>
+          <p class="step-statement"></p>
         </div>
       </div>
       <div class="step-block d-none" id="step-2-boolean">
@@ -120,7 +126,7 @@
         <div class="inactive d-none">
           <h2>What is the goal?</h2>
           <button class="link-button edit">Edit</button>
-          <p class="step-statement mt-3">Mark as done when completed</p>
+          <p class="step-statement">Mark as done when completed</p>
         </div>
       </div>
       <div class="step-block d-none" id="step-3">

--- a/app/components/dashboard/dr_rai_report.html.erb
+++ b/app/components/dashboard/dr_rai_report.html.erb
@@ -1,69 +1,54 @@
+<h4 class="mt-5" style="margin-bottom: 0px;">Action plans</h4>
 <div id="dr-rai--progress">
-  <div class="actions-block">
-    <div class="actions-header">
-      <h4>Action plans</h4>
-      <% quarterlies.each do |period, info| %>
-        <%= link_to human_readable(period), "#{request.path}?#{request.query_parameters.merge(selected_quarter: period.value.to_s).to_param}", class: classes_for_period(period) %>
-      <% end %>
-      <% if current_period? %>
-      <button class="actions-header-add-action" type="button" data-toggle="canvas" data-target="#dr-rai--sidebar" aria-expanded="false" aria-controls="dr-rai--sidebar">&#x2b; Add an action</button>
-      <% end %>
-    </div>
-
+  <div class="actions-periods-navigation">
+    <% quarterlies.each do |period, info| %>
+      <%= link_to human_readable(period), "#{request.path}?#{request.query_parameters.merge(selected_quarter: period.value.to_s).to_param}", class: classes_for_period(period) %>
+    <% end %>
+  </div>
+  <div class="actions-block <%= 'empty' unless action_plans.present? %>">
     <% if action_plans.present? %>
       <% action_plans.each do |action_plan| %>
-        <div class="action-progress-block my-2">
-          <div class="dropdown progress-options">
+        <div class="action-card">
+          <div class="dropdown options">
             <button class="" type="button" data-toggle="dropdown" aria-expanded="false">
               <i class="fa-solid fa-ellipsis"></i>
             </button>
             <div class="dropdown-menu dropdown-menu-right">
-              <%# <a class="dropdown-item" href="#">Edit</a> %>
-              <%# <div class="dropdown-divider"></div> %>
-              <%= link_to "Delete", dr_rai_action_plan_path(action_plan), method: :delete, class: "dropdown-item" %>
+              <a class="dropdown-item edit" href="#">Edit</a>
+              <div class="dropdown-divider"></div>
+              <%= link_to "Delete", dr_rai_action_plan_path(action_plan), method: :delete, class: "dropdown-item delete" %>
             </div>
           </div>
           <div>
             <h3><%= action_plan.statement %></h3>
             <% if !action_plan.actions.nil? %>
               <ul>
-              <% action_plan.actions.lines.each do |line| %>
-                <li>
-                  <p><%= line %></p>
-                </li>
-              <% end %>
+                <% action_plan.actions.lines.each do |line| %>
+                  <li>
+                    <p><%= line %></p>
+                  </li>
+                <% end %>
               </ul>
             <% end %>
           </div>
-          <div class="progress-right-col">
-            <p class="progress-statement"><%= action_plan.numerator %> of <%= action_plan.denominator %> overdue patients</p>
-            <div class="progress-bar">
-              <div class="progress-bar-fill" style="width: <%= action_plan.progress %>%">
-                <span class="progress-number progress-number-over-88-percent"><%= action_plan.progress %>%</span>
+          <div class="action-progress">
+            <p class="statement"><%= action_plan.numerator %> of <%= action_plan.denominator %> overdue patients</p>
+            <div class="bar">
+              <div class="bar-fill" style="width: <%= action_plan.progress %>%">
+                <span class="bar-number over-88-percent"><%= action_plan.progress %>%</span>
               </div>
             </div>
           </div>
         </div>
       <% end %>
     <% else %>
-      <div class="empty-goals-block">
-        <% if current_period? %>
-        <p class="empty-goals-message">
-          Add an action for <%= start_of(selected_period) %> to <%= end_of(selected_period) %>
-        </p>
-        <button class="empty-goals-add-button" type="button" data-toggle="canvas" data-target="#dr-rai--sidebar" aria-expanded="false" aria-controls="dr-rai--sidebar">
-          &#x2b; Add an action
-        </button>
-        <% else %>
-        <p class="empty-goals-message">
-          No actions for <%= start_of(selected_period) %> to <%= end_of(selected_period) %>
-        </p>
-        <% end %>
-      </div>
+      <p class="empty-message">
+        No actions for <%= start_of(selected_period) %> to <%= end_of(selected_period) %>
+      </p>
     <% end %>
   </div>
+  <button class="add-action-button" type="button" data-toggle="canvas" data-target="#dr-rai--sidebar" aria-expanded="false" aria-controls="dr-rai--sidebar">&#x2b; Add an action</button>
 </div>
-
 <div class="sidepanel bs-canvas bs-canvas-right position-fixed h-100" tabindex="-1" id="dr-rai--sidebar" data-period="<%= current_period.value %>" data-region="<%= region.slug %>">
   <div class="header">
     <p>Create action</p>
@@ -72,96 +57,95 @@
     </button>
   </div>
   <% if current_period? %>
-  <div class="content">
-    <h1><%= start_of(selected_period) %> - <%= end_of(selected_period) %> (<%= human_readable(selected_period) %>)</h1>
-    <div class="step-block" id="step-1">
-      <div class="active">
-        <h2>Which indicator to improve?</h2>
-        <%# <button class="link-button edit">Edit</button> %>
-        <ul>
-        <% indicators.each do |indicator| %>
-          <li><button class="link-button advancer" data-target-type="<%= indicator.target_type %>" data-target-ui="<%= indicator.target_type_frontend %>" data-indicator-id=<%= indicator.id %> data-indicator-denominator="<%= indicator_denominator(indicator) %>" data-indicator-previous-numerator="<%= indicator_previous_numerator(indicator) %>" data-indicator-action="<%= indicator.action %>">Contact overdue patients</button></li>
-        <% end %>
+    <div class="content">
+      <h1><%= start_of(selected_period) %> - <%= end_of(selected_period) %> (<%= human_readable(selected_period) %>)</h1>
+      <div class="step-block" id="step-1">
+        <div class="active">
+          <h2>Which indicator to improve?</h2>
+          <%# <button class="link-button edit">Edit</button> %>
+          <ul>
+            <% indicators.each do |indicator| %>
+              <li><button class="link-button advancer" data-target-type="<%= indicator.target_type %>" data-target-ui="<%= indicator.target_type_frontend %>" data-indicator-id=<%= indicator.id %> data-indicator-denominator="<%= indicator_denominator(indicator) %>" data-indicator-previous-numerator="<%= indicator_previous_numerator(indicator) %>" data-indicator-action="<%= indicator.action %>">Contact overdue patients</button></li>
+            <% end %>
+          </ul>
+        </div>
+        <div class='inactive d-none'>
+          <h2>Which indicator to improve?</h2>
+          <p class="step-statement mt-3"></p>
+        </div>
+      </div>
+      <div class="step-block d-none" id="step-2-percent">
+        <div class='active'>
+          <h2>What is the goal?</h2>
+          <%# <button class="link-button edit">Edit</button> %>
+          <label class="goal-input-block">
+            <input type="text" placeholder="Q2 goal">
+            <span class="">%</span>
+          </label>
+          <p class="activity-promise d-none">Contact <span class="highlight target-number">500</span> overdue patients by <%= end_of(selected_period) %></p>
+          <p class="activity-statement"><span class="highlight"><span class="previous-percentage">6</span>%</span> <span class='indicator-action'></span> (<span class='indicator-previous-numerator'></span> of <span class='indicator-denominator'></span>) in <%= human_readable(selected_period.previous) %></p>
+          <button class="next-button">Next</button>
+        </div>
+        <div class="inactive d-none">
+          <h2>What is the goal?</h2>
+          <button class="link-button edit">Edit</button>
+          <p class="step-statement mt-3"></p>
+        </div>
+      </div>
+      <div class="step-block d-none" id="step-2-numeric">
+        <div class='active'>
+          <h2>What is the goal?</h2>
+          <%# <button class="link-button edit">Edit</button> %>
+          <label class="goal-input-block">
+            <input type="text" placeholder="Q2 goal">
+            <span class="">patients</span>
+          </label>
+          <p class="activity-promise d-none">Contact <span class="highlight target-number">500</span> overdue patients by <%= end_of(selected_period) %></p>
+          <p class="activity-statement"><span class="highlight"><span class="indicator-previous-numerator">6</span></span> <span class='indicator-action'></span> (<span class='indicator-previous-numerator'></span> of <span class='indicator-denominator'></span>) in <%= human_readable(selected_period.previous) %></p>
+          <p class="activity-statement"><span class="highlight">6%</span> overdue patients called (600 of 10,000) in <%= human_readable(selected_period.previous) %></p>
+          <button class="next-button">Next</button>
+        </div>
+        <div class="inactive d-none">
+          <h2>What is the goal?</h2>
+          <button class="link-button edit">Edit</button>
+          <p class="step-statement mt-3"></p>
+        </div>
+      </div>
+      <div class="step-block d-none" id="step-2-boolean">
+        <div class='active'>
+          <h2>What is the goal?</h2>
+          <%# <button class="link-button edit">Edit</button> %>
+          <button class="next-button">Next</button>
+        </div>
+        <div class="inactive d-none">
+          <h2>What is the goal?</h2>
+          <button class="link-button edit">Edit</button>
+          <p class="step-statement mt-3">Mark as done when completed</p>
+        </div>
+      </div>
+      <div class="step-block d-none" id="step-3">
+        <h2>What action should be taken?</h2>
+        <textarea class="custom-actions-list" rows="4" placeholder="Write actions or select from list below..."></textarea>
+        <p>Common actions:</p>
+        <ul class="common-actions-list">
+          <li><button class="link-button">Allocate staff time for calling patients</button></li>
+          <li><button class="link-button">Train staff on SOP for calling overdue patients</button></li>
+          <li><button class="link-button">Call 25 patients per day</button></li>
+          <li classs="clicked"><button class="link-button ">Record call outcomes in Simple</button></li>
         </ul>
       </div>
-      <div class='inactive d-none'>
-        <h2>Which indicator to improve?</h2>
-        <p class="step-statement mt-3"></p>
+      <div class="action-buttons-block">
+        <button class="action-button cancel-button">Cancel</button>
+        <button class="action-button save-button invisible">Save</button>
       </div>
     </div>
-    <div class="step-block d-none" id="step-2-percent">
-      <div class='active'>
-        <h2>What is the goal?</h2>
-        <%# <button class="link-button edit">Edit</button> %>
-        <label class="goal-input-block">
-          <input type="text" placeholder="Q2 goal">
-          <span class="">%</span>
-        </label>
-        <p class="activity-promise d-none">Contact <span class="highlight target-number">500</span> overdue patients by <%= end_of(selected_period) %></p>
-      <p class="activity-statement"><span class="highlight"><span class="previous-percentage">6</span>%</span> <span class='indicator-action'></span> (<span class='indicator-previous-numerator'></span> of <span class='indicator-denominator'></span>) in <%= human_readable(selected_period.previous) %></p>
-        <button class="next-button">Next</button>
-      </div>
-      <div class="inactive d-none">
-        <h2>What is the goal?</h2>
-        <button class="link-button edit">Edit</button>
-        <p class="step-statement mt-3"></p>
-      </div>
-    </div>
-    <div class="step-block d-none" id="step-2-numeric">
-      <div class='active'>
-        <h2>What is the goal?</h2>
-        <%# <button class="link-button edit">Edit</button> %>
-        <label class="goal-input-block">
-          <input type="text" placeholder="Q2 goal">
-          <span class="">patients</span>
-        </label>
-        <p class="activity-promise d-none">Contact <span class="highlight target-number">500</span> overdue patients by <%= end_of(selected_period) %></p>
-      <p class="activity-statement"><span class="highlight"><span class="indicator-previous-numerator">6</span></span> <span class='indicator-action'></span> (<span class='indicator-previous-numerator'></span> of <span class='indicator-denominator'></span>) in <%= human_readable(selected_period.previous) %></p>
-        <p class="activity-statement"><span class="highlight">6%</span> overdue patients called (600 of 10,000) in <%= human_readable(selected_period.previous) %></p>
-        <button class="next-button">Next</button>
-      </div>
-      <div class="inactive d-none">
-        <h2>What is the goal?</h2>
-        <button class="link-button edit">Edit</button>
-        <p class="step-statement mt-3"></p>
-      </div>
-    </div>
-    <div class="step-block d-none" id="step-2-boolean">
-      <div class='active'>
-        <h2>What is the goal?</h2>
-        <%# <button class="link-button edit">Edit</button> %>
-        <button class="next-button">Next</button>
-      </div>
-      <div class="inactive d-none">
-        <h2>What is the goal?</h2>
-        <button class="link-button edit">Edit</button>
-        <p class="step-statement mt-3">Mark as done when completed</p>
-      </div>
-    </div>
-    <div class="step-block d-none" id="step-3">
-      <h2>What action should be taken?</h2>
-      <textarea class="custom-actions-list" rows="4" placeholder="Write actions or select from list below..."></textarea>
-      <p>Common actions:</p>
-      <ul class="common-actions-list">
-        <li><button class="link-button">Allocate staff time for calling patients</button></li>
-        <li><button class="link-button">Train staff on SOP for calling overdue patients</button></li>
-        <li><button class="link-button">Call 25 patients per day</button></li>
-        <li classs="clicked"><button class="link-button ">Record call outcomes in Simple</button></li>
-      </ul>
-    </div>
-    <div class="action-buttons-block">
-      <button class="action-button cancel-button">Cancel</button>
-      <button class="action-button save-button invisible">Save</button>
-    </div>
-  </div>
   <% else %>
-  <div class="content" %>
-    <h1><%= start_of(selected_period) %> - <%= end_of(selected_period) %> (<%= human_readable(selected_period) %>)</h1>
-    <p>Cannot create action plans for periods in the past</p>
-  </div>
+    <div class="content" %>
+      <h1><%= start_of(selected_period) %> - <%= end_of(selected_period) %> (<%= human_readable(selected_period) %>)</h1>
+      <p>Cannot create action plans for periods in the past</p>
+    </div>
   <% end %>
 </div>
-
 <script type="text/javascript" charset="utf-8">
   jQuery(document).ready(function($) {
     var bsDefaults = { offset: false, overlay: true, width: '450px' },

--- a/app/components/dashboard/dr_rai_report.html.erb
+++ b/app/components/dashboard/dr_rai_report.html.erb
@@ -142,7 +142,7 @@
       </div>
       <div class="action-buttons-block">
         <button class="action-button cancel-button">Cancel</button>
-        <button class="action-button save-button invisible">Save</button>
+        <button class="action-button save-button invisible">Create</button>
       </div>
     </div>
   <% else %>

--- a/app/components/dashboard/dr_rai_report.rb
+++ b/app/components/dashboard/dr_rai_report.rb
@@ -46,8 +46,8 @@ class Dashboard::DrRaiReport < ApplicationComponent
 
   def classes_for_period period
     raise "#{period} is not a Period" unless period.is_a? Period
-    candidates = ["actions-header-button"]
-    candidates << "action-header-selected" if period == selected_period
+    candidates = ["period-button"]
+    candidates << "selected" if period == selected_period
     candidates.join(" ")
   end
 


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

## Because

Here are some further refinements in the CSS and some small edits to the HTML structure to simplify both.

It looks like a lot but its mostly styling improvements, fixes, and simplification

## This addresses

**Action plan block:**
- Move h4 so it's standard design (instead of a weird hacky variation)
- Place quarter nav below h4
- Standardise base and hover styling for quarter nav (so it matches main nav styles)
- Remove the add button from quarter nav
- Remove the add button in the empty state container
- Remove empty action plan container, everything is rolled into a single div 'actions-block' that requires an 'empty' class when nothing is present (this is working in the code)
- Place the add button below the' action plan container'

**Action card:**
- Update name to `action-card`
- Improve meatball button styling
- Add edit button and divider to the dropdown menu
- Improve styling to edit and delete in the dropdown
- Simplify progress block naming

**Side panel:**
- Improved styling and better CSS
- New wrapper on 'goal-input-block', this allows for adding a warning message for no input when pressing save
- No input warning message <p>

**CSS:**
- Removing unused styles
- Some renaming

## Test instructions

Everything seems to be working as it was previously