### PR TITLE
fix(Dr. Rai Reports): Respect 'non-contactable' switch

### DIFF
--- a/app/components/dashboard/dr_rai_report.rb
+++ b/app/components/dashboard/dr_rai_report.rb
@@ -3,15 +3,16 @@ class Dashboard::DrRaiReport < ApplicationComponent
   attr_reader :periods, :region
   attr_accessor :selected_period
 
-  def initialize(periods, region_slug, selected_quarter = nil, lite = false)
+  def initialize(periods, region_slug, options, lite = false)
     @lite = lite
     @periods = periods
     @region = Region.find_by(slug: region_slug)
-    @selected_period = if selected_quarter.nil?
+    @selected_period = if options[:selected_quarter].nil?
       Period.new(type: :quarter, value: current_period.value.to_s)
     else
-      Period.new(type: :quarter, value: selected_quarter)
+      Period.new(type: :quarter, value: options[:selected_quarter])
     end
+    @with_non_contactable = options[:with_non_contactable].present?
   end
 
   def indicators
@@ -40,11 +41,11 @@ class Dashboard::DrRaiReport < ApplicationComponent
   end
 
   def indicator_numerator(indicator, period = selected_period)
-    indicator.numerator(region, period)
+    indicator.numerator(region, period, with_non_contactable: @with_non_contactable)
   end
 
   def indicator_denominator(indicator, period = selected_period)
-    indicator.denominator(region, period)
+    indicator.denominator(region, period, with_non_contactable: @with_non_contactable)
   end
 
   def current_period

--- a/app/controllers/reports/progress_controller.rb
+++ b/app/controllers/reports/progress_controller.rb
@@ -5,6 +5,7 @@ class Reports::ProgressController < AdminController
   before_action :require_feature_flag
   before_action :set_period
   before_action :find_region
+  before_action :set_dr_rai_vars, only: [:show]
   around_action :set_reporting_time_zone
 
   def show
@@ -65,5 +66,12 @@ class Reports::ProgressController < AdminController
   def set_period
     period_params = report_params[:period].presence || Reports.default_period.attributes
     @period = Period.new(period_params)
+  end
+
+  def set_dr_rai_vars
+    @dr_rai_periods = Period.quarters_between(10.months.ago, 2.months.from_now)
+
+    option_keys = %i[ selected_quarter with_non_contactable ]
+    @dr_rai_options = params.select { |k, _| option_keys.include?(k) }
   end
 end

--- a/app/controllers/reports/regions_controller.rb
+++ b/app/controllers/reports/regions_controller.rb
@@ -4,7 +4,7 @@ class Reports::RegionsController < AdminController
   include RegionSearch
 
   before_action :set_period, except: [:index, :fastindex]
-  before_action :set_dr_rai_periods, only: [:show, :diabetes]
+  before_action :set_dr_rai_vars, only: [:show, :diabetes]
   before_action :set_page, only: [:show, :details, :diabetes]
   before_action :set_per_page, only: [:show, :details, :diabetes]
   before_action :find_region, except: [:index, :fastindex]
@@ -469,7 +469,10 @@ class Reports::RegionsController < AdminController
     ((numerator.to_f / denominator) * 100).round(2)
   end
 
-  def set_dr_rai_periods
+  def set_dr_rai_vars
     @dr_rai_periods = Period.quarters_between(10.months.ago, 2.months.from_now)
+
+    option_keys = %i[ selected_quarter with_non_contactable ]
+    @dr_rai_options = params.select { |k, _| option_keys.include?(k) }
   end
 end

--- a/app/models/dr_rai/contact_overdue_patients_indicator.rb
+++ b/app/models/dr_rai/contact_overdue_patients_indicator.rb
@@ -12,12 +12,16 @@ module DrRai
       "percent"
     end
 
-    def numerator_key
+    def numerator_key all: nil
+      return "patients_called" if all
+
       "contactable_patients_called"
     end
 
-    def denominator_key
-      "overdue_patients"
+    def denominator_key all: nil
+      return "overdue_patients" if all
+
+      "contactable_overdue_patients"
     end
 
     def unit

--- a/app/models/dr_rai/indicator.rb
+++ b/app/models/dr_rai/indicator.rb
@@ -51,27 +51,35 @@ class DrRai::Indicator < ApplicationRecord
     DrRai::Target::TYPES[target_type_frontend]
   end
 
-  def numerator(region, the_period = period)
+  def numerator(region, the_period = period, with_non_contactable: nil)
     0 unless is_supported?(region)
-    numerators(region)[the_period]
+    numerators(region, all: with_non_contactable)[the_period]
   end
 
-  def denominator(region, the_period = period)
+  def denominator(region, the_period = period, with_non_contactable: nil)
     0 unless is_supported?(region)
-    denominators(region)[the_period]
+    denominators(region, all: with_non_contactable)[the_period]
   end
 
-  def numerators(region)
+  def numerators(region, all: nil)
     [] unless is_supported?(region)
     datasource(region).map do |t, data|
-      [t, data[numerator_key]]
+      unless all.nil?
+        [t, data[numerator_key(all: all)]]
+      else
+        [t, data[numerator_key]]
+      end
     end.to_h
   end
 
-  def denominators(region)
+  def denominators(region, all: nil)
     [] unless is_supported?(region)
     datasource(region).map do |t, data|
-      [t, data[denominator_key]]
+      unless all.nil?
+        [t, data[denominator_key(all: all)]]
+      else
+        [t, data[denominator_key]]
+      end
     end.to_h
   end
 

--- a/app/models/dr_rai/statins_indicator.rb
+++ b/app/models/dr_rai/statins_indicator.rb
@@ -20,11 +20,11 @@ module DrRai
       "percent"
     end
 
-    def numerator_key
+    def numerator_key all: nil
       :patients_prescribed_statins
     end
 
-    def denominator_key
+    def denominator_key all: nil
       :eligible_patients
     end
 

--- a/app/models/dr_rai/titration_indicator.rb
+++ b/app/models/dr_rai/titration_indicator.rb
@@ -16,11 +16,11 @@ module DrRai
       "percent"
     end
 
-    def numerator_key
+    def numerator_key all: nil
       :titrated_count
     end
 
-    def denominator_key
+    def denominator_key all: nil
       :follow_up_count
     end
 

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -20,7 +20,7 @@
   <body>
     <div id="home-page">
       <% if Flipper.enabled?(:dr_rai_reports) && Flipper.enabled?(:dr_rai_progress) && @region.facility_region? %>
-        <% dr_rai_component = Dashboard::DrRaiReport.new(nil, @region.slug, params[:selected_quarter], true) %>
+        <% dr_rai_component = Dashboard::DrRaiReport.new(nil, @region.slug, @dr_rai_options, true) %>
         <% unless dr_rai_component.action_plans.empty? %>
         <div class="mb-8px p-16px bgc-white bs-card">
           <h1 class="m-0px mb-16px fw-bold fs-24px c-black">

--- a/app/views/reports/regions/diabetes.html.erb
+++ b/app/views/reports/regions/diabetes.html.erb
@@ -5,7 +5,7 @@
 <%= render "header" %>
 
 <% if Flipper.enabled?(:dr_rai_reports, current_admin) && @region.facility_region? %>
-  <%= render Dashboard::DrRaiReport.new(@dr_rai_periods, @region.slug, params[:selected_quarter]) %>
+  <%= render Dashboard::DrRaiReport.new(@dr_rai_periods, @region.slug, @dr_rai_options) %>
 <% end %>
 
 <h4 class="mt-5 mb-32px"></h4>

--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -96,7 +96,7 @@
 <%= render "header" %>
 
 <% if Flipper.enabled?(:dr_rai_reports, current_admin) && @region.facility_region? %>
-  <%= render Dashboard::DrRaiReport.new(@dr_rai_periods, @region.slug, params[:selected_quarter]) %>
+  <%= render Dashboard::DrRaiReport.new(@dr_rai_periods, @region.slug, @dr_rai_options) %>
 <% end %>
 
 <% control_graph_denominator_copy = @with_ltfu ? "denominator_with_ltfu_copy" : "denominator_copy" %>


### PR DESCRIPTION
**Story card:** [sc-XXXX](URL)

## Because

We're using the `overdue_patients` regardless of the dashboard only considering `contactable_overdue_patients`

## This addresses

Using the right numerator and denominator keys depending on if
non-contactable patients are included in the dashboard calculations.

## Test instructions

suite tests
