### PR TITLE
fix(Dr. Rai Reports): Fix early return

### DIFF
--- a/app/models/dr_rai/indicator.rb
+++ b/app/models/dr_rai/indicator.rb
@@ -52,24 +52,24 @@ class DrRai::Indicator < ApplicationRecord
   end
 
   def numerator(region, the_period = period, with_non_contactable: nil)
-    0 unless is_supported?(region)
+    return 0 unless is_supported?(region)
     numerators(region, all: with_non_contactable)[the_period]
   end
 
   def denominator(region, the_period = period, with_non_contactable: nil)
-    0 unless is_supported?(region)
+    return 0 unless is_supported?(region)
     denominators(region, all: with_non_contactable)[the_period]
   end
 
   def numerators(region, all: nil)
-    [] unless is_supported?(region)
+    return [] unless is_supported?(region)
     datasource(region).map do |t, data|
       [t, data[numerator_key(all: all)]]
     end.to_h
   end
 
   def denominators(region, all: nil)
-    [] unless is_supported?(region)
+    return [] unless is_supported?(region)
     datasource(region).map do |t, data|
       [t, data[denominator_key(all: all)]]
     end.to_h


### PR DESCRIPTION
**Story card:** [sc-16738](https://app.shortcut.com/simpledotorg/story/16738/handle-null-case-for-indicator-datasource)

## Because

The early return was not properly written

```ruby
def something flag: false
  0 if flag

  calculate!
end
```

This :point-up: is the original form of the method; which is wrong. The intention is to return early.

## This addresses

Returning early where necessary

## Test instructions

suite tests
