### PR TITLE
feat(OpenSRP Exporter): Selective Exporting

### DIFF
--- a/app/services/one_off/opensrp/exporter.rb
+++ b/app/services/one_off/opensrp/exporter.rb
@@ -4,8 +4,213 @@ module OneOff
     #
     # Base class which acts as an entry point for the rake task.
     class Exporter
+      class Config
+        attr_reader :report_start, :report_end, :facilities, :time_window
+
+        def initialize config_file
+          data = YAML.load_file(config_file).deep_symbolize_keys.with_indifferent_access
+          time_boundaries = data["time_boundaries"]
+
+          @report_start = if has_report_start?(data)
+            time_boundaries["report_start"]
+          else
+            DateTime.parse("2020-01-01")
+          end
+          @report_end = if has_report_end?(data)
+            time_boundaries["report_end"]
+          else
+            DateTime.now
+          end
+          @facilities = data["facilities"]
+          @time_bound = using_time_boundaries? data
+          @time_window = @report_start..@report_end
+        end
+
+        def time_bound?
+          @time_bound || false
+        end
+
+        def using_time_boundaries?(config)
+          config.has_key? "time_boundaries"
+        end
+
+        def has_report_start?(config)
+          using_time_boundaries?(config) && config["time_boundaries"].has_key?("report_start")
+        end
+
+        def has_report_end?(config)
+          using_time_boundaries?(config) && config["time_boundaries"].has_key?("report_end")
+        end
+      end
+
       def self.export config, output
         new(config, output).call!
+      end
+
+      def initialize config_file, output_file, logger: nil
+        raise "Config file should be YAML" unless %w[yaml yml].include?(config_file.split(".").last)
+        raise "Output file should be JSON" unless output_file.split(".").last == "json"
+
+        if logger.nil?
+          initialize_logger
+        else
+          @logger = logger
+        end
+
+        @config = Config.new config_file
+        @logger.info "Exporting data using config at #{config_file}"
+        @output = output_file
+        @resources = []
+        @encounters = []
+        @tally = Hash.new(0)
+      end
+
+      def initialize_logger
+        logfile = Rails.root.join("log", "#{Rails.env}.log")
+        @logger = ActiveSupport::Logger.new(logfile)
+        @logger.extend(ActiveSupport::Logger.broadcast(ActiveSupport::Logger.new($stdout)))
+      end
+
+      def call!
+        @logger.info "Time Boundaries: [#{@config.report_start}..#{@config.report_end}]"
+
+        patients = select_patients @config.facilities.keys
+        patients.each do |patient|
+          export_patient_details patient
+          export_blood_pressure_details patient
+          export_blood_sugar_details patient
+          export_prescription_drugs_details patient
+          export_appointments_details patient
+          export_medical_history_details patient
+        end
+
+        @tally[:encounters] += @encounters.size
+        @resources << OneOff::Opensrp::EncounterGenerator.new(@encounters).generate
+
+        write_audit_trail
+      end
+
+      def select_patients from_facilities: []
+        raise "No facility selected for export" if from_facilities.empty?
+
+        Patient.where(assigned_facility_id: from_facilities)
+      end
+
+      def export_patient_details patient
+        return unless @config.time_window.cover?(patient.recorded_at)
+
+        patient_exporter = OneOff::Opensrp::PatientExporter.new(patient, facilities_to_export)
+        @resources << patient_exporter.export
+        @tally[:patients] += 1
+
+        @resources << patient_exporter.export_registration_questionnaire_response
+        @tally[:questionnaire_response] += 1
+
+        @encounters << patient_exporter.export_registration_encounter
+      end
+
+      def export_blood_pressure_details patient
+        blood_pressures = if @config.time_bound?
+          patient.blood_pressures
+        else
+          blood_pressures.where(recorded_at: @config.time_window).or(blood_pressures.where(updated_at: @config.time_window))
+        end
+        @logger.debug "Patient[##{patient.id}] has #{blood_pressures.size} blood pressure readings."
+        @tally[:observation] += blood_pressures.size
+        blood_pressures.each do |bp|
+          # This is technically an FHIR::Observation, with code set to a blood pressure code
+          bp_exporter = OneOff::Opensrp::BloodPressureExporter.new(bp, @config.facilities)
+          @resources << bp_exporter.export
+          @encounters << bp_exporter.export_encounter
+        end
+      end
+
+      def export_blood_sugar_details patient
+        blood_sugars = if @config.time_bound?
+          patient
+            .blood_sugars
+            .where(recorded_at: @config.time_window)
+            .or(blood_sugars.where(updated_at: @config.time_window))
+        else
+          patient.blood_sugars
+        end
+        @logger.debug "Patient[##{patient.id}] has #{blood_sugars.size} blood sugar readings."
+        @tally[:observation] += blood_sugars.size
+        blood_sugars.each do |bs|
+          # This is technically an FHIR::Observation, with code set to a blood sugar code
+          bs_exporter = OneOff::Opensrp::BloodSugarExporter.new(bs, @config.facilities)
+          if patient.medical_history.diabetes_no?
+            @resources << bs_exporter.export_no_diabetes_observation
+          end
+          @resources << bs_exporter.export
+          @encounters << bs_exporter.export_encounter
+        end
+      end
+
+      def export_prescription_drugs_details patient
+        prescription_drugs = if @config.time_bound?
+          patient
+            .prescription_drugs
+            .where(created_at: @config.time_window)
+            .or(prescription_drugs.where(updated_at: @config.time_window))
+        else
+          patient
+            .prescription_drugs
+        end
+        @logger.debug "Patient[##{patient.id}] has #{prescription_drugs.size} drugs prescribed."
+        @tally[:flags] += prescription_drugs.size
+        prescription_drugs.each do |drug|
+          drug_exporter = OneOff::Opensrp::PrescriptionDrugExporter.new(drug, @config.facilities)
+          @resources << drug_exporter.export_dosage_flag
+          @encounters << drug_exporter.export_encounter
+        end
+      end
+
+      def export_appointments_details patient
+        appointments = if @config.time_bound?
+          patients
+            .appointments
+            .where(created_at: @config.time_window)
+            .or(appointments.where(updated_at: @config.time_window))
+        else
+          patient.appointments
+        end
+        @logger.debug "Patient[##{patient.id}] has #{appointments.size} appointments."
+        @tally[:appointments] += appointments.size
+        @tally[:tasks] += appointments.includes(:call_results).where.not(call_results: {id: nil}).size
+        @tally[:flags] += appointments.includes(:call_results).where.not(call_results: {id: nil}).size
+        appointments.each do |appointment|
+          appointment_exporter = OneOff::Opensrp::AppointmentExporter.new(appointment, @config.facilities)
+          resources << appointment_exporter.export
+          if appointment.call_results.present?
+            @resources << appointment_exporter.export_call_outcome_task
+            @resources << appointment_exporter.export_call_outcome_flag
+          end
+          @encounters << appointment_exporter.export_encounter
+        end
+      end
+
+      def export_medical_history_details patient
+        OneOff::Opensrp::MedicalHistoryExporter.new(patient.medical_history, @config.facilities).then do |medical_history_exporter|
+          @resources << medical_history_exporter.export
+          @encounters << medical_history_exporter.export_encounter
+        end
+        @tally[:conditions] += 1
+      end
+
+      def write_audit_trail patients
+        CSV.open("audit_trail.csv", "w") do |csv|
+          csv << create_audit_record(facilities_to_export, patients.first).keys
+          patients.each do |patient|
+            csv << create_audit_record(facilities_to_export, patient).values
+          end
+        end
+      end
+
+      private
+
+      def read config_file
+        YAML.load_file(config_file).deep_symbolize_keys.with_indifferent_access
       end
     end
   end

--- a/spec/services/one_off/opensrp/exporter_spec.rb
+++ b/spec/services/one_off/opensrp/exporter_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+describe OneOff::Opensrp::Exporter do
+  context "configuration" do
+    let(:config_path) { Rails.root.join("tmp", "mock_opensrp_config.yml") }
+    let(:the_config) { described_class::Config.new config_path }
+
+    before do
+      config_content = <<-YAML
+      time_boundaries:
+        report_start: 2001-01-01
+        report_end: 2002-02-02
+      facilities:
+        d1dbd3c6-26bb-48e7-aa89-bc8a0b2bf75b:
+          name: Health Facility 1
+          practitioner_id: 0c375fe8-b38f-484e-aa64-c02750ee183b
+          organization_id: d3363aea-66ad-4370-809a-8e4436a4218f
+          care_team_id: 1c8100b5-222b-4815-ba4d-3ebde537c6ce
+          location_id: ABC01230123
+      YAML
+      File.write config_path, config_content
+    end
+
+    after do
+      File.delete(config_path) if File.exist?(config_path)
+    end
+
+    it "parses :report_start" do
+      expect(the_config.report_start).to eq(Date.parse("2001-01-01"))
+    end
+
+    it "parses :report_end" do
+      expect(the_config.report_end).to eq(Date.parse("2002-02-02"))
+    end
+
+    it "parses :facilities to export" do
+      facility_keys = %i[
+        care_team_id
+        location_id
+        name
+        organization_id
+        practitioner_id
+      ]
+      expect(the_config.facilities.size).to eq 1
+      # This weird quirk is because Hash#first returns an array [key, value]
+      facility_spec = the_config.facilities.first.last
+      expect(facility_spec[:name]).to eq "Health Facility 1"
+      expect(facility_spec.keys.map(&:to_sym)).to match_array(facility_keys)
+    end
+
+    it "parses :time_window" do
+      expect(the_config.time_window).to eq(the_config.report_start..the_config.report_end)
+    end
+  end
+
+  describe "initialization" do
+    let(:valid_config) { "config.yml" }
+    let(:valid_output) { "output.json" }
+
+    it "raises an error for non-YAML config files" do
+      expect { described_class.new("config.txt", valid_output) }.to raise_error("Config file should be YAML")
+    end
+
+    it "raises an error for non-JSON output files" do
+      expect { described_class.new(valid_config, "output.txt") }.to raise_error("Output file should be JSON")
+    end
+
+    it "expects config to be YAML, and output to be JSON" do
+      allow(described_class::Config).to receive(:new)
+      nulloger = ActiveSupport::Logger.new("/dev/null")
+      expect { described_class.new(valid_config, valid_output, logger: nulloger) }.not_to raise_error
+    end
+  end
+
+  describe "#call!" do
+    # TODO: Setting this up is so involved!!!
+    let(:facility_id) { "e120e6c6-141a-4c86-9cab-4d3871ff5fe7" }
+    let(:config_path) { Rails.root.join("tmp", "test_config.yml") }
+    let(:output_path) { Rails.root.join("tmp", "test_output.json") }
+
+    let(:patient) { create(:patient) }
+  end
+end


### PR DESCRIPTION
**Story card:** [sc-16544](https://app.shortcut.com/simpledotorg/story/16544/opensrp-selective-exporting)

## Because

To reduce impact on data, we need to enable differential exports.

## This addresses

- Refactoring the `opensrp:export` task into a one-off service
- Testing that service
- Filtering selected patients for export [probably from config file]

## Test instructions

suite tests
