### PR TITLE
fix(Dr. Rai Reports): Revert default indicator aggreation strategy

### DIFF
--- a/app/models/dr_rai/indicator.rb
+++ b/app/models/dr_rai/indicator.rb
@@ -22,7 +22,7 @@ class DrRai::Indicator < ApplicationRecord
 
   def quarterlies(region)
     data = Reports::RegionSummary.call(region, range: DEFAULT_RANGE)
-    Reports::RegionSummaryAggregator.new(data).quarterly(with: :rollup)[region.slug]
+    Reports::RegionSummaryAggregator.new(data).quarterly(with: :sum)[region.slug]
   end
 
   def period


### PR DESCRIPTION
**Story card:** [sc-16697](https://app.shortcut.com/simpledotorg/story/16697/fix-contactoverduepatientindicator-denominator)

## Because

The numbers just don't work with `:rollup`

## This addresses

Revert to `:sum` — see [this comment](https://app.shortcut.com/simpledotorg/story/16697/fix-contactoverduepatientindicator-denominator#activity-16745)

## Test instructions

suite tests
