### PR TITLE
Add subtitle to protected patients

### DIFF
--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -69,6 +69,7 @@
 <% show_htn_cascade = %[organization state district].include?(@region.region_type) %>
 
 <% if Flipper.enabled?(:patients_protected, current_admin) %>
+<h4 class="mt-5 mb-32px">Program overview</h4>
 <div class="d-lg-flex flex-lg-wrap">
   <div class="d-lg-flex flex-fill">
     <%= render(Dashboard::Hypertension::PatientsProtectedComponent.new(


### PR DESCRIPTION
**Story card:** [sc-6490](https://app.shortcut.com/simpledotorg/story/16490/add-a-subtitle-to-patients-protected-card-to-fix-spacing-issue-with-action-plans?vc_group_by=week&ct_workflow=all&cf_workflow=500000031)

Awaiting review from designers.

## Because

When 'Protected patients' card is visible on the dashboard, there is a spacing issue with Action plans.
This happens because the card does not have a subtitle (H4).

<img width="1476" height="785" alt="Screenshot 2025-08-26 at 11 56 45" src="https://github.com/user-attachments/assets/e5ea31be-b55f-4711-92cc-1e90745b281d" />

## This addresses

Adding the subtitle fixes this issue.

<img width="1481" height="795" alt="Screenshot 2025-08-26 at 11 57 43" src="https://github.com/user-attachments/assets/a52445d7-8367-42e2-9b47-48b890cfaf5d" />

## Test instructions

Load dashboard, ensure the 'Protected patients' flipper flag is active.
Flag: `patients-protected`