### PR TITLE
fix(Dr. Rai Reports): Fix flipper check in Progress

### DIFF
--- a/app/controllers/reports/progress_controller.rb
+++ b/app/controllers/reports/progress_controller.rb
@@ -72,6 +72,6 @@ class Reports::ProgressController < AdminController
     @dr_rai_periods = Period.quarters_between(10.months.ago, 2.months.from_now)
 
     option_keys = %i[selected_quarter with_non_contactable]
-    @dr_rai_options = params.select { |k, _| option_keys.include?(k) }
+    @dr_rai_options = params.slice(*option_keys)
   end
 end

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -19,7 +19,7 @@
   </head>
   <body>
     <div id="home-page">
-      <% if Flipper.enabled?(:dr_rai_reports) && Flipper.enabled?(:dr_rai_progress) && @region.facility_region? %>
+      <% if Flipper.enabled?(:dr_rai_reports, current_admin) && Flipper.enabled?(:dr_rai_progress) && @region.facility_region? %>
         <% dr_rai_component = Dashboard::DrRaiReport.new(nil, @region.slug, @dr_rai_options, true) %>
         <% unless dr_rai_component.action_plans.empty? %>
         <div class="mb-8px p-16px bgc-white bs-card">

--- a/app/views/api/v3/analytics/user_analytics/show.html.erb
+++ b/app/views/api/v3/analytics/user_analytics/show.html.erb
@@ -19,7 +19,7 @@
   </head>
   <body>
     <div id="home-page">
-      <% if Flipper.enabled?(:dr_rai_reports, current_admin) && Flipper.enabled?(:dr_rai_progress) && @region.facility_region? %>
+      <% if Flipper.enabled?(:dr_rai_reports, current_user) && Flipper.enabled?(:dr_rai_progress) && @region.facility_region? %>
         <% dr_rai_component = Dashboard::DrRaiReport.new(nil, @region.slug, @dr_rai_options, true) %>
         <% unless dr_rai_component.action_plans.empty? %>
         <div class="mb-8px p-16px bgc-white bs-card">


### PR DESCRIPTION
**Story card:** [sc-16344](https://app.shortcut.com/simpledotorg/story/16344/add-dr-rai-to-progress-tab)

## Because

In some environments, depending on how the feature is enabled, the component does not show up in the Progress tab

## This addresses

Ensuring we check Flipper the right way

## Test instructions

- selectively turn on the feature for a few users; yourself included
- ensure it shows up in the Progress tab
