### PR TITLE
fix(Dr. Rai Report): Remove Quartierles from Progress Tab

### DIFF
--- a/app/components/dashboard/dr_rai_report.rb
+++ b/app/components/dashboard/dr_rai_report.rb
@@ -22,6 +22,7 @@ class Dashboard::DrRaiReport < ApplicationComponent
   end
 
   def custom_indicators
+    return nil if @lite
     return [] unless region.source_type == "Facility"
     DrRai::Indicator.all.filter do |indicator|
       indicator.is_supported?(region)

--- a/app/controllers/reports/progress_controller.rb
+++ b/app/controllers/reports/progress_controller.rb
@@ -19,7 +19,6 @@ class Reports::ProgressController < AdminController
     start_period = @period.advance(months: months)
     range = Range.new(start_period, @period)
     @repository = Reports::Repository.new([@region], periods: range)
-    @quarterlies = quarterly_region_summary(@repository, @region.slug)
     @drug_stocks = DrugStock.latest_for_facilities_grouped_by_protocol_drug(current_facility, @for_end_of_month)
     unless @drug_stocks.empty?
       @drug_stocks_query = DrugStocksQuery.new(facilities: [current_facility],
@@ -66,12 +65,5 @@ class Reports::ProgressController < AdminController
   def set_period
     period_params = report_params[:period].presence || Reports.default_period.attributes
     @period = Period.new(period_params)
-  end
-
-  def quarterly_region_summary(repository, region)
-    data = repository.schema.send(:region_summaries)
-    quarterlies = Reports::RegionSummary.group_by(grouping: :quarter, data: data)
-    cut_off = Period.new(type: :quarter, value: 1.year.ago.to_period.to_quarter_period.value.to_s)
-    quarterlies[region].select { |k, _| k > cut_off }
   end
 end

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -20,7 +20,7 @@
   <body>
     <div id="home-page">
       <% if Flipper.enabled?(:dr_rai_reports) && Flipper.enabled?(:dr_rai_progress) && @region.facility_region? %>
-        <% dr_rai_component = Dashboard::DrRaiReport.new(@quarterlies, @region.slug, params[:selected_quarter], true) %>
+        <% dr_rai_component = Dashboard::DrRaiReport.new(nil, @region.slug, params[:selected_quarter], true) %>
         <% unless dr_rai_component.action_plans.empty? %>
         <div class="mb-8px p-16px bgc-white bs-card">
           <h1 class="m-0px mb-16px fw-bold fs-24px c-black">


### PR DESCRIPTION
**Story card:** [sc-16476](https://app.shortcut.com/simpledotorg/story/16476/high-not-showing-in-the-progress-tab-for-the-facility-when-action-plans-are-created-on-bd-production)

## Because

The progress tab does not load in BD-PROD. In a bid not to debug in prod, the assumption behind this change is that there is much data to crunch in BD. So things like `quarterlies` which aren't really needed but are still computed may be adding to load time.

## This addresses

Removing quarterlies from the lite version of Dr. Rai Reports

## Test instructions

n.a
