### PR TITLE
Moving cache warmer job to a rake task

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -113,7 +113,7 @@ every :day, at: local("02:30 am"), roles: [:cron] do
 end
 
 every REPORTS_REFRESH_FREQUENCY, at: local(REPORTS_CACHE_REFRESH_TIME), roles: [:cron] do
-  runner "Reports::RegionCacheWarmer.call"
+  rake "db:warm_up_cache"
 end
 
 every 1.month, at: local("04:00 am"), roles: [:cron] do

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -5,6 +5,11 @@ namespace :db do
     puts "Reporting views have been refreshed"
   end
 
+  desc "Refresh caches for region summary"
+  task warm_up_cache: :environment do
+    Reports::RegionCacheWarmer.call
+  end
+
   task refresh_matviews: :refresh_reporting_views
 
   desc "Refresh matviews for daily follow ups"


### PR DESCRIPTION
**Story card:** [sc-16582](https://app.shortcut.com/simpledotorg/story/16582/move-regioncachewarmer-job-to-a-rake-task)

## Because

We are currently running Reports::RegionCacheWarmer.call through runner which fails in production env because of Spring contexts not properly loaded into it.
As a result the indicator percentage caches carry stale data and causes discrepancy in the dashboard.

## This addresses

Moving the execution to a rake task

## Test instructions

bundle exec rake db:warm_up_cache 
This should run without errors and must trigger the sidekiq jobs for clearing up the caches