### PR TITLE
fix: add "empty" clause for Questionnaire layout

### DIFF
--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -73,7 +73,12 @@ class Questionnaire < ApplicationRecord
     return sub_layout unless text
     return sub_layout if text.empty?
 
-    sub_layout.merge({"text" => I18n.t!(text)})
+    translation = if text == "empty"
+      ""
+    else
+      I18n.t!(text)
+    end
+    sub_layout.merge({"text" => translation})
   end
 
   def generate_layout_id(sub_layout)

--- a/spec/models/questionnaire_spec.rb
+++ b/spec/models/questionnaire_spec.rb
@@ -98,7 +98,8 @@ RSpec.describe Questionnaire, type: :model do
            {"text" => "test_translations.test_string"}
          ]},
         {"text" => "test_translations.test_string"},
-        {"text" => ""}
+        {"text" => ""},
+        {"text" => "empty"}
       ]}
 
       localized_layout = {"item" => [
@@ -108,6 +109,7 @@ RSpec.describe Questionnaire, type: :model do
            {"text" => "Test"}
          ]},
         {"text" => "Test"},
+        {"text" => ""},
         {"text" => ""}
       ]}
 


### PR DESCRIPTION
**Story card:** [sc-16019](https://app.shortcut.com/simpledotorg/story/16019/sync-is-failing-for-qa-sandbox-and-demo-environments)

## Because

Questionnaire sync is broken on this

## This addresses

Accounting for the case when the string to be translated is `"empty"`

## Test instructions

suite tests
