### PR TITLE
Fix deleteing overlay bug on progress tab

### DIFF
--- a/app/assets/stylesheets/dr_rai.scss
+++ b/app/assets/stylesheets/dr_rai.scss
@@ -583,6 +583,7 @@ $font-condensed: "Roboto Condensed", sans-serif;
 }
 
 .deleting-overlay {
+  display: none; // flex element
   position: absolute;
   top: 0;
   left: 0;
@@ -592,7 +593,6 @@ $font-condensed: "Roboto Condensed", sans-serif;
   color: white;
   background: rgba(77, 78, 54, 0.65);
   border-radius: 4px;
-  display: flex;
   justify-content: center;
   align-items: center;
   opacity: 1;

--- a/app/components/dashboard/dr_rai_report.html.erb
+++ b/app/components/dashboard/dr_rai_report.html.erb
@@ -46,7 +46,7 @@
               </div>
             </div>
           </div>
-          <div class="deleting-overlay d-none">
+          <div class="deleting-overlay">
               <i class=" fa-solid fa-spinner-third fa-spin fa-fast-spin"></i>
               <p >Removing action, this page will refresh shortly...</p>
           </div>
@@ -420,7 +420,7 @@
 
     // show action delete overlay, takes several seconds to process
     $('.dropdown-item.delete').on("click", function(e) {
-      $(this).closest('.action-card').find('.deleting-overlay').removeClass('d-none'); // show overlay only for this card
+      $(this).closest('.action-card').find('.deleting-overlay').addClass('d-flex'); // show overlay only for this card, needs flex
     });
 
     // show loading on action plan period navigation


### PR DESCRIPTION
**Story card:** [sc-16754](https://app.shortcut.com/simpledotorg/story/16754/delete-overlay-persists-in-the-progress-tab)

## Because

On the progress tab, the 'deleting action' overlay is showing by default.
This overlay should never be shown on the progress tab, it's a dashboard action.

<img width="616" height="548" alt="Screenshot 2025-09-25 at 12 25 26" src="https://github.com/user-attachments/assets/7a1908ba-4556-4391-9565-070cf40022ab" />

## This addresses

- Base state 'display: none;'
- On delete action, add `d-flex` (display: flex;) to show element.

## Test instructions

- Branch `dr-rai-deleting-overlay-progress-tab-fix`
- Add any action to the current quarter action plan.
- Navigate to the progress tab
- The deleteing overlay should not be visible.