### PR TITLE
sc-16765 Fix aggregate_state_totals patient_days calculation

### DIFF
--- a/app/views/my_facilities/drug_stocks/_all_district_drug_stock_table.html.erb
+++ b/app/views/my_facilities/drug_stocks/_all_district_drug_stock_table.html.erb
@@ -83,7 +83,7 @@
       </thead>
 
       <% grouped.each do |state, districts| %>
-        <% state_data = aggregate_state_totals(districts, first_drugs_by_category) %>
+        <% state_data = aggregate_state_totals(districts, first_drugs_by_category, state) %>
         <% state_totals = state_data[:totals] %>
         <% state_patient_days = state_data[:patient_days] %>
         <% state_patient_count = state_data[:patient_count] %>
@@ -105,9 +105,19 @@
               <% end %>
               <% unless drug_category == "diabetes" %>
                 <% if state_patient_days[drug_category].present? %>
-                  <td class="type-percent">
-                    <em class="<%= patient_days_css_class(state_patient_days[drug_category]) %>"><%= state_patient_days[drug_category] %></em>
-                  </td>
+                <td class="type-percent"
+                  data-html="true"
+                  data-toggle="tooltip"
+                  data-placement="top"
+                  data-trigger="hover focus"
+                  data-template="<%= render 'wide_tooltip_template' %>"
+                  data-original-title="<%= render 'drug_stocks_tooltip', report: state_data[:patient_days_report][drug_category] %>"
+                  data-sort-value="<%= state_patient_days[drug_category] %>">
+                <em class="<%= patient_days_css_class(state_patient_days[drug_category]) %>">
+                  <%= state_patient_days[drug_category] %>
+                </em>
+              </td>
+
                 <% else %>
                   <td class="type-blank"><span>&#8212;</span></td>
                 <% end %>

--- a/spec/helpers/drug_stock_helper_spec.rb
+++ b/spec/helpers/drug_stock_helper_spec.rb
@@ -65,19 +65,28 @@ RSpec.describe DrugStockHelper, type: :helper do
           report: {
             total_drugs_in_stock: {"979467" => 10, "316764" => 0, "329528" => 5},
             total_patient_days: {"hypertension_arb" => {patient_days: 3}, "hypertension_ccb" => {patient_days: 1}},
-            district_patient_count: 7
+            district_patient_count: 7,
+            patient_days_report: {
+              "hypertension_arb" => {patient_days: 1},
+              "hypertension_ccb" => {patient_days: 0}
+            }
           }
         }
       }
     end
 
-    it "aggregates totals, patient_days, and patient_count correctly" do
+    it "aggregates totals, patient_days, patient_count, and patient_days_report correctly" do
       result = helper.aggregate_state_totals(districts, drugs_by_category)
-      expect(result).to eq(
-        totals: {"979467" => 10, "316764" => 0, "329528" => 5},
-        patient_days: {"hypertension_arb" => 3, "hypertension_ccb" => 1},
-        patient_count: 7
-      )
+
+      expect(result[:totals]).to eq({"979467" => 10, "316764" => 0, "329528" => 5})
+      expect(result[:patient_count]).to eq(7)
+      expect(result[:patient_days]).to eq({"hypertension_arb" => 1, "hypertension_ccb" => 0})
+
+      report_arb = result[:patient_days_report]["hypertension_arb"]
+      report_ccb = result[:patient_days_report]["hypertension_ccb"]
+
+      expect(report_arb[:patient_days]).to eq(1)
+      expect(report_ccb[:patient_days]).to eq(0)
     end
   end
 


### PR DESCRIPTION
**Story card:** [sc-16765](https://app.shortcut.com/simpledotorg/story/16765/fix-drug-stock-calculation-in-bd)

## Because

The Drug Stock table in the Bangladesh dashboard is showing incorrect patient days.  
Currently, we are summing patient days across all facilities and districts within a division, which misrepresents the actual values.  
Patient days should instead be calculated using the existing patient day formula.

## This addresses

Patient days now reflect the proper calculation instead of a simple sum of facilities and districts.  
At the division and subtotal levels, the value is computed based on:

- The subtotal of drugs  
- The total number of patients  
- The patient day calculation formula

Key changes:
- Fixed patient day calculation in the Drug Stock table
- Removed incorrect summing of facilities and district patient days
- Ensures values at division and subtotal levels match the intended formula

## Test instructions

- Navigate to the Drug Stock section.  
- Hover over the patient days value to view the calculation formula being applied.
