### PR TITLE
feat(Dr. Rai Reports): Optimize Titration Indicator Data

### DIFF
--- a/app/components/dashboard/dr_rai_report.html.erb
+++ b/app/components/dashboard/dr_rai_report.html.erb
@@ -242,7 +242,7 @@
       } else {
         if (target.ui == 'percent') {
           var previousPercentage
-          if (indicator.previous_numerator < 1) {
+          if (indicator.previous_numerator < 1 || indicator.denominator == '' || indicator.denominator === undefined) {
             previousPercentage = 0
           } else {
             previousPercentage = Math.round(indicator.previous_numerator / indicator.denominator * 100)

--- a/app/models/concerns/dr_rai/chartable.rb
+++ b/app/models/concerns/dr_rai/chartable.rb
@@ -1,0 +1,47 @@
+# Contains methods required to transform data from their normal form to chartable data
+module DrRai
+  module Chartable
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def chartable_internal_keys *keys
+        @chartable_internal_keys = keys.map(&:to_sym)
+      end
+
+      def chartable_period_key key
+        @chartable_period_key = key.to_sym
+      end
+
+      def chartable_outer_grouping key
+        @chartable_outer_grouping = key.to_sym
+      end
+
+      def chartable
+        result = {}
+        all.each do |record|
+          period_key = @chartable_period_key
+          the_period = Period.quarter(record.send(period_key))
+
+          internal_keys = @chartable_internal_keys
+          internal_data = internal_keys.map { |k| [k, record.send(k)] }.to_h
+
+          outer_grouping = record.send @chartable_outer_grouping
+          if result.has_key? outer_grouping
+            if result[outer_grouping].has_key?(the_period)
+              internal_keys.each do |k|
+                result[outer_grouping][the_period][k] += record.send(k)
+              end
+            else
+              result[outer_grouping][the_period] = internal_data
+            end
+          else
+            result[outer_grouping] = {
+              the_period => internal_data
+            }
+          end
+        end
+        result
+      end
+    end
+  end
+end

--- a/app/models/dr_rai/data.rb
+++ b/app/models/dr_rai/data.rb
@@ -1,0 +1,5 @@
+module DrRai::Data
+  def self.table_name_prefix
+    'dr_rai_data_'
+  end
+end

--- a/app/models/dr_rai/data/titration.rb
+++ b/app/models/dr_rai/data/titration.rb
@@ -1,3 +1,9 @@
 class DrRai::Data::Titration < ApplicationRecord
+  include DrRai::Chartable
+
   default_scope { where(month_date: 1.year.ago..Date.today) }
+
+  chartable_internal_keys :follow_up_count, :titrated_count
+  chartable_period_key :month_date
+  chartable_outer_grouping :facility_name
 end

--- a/app/models/dr_rai/data/titration.rb
+++ b/app/models/dr_rai/data/titration.rb
@@ -1,0 +1,3 @@
+class DrRai::Data::Titration < ApplicationRecord
+  default_scope { where(month_date: 1.year.ago..Date.today) }
+end

--- a/app/models/dr_rai/titration_indicator.rb
+++ b/app/models/dr_rai/titration_indicator.rb
@@ -4,8 +4,8 @@ module DrRai
 
     def datasource(region)
       @region = region
-      @query ||= TitrationQuery.new(region).call
-      @query[region.name]
+      @source ||= DrRai::Data::Titration.chartable
+      @source[region.name]
     end
 
     def display_name
@@ -17,11 +17,11 @@ module DrRai
     end
 
     def numerator_key
-      "titrated"
+      :titrated_count
     end
 
     def denominator_key
-      "patients"
+      :follow_up_count
     end
 
     def action_passive
@@ -37,16 +37,17 @@ module DrRai
     end
 
     def is_supported?(region)
-      case CountryConfig.current[:name]
-      when "Bangladesh"
-        region.path.split(".").include?("nhf")
-      when "Ethiopia"
-        region.path.split(".").none? { |level| level.include?("non_rtsl") }
-      when "Sri Lanka"
-        region.path.split(".").include?("sri_lanka_organization")
-      else
-        false
-      end
+      true
+      # case CountryConfig.current[:name]
+      # when "Bangladesh"
+      #   region.path.split(".").include?("nhf")
+      # when "Ethiopia"
+      #   region.path.split(".").none? { |level| level.include?("non_rtsl") }
+      # when "Sri Lanka"
+      #   region.path.split(".").include?("sri_lanka_organization")
+      # else
+      #   false
+      # end
     end
   end
 end

--- a/app/queries/dr_rai/query_factory.rb
+++ b/app/queries/dr_rai/query_factory.rb
@@ -1,0 +1,71 @@
+module DrRai
+  # Query Factory
+  #
+  # When creating SQL-backed indicators, these indicators come with their own
+  # queries. The query factory tells the query necessary for certain
+  # indicators. By default, it vends one query for inserting, and another for
+  # updating. The primary client for this is the DrRai::DataService which uses
+  # this to populate the data in the tables.
+  class QueryFactory
+    attr_reader :from_date, :to_date
+
+    class << self
+      def for klazz, from: nil, to: nil
+        raise unless klazz < ApplicationRecord
+
+        instance = nil
+
+        case
+        when klazz <= Data::Titration
+          instance = DrRai::TitrationQueryFactory.new(from, to)
+        else
+          raise "Unsupported"
+        end
+
+        instance
+      end
+    end
+
+    def initialize from, to
+      @from = from
+      @to = to
+
+      set_date_boundaries!
+    end
+
+    def inserter
+      # Format should be
+      #   insert into <tbl> ([...columns]) [..query]
+      raise "Unimplemented"
+    end
+
+    def updater
+      # Format should be
+      #   merge into <tbl> as t
+      #   using [...query]
+      #   on month_date
+      #   when not matched and [column compare - insert clause] then
+      #     insert values ([select values])
+      #   when matched and [column compare - update clause] then
+      #     update set [col = old_col <op> new_col];
+      # see https://www.postgresql.org/docs/current/sql-merge.html#id-1.9.3.156.9
+      raise "Unimplemented"
+    end
+
+    private
+
+    def set_date_boundaries!
+      if @from.nil?
+        @from_date = 1.year.ago.to_date
+      else
+        @from_date = @from
+      end
+
+      if @to.nil?
+        @to_date = Date.today
+      else
+        @to_date = @to
+      end
+    end
+  end
+end

--- a/app/queries/dr_rai/titration_query_factory.rb
+++ b/app/queries/dr_rai/titration_query_factory.rb
@@ -1,0 +1,99 @@
+module DrRai
+  class TitrationQueryFactory < QueryFactory
+    def inserter
+      base_query do
+        "insert into public.dr_rai_data_titrations (month_date, facility_name, follow_up_count, titrated_count, titration_rate)"
+      end
+    end
+
+    def updater
+      <<-SQL
+      merge into public.dr_rai_data_titrations as existing
+      using (#{ base_query { "" } }) as incoming
+      on existing.month_date = incoming.month_date and existing.facility_name = incoming.facility_name
+      when not matched
+        insert (
+          month_date,
+          facility_name,
+          follow_up_count,
+          titrated_count,
+          titration_rate,
+          created_at,
+          updated_at
+        )
+        values (
+          incoming.month_date,
+          incoming.facility_name,
+          incoming.follow_up_count,
+          incoming.titrated_count,
+          incoming.titration_rate,
+          now(), -- for created_at
+          now(), -- for updated_at
+        )
+      when matched and existing.titration_rate != incoming.titration_rate
+        update
+          set
+            follow_up_count = incoming.follow_up_count,
+            titrated_count = incoming.titrated_count,
+            titration_rate = incoming.titration_rate;
+      SQL
+    end
+
+    private
+
+    def base_query
+      <<~SQL
+        with facility_titrations as (
+          select
+            reporting_patient_states.month_date,
+            facility_name,
+            count(*) as follow_up_count,
+            count(*) filter (where titrated) as titrated_count,
+            count(*) filter (where titrated)::float / count(*) * 100 as titration_rate
+          from reporting_patient_states
+          inner join reporting_facilities
+          on reporting_facilities.facility_id = reporting_patient_states.bp_facility_id
+          where 1 = 1
+            and "public"."reporting_patient_states"."month_date" between date '#{from_date}' and date '#{to_date}'
+            and reporting_patient_states.months_since_bp = 0
+            and reporting_patient_states.last_bp_state = 'uncontrolled'
+            and reporting_patient_states.months_since_registration > 0
+          group by 1, 2
+          order by 1, 2
+        ),
+
+        selected_facility_titrations as (
+          select
+            month_date,
+            facility_name,
+            follow_up_count,
+            titrated_count,
+            titration_rate
+          from facility_titrations
+          where facility_name in (
+            select facility_name
+            from reporting_facilities
+          )
+        ),
+
+        averages as (
+          select
+            month_date,
+            'average' as facility_name,
+            sum(follow_up_count) as follow_up_count,
+            sum(titrated_count) as titrated_count,
+            (sum(titrated_count)::float / sum(follow_up_count)) * 100 as titration_rate
+          from facility_titrations
+          group by month_date
+        )
+
+        #{ yield }
+        (
+          select * from selected_facility_titrations
+          union all
+          select * from averages
+        );
+      SQL
+    end
+  end
+end

--- a/app/services/dr_rai/data_service.rb
+++ b/app/services/dr_rai/data_service.rb
@@ -1,0 +1,36 @@
+module DrRai
+  class DataService
+    class << self
+      def populate klazz, timeline: nil
+        raise "Can only populate models" unless klazz < ApplicationRecord
+        if timeline.present?
+          raise "timeline must be Date range" unless timelines.is_a?(Range)
+        end
+        new(klazz, timeline).populate!
+      end
+    end
+
+    def initialize klazz, timeline
+      @klazz = klazz
+      @timeline = timeline
+      @timeline = 1.year.ago.to_date..Date.today if @timeline.nil?
+      @query_factory = QueryFactory.for(klazz, from: @timeline.begin, to: @timeline.end)
+    end
+
+    def populate!
+      if inserting?
+        @query = @query_factory.inserter
+      else
+        @query = @query_factory.updater
+      end
+
+      ApplicationRecord.connection.exec_query(@query)
+    end
+
+    private
+
+    def inserting?
+      @klazz.where(month_date: @timeline).count == 0
+    end
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -88,6 +88,12 @@ every :week, at: local("01:00 am"), roles: [:whitelist_phone_numbers] do
   rake "exotel_tasks:update_all_patients_phone_number_details"
 end
 
+every :day, at: local("03:00 am"), roles: [:cron] do
+  from = 1.month.ago.to_date.to_s
+  to = Date.today.to_s
+  rake "dr_rai:populate_titration_data[#{from}, #{to}]"
+end
+
 every :day, at: local("01:00 am"), roles: [:cron] do
   runner "MarkPatientMobileNumbers.call"
 end

--- a/db/migrate/20250813062338_create_dr_rai_data_titrations.rb
+++ b/db/migrate/20250813062338_create_dr_rai_data_titrations.rb
@@ -1,0 +1,13 @@
+class CreateDrRaiDataTitrations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :dr_rai_data_titrations do |t|
+      t.string :facility_name
+      t.integer :titrated_count
+      t.integer :follow_up_count
+      t.datetime :month_date
+      t.decimal :titration_rate, precision: 5, scale: 2
+
+      t.timestamps default: -> { 'CURRENT_TIMESTAMP' }, null: false
+    end
+  end
+end

--- a/db/migrate/20250813064810_add_deleted_at_to_dr_rai_data_titrations.rb
+++ b/db/migrate/20250813064810_add_deleted_at_to_dr_rai_data_titrations.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToDrRaiDataTitrations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :dr_rai_data_titrations, :deleted_at, :timestamp
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1099,6 +1099,42 @@ ALTER SEQUENCE public.dr_rai_actions_id_seq OWNED BY public.dr_rai_actions.id;
 
 
 --
+-- Name: dr_rai_data_titrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.dr_rai_data_titrations (
+    id bigint NOT NULL,
+    facility_name character varying,
+    titrated_count integer,
+    follow_up_count integer,
+    month_date timestamp without time zone,
+    titration_rate numeric(5,2),
+    created_at timestamp(6) without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp(6) without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    deleted_at timestamp without time zone
+);
+
+
+--
+-- Name: dr_rai_data_titrations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.dr_rai_data_titrations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: dr_rai_data_titrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.dr_rai_data_titrations_id_seq OWNED BY public.dr_rai_data_titrations.id;
+
+
+--
 -- Name: dr_rai_indicators; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5896,6 +5932,366 @@ CREATE TABLE public.users (
 
 
 --
+-- Name: reporting_patient_states_20240401; Type: TABLE; Schema: simple_reporting; Owner: -
+--
+
+CREATE TABLE simple_reporting.reporting_patient_states_20240401 (
+    patient_id uuid,
+    recorded_at timestamp without time zone,
+    status character varying,
+    gender character varying,
+    age integer,
+    age_updated_at timestamp without time zone,
+    date_of_birth date,
+    current_age double precision,
+    month_date date,
+    month double precision,
+    quarter double precision,
+    year double precision,
+    month_string text,
+    quarter_string text,
+    hypertension text,
+    prior_heart_attack text,
+    prior_stroke text,
+    chronic_kidney_disease text,
+    receiving_treatment_for_hypertension text,
+    diabetes text,
+    assigned_facility_id uuid,
+    assigned_facility_size character varying,
+    assigned_facility_type character varying,
+    assigned_facility_slug character varying,
+    assigned_facility_region_id uuid,
+    assigned_block_slug character varying,
+    assigned_block_region_id uuid,
+    assigned_district_slug character varying,
+    assigned_district_region_id uuid,
+    assigned_state_slug character varying,
+    assigned_state_region_id uuid,
+    assigned_organization_slug character varying,
+    assigned_organization_region_id uuid,
+    registration_facility_id uuid,
+    registration_facility_size character varying,
+    registration_facility_type character varying,
+    registration_facility_slug character varying,
+    registration_facility_region_id uuid,
+    registration_block_slug character varying,
+    registration_block_region_id uuid,
+    registration_district_slug character varying,
+    registration_district_region_id uuid,
+    registration_state_slug character varying,
+    registration_state_region_id uuid,
+    registration_organization_slug character varying,
+    registration_organization_region_id uuid,
+    blood_pressure_id uuid,
+    bp_facility_id uuid,
+    bp_recorded_at timestamp without time zone,
+    systolic integer,
+    diastolic integer,
+    blood_sugar_id uuid,
+    bs_facility_id uuid,
+    bs_recorded_at timestamp without time zone,
+    blood_sugar_type character varying,
+    blood_sugar_value numeric,
+    blood_sugar_risk_state text,
+    encounter_id uuid,
+    encounter_recorded_at timestamp without time zone,
+    prescription_drug_id uuid,
+    prescription_drug_recorded_at timestamp without time zone,
+    appointment_id uuid,
+    appointment_recorded_at timestamp without time zone,
+    visited_facility_ids uuid[],
+    months_since_registration double precision,
+    quarters_since_registration double precision,
+    months_since_visit double precision,
+    quarters_since_visit double precision,
+    months_since_bp double precision,
+    quarters_since_bp double precision,
+    months_since_bs double precision,
+    quarters_since_bs double precision,
+    last_bp_state text,
+    htn_care_state text,
+    htn_treatment_outcome_in_last_3_months text,
+    htn_treatment_outcome_in_last_2_months text,
+    htn_treatment_outcome_in_quarter text,
+    diabetes_treatment_outcome_in_last_3_months text,
+    diabetes_treatment_outcome_in_last_2_months text,
+    diabetes_treatment_outcome_in_quarter text,
+    titrated boolean,
+    CONSTRAINT reporting_patient_states_month_date_shard_check CHECK ((month_date = (date_trunc('month'::text, (to_date('20240401'::text, 'YYYYMMDD'::text))::timestamp with time zone))::date))
+);
+
+
+--
+-- Name: reporting_patient_states_20240701; Type: TABLE; Schema: simple_reporting; Owner: -
+--
+
+CREATE TABLE simple_reporting.reporting_patient_states_20240701 (
+    patient_id uuid,
+    recorded_at timestamp without time zone,
+    status character varying,
+    gender character varying,
+    age integer,
+    age_updated_at timestamp without time zone,
+    date_of_birth date,
+    current_age double precision,
+    month_date date,
+    month double precision,
+    quarter double precision,
+    year double precision,
+    month_string text,
+    quarter_string text,
+    hypertension text,
+    prior_heart_attack text,
+    prior_stroke text,
+    chronic_kidney_disease text,
+    receiving_treatment_for_hypertension text,
+    diabetes text,
+    assigned_facility_id uuid,
+    assigned_facility_size character varying,
+    assigned_facility_type character varying,
+    assigned_facility_slug character varying,
+    assigned_facility_region_id uuid,
+    assigned_block_slug character varying,
+    assigned_block_region_id uuid,
+    assigned_district_slug character varying,
+    assigned_district_region_id uuid,
+    assigned_state_slug character varying,
+    assigned_state_region_id uuid,
+    assigned_organization_slug character varying,
+    assigned_organization_region_id uuid,
+    registration_facility_id uuid,
+    registration_facility_size character varying,
+    registration_facility_type character varying,
+    registration_facility_slug character varying,
+    registration_facility_region_id uuid,
+    registration_block_slug character varying,
+    registration_block_region_id uuid,
+    registration_district_slug character varying,
+    registration_district_region_id uuid,
+    registration_state_slug character varying,
+    registration_state_region_id uuid,
+    registration_organization_slug character varying,
+    registration_organization_region_id uuid,
+    blood_pressure_id uuid,
+    bp_facility_id uuid,
+    bp_recorded_at timestamp without time zone,
+    systolic integer,
+    diastolic integer,
+    blood_sugar_id uuid,
+    bs_facility_id uuid,
+    bs_recorded_at timestamp without time zone,
+    blood_sugar_type character varying,
+    blood_sugar_value numeric,
+    blood_sugar_risk_state text,
+    encounter_id uuid,
+    encounter_recorded_at timestamp without time zone,
+    prescription_drug_id uuid,
+    prescription_drug_recorded_at timestamp without time zone,
+    appointment_id uuid,
+    appointment_recorded_at timestamp without time zone,
+    visited_facility_ids uuid[],
+    months_since_registration double precision,
+    quarters_since_registration double precision,
+    months_since_visit double precision,
+    quarters_since_visit double precision,
+    months_since_bp double precision,
+    quarters_since_bp double precision,
+    months_since_bs double precision,
+    quarters_since_bs double precision,
+    last_bp_state text,
+    htn_care_state text,
+    htn_treatment_outcome_in_last_3_months text,
+    htn_treatment_outcome_in_last_2_months text,
+    htn_treatment_outcome_in_quarter text,
+    diabetes_treatment_outcome_in_last_3_months text,
+    diabetes_treatment_outcome_in_last_2_months text,
+    diabetes_treatment_outcome_in_quarter text,
+    titrated boolean,
+    CONSTRAINT reporting_patient_states_month_date_shard_check CHECK ((month_date = (date_trunc('month'::text, (to_date('20240701'::text, 'YYYYMMDD'::text))::timestamp with time zone))::date))
+);
+
+
+--
+-- Name: reporting_patient_states_20250601; Type: TABLE; Schema: simple_reporting; Owner: -
+--
+
+CREATE TABLE simple_reporting.reporting_patient_states_20250601 (
+    patient_id uuid,
+    recorded_at timestamp without time zone,
+    status character varying,
+    gender character varying,
+    age integer,
+    age_updated_at timestamp without time zone,
+    date_of_birth date,
+    current_age double precision,
+    month_date date,
+    month double precision,
+    quarter double precision,
+    year double precision,
+    month_string text,
+    quarter_string text,
+    hypertension text,
+    prior_heart_attack text,
+    prior_stroke text,
+    chronic_kidney_disease text,
+    receiving_treatment_for_hypertension text,
+    diabetes text,
+    assigned_facility_id uuid,
+    assigned_facility_size character varying,
+    assigned_facility_type character varying,
+    assigned_facility_slug character varying,
+    assigned_facility_region_id uuid,
+    assigned_block_slug character varying,
+    assigned_block_region_id uuid,
+    assigned_district_slug character varying,
+    assigned_district_region_id uuid,
+    assigned_state_slug character varying,
+    assigned_state_region_id uuid,
+    assigned_organization_slug character varying,
+    assigned_organization_region_id uuid,
+    registration_facility_id uuid,
+    registration_facility_size character varying,
+    registration_facility_type character varying,
+    registration_facility_slug character varying,
+    registration_facility_region_id uuid,
+    registration_block_slug character varying,
+    registration_block_region_id uuid,
+    registration_district_slug character varying,
+    registration_district_region_id uuid,
+    registration_state_slug character varying,
+    registration_state_region_id uuid,
+    registration_organization_slug character varying,
+    registration_organization_region_id uuid,
+    blood_pressure_id uuid,
+    bp_facility_id uuid,
+    bp_recorded_at timestamp without time zone,
+    systolic integer,
+    diastolic integer,
+    blood_sugar_id uuid,
+    bs_facility_id uuid,
+    bs_recorded_at timestamp without time zone,
+    blood_sugar_type character varying,
+    blood_sugar_value numeric,
+    blood_sugar_risk_state text,
+    encounter_id uuid,
+    encounter_recorded_at timestamp without time zone,
+    prescription_drug_id uuid,
+    prescription_drug_recorded_at timestamp without time zone,
+    appointment_id uuid,
+    appointment_recorded_at timestamp without time zone,
+    visited_facility_ids uuid[],
+    months_since_registration double precision,
+    quarters_since_registration double precision,
+    months_since_visit double precision,
+    quarters_since_visit double precision,
+    months_since_bp double precision,
+    quarters_since_bp double precision,
+    months_since_bs double precision,
+    quarters_since_bs double precision,
+    last_bp_state text,
+    htn_care_state text,
+    htn_treatment_outcome_in_last_3_months text,
+    htn_treatment_outcome_in_last_2_months text,
+    htn_treatment_outcome_in_quarter text,
+    diabetes_treatment_outcome_in_last_3_months text,
+    diabetes_treatment_outcome_in_last_2_months text,
+    diabetes_treatment_outcome_in_quarter text,
+    titrated boolean,
+    CONSTRAINT reporting_patient_states_month_date_shard_check CHECK ((month_date = (date_trunc('month'::text, (to_date('20250601'::text, 'YYYYMMDD'::text))::timestamp with time zone))::date))
+);
+
+
+--
+-- Name: reporting_patient_states_20250701; Type: TABLE; Schema: simple_reporting; Owner: -
+--
+
+CREATE TABLE simple_reporting.reporting_patient_states_20250701 (
+    patient_id uuid,
+    recorded_at timestamp without time zone,
+    status character varying,
+    gender character varying,
+    age integer,
+    age_updated_at timestamp without time zone,
+    date_of_birth date,
+    current_age double precision,
+    month_date date,
+    month double precision,
+    quarter double precision,
+    year double precision,
+    month_string text,
+    quarter_string text,
+    hypertension text,
+    prior_heart_attack text,
+    prior_stroke text,
+    chronic_kidney_disease text,
+    receiving_treatment_for_hypertension text,
+    diabetes text,
+    assigned_facility_id uuid,
+    assigned_facility_size character varying,
+    assigned_facility_type character varying,
+    assigned_facility_slug character varying,
+    assigned_facility_region_id uuid,
+    assigned_block_slug character varying,
+    assigned_block_region_id uuid,
+    assigned_district_slug character varying,
+    assigned_district_region_id uuid,
+    assigned_state_slug character varying,
+    assigned_state_region_id uuid,
+    assigned_organization_slug character varying,
+    assigned_organization_region_id uuid,
+    registration_facility_id uuid,
+    registration_facility_size character varying,
+    registration_facility_type character varying,
+    registration_facility_slug character varying,
+    registration_facility_region_id uuid,
+    registration_block_slug character varying,
+    registration_block_region_id uuid,
+    registration_district_slug character varying,
+    registration_district_region_id uuid,
+    registration_state_slug character varying,
+    registration_state_region_id uuid,
+    registration_organization_slug character varying,
+    registration_organization_region_id uuid,
+    blood_pressure_id uuid,
+    bp_facility_id uuid,
+    bp_recorded_at timestamp without time zone,
+    systolic integer,
+    diastolic integer,
+    blood_sugar_id uuid,
+    bs_facility_id uuid,
+    bs_recorded_at timestamp without time zone,
+    blood_sugar_type character varying,
+    blood_sugar_value numeric,
+    blood_sugar_risk_state text,
+    encounter_id uuid,
+    encounter_recorded_at timestamp without time zone,
+    prescription_drug_id uuid,
+    prescription_drug_recorded_at timestamp without time zone,
+    appointment_id uuid,
+    appointment_recorded_at timestamp without time zone,
+    visited_facility_ids uuid[],
+    months_since_registration double precision,
+    quarters_since_registration double precision,
+    months_since_visit double precision,
+    quarters_since_visit double precision,
+    months_since_bp double precision,
+    quarters_since_bp double precision,
+    months_since_bs double precision,
+    quarters_since_bs double precision,
+    last_bp_state text,
+    htn_care_state text,
+    htn_treatment_outcome_in_last_3_months text,
+    htn_treatment_outcome_in_last_2_months text,
+    htn_treatment_outcome_in_quarter text,
+    diabetes_treatment_outcome_in_last_3_months text,
+    diabetes_treatment_outcome_in_last_2_months text,
+    diabetes_treatment_outcome_in_quarter text,
+    titrated boolean,
+    CONSTRAINT reporting_patient_states_month_date_shard_check CHECK ((month_date = (date_trunc('month'::text, (to_date('20250701'::text, 'YYYYMMDD'::text))::timestamp with time zone))::date))
+);
+
+
+--
 -- Name: simple_reporting_runs; Type: TABLE; Schema: simple_reporting; Owner: -
 --
 
@@ -5910,6 +6306,34 @@ CREATE TABLE simple_reporting.simple_reporting_runs (
     sql_state character varying(255),
     sql_error_message character varying(255)
 );
+
+
+--
+-- Name: reporting_patient_states_20240401; Type: TABLE ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER TABLE ONLY simple_reporting.reporting_patient_states ATTACH PARTITION simple_reporting.reporting_patient_states_20240401 FOR VALUES IN ('2024-04-01');
+
+
+--
+-- Name: reporting_patient_states_20240701; Type: TABLE ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER TABLE ONLY simple_reporting.reporting_patient_states ATTACH PARTITION simple_reporting.reporting_patient_states_20240701 FOR VALUES IN ('2024-07-01');
+
+
+--
+-- Name: reporting_patient_states_20250601; Type: TABLE ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER TABLE ONLY simple_reporting.reporting_patient_states ATTACH PARTITION simple_reporting.reporting_patient_states_20250601 FOR VALUES IN ('2025-06-01');
+
+
+--
+-- Name: reporting_patient_states_20250701; Type: TABLE ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER TABLE ONLY simple_reporting.reporting_patient_states ATTACH PARTITION simple_reporting.reporting_patient_states_20250701 FOR VALUES IN ('2025-07-01');
 
 
 --
@@ -5966,6 +6390,13 @@ ALTER TABLE ONLY public.dr_rai_action_plans ALTER COLUMN id SET DEFAULT nextval(
 --
 
 ALTER TABLE ONLY public.dr_rai_actions ALTER COLUMN id SET DEFAULT nextval('public.dr_rai_actions_id_seq'::regclass);
+
+
+--
+-- Name: dr_rai_data_titrations id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dr_rai_data_titrations ALTER COLUMN id SET DEFAULT nextval('public.dr_rai_data_titrations_id_seq'::regclass);
 
 
 --
@@ -6212,6 +6643,14 @@ ALTER TABLE ONLY public.dr_rai_action_plans
 
 ALTER TABLE ONLY public.dr_rai_actions
     ADD CONSTRAINT dr_rai_actions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: dr_rai_data_titrations dr_rai_data_titrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dr_rai_data_titrations
+    ADD CONSTRAINT dr_rai_data_titrations_pkey PRIMARY KEY (id);
 
 
 --
@@ -8120,6 +8559,34 @@ CREATE INDEX patient_states_registration_facility ON ONLY simple_reporting.repor
 
 
 --
+-- Name: reporting_patient_states_20240401_age_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240401_age_idx ON simple_reporting.reporting_patient_states_20240401 USING btree (age);
+
+
+--
+-- Name: reporting_patient_states_20240401_assigned_block_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240401_assigned_block_region_id_idx ON simple_reporting.reporting_patient_states_20240401 USING btree (assigned_block_region_id);
+
+
+--
+-- Name: reporting_patient_states_20240401_assigned_facility_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240401_assigned_facility_id_idx ON simple_reporting.reporting_patient_states_20240401 USING btree (assigned_facility_id);
+
+
+--
+-- Name: reporting_patient_states_20240401_assigned_state_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240401_assigned_state_region_id_idx ON simple_reporting.reporting_patient_states_20240401 USING btree (assigned_state_region_id);
+
+
+--
 -- Name: reporting_patient_states_bp_facility_id; Type: INDEX; Schema: simple_reporting; Owner: -
 --
 
@@ -8127,10 +8594,766 @@ CREATE INDEX reporting_patient_states_bp_facility_id ON ONLY simple_reporting.re
 
 
 --
+-- Name: reporting_patient_states_20240401_bp_facility_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240401_bp_facility_id_idx ON simple_reporting.reporting_patient_states_20240401 USING btree (bp_facility_id);
+
+
+--
+-- Name: reporting_patient_states_20240401_gender_age_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240401_gender_age_idx ON simple_reporting.reporting_patient_states_20240401 USING btree (gender, age);
+
+
+--
+-- Name: reporting_patient_states_20240401_gender_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240401_gender_idx ON simple_reporting.reporting_patient_states_20240401 USING btree (gender);
+
+
+--
+-- Name: reporting_patient_states_20240401_month_date_patient_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE UNIQUE INDEX reporting_patient_states_20240401_month_date_patient_id_idx ON simple_reporting.reporting_patient_states_20240401 USING btree (month_date, patient_id);
+
+
+--
+-- Name: reporting_patient_states_20240401_registration_facility_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240401_registration_facility_id_idx ON simple_reporting.reporting_patient_states_20240401 USING btree (registration_facility_id);
+
+
+--
 -- Name: reporting_patient_states_titrated; Type: INDEX; Schema: simple_reporting; Owner: -
 --
 
 CREATE INDEX reporting_patient_states_titrated ON ONLY simple_reporting.reporting_patient_states USING btree (titrated);
+
+
+--
+-- Name: reporting_patient_states_20240401_titrated_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240401_titrated_idx ON simple_reporting.reporting_patient_states_20240401 USING btree (titrated);
+
+
+--
+-- Name: reporting_patient_states_202404_assigned_district_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_202404_assigned_district_region_id_idx ON simple_reporting.reporting_patient_states_20240401 USING btree (assigned_district_region_id);
+
+
+--
+-- Name: reporting_patient_states_202404_assigned_facility_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_202404_assigned_facility_region_id_idx ON simple_reporting.reporting_patient_states_20240401 USING btree (assigned_facility_region_id);
+
+
+--
+-- Name: reporting_patient_states_20240701_age_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240701_age_idx ON simple_reporting.reporting_patient_states_20240701 USING btree (age);
+
+
+--
+-- Name: reporting_patient_states_20240701_assigned_block_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240701_assigned_block_region_id_idx ON simple_reporting.reporting_patient_states_20240701 USING btree (assigned_block_region_id);
+
+
+--
+-- Name: reporting_patient_states_20240701_assigned_facility_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240701_assigned_facility_id_idx ON simple_reporting.reporting_patient_states_20240701 USING btree (assigned_facility_id);
+
+
+--
+-- Name: reporting_patient_states_20240701_assigned_state_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240701_assigned_state_region_id_idx ON simple_reporting.reporting_patient_states_20240701 USING btree (assigned_state_region_id);
+
+
+--
+-- Name: reporting_patient_states_20240701_bp_facility_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240701_bp_facility_id_idx ON simple_reporting.reporting_patient_states_20240701 USING btree (bp_facility_id);
+
+
+--
+-- Name: reporting_patient_states_20240701_gender_age_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240701_gender_age_idx ON simple_reporting.reporting_patient_states_20240701 USING btree (gender, age);
+
+
+--
+-- Name: reporting_patient_states_20240701_gender_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240701_gender_idx ON simple_reporting.reporting_patient_states_20240701 USING btree (gender);
+
+
+--
+-- Name: reporting_patient_states_20240701_month_date_patient_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE UNIQUE INDEX reporting_patient_states_20240701_month_date_patient_id_idx ON simple_reporting.reporting_patient_states_20240701 USING btree (month_date, patient_id);
+
+
+--
+-- Name: reporting_patient_states_20240701_registration_facility_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240701_registration_facility_id_idx ON simple_reporting.reporting_patient_states_20240701 USING btree (registration_facility_id);
+
+
+--
+-- Name: reporting_patient_states_20240701_titrated_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20240701_titrated_idx ON simple_reporting.reporting_patient_states_20240701 USING btree (titrated);
+
+
+--
+-- Name: reporting_patient_states_202407_assigned_district_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_202407_assigned_district_region_id_idx ON simple_reporting.reporting_patient_states_20240701 USING btree (assigned_district_region_id);
+
+
+--
+-- Name: reporting_patient_states_202407_assigned_facility_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_202407_assigned_facility_region_id_idx ON simple_reporting.reporting_patient_states_20240701 USING btree (assigned_facility_region_id);
+
+
+--
+-- Name: reporting_patient_states_2024_hypertension_htn_care_state__idx1; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_2024_hypertension_htn_care_state__idx1 ON simple_reporting.reporting_patient_states_20240401 USING btree (hypertension, htn_care_state, htn_treatment_outcome_in_last_3_months);
+
+
+--
+-- Name: reporting_patient_states_2024_hypertension_htn_care_state_h_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_2024_hypertension_htn_care_state_h_idx ON simple_reporting.reporting_patient_states_20240701 USING btree (hypertension, htn_care_state, htn_treatment_outcome_in_last_3_months);
+
+
+--
+-- Name: reporting_patient_states_2024_registration_facility_region__idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_2024_registration_facility_region__idx ON simple_reporting.reporting_patient_states_20240701 USING btree (registration_facility_region_id);
+
+
+--
+-- Name: reporting_patient_states_2024_registration_facility_region_idx1; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_2024_registration_facility_region_idx1 ON simple_reporting.reporting_patient_states_20240401 USING btree (registration_facility_region_id);
+
+
+--
+-- Name: reporting_patient_states_20250601_age_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250601_age_idx ON simple_reporting.reporting_patient_states_20250601 USING btree (age);
+
+
+--
+-- Name: reporting_patient_states_20250601_assigned_block_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250601_assigned_block_region_id_idx ON simple_reporting.reporting_patient_states_20250601 USING btree (assigned_block_region_id);
+
+
+--
+-- Name: reporting_patient_states_20250601_assigned_facility_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250601_assigned_facility_id_idx ON simple_reporting.reporting_patient_states_20250601 USING btree (assigned_facility_id);
+
+
+--
+-- Name: reporting_patient_states_20250601_assigned_state_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250601_assigned_state_region_id_idx ON simple_reporting.reporting_patient_states_20250601 USING btree (assigned_state_region_id);
+
+
+--
+-- Name: reporting_patient_states_20250601_bp_facility_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250601_bp_facility_id_idx ON simple_reporting.reporting_patient_states_20250601 USING btree (bp_facility_id);
+
+
+--
+-- Name: reporting_patient_states_20250601_gender_age_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250601_gender_age_idx ON simple_reporting.reporting_patient_states_20250601 USING btree (gender, age);
+
+
+--
+-- Name: reporting_patient_states_20250601_gender_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250601_gender_idx ON simple_reporting.reporting_patient_states_20250601 USING btree (gender);
+
+
+--
+-- Name: reporting_patient_states_20250601_month_date_patient_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE UNIQUE INDEX reporting_patient_states_20250601_month_date_patient_id_idx ON simple_reporting.reporting_patient_states_20250601 USING btree (month_date, patient_id);
+
+
+--
+-- Name: reporting_patient_states_20250601_registration_facility_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250601_registration_facility_id_idx ON simple_reporting.reporting_patient_states_20250601 USING btree (registration_facility_id);
+
+
+--
+-- Name: reporting_patient_states_20250601_titrated_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250601_titrated_idx ON simple_reporting.reporting_patient_states_20250601 USING btree (titrated);
+
+
+--
+-- Name: reporting_patient_states_202506_assigned_district_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_202506_assigned_district_region_id_idx ON simple_reporting.reporting_patient_states_20250601 USING btree (assigned_district_region_id);
+
+
+--
+-- Name: reporting_patient_states_202506_assigned_facility_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_202506_assigned_facility_region_id_idx ON simple_reporting.reporting_patient_states_20250601 USING btree (assigned_facility_region_id);
+
+
+--
+-- Name: reporting_patient_states_20250701_age_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250701_age_idx ON simple_reporting.reporting_patient_states_20250701 USING btree (age);
+
+
+--
+-- Name: reporting_patient_states_20250701_assigned_block_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250701_assigned_block_region_id_idx ON simple_reporting.reporting_patient_states_20250701 USING btree (assigned_block_region_id);
+
+
+--
+-- Name: reporting_patient_states_20250701_assigned_facility_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250701_assigned_facility_id_idx ON simple_reporting.reporting_patient_states_20250701 USING btree (assigned_facility_id);
+
+
+--
+-- Name: reporting_patient_states_20250701_assigned_state_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250701_assigned_state_region_id_idx ON simple_reporting.reporting_patient_states_20250701 USING btree (assigned_state_region_id);
+
+
+--
+-- Name: reporting_patient_states_20250701_bp_facility_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250701_bp_facility_id_idx ON simple_reporting.reporting_patient_states_20250701 USING btree (bp_facility_id);
+
+
+--
+-- Name: reporting_patient_states_20250701_gender_age_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250701_gender_age_idx ON simple_reporting.reporting_patient_states_20250701 USING btree (gender, age);
+
+
+--
+-- Name: reporting_patient_states_20250701_gender_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250701_gender_idx ON simple_reporting.reporting_patient_states_20250701 USING btree (gender);
+
+
+--
+-- Name: reporting_patient_states_20250701_month_date_patient_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE UNIQUE INDEX reporting_patient_states_20250701_month_date_patient_id_idx ON simple_reporting.reporting_patient_states_20250701 USING btree (month_date, patient_id);
+
+
+--
+-- Name: reporting_patient_states_20250701_registration_facility_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250701_registration_facility_id_idx ON simple_reporting.reporting_patient_states_20250701 USING btree (registration_facility_id);
+
+
+--
+-- Name: reporting_patient_states_20250701_titrated_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_20250701_titrated_idx ON simple_reporting.reporting_patient_states_20250701 USING btree (titrated);
+
+
+--
+-- Name: reporting_patient_states_202507_assigned_district_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_202507_assigned_district_region_id_idx ON simple_reporting.reporting_patient_states_20250701 USING btree (assigned_district_region_id);
+
+
+--
+-- Name: reporting_patient_states_202507_assigned_facility_region_id_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_202507_assigned_facility_region_id_idx ON simple_reporting.reporting_patient_states_20250701 USING btree (assigned_facility_region_id);
+
+
+--
+-- Name: reporting_patient_states_2025_hypertension_htn_care_state__idx1; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_2025_hypertension_htn_care_state__idx1 ON simple_reporting.reporting_patient_states_20250701 USING btree (hypertension, htn_care_state, htn_treatment_outcome_in_last_3_months);
+
+
+--
+-- Name: reporting_patient_states_2025_hypertension_htn_care_state_h_idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_2025_hypertension_htn_care_state_h_idx ON simple_reporting.reporting_patient_states_20250601 USING btree (hypertension, htn_care_state, htn_treatment_outcome_in_last_3_months);
+
+
+--
+-- Name: reporting_patient_states_2025_registration_facility_region__idx; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_2025_registration_facility_region__idx ON simple_reporting.reporting_patient_states_20250601 USING btree (registration_facility_region_id);
+
+
+--
+-- Name: reporting_patient_states_2025_registration_facility_region_idx1; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX reporting_patient_states_2025_registration_facility_region_idx1 ON simple_reporting.reporting_patient_states_20250701 USING btree (registration_facility_region_id);
+
+
+--
+-- Name: reporting_patient_states_20240401_age_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.index_reporting_patient_states_on_age ATTACH PARTITION simple_reporting.reporting_patient_states_20240401_age_idx;
+
+
+--
+-- Name: reporting_patient_states_20240401_assigned_block_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_block ATTACH PARTITION simple_reporting.reporting_patient_states_20240401_assigned_block_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20240401_assigned_facility_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_month_date_assigned_facility ATTACH PARTITION simple_reporting.reporting_patient_states_20240401_assigned_facility_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20240401_assigned_state_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_state ATTACH PARTITION simple_reporting.reporting_patient_states_20240401_assigned_state_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20240401_bp_facility_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.reporting_patient_states_bp_facility_id ATTACH PARTITION simple_reporting.reporting_patient_states_20240401_bp_facility_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20240401_gender_age_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.index_reporting_patient_states_on_gender_and_age ATTACH PARTITION simple_reporting.reporting_patient_states_20240401_gender_age_idx;
+
+
+--
+-- Name: reporting_patient_states_20240401_gender_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.index_reporting_patient_states_on_gender ATTACH PARTITION simple_reporting.reporting_patient_states_20240401_gender_idx;
+
+
+--
+-- Name: reporting_patient_states_20240401_month_date_patient_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_month_date_patient_id ATTACH PARTITION simple_reporting.reporting_patient_states_20240401_month_date_patient_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20240401_registration_facility_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_registration_facility ATTACH PARTITION simple_reporting.reporting_patient_states_20240401_registration_facility_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20240401_titrated_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.reporting_patient_states_titrated ATTACH PARTITION simple_reporting.reporting_patient_states_20240401_titrated_idx;
+
+
+--
+-- Name: reporting_patient_states_202404_assigned_district_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_district ATTACH PARTITION simple_reporting.reporting_patient_states_202404_assigned_district_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_202404_assigned_facility_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_facility ATTACH PARTITION simple_reporting.reporting_patient_states_202404_assigned_facility_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20240701_age_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.index_reporting_patient_states_on_age ATTACH PARTITION simple_reporting.reporting_patient_states_20240701_age_idx;
+
+
+--
+-- Name: reporting_patient_states_20240701_assigned_block_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_block ATTACH PARTITION simple_reporting.reporting_patient_states_20240701_assigned_block_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20240701_assigned_facility_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_month_date_assigned_facility ATTACH PARTITION simple_reporting.reporting_patient_states_20240701_assigned_facility_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20240701_assigned_state_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_state ATTACH PARTITION simple_reporting.reporting_patient_states_20240701_assigned_state_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20240701_bp_facility_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.reporting_patient_states_bp_facility_id ATTACH PARTITION simple_reporting.reporting_patient_states_20240701_bp_facility_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20240701_gender_age_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.index_reporting_patient_states_on_gender_and_age ATTACH PARTITION simple_reporting.reporting_patient_states_20240701_gender_age_idx;
+
+
+--
+-- Name: reporting_patient_states_20240701_gender_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.index_reporting_patient_states_on_gender ATTACH PARTITION simple_reporting.reporting_patient_states_20240701_gender_idx;
+
+
+--
+-- Name: reporting_patient_states_20240701_month_date_patient_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_month_date_patient_id ATTACH PARTITION simple_reporting.reporting_patient_states_20240701_month_date_patient_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20240701_registration_facility_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_registration_facility ATTACH PARTITION simple_reporting.reporting_patient_states_20240701_registration_facility_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20240701_titrated_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.reporting_patient_states_titrated ATTACH PARTITION simple_reporting.reporting_patient_states_20240701_titrated_idx;
+
+
+--
+-- Name: reporting_patient_states_202407_assigned_district_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_district ATTACH PARTITION simple_reporting.reporting_patient_states_202407_assigned_district_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_202407_assigned_facility_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_facility ATTACH PARTITION simple_reporting.reporting_patient_states_202407_assigned_facility_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_2024_hypertension_htn_care_state__idx1; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_care_state ATTACH PARTITION simple_reporting.reporting_patient_states_2024_hypertension_htn_care_state__idx1;
+
+
+--
+-- Name: reporting_patient_states_2024_hypertension_htn_care_state_h_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_care_state ATTACH PARTITION simple_reporting.reporting_patient_states_2024_hypertension_htn_care_state_h_idx;
+
+
+--
+-- Name: reporting_patient_states_2024_registration_facility_region__idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_month_date_registration_facility_region ATTACH PARTITION simple_reporting.reporting_patient_states_2024_registration_facility_region__idx;
+
+
+--
+-- Name: reporting_patient_states_2024_registration_facility_region_idx1; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_month_date_registration_facility_region ATTACH PARTITION simple_reporting.reporting_patient_states_2024_registration_facility_region_idx1;
+
+
+--
+-- Name: reporting_patient_states_20250601_age_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.index_reporting_patient_states_on_age ATTACH PARTITION simple_reporting.reporting_patient_states_20250601_age_idx;
+
+
+--
+-- Name: reporting_patient_states_20250601_assigned_block_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_block ATTACH PARTITION simple_reporting.reporting_patient_states_20250601_assigned_block_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20250601_assigned_facility_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_month_date_assigned_facility ATTACH PARTITION simple_reporting.reporting_patient_states_20250601_assigned_facility_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20250601_assigned_state_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_state ATTACH PARTITION simple_reporting.reporting_patient_states_20250601_assigned_state_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20250601_bp_facility_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.reporting_patient_states_bp_facility_id ATTACH PARTITION simple_reporting.reporting_patient_states_20250601_bp_facility_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20250601_gender_age_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.index_reporting_patient_states_on_gender_and_age ATTACH PARTITION simple_reporting.reporting_patient_states_20250601_gender_age_idx;
+
+
+--
+-- Name: reporting_patient_states_20250601_gender_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.index_reporting_patient_states_on_gender ATTACH PARTITION simple_reporting.reporting_patient_states_20250601_gender_idx;
+
+
+--
+-- Name: reporting_patient_states_20250601_month_date_patient_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_month_date_patient_id ATTACH PARTITION simple_reporting.reporting_patient_states_20250601_month_date_patient_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20250601_registration_facility_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_registration_facility ATTACH PARTITION simple_reporting.reporting_patient_states_20250601_registration_facility_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20250601_titrated_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.reporting_patient_states_titrated ATTACH PARTITION simple_reporting.reporting_patient_states_20250601_titrated_idx;
+
+
+--
+-- Name: reporting_patient_states_202506_assigned_district_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_district ATTACH PARTITION simple_reporting.reporting_patient_states_202506_assigned_district_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_202506_assigned_facility_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_facility ATTACH PARTITION simple_reporting.reporting_patient_states_202506_assigned_facility_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20250701_age_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.index_reporting_patient_states_on_age ATTACH PARTITION simple_reporting.reporting_patient_states_20250701_age_idx;
+
+
+--
+-- Name: reporting_patient_states_20250701_assigned_block_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_block ATTACH PARTITION simple_reporting.reporting_patient_states_20250701_assigned_block_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20250701_assigned_facility_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_month_date_assigned_facility ATTACH PARTITION simple_reporting.reporting_patient_states_20250701_assigned_facility_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20250701_assigned_state_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_state ATTACH PARTITION simple_reporting.reporting_patient_states_20250701_assigned_state_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20250701_bp_facility_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.reporting_patient_states_bp_facility_id ATTACH PARTITION simple_reporting.reporting_patient_states_20250701_bp_facility_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20250701_gender_age_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.index_reporting_patient_states_on_gender_and_age ATTACH PARTITION simple_reporting.reporting_patient_states_20250701_gender_age_idx;
+
+
+--
+-- Name: reporting_patient_states_20250701_gender_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.index_reporting_patient_states_on_gender ATTACH PARTITION simple_reporting.reporting_patient_states_20250701_gender_idx;
+
+
+--
+-- Name: reporting_patient_states_20250701_month_date_patient_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_month_date_patient_id ATTACH PARTITION simple_reporting.reporting_patient_states_20250701_month_date_patient_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20250701_registration_facility_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_registration_facility ATTACH PARTITION simple_reporting.reporting_patient_states_20250701_registration_facility_id_idx;
+
+
+--
+-- Name: reporting_patient_states_20250701_titrated_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.reporting_patient_states_titrated ATTACH PARTITION simple_reporting.reporting_patient_states_20250701_titrated_idx;
+
+
+--
+-- Name: reporting_patient_states_202507_assigned_district_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_district ATTACH PARTITION simple_reporting.reporting_patient_states_202507_assigned_district_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_202507_assigned_facility_region_id_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_assigned_facility ATTACH PARTITION simple_reporting.reporting_patient_states_202507_assigned_facility_region_id_idx;
+
+
+--
+-- Name: reporting_patient_states_2025_hypertension_htn_care_state__idx1; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_care_state ATTACH PARTITION simple_reporting.reporting_patient_states_2025_hypertension_htn_care_state__idx1;
+
+
+--
+-- Name: reporting_patient_states_2025_hypertension_htn_care_state_h_idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_care_state ATTACH PARTITION simple_reporting.reporting_patient_states_2025_hypertension_htn_care_state_h_idx;
+
+
+--
+-- Name: reporting_patient_states_2025_registration_facility_region__idx; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_month_date_registration_facility_region ATTACH PARTITION simple_reporting.reporting_patient_states_2025_registration_facility_region__idx;
+
+
+--
+-- Name: reporting_patient_states_2025_registration_facility_region_idx1; Type: INDEX ATTACH; Schema: simple_reporting; Owner: -
+--
+
+ALTER INDEX simple_reporting.patient_states_month_date_registration_facility_region ATTACH PARTITION simple_reporting.reporting_patient_states_2025_registration_facility_region_idx1;
 
 
 --
@@ -8663,6 +9886,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250619152733'),
 ('20250619195214'),
 ('20250619222520'),
-('20250619225935');
+('20250619225935'),
+('20250813062338'),
+('20250813064810');
 
 

--- a/lib/tasks/dr_rai.rake
+++ b/lib/tasks/dr_rai.rake
@@ -1,0 +1,11 @@
+namespace :dr_rai do
+  desc "Populate Titration Data"
+  task :populate_titration_data, [:from_date, :to_date] => :environment do
+    args.with_defaults(from_date: 1.year.ago.to_date, to_date: Date.today)
+    puts "Attempting to populate Dr. Rai titration data"
+    from_date = Date.parse(args[:from_date])
+    to_date = Date.parse(args[:to_date])
+    DrRai::DataService.populate(DrRai::Data::Titration, from_date..to_date)
+    puts "Done populating Dr. Rai Titration data"
+  end
+end

--- a/spec/models/dr_rai/data/titration_spec.rb
+++ b/spec/models/dr_rai/data/titration_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe DrRai::Data::Titration, type: :model do
+  context "data transformations" do
+    # from
+    # month_date, facility_name, follow_up_count, titrated_count, titration_rate
+    # May 1 2025, Some Hospital, 120, 14, 11.67
+    # to
+    # {
+    #   "Some Hospital": {
+    #     <Period value: "Q2-2025">: {
+    #       follow_up_count: 120,
+    #       titrated_count: 14,
+    #       titration_rate: 106,
+    #     }
+    #   }
+    # }
+    pending "transforms into dashboard format"
+  end
+end

--- a/spec/queries/dr_rai/query_factory_spec.rb
+++ b/spec/queries/dr_rai/query_factory_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe DrRai::QueryFactory do
+  around do |xmpl|
+    with_reporting_time_zone { xmpl.run }
+  end
+
+  describe "setup" do
+    context "without dates" do
+      it "sets date boundaries to 1 year from today" do
+        qf = DrRai::QueryFactory.new(nil, nil)
+        expect(qf.from_date).to eq 1.year.ago.to_date
+        expect(qf.to_date).to eq Date.today
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-16391](https://app.shortcut.com/simpledotorg/story/16391/optimize-data-load-for-titration-indicator)

## Because

Running the SQL query within the reqyest lifecycle causes a timeout in environments which have plenty data.

## This addresses

- Creating a table / model which would hold the data for the indicator
- Load in the data from teh SQL query
- Adding a rake task for populating the data; manually and on schedule

## Test instructions

suite-tests
