### PR TITLE
sc-16799 fix: drug stock table hover to not persist on click

### DIFF
--- a/app/views/my_facilities/drug_stocks/_all_district_drug_consumption_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_all_district_drug_consumption_table.html.erb
@@ -62,7 +62,7 @@
             data-html="true"
             data-toggle="tooltip"
             data-placement="top"
-            data-trigger="hover focus click"
+            data-trigger="hover focus"
             data-original-title='<%= "All States: #{all_totals.values.sum} units, #{all_patient_count} patients" %>'>
           All
         </td>
@@ -97,7 +97,7 @@
                 data-html="true"
                 data-toggle="tooltip"
                 data-placement="top"
-                data-trigger="hover focus click"
+                data-trigger="hover focus"
                 data-original-title='<%= "#{state}: #{state_data[:totals].values.sum} units, #{state_data[:patient_count]} patients" %>'>
               <%= state %><br><span> subtotal </span>
             </td>
@@ -130,7 +130,7 @@
                   data-html="true"
                   data-toggle="tooltip"
                   data-placement="top"
-                  data-trigger="hover focus click"
+                  data-trigger="hover focus"
                   data-original-title='<%= "#{district.name}: #{report[:district_patient_count]} patients" %>'>
                 <a href="<%= my_facilities_drug_consumption_path(facility_group: district.slug, for_end_of_month: @for_end_of_month_display) %>">
                   <%= district.name %>
@@ -151,7 +151,7 @@
                         data-html="true"
                         data-toggle="tooltip"
                         data-placement="top"
-                        data-trigger="hover focus click"
+                        data-trigger="hover focus"
                         data-original-title="<%= render 'drug_consumption_tooltip', report: report[:total_drug_consumption][drug_category][drug] %>"
                         data-sort-value="<%= consumed %>"
                         data-sort-column-key="<%= drug&.id %>">

--- a/app/views/my_facilities/drug_stocks/_all_district_drug_stock_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_all_district_drug_stock_table.html.erb
@@ -56,7 +56,7 @@
               data-html="true"
               data-toggle="tooltip"
               data-placement="top"
-              data-trigger="hover focus click"
+              data-trigger="hover focus"
               data-original-title='<%= "All States: #{all_totals.values.sum} drugs, #{all_patient_count} patients" %>'>
             All
           </td>
@@ -92,7 +92,7 @@
           <tr class="row-total font-weight-bold warning" data-sort-method="none">
             <td class="type-title"
                 data-toggle="tooltip"
-                data-trigger="hover focus click"
+                data-trigger="hover focus"
                 data-original-title='<%= "#{state}: #{state_totals.values.sum} drugs, #{state_patient_count} patients" %>'>
               <%= state %><br><span> subtotal </span>
             </td>
@@ -122,7 +122,7 @@
                   data-html="true"
                   data-toggle="tooltip"
                   data-placement="top"
-                  data-trigger="hover focus click"
+                  data-trigger="hover focus"
                   data-original-title='<%= "#{district.name}: #{patient_count_for(report)} patients" %>'>
                 <a href="<%= my_facilities_drug_stocks_path(facility_group: district.slug, for_end_of_month: @for_end_of_month_display) %>" >
                   <%= district.name %>
@@ -149,7 +149,7 @@
                         data-html="true"
                         data-toggle="tooltip"
                         data-placement="top"
-                        data-trigger="hover focus click"
+                        data-trigger="hover focus"
                         data-template="<%= render 'wide_tooltip_template' %>"
                         data-original-title="<%= render 'drug_stocks_tooltip', report: report.dig(:total_patient_days, drug_category) %>"
                         data-sort-value="<%= patient_days %>">

--- a/app/views/my_facilities/drug_stocks/_drug_consumption_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_consumption_table.html.erb
@@ -62,7 +62,7 @@
 
     <tbody>
       <tr class="row-total" data-sort-method="none">
-        <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+        <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
             title="" data-original-title="All facilities: <%= "#{@report[:total_patient_count]} patients" %>">
           All
         </td>
@@ -78,7 +78,7 @@
               <td class="type-blank"><span>&#8212;</span></td>
             <% else %>
               <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top"
-                  data-trigger="hover focus click" data-original-title="<%= render 'drug_consumption_tooltip', report: @report.dig(:total_drug_consumption, drug_category, drug) %>"
+                  data-trigger="hover focus" data-original-title="<%= render 'drug_consumption_tooltip', report: @report.dig(:total_drug_consumption, drug_category, drug) %>"
                   data-sort-column-key=<%= drug.id %>>
                 <%= consumed %>
               </td>
@@ -91,7 +91,7 @@
             <td class="type-blank"><span>?</span></td>
           <% else %>
             <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top"
-                data-trigger="hover focus click"
+                data-trigger="hover focus"
                 data-template="<%= render 'wide_tooltip_template' %>"
                 data-original-title="<%= render 'base_doses_tooltip', report: @report.dig(:total_drug_consumption, drug_category, :base_doses) %>"
                 data-sort-column-key=<%= "#{drug_category}_base_doses" %>>
@@ -104,7 +104,7 @@
 
       <tr data-sort-method="none">
         <% report = @report[:district_drug_consumption] %>
-        <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+        <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
             data-original-title='District: <%= "#{@report[:district_patient_count]} patients" %>'>
           <%= link_to(reports_region_path(@district_region, report_scope: "district"), class: "allow-wrap") do %>
             <%= drug_stock_region_label(@district_region).titleize %>
@@ -119,7 +119,7 @@
             <% if consumed.nil? || consumed == "error" %>
               <td class="type-blank"><span>?</span></td>
             <% else %>
-              <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+              <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
                   data-template="<%= render 'wide_tooltip_template' %>"
                   data-original-title="<%= render 'drug_consumption_tooltip', report: report.dig(drug_category, drug) %>"
                   data-sort-column-key=<%= drug.id %>>
@@ -133,7 +133,7 @@
           <% if total.nil? || total == "error" %>
             <td class="type-blank"><span>?</span></td>
           <% else %>
-            <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+            <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
                 data-template="<%= render 'wide_tooltip_template' %>"
                 data-original-title="<%= render 'base_doses_tooltip', report: report.dig(drug_category, :base_doses) %>"
                 data-sort-column-key=<%= "#{drug_category}_base_doses" %>>
@@ -147,7 +147,7 @@
       <% @blocks.each do |block| %>
         <tr data-sort-method="none">
           <% block_report = @report[:drug_consumption_by_block_id][block.id] %>
-          <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+          <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
               data-original-title='<%= "#{block.name}: #{@report[:patient_count_by_block_id][block.id]} patients" %>'>
             <%= link_to(reports_region_path(block, report_scope: "block"), class: "allow-wrap") do %>
               <%= block.name %>
@@ -162,7 +162,7 @@
               <% if consumed.nil? || consumed == "error" %>
                 <td class="type-blank"><span>?</span></td>
               <% else %>
-                <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+                <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
                     data-template="<%= render 'wide_tooltip_template' %>"
                     data-original-title="<%= render 'drug_consumption_tooltip', report: block_report[drug_category][drug] %>"
                     data-sort-column-key=<%= drug.id %>>
@@ -176,7 +176,7 @@
             <% if total.nil? || total == "error" %>
               <td class="type-blank"><span>?</span></td>
             <% else %>
-              <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+              <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
                   data-template="<%= render 'wide_tooltip_template' %>"
                   data-original-title="<%= render 'base_doses_tooltip', report: block_report[drug_category][:base_doses] %>"
                   data-sort-column-key=<%= "#{drug_category}_base_doses" %>>
@@ -189,7 +189,7 @@
       <% end %>
 
       <tr class="row-total" data-sort-method="none">
-        <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+        <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
             title="" data-original-title="All facilities: <%= "#{@report[:patient_count]} patients" %>">
           Facilities subtotal
         </td>
@@ -204,7 +204,7 @@
             <% elsif consumed.nil? %>
               <td class="type-blank"><span>&#8212;</span></td>
             <% else %>
-              <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+              <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
                   data-original-title="<%= render 'drug_consumption_tooltip', report: @report.dig(:facilities_total_drug_consumption, drug_category, drug) %>"
                   data-sort-column-key=<%= drug.id %>>
                 <%= consumed %>
@@ -217,7 +217,7 @@
           <% if total.nil? || total == "error" %>
             <td class="type-blank"><span>?</span></td>
           <% else %>
-            <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+            <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
                 data-template="<%= render 'wide_tooltip_template' %>"
                 data-original-title="<%= render 'base_doses_tooltip', report: @report.dig(:all_drug_consumption, drug_category, :base_doses) %>"
                 data-sort-column-key=<%= "#{drug_category}_base_doses" %>>
@@ -231,7 +231,7 @@
       <% @facilities.each do |facility| %>
         <tr>
           <% facility_report = @report[:drug_consumption_by_facility_id][facility.id] %>
-          <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+          <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
               title="" data-original-title='<%= "#{facility.name}: #{@report[:patient_count_by_facility_id][facility.id]} patients" %>'>
             <%= link_to(reports_region_path(facility, report_scope: "facility"), class: "allow-wrap") do %>
               <%= facility.name %>
@@ -246,7 +246,7 @@
               <% if consumed.nil? || consumed == "error" %>
                 <td class="type-blank"><span>?</span></td>
               <% else %>
-                <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+                <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
                     data-template="<%= render 'wide_tooltip_template' %>"
                     data-original-title="<%= render 'drug_consumption_tooltip', report: facility_report[drug_category][drug] %>"
                     data-sort-column-key=<%= drug.id %>>
@@ -260,7 +260,7 @@
             <% if total.nil? || total == "error" %>
               <td class="type-blank"><span>?</span></td>
             <% else %>
-              <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+              <td class="type-number text-center" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
                   data-template="<%= render 'wide_tooltip_template' %>"
                   data-original-title="<%= render 'base_doses_tooltip', report: facility_report[drug_category][:base_doses] %>"
                   data-sort-column-key=<%= "#{drug_category}_base_doses" %>>

--- a/app/views/my_facilities/drug_stocks/_drug_stocks_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_drug_stocks_table.html.erb
@@ -57,7 +57,7 @@
 
     <tbody>
       <tr class="row-total" data-sort-method="none">
-        <td class="type-title" colspan="2" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click" data-original-title="All facilities: <%= "#{@report&.dig(:total_patient_count)} patients" %>">
+        <td class="type-title" colspan="2" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus" data-original-title="All facilities: <%= "#{@report&.dig(:total_patient_count)} patients" %>">
           All
         </td>
         <% if can_view_all_districts_nav? %>
@@ -79,7 +79,7 @@
           <% end %>
           <% unless drug_category == "diabetes" %>
             <% if patient_days&.present? %>
-              <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+              <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
                 data-template="<%= render "wide_tooltip_template" %>"
                 data-original-title="<%= render "drug_stocks_tooltip", report: @report&.dig(:total_patient_days, drug_category) %>"
                 data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
@@ -95,7 +95,7 @@
       </tr>
 
       <tr data-sort-method="none">
-        <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+        <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
           data-original-title='District: <%= "#{@report&.dig(:district_patient_count)} patients" %>'>
           <% if @district_region&.id.present? %>
             <%= link_to(reports_region_path(@district_region, report_scope: "district"), class: "allow-wrap") do %>
@@ -133,7 +133,7 @@
           <% end %>
           <% unless drug_category == "diabetes" %>
             <% if patient_days&.present? %>
-              <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+              <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
                 data-template="<%= render "wide_tooltip_template" %>"
                 data-original-title="<%= render "drug_stocks_tooltip", report: district_patient_days_report&.dig(drug_category) %>"
                 data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
@@ -151,7 +151,7 @@
       <% @blocks&.each do |block| %>
         <tr data-sort-method="none">
           <% block_patient_days_report = @report&.dig(:patient_days_by_block_id, block&.id) %>
-          <td class="type-title" colspan="2" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+          <td class="type-title" colspan="2" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
             data-original-title='<%= "#{block&.name}: #{@report&.dig(:patient_count_by_block_id, block&.id)} patients" %>'>
             <%= link_to(reports_region_path(block, report_scope: "block"), class: "allow-wrap") do %>
               <%= block&.name %>
@@ -176,7 +176,7 @@
             <% end %>
             <% unless drug_category == "diabetes" %>
               <% if patient_days&.present? %>
-                <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+                <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
                   data-template="<%= render "wide_tooltip_template" %>"
                   data-original-title="<%= render "drug_stocks_tooltip", report: block_patient_days_report&.dig(drug_category) %>"
                   data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
@@ -193,7 +193,7 @@
       <% end %>
 
       <tr class="row-total" data-sort-method="none">
-        <td class="type-title" colspan="2" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click" data-original-title="All facilities: <%= "#{@report&.dig(:facilities_total_patient_count)} patients" %>">
+        <td class="type-title" colspan="2" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus" data-original-title="All facilities: <%= "#{@report&.dig(:facilities_total_patient_count)} patients" %>">
           Facilities subtotal
         </td>
         <% if can_view_all_districts_nav? %>
@@ -215,7 +215,7 @@
           <% end %>
           <% unless drug_category == "diabetes" %>
             <% if patient_days&.present? %>
-              <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+              <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
                 data-template="<%= render "wide_tooltip_template" %>"
                 data-original-title="<%= render "drug_stocks_tooltip", report: @report&.dig(:facilities_total_patient_days, drug_category) %>"
                 data-sort-column-key=<%= "#{drug_category}_patient_days" %>>
@@ -233,7 +233,7 @@
       <% @facilities&.each do |facility| %>
         <tr>
           <% facility_patient_days_report = @report&.dig(:patient_days_by_facility_id, facility&.id) %>
-          <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+          <td class="type-title" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
             data-original-title='<%= "#{facility&.name}: #{@report&.dig(:patient_count_by_facility_id, facility&.id)} patients" %>'>
             <%= link_to(reports_region_path(facility, report_scope: "facility"), class: "allow-wrap") do %>
               <%= facility&.name %>
@@ -270,7 +270,7 @@
             <% end %>
             <% unless drug_category == "diabetes" %>
               <% if patient_days&.present? %>
-                <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus click"
+                <td class="type-percent" data-html="true" data-toggle="tooltip" data-placement="top" data-trigger="hover focus"
                   data-template="<%= render "wide_tooltip_template" %>"
                   data-original-title="<%= render "drug_stocks_tooltip", report: facility_patient_days_report&.dig(drug_category) %>"
                   data-sort-column-key=<%= "#{drug_category}_patient_days" %>>


### PR DESCRIPTION
**Story card:** [sc-16799](https://app.shortcut.com/simpledotorg/story/16799/fix-hover-behaviour-in-drug-stock-table)

## Because

The Drug Stock table currently has a hover issue.
When a user clicks on any value, the hover state gets "paused" and remains visible, which can be confusing.  
This update ensures the hover behavior is intuitive and only shows while hovering.

![Screenshot from 2025-10-07 19-49-23](https://github.com/user-attachments/assets/9fe2e8a8-c919-4e5a-b4f6-d8f43c55c10e)

![Screenshot from 2025-10-07 19-48-13](https://github.com/user-attachments/assets/e605db10-0dc9-48a6-b614-43f3dc4060c0)


## This addresses

Clicking on table values should not lock the hover state.  
Now, table cells will only display the hover styling while the mouse is over them.

Key changes:
- Fixed hover behavior for all values in the Drug Stock table
- Clicking a value no longer locks the hover state
- Hover effects remain visible only while the mouse is over a cell

## Test instructions

- Navigate to the Drug Stock Section
- Hover over any value and verify the hover effect disappears when the mouse moves away
- Click on a value and verify the hover effect does not remain.
