### PR TITLE
fix(dm-dashboard): statins and BP controlled queries in v14 view

### DIFF
--- a/db/migrate/20260422120000_update_reporting_facility_states_to_version14.rb
+++ b/db/migrate/20260422120000_update_reporting_facility_states_to_version14.rb
@@ -1,0 +1,27 @@
+class UpdateReportingFacilityStatesToVersion14 < ActiveRecord::Migration[6.1]
+  def up
+    drop_view :reporting_facility_states, materialized: true
+
+    execute <<-SQL
+      CREATE MATERIALIZED VIEW public.reporting_facility_states AS
+      #{File.read(Rails.root.join("db/views/reporting_facility_states_v14.sql"))}
+      WITH NO DATA;
+    SQL
+
+    add_index :reporting_facility_states, [:month_date, :facility_region_id], name: :index_fs_month_date_region_id, unique: true
+    add_index :reporting_facility_states, [:block_region_id, :month_date], name: :index_fs_block_month_date
+    add_index :reporting_facility_states, [:district_region_id, :month_date], name: :index_fs_district_month_date
+    add_index :reporting_facility_states, [:state_region_id, :month_date], name: :index_fs_state_month_date
+    add_index :reporting_facility_states, [:organization_region_id, :month_date], name: :index_fs_organization_month_date
+  end
+
+  def down
+    drop_view :reporting_facility_states, materialized: true
+    create_view :reporting_facility_states, materialized: true, version: 13
+    add_index :reporting_facility_states, [:month_date, :facility_region_id], name: :index_fs_month_date_region_id, unique: true
+    add_index :reporting_facility_states, [:block_region_id, :month_date], name: :index_fs_block_month_date
+    add_index :reporting_facility_states, [:district_region_id, :month_date], name: :index_fs_district_month_date
+    add_index :reporting_facility_states, [:state_region_id, :month_date], name: :index_fs_state_month_date
+    add_index :reporting_facility_states, [:organization_region_id, :month_date], name: :index_fs_organization_month_date
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5614,8 +5614,8 @@ CREATE MATERIALIZED VIEW public.reporting_facility_states AS
             count(DISTINCT reporting_patient_states.patient_id) FILTER (WHERE ((reporting_patient_states.htn_care_state = 'lost_to_follow_up'::text) AND (reporting_patient_states.diabetes_treatment_outcome_in_last_3_months = 'missed_visit'::text))) AS bs_missed_visit_lost_to_follow_up,
             count(DISTINCT reporting_patient_states.patient_id) FILTER (WHERE (reporting_patient_states.htn_care_state = 'under_care'::text)) AS diabetes_patients_under_care,
             count(DISTINCT reporting_patient_states.patient_id) FILTER (WHERE (reporting_patient_states.htn_care_state = 'lost_to_follow_up'::text)) AS diabetes_patients_lost_to_follow_up,
-            count(DISTINCT reporting_patient_states.patient_id) FILTER (WHERE ((reporting_patient_states.htn_care_state = 'under_care'::text) AND (reporting_patient_states.months_since_visit < (3)::double precision) AND (reporting_patient_states.systolic < (140)::double precision) AND (reporting_patient_states.diastolic < (90)::double precision) AND (reporting_patient_states.systolic IS NOT NULL) AND (reporting_patient_states.diastolic IS NOT NULL))) AS dm_bp_below_140_90_under_care,
-            count(DISTINCT reporting_patient_states.patient_id) FILTER (WHERE ((reporting_patient_states.htn_care_state = 'under_care'::text) AND (reporting_patient_states.months_since_visit < (3)::double precision) AND (reporting_patient_states.systolic < (130)::double precision) AND (reporting_patient_states.diastolic < (80)::double precision) AND (reporting_patient_states.systolic IS NOT NULL) AND (reporting_patient_states.diastolic IS NOT NULL))) AS dm_bp_below_130_80_under_care
+            count(DISTINCT reporting_patient_states.patient_id) FILTER (WHERE ((reporting_patient_states.htn_care_state = 'under_care'::text) AND (reporting_patient_states.htn_treatment_outcome_in_last_3_months = 'controlled'::text))) AS dm_bp_below_140_90_under_care,
+            count(DISTINCT reporting_patient_states.patient_id) FILTER (WHERE ((reporting_patient_states.htn_care_state = 'under_care'::text) AND (reporting_patient_states.htn_treatment_outcome_in_last_3_months = 'controlled'::text) AND (reporting_patient_states.systolic < (130)::double precision) AND (reporting_patient_states.diastolic < (80)::double precision))) AS dm_bp_below_130_80_under_care
            FROM public.reporting_patient_states
           WHERE ((reporting_patient_states.diabetes = 'yes'::text) AND (reporting_patient_states.months_since_registration >= (3)::double precision))
           GROUP BY reporting_patient_states.assigned_facility_region_id, reporting_patient_states.month_date
@@ -5644,7 +5644,7 @@ CREATE MATERIALIZED VIEW public.reporting_facility_states AS
                         ELSE (date_part('year'::text, age(reporting_patient_states.month_date, ((reporting_patient_states.age_updated_at AT TIME ZONE 'UTC'::text) AT TIME ZONE (SELECT current_setting('TIMEZONE'::text)))::date)) + reporting_patient_states.age)
                     END AS age_on_month_date
                    FROM public.reporting_patient_states
-                  WHERE ((reporting_patient_states.diabetes = 'yes'::text) AND (reporting_patient_states.months_since_registration >= (3)::double precision))
+                  WHERE (reporting_patient_states.diabetes = 'yes'::text)
                 )
          SELECT age_rps.assigned_facility_region_id AS region_id,
             age_rps.month_date,
@@ -6347,21 +6347,21 @@ COMMENT ON COLUMN public.reporting_facility_states.adjusted_dm_bp_below_130_80_u
 -- Name: COLUMN reporting_facility_states.adjusted_dm_patients_40_and_above_under_care; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.reporting_facility_states.adjusted_dm_patients_40_and_above_under_care IS 'The number of diabetic patients assigned to the facility that are age 40 or above, under care, and were registered before the last 3 months. Dead and lost to follow-up patients are excluded.';
+COMMENT ON COLUMN public.reporting_facility_states.adjusted_dm_patients_40_and_above_under_care IS 'The number of diabetic patients assigned to the facility that are age 40 or above and under care. Dead and lost to follow-up patients are excluded.';
 
 
 --
 -- Name: COLUMN reporting_facility_states.adjusted_dm_patients_40_and_above_with_statins; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.reporting_facility_states.adjusted_dm_patients_40_and_above_with_statins IS 'The number of diabetic patients assigned to the facility that are age 40 or above, under care, have at least one valid statin prescription in the same month, and were registered before the last 3 months. Dead and lost to follow-up patients are excluded.';
+COMMENT ON COLUMN public.reporting_facility_states.adjusted_dm_patients_40_and_above_with_statins IS 'The number of diabetic patients assigned to the facility that are age 40 or above, under care, and have at least one valid statin prescription in the same month. Dead and lost to follow-up patients are excluded.';
 
 
 --
 -- Name: COLUMN reporting_facility_states.adjusted_dm_patients_40_and_above_with_ltfu; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.reporting_facility_states.adjusted_dm_patients_40_and_above_with_ltfu IS 'The number of diabetic patients assigned to the facility that are age 40 or above, not dead, and were registered before the last 3 months. Includes both under care and lost to follow-up patients.';
+COMMENT ON COLUMN public.reporting_facility_states.adjusted_dm_patients_40_and_above_with_ltfu IS 'The number of diabetic patients assigned to the facility that are age 40 or above and not dead. Includes both under care and lost to follow-up patients.';
 
 
 --
@@ -9764,6 +9764,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260212195326'),
 ('20260224063659'),
 ('20260316093605'),
-('20260407162829');
+('20260407162829'),
+('20260422120000');
 
 

--- a/db/views/reporting_facility_states_v14.sql
+++ b/db/views/reporting_facility_states_v14.sql
@@ -1,0 +1,404 @@
+WITH
+    registered_patients AS (
+        SELECT registration_facility_region_id AS region_id, month_date,
+               COUNT(*) AS cumulative_registrations,
+               COUNT(*) FILTER (WHERE months_since_registration = 0) AS monthly_registrations
+
+        FROM reporting_patient_states
+        WHERE hypertension = 'yes'
+        GROUP BY 1, 2
+    ),
+
+    registered_diabetes_patients AS (
+        SELECT registration_facility_region_id AS region_id, month_date,
+               COUNT(*) AS cumulative_diabetes_registrations,
+               COUNT(*) FILTER (WHERE months_since_registration = 0) AS monthly_diabetes_registrations
+
+        FROM reporting_patient_states
+        WHERE diabetes = 'yes'
+        GROUP BY 1, 2
+    ),
+
+    registered_hypertension_and_diabetes_patients AS (
+        SELECT registration_facility_region_id AS region_id, month_date,
+               COUNT(*) AS cumulative_hypertension_and_diabetes_registrations,
+               COUNT(*) FILTER (WHERE months_since_registration = 0) AS monthly_hypertension_and_diabetes_registrations
+
+        FROM reporting_patient_states
+        WHERE (hypertension = 'yes' and diabetes = 'yes')
+        GROUP BY 1, 2
+    ),
+
+    assigned_patients AS (
+        SELECT assigned_facility_region_id AS region_id, month_date,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care') AS under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'lost_to_follow_up') AS lost_to_follow_up,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'dead') AS dead,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state != 'dead') AS cumulative_assigned_patients
+
+        FROM reporting_patient_states
+        WHERE hypertension = 'yes'
+        GROUP BY 1, 2
+    ),
+
+    assigned_diabetes_patients AS (
+        SELECT assigned_facility_region_id AS region_id, month_date,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care') AS diabetes_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'lost_to_follow_up') AS diabetes_lost_to_follow_up,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'dead') AS diabetes_dead,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state != 'dead') AS cumulative_assigned_diabetic_patients
+
+        FROM reporting_patient_states
+        WHERE diabetes = 'yes'
+        GROUP BY 1, 2
+    ),
+
+    adjusted_outcomes AS (
+        SELECT assigned_facility_region_id AS region_id, month_date,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND htn_treatment_outcome_in_last_3_months = 'controlled') AS controlled_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND htn_treatment_outcome_in_last_3_months = 'uncontrolled') AS uncontrolled_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND htn_treatment_outcome_in_last_3_months = 'missed_visit') AS missed_visit_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND htn_treatment_outcome_in_last_3_months = 'visited_no_bp') AS visited_no_bp_under_care,
+
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'lost_to_follow_up' AND htn_treatment_outcome_in_last_3_months = 'missed_visit') AS missed_visit_lost_to_follow_up,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'lost_to_follow_up' AND htn_treatment_outcome_in_last_3_months = 'visited_no_bp') AS visited_no_bp_lost_to_follow_up,
+
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care') AS patients_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'lost_to_follow_up') AS patients_lost_to_follow_up
+
+        FROM reporting_patient_states
+        WHERE hypertension = 'yes'
+          AND months_since_registration >= 3
+        GROUP BY 1, 2
+    ),
+
+    adjusted_diabetes_outcomes AS (
+        SELECT assigned_facility_region_id AS region_id, month_date,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_below_200' AND blood_sugar_type = 'random') AS random_bs_below_200_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_below_200' AND blood_sugar_type = 'post_prandial') AS post_prandial_bs_below_200_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_below_200' AND blood_sugar_type = 'fasting') AS fasting_bs_below_200_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_below_200' AND blood_sugar_type = 'hba1c') AS hba1c_bs_below_200_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_below_200') AS bs_below_200_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_200_to_300' AND blood_sugar_type = 'random') AS random_bs_200_to_300_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_200_to_300' AND blood_sugar_type = 'post_prandial') AS post_prandial_bs_200_to_300_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_200_to_300' AND blood_sugar_type = 'fasting') AS fasting_bs_200_to_300_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_200_to_300' AND blood_sugar_type = 'hba1c') AS hba1c_bs_200_to_300_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_200_to_300') AS bs_200_to_300_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_over_300' AND blood_sugar_type = 'random') AS random_bs_over_300_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_over_300' AND blood_sugar_type = 'post_prandial') AS post_prandial_bs_over_300_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_over_300' AND blood_sugar_type = 'fasting') AS fasting_bs_over_300_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_over_300' AND blood_sugar_type = 'hba1c') AS hba1c_bs_over_300_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'bs_over_300') AS bs_over_300_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'missed_visit') AS bs_missed_visit_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND diabetes_treatment_outcome_in_last_3_months = 'visited_no_bs') AS visited_no_bs_under_care,
+
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'lost_to_follow_up' AND diabetes_treatment_outcome_in_last_3_months = 'missed_visit') AS bs_missed_visit_lost_to_follow_up,
+
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care') AS diabetes_patients_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'lost_to_follow_up') AS diabetes_patients_lost_to_follow_up,
+
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND htn_treatment_outcome_in_last_3_months = 'controlled') AS dm_bp_below_140_90_under_care,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_care_state = 'under_care' AND htn_treatment_outcome_in_last_3_months = 'controlled' AND systolic < 130 AND diastolic < 80) AS dm_bp_below_130_80_under_care
+
+        FROM reporting_patient_states
+        WHERE diabetes = 'yes'
+          AND months_since_registration >= 3
+        GROUP BY 1, 2
+    ),
+
+    dm_statins_outcomes AS (
+        WITH latest_visits_for_statins AS (
+            SELECT
+                patient_id,
+                month_date,
+                visited_at
+            FROM reporting_patient_visits
+        ),
+        statin_prescriptions_by_month AS (
+            SELECT
+                DISTINCT ON (pd.patient_id, cal.month_date)
+                pd.patient_id,
+                cal.month_date,
+                pd.id AS statin_prescription_id
+            FROM prescription_drugs pd
+            LEFT JOIN reporting_months cal
+                ON TO_CHAR(pd.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT CURRENT_SETTING('TIMEZONE')), 'YYYY-MM') <= TO_CHAR(cal.month_date, 'YYYY-MM')
+            LEFT JOIN latest_visits_for_statins lv
+                ON lv.month_date = cal.month_date
+                AND lv.patient_id = pd.patient_id
+            WHERE pd.name ILIKE '%statin%'
+                AND (pd.is_deleted = false OR (pd.is_deleted = true AND lv.visited_at IS NOT NULL AND pd.device_updated_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) >= lv.visited_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE'))))
+                AND pd.deleted_at IS NULL
+            ORDER BY pd.patient_id, cal.month_date DESC, pd.device_created_at DESC
+        ),
+        rps_with_age_for_statins AS (
+            SELECT
+                rps.assigned_facility_region_id,
+                rps.patient_id,
+                rps.month_date,
+                rps.htn_care_state,
+                CASE
+                    WHEN rps.date_of_birth IS NOT NULL THEN DATE_PART('year', AGE(rps.month_date, rps.date_of_birth))
+                    ELSE DATE_PART('year', AGE(rps.month_date, (rps.age_updated_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT CURRENT_SETTING('TIMEZONE')))::Date)) + rps.age
+                END AS age_on_month_date
+            FROM reporting_patient_states rps
+            WHERE rps.diabetes = 'yes'
+        )
+        SELECT
+            age_rps.assigned_facility_region_id AS region_id,
+            age_rps.month_date,
+            COUNT(distinct(age_rps.patient_id)) FILTER (WHERE age_rps.htn_care_state = 'under_care' AND age_rps.age_on_month_date >= 40) AS dm_patients_40_and_above_under_care,
+            COUNT(distinct(age_rps.patient_id)) FILTER (WHERE age_rps.htn_care_state = 'under_care' AND age_rps.age_on_month_date >= 40 AND sp.statin_prescription_id IS NOT NULL) AS dm_patients_40_and_above_with_statins,
+            COUNT(distinct(age_rps.patient_id)) FILTER (WHERE age_rps.htn_care_state != 'dead' AND age_rps.age_on_month_date >= 40) AS dm_patients_40_and_above_with_ltfu
+        FROM rps_with_age_for_statins age_rps
+        LEFT JOIN statin_prescriptions_by_month sp
+            ON sp.patient_id = age_rps.patient_id
+            AND sp.month_date = age_rps.month_date
+        GROUP BY age_rps.assigned_facility_region_id, age_rps.month_date
+    ),
+
+    monthly_cohort_outcomes AS (
+        SELECT assigned_facility_region_id AS region_id, month_date,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_treatment_outcome_in_last_2_months = 'controlled') AS controlled,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_treatment_outcome_in_last_2_months = 'uncontrolled') AS uncontrolled,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_treatment_outcome_in_last_2_months = 'missed_visit') AS missed_visit,
+               COUNT(distinct(patient_id)) FILTER (WHERE htn_treatment_outcome_in_last_2_months = 'visited_no_bp') AS visited_no_bp,
+               COUNT(distinct(patient_id)) AS patients
+
+        FROM reporting_patient_states
+        WHERE hypertension = 'yes'
+          AND months_since_registration = 2
+        GROUP BY 1, 2
+    ),
+
+    monthly_overdue_calls AS (
+        SELECT appointment_facility_region_id AS region_id, month_date,
+               COUNT(distinct(appointment_id)) AS call_results
+        FROM reporting_overdue_calls
+        GROUP BY 1, 2
+    ),
+
+    monthly_follow_ups AS (
+        SELECT facility_id, month_date, COUNT(distinct(patient_id)) as follow_ups
+        FROM reporting_patient_follow_ups
+        WHERE hypertension = 'yes'
+        GROUP BY facility_id, month_date
+    ),
+
+    monthly_diabetes_follow_ups AS (
+        SELECT facility_id, month_date, COUNT(distinct(patient_id)) as follow_ups
+        FROM reporting_patient_follow_ups
+        WHERE diabetes = 'yes'
+        GROUP BY facility_id, month_date
+    ),
+
+    monthly_hypertension_overdue_patients as (
+        SELECT assigned_facility_region_id, month_date,
+           COUNT(*) filter(where is_overdue = 'yes')  as overdue_patients,
+           COUNT(*) filter(where is_overdue = 'yes' and removed_from_overdue_list = 'no' and has_phone = 'yes') as contactable_overdue_patients,
+
+           COUNT(*) filter(where has_called = 'yes') as patients_called,
+           COUNT(*) filter(where has_called = 'yes' and next_call_result_type = 'agreed_to_visit') as patients_called_with_result_agreed_to_visit,
+           COUNT(*) filter(where has_called = 'yes' and next_call_result_type = 'remind_to_call_later') as patients_called_with_result_remind_to_call_later,
+           COUNT(*) filter(where has_called = 'yes' and next_call_result_type = 'removed_from_overdue_list') as patients_called_with_result_removed_from_list,
+
+           COUNT(*) filter(where has_called = 'yes' and removed_from_overdue_list = 'no' and has_phone = 'yes') as contactable_patients_called,
+           COUNT(*) filter(where has_called = 'yes' and removed_from_overdue_list = 'no' and has_phone = 'yes' and next_call_result_type = 'agreed_to_visit') as contactable_patients_called_with_result_agreed_to_visit,
+           COUNT(*) filter(where has_called = 'yes' and removed_from_overdue_list = 'no' and has_phone = 'yes' and next_call_result_type = 'remind_to_call_later') as contactable_patients_called_with_result_remind_to_call_later,
+           COUNT(*) filter(where has_called = 'yes' and removed_from_overdue_list = 'no' and has_phone = 'yes' and next_call_result_type = 'removed_from_overdue_list') as contactable_patients_called_with_result_removed_from_list,
+
+           COUNT(*) filter(where has_visited_following_call = 'yes') as patients_returned_after_call,
+           COUNT(*) filter(where has_visited_following_call = 'yes' and next_call_result_type = 'agreed_to_visit') as patients_returned_with_result_agreed_to_visit,
+           COUNT(*) filter(where has_visited_following_call = 'yes' and next_call_result_type = 'remind_to_call_later') as patients_returned_with_result_remind_to_call_later,
+           COUNT(*) filter(where has_visited_following_call = 'yes' and next_call_result_type = 'removed_from_overdue_list') as patients_returned_with_result_removed_from_list,
+
+           COUNT(*) filter(where has_visited_following_call = 'yes' and removed_from_overdue_list = 'no' and has_phone = 'yes') as contactable_patients_returned_after_call,
+           COUNT(*) filter(where has_visited_following_call = 'yes' and removed_from_overdue_list = 'no' and has_phone = 'yes' and next_call_result_type = 'agreed_to_visit') as contactable_patients_returned_with_result_agreed_to_visit,
+           COUNT(*) filter(where has_visited_following_call = 'yes' and removed_from_overdue_list = 'no' and has_phone = 'yes' and next_call_result_type = 'remind_to_call_later') as contactable_patients_returned_with_result_remind_to_call_later,
+           COUNT(*) filter(where has_visited_following_call = 'yes' and removed_from_overdue_list = 'no' and has_phone = 'yes' and next_call_result_type = 'removed_from_overdue_list') as contactable_patients_returned_with_result_removed_from_list
+
+        FROM reporting_overdue_patients
+        WHERE hypertension = 'yes'
+            AND under_care = 'yes'
+        GROUP BY assigned_facility_region_id, month_date
+    )
+
+SELECT
+-- months and facilities
+cal.*,
+rf.*,
+
+-- registration counts of hypertensive patients
+registered_patients.cumulative_registrations,
+registered_patients.monthly_registrations,
+
+-- registration counts of diabetic patients
+registered_diabetes_patients.cumulative_diabetes_registrations,
+registered_diabetes_patients.monthly_diabetes_registrations,
+
+-- registration counts of hypertension and diabetes patients
+registered_hypertension_and_diabetes_patients.cumulative_hypertension_and_diabetes_registrations,
+registered_hypertension_and_diabetes_patients.monthly_hypertension_and_diabetes_registrations,
+
+-- htn assigned counts by care state
+assigned_patients.under_care,
+assigned_patients.lost_to_follow_up,
+assigned_patients.dead,
+assigned_patients.cumulative_assigned_patients,
+
+-- diabetes assigned counts by care state
+assigned_diabetes_patients.diabetes_under_care,
+assigned_diabetes_patients.diabetes_lost_to_follow_up,
+assigned_diabetes_patients.diabetes_dead,
+assigned_diabetes_patients.cumulative_assigned_diabetic_patients,
+
+-- adjusted htn outcomes
+adjusted_outcomes.controlled_under_care AS adjusted_controlled_under_care,
+adjusted_outcomes.uncontrolled_under_care AS adjusted_uncontrolled_under_care,
+adjusted_outcomes.missed_visit_under_care AS adjusted_missed_visit_under_care,
+adjusted_outcomes.visited_no_bp_under_care AS adjusted_visited_no_bp_under_care,
+
+adjusted_outcomes.missed_visit_lost_to_follow_up AS adjusted_missed_visit_lost_to_follow_up,
+adjusted_outcomes.visited_no_bp_lost_to_follow_up AS adjusted_visited_no_bp_lost_to_follow_up,
+
+adjusted_outcomes.patients_under_care AS adjusted_patients_under_care,
+adjusted_outcomes.patients_lost_to_follow_up AS adjusted_patients_lost_to_follow_up,
+
+-- adjusted diabetes outcomes
+adjusted_diabetes_outcomes.random_bs_below_200_under_care AS adjusted_random_bs_below_200_under_care,
+adjusted_diabetes_outcomes.fasting_bs_below_200_under_care AS adjusted_fasting_bs_below_200_under_care,
+adjusted_diabetes_outcomes.post_prandial_bs_below_200_under_care AS adjusted_post_prandial_bs_below_200_under_care,
+adjusted_diabetes_outcomes.hba1c_bs_below_200_under_care AS adjusted_hba1c_bs_below_200_under_care,
+adjusted_diabetes_outcomes.bs_below_200_under_care AS adjusted_bs_below_200_under_care,
+
+adjusted_diabetes_outcomes.random_bs_200_to_300_under_care AS adjusted_random_bs_200_to_300_under_care,
+adjusted_diabetes_outcomes.fasting_bs_200_to_300_under_care AS adjusted_fasting_bs_200_to_300_under_care,
+adjusted_diabetes_outcomes.post_prandial_bs_200_to_300_under_care AS adjusted_post_prandial_bs_200_to_300_under_care,
+adjusted_diabetes_outcomes.hba1c_bs_200_to_300_under_care AS adjusted_hba1c_bs_200_to_300_under_care,
+adjusted_diabetes_outcomes.bs_200_to_300_under_care AS adjusted_bs_200_to_300_under_care,
+
+adjusted_diabetes_outcomes.random_bs_over_300_under_care AS adjusted_random_bs_over_300_under_care,
+adjusted_diabetes_outcomes.fasting_bs_over_300_under_care AS adjusted_fasting_bs_over_300_under_care,
+adjusted_diabetes_outcomes.post_prandial_bs_over_300_under_care AS adjusted_post_prandial_bs_over_300_under_care,
+adjusted_diabetes_outcomes.hba1c_bs_over_300_under_care AS adjusted_hba1c_bs_over_300_under_care,
+adjusted_diabetes_outcomes.bs_over_300_under_care AS adjusted_bs_over_300_under_care,
+
+adjusted_diabetes_outcomes.bs_missed_visit_under_care AS adjusted_bs_missed_visit_under_care,
+adjusted_diabetes_outcomes.visited_no_bs_under_care AS adjusted_visited_no_bs_under_care,
+
+adjusted_diabetes_outcomes.bs_missed_visit_lost_to_follow_up AS adjusted_bs_missed_visit_lost_to_follow_up,
+
+adjusted_diabetes_outcomes.diabetes_patients_under_care AS adjusted_diabetes_patients_under_care,
+adjusted_diabetes_outcomes.diabetes_patients_lost_to_follow_up AS adjusted_diabetes_patients_lost_to_follow_up,
+
+adjusted_diabetes_outcomes.dm_bp_below_140_90_under_care AS adjusted_dm_bp_below_140_90_under_care,
+adjusted_diabetes_outcomes.dm_bp_below_130_80_under_care AS adjusted_dm_bp_below_130_80_under_care,
+
+-- DM statins outcomes
+dm_statins_outcomes.dm_patients_40_and_above_under_care AS adjusted_dm_patients_40_and_above_under_care,
+dm_statins_outcomes.dm_patients_40_and_above_with_statins AS adjusted_dm_patients_40_and_above_with_statins,
+dm_statins_outcomes.dm_patients_40_and_above_with_ltfu AS adjusted_dm_patients_40_and_above_with_ltfu,
+
+-- monthly cohort outcomes
+monthly_cohort_outcomes.controlled AS monthly_cohort_controlled,
+monthly_cohort_outcomes.uncontrolled AS monthly_cohort_uncontrolled,
+monthly_cohort_outcomes.missed_visit AS monthly_cohort_missed_visit,
+monthly_cohort_outcomes.visited_no_bp AS monthly_cohort_visited_no_bp,
+monthly_cohort_outcomes.patients AS monthly_cohort_patients,
+
+-- monthly overdue calls
+monthly_overdue_calls.call_results AS monthly_overdue_calls,
+
+-- monthly htn follow ups
+monthly_follow_ups.follow_ups AS monthly_follow_ups,
+
+-- monthly diabetes follow ups
+monthly_diabetes_follow_ups.follow_ups AS monthly_diabetes_follow_ups,
+
+-- appointment scheduled days distribution
+reporting_facility_appointment_scheduled_days.htn_total_appts_scheduled AS total_appts_scheduled,
+reporting_facility_appointment_scheduled_days.htn_appts_scheduled_0_to_14_days AS appts_scheduled_0_to_14_days,
+reporting_facility_appointment_scheduled_days.htn_appts_scheduled_15_to_31_days AS appts_scheduled_15_to_31_days,
+reporting_facility_appointment_scheduled_days.htn_appts_scheduled_32_to_62_days AS appts_scheduled_32_to_62_days,
+reporting_facility_appointment_scheduled_days.htn_appts_scheduled_more_than_62_days AS appts_scheduled_more_than_62_days,
+
+reporting_facility_appointment_scheduled_days.diabetes_total_appts_scheduled AS diabetes_total_appts_scheduled,
+reporting_facility_appointment_scheduled_days.diabetes_appts_scheduled_0_to_14_days AS diabetes_appts_scheduled_0_to_14_days,
+reporting_facility_appointment_scheduled_days.diabetes_appts_scheduled_15_to_31_days AS diabetes_appts_scheduled_15_to_31_days,
+reporting_facility_appointment_scheduled_days.diabetes_appts_scheduled_32_to_62_days AS diabetes_appts_scheduled_32_to_62_days,
+reporting_facility_appointment_scheduled_days.diabetes_appts_scheduled_more_than_62_days AS diabetes_appts_scheduled_more_than_62_days,
+
+-- overdue patients at beginning of a month
+monthly_hypertension_overdue_patients.overdue_patients,
+monthly_hypertension_overdue_patients.contactable_overdue_patients,
+
+-- patients who got a call
+monthly_hypertension_overdue_patients.patients_called,
+monthly_hypertension_overdue_patients.contactable_patients_called,
+
+-- patients grouped by call result
+monthly_hypertension_overdue_patients.patients_called_with_result_agreed_to_visit,
+monthly_hypertension_overdue_patients.patients_called_with_result_remind_to_call_later,
+monthly_hypertension_overdue_patients.patients_called_with_result_removed_from_list,
+monthly_hypertension_overdue_patients.contactable_patients_called_with_result_agreed_to_visit,
+monthly_hypertension_overdue_patients.contactable_patients_called_with_result_remind_to_call_later,
+monthly_hypertension_overdue_patients.contactable_patients_called_with_result_removed_from_list,
+
+-- patients returned to care after a call
+monthly_hypertension_overdue_patients.patients_returned_after_call,
+monthly_hypertension_overdue_patients.contactable_patients_returned_after_call,
+
+-- patients returned to care after a call grouped by call result
+monthly_hypertension_overdue_patients.patients_returned_with_result_agreed_to_visit,
+monthly_hypertension_overdue_patients.patients_returned_with_result_remind_to_call_later,
+monthly_hypertension_overdue_patients.patients_returned_with_result_removed_from_list,
+monthly_hypertension_overdue_patients.contactable_patients_returned_with_result_agreed_to_visit,
+monthly_hypertension_overdue_patients.contactable_patients_returned_with_result_remind_to_call_later,
+monthly_hypertension_overdue_patients.contactable_patients_returned_with_result_removed_from_list
+
+FROM reporting_facilities rf
+INNER JOIN reporting_months cal
+-- ensure a row for every facility and month combination
+    ON TRUE
+LEFT OUTER JOIN registered_patients
+    ON registered_patients.month_date = cal.month_date
+    AND registered_patients.region_id = rf.facility_region_id
+LEFT OUTER JOIN registered_diabetes_patients
+    ON registered_diabetes_patients.month_date = cal.month_date
+    AND registered_diabetes_patients.region_id = rf.facility_region_id
+LEFT OUTER JOIN registered_hypertension_and_diabetes_patients
+    ON registered_hypertension_and_diabetes_patients.month_date = cal.month_date
+    AND registered_hypertension_and_diabetes_patients.region_id = rf.facility_region_id
+LEFT OUTER JOIN assigned_patients
+    ON assigned_patients.month_date = cal.month_date
+    AND assigned_patients.region_id = rf.facility_region_id
+LEFT OUTER JOIN assigned_diabetes_patients
+    ON assigned_diabetes_patients.month_date = cal.month_date
+    AND assigned_diabetes_patients.region_id = rf.facility_region_id
+LEFT OUTER JOIN adjusted_outcomes
+    ON adjusted_outcomes.month_date = cal.month_date
+    AND adjusted_outcomes.region_id = rf.facility_region_id
+LEFT OUTER JOIN adjusted_diabetes_outcomes
+    ON adjusted_diabetes_outcomes.month_date = cal.month_date
+    AND adjusted_diabetes_outcomes.region_id = rf.facility_region_id
+LEFT OUTER JOIN dm_statins_outcomes
+    ON dm_statins_outcomes.month_date = cal.month_date
+    AND dm_statins_outcomes.region_id = rf.facility_region_id
+LEFT OUTER JOIN monthly_cohort_outcomes
+    ON monthly_cohort_outcomes.month_date = cal.month_date
+    AND monthly_cohort_outcomes.region_id = rf.facility_region_id
+LEFT OUTER JOIN monthly_overdue_calls
+    ON monthly_overdue_calls.month_date = cal.month_date
+    AND monthly_overdue_calls.region_id = rf.facility_region_id
+LEFT OUTER JOIN monthly_follow_ups
+    ON monthly_follow_ups.month_date = cal.month_date
+    AND monthly_follow_ups.facility_id = rf.facility_id
+LEFT OUTER JOIN monthly_diabetes_follow_ups
+    ON monthly_diabetes_follow_ups.month_date = cal.month_date
+    AND monthly_diabetes_follow_ups.facility_id = rf.facility_id
+LEFT OUTER JOIN reporting_facility_appointment_scheduled_days
+    ON reporting_facility_appointment_scheduled_days.month_date = cal.month_date
+    AND reporting_facility_appointment_scheduled_days.facility_id = rf.facility_id
+LEFT OUTER JOIN monthly_hypertension_overdue_patients
+    ON  monthly_hypertension_overdue_patients.month_date = cal.month_date
+    AND monthly_hypertension_overdue_patients.assigned_facility_region_id = rf.facility_region_id


### PR DESCRIPTION
**Story card:** [Audit and release DM dashboard cards [Controlled BP & Statins]](https://rtsl.atlassian.net/browse/SIMPLEBACK-68)

## **Because**

Two bugs were found on the Diabetes (DM) dashboard:

1. **Statins card** was excluding DM patients aged 40+ who were registered within the last 3 months, even though the indicator should cover all DM patients over 40 regardless of registration date.
2. **BP Controlled card** was over-counting patients — anyone with a recent visit (e.g. a blood sugar record) but a stale BP measurement from > 3 months ago was being counted as "controlled," because the numerator used manual `months_since_visit` + `systolic/diastolic IS NOT NULL` checks that didn't verify the BP itself was recent.

## **This addresses**

Introduces `reporting_facility_states` view **v14** with two fixes inside the `adjusted_diabetes_outcomes` / `dm_statins_outcomes` CTEs:

1. **Statins card**: removed `AND rps.months_since_registration >= 3` from the `rps_with_age_for_statins` CTE.
2. **BP Controlled card**: the `dm_bp_below_140_90_under_care` numerator now uses `htn_treatment_outcome_in_last_3_months = 'controlled'` (the same pre-calculated flag the HTN dashboard uses), which correctly requires a recent visit *and* a recent BP < 140/90. The `dm_bp_below_130_80_under_care` numerator uses the same `controlled` flag plus an additional `systolic < 130 AND diastolic < 80` filter.

Files:
- `db/views/reporting_facility_states_v14.sql` (new)
- `db/migrate/20260422120000_update_reporting_facility_states_to_version14.rb` (new)
- `db/structure.sql` (updated)


## **Test instructions**

1. Run `rails db:migrate` and confirm the view rebuilds cleanly and `db/structure.sql` matches the committed diff.
2. Refresh the reporting views and load the Diabetes dashboard for a region.
3. Add filpper flag: **diabetes_cvd_indicators**
4. **Statins card**: verify DM patients 40+ registered within the last 3 months now appear in the denominator.
5. **BP Controlled card**: verify a DM patient whose only recent encounter in the last 3 months is a blood sugar (no BP in last 3 months, even if an older BP exists) is **not** counted in the <140/90 numerator.
6. Spot-check the <130/80 numerator is a subset of the <140/90 numerator.
7. Run existing specs:
   - `bundle exec rspec spec/models/reports/region_summary_schema_spec.rb`
   - `bundle exec rspec spec/models/reports/repository_spec.rb`
