### PR TITLE
fix(Dr. Rai Reports): Tie Sidebar to selected period

### DIFF
--- a/app/components/dashboard/dr_rai_report.html.erb
+++ b/app/components/dashboard/dr_rai_report.html.erb
@@ -69,7 +69,7 @@
   <% end %>
 </div>
 <% unless is_lite_version? %>
-<div class="sidepanel bs-canvas bs-canvas-right position-fixed h-100" tabindex="-1" id="dr-rai--sidebar" data-period="<%= current_period.value %>" data-region="<%= region.slug %>">
+<div class="sidepanel bs-canvas bs-canvas-right position-fixed h-100" tabindex="-1" id="dr-rai--sidebar" data-period="<%= selected_period.value %>" data-region="<%= region.slug %>">
   <div class="header">
     <p>Create action</p>
     <button class="bs-canvas-close float-left close" aria-label="Close">


### PR DESCRIPTION
**Story card:** [sc-16421](https://app.shortcut.com/simpledotorg/story/16421/fixes-to-dr-rai-mvp)

## Because

With #5675, tying the sidebar to the current period no longe rmakes sense.

## This addresses

Ensuring the sidebar works with the selected period instead of the current period

## Test instructions

create a future plan
