### PR TITLE
fix(QuickLinks): Use slug for name in Statins

### DIFF
--- a/app/views/reports/regions/show.html.erb
+++ b/app/views/reports/regions/show.html.erb
@@ -38,7 +38,7 @@
         </a>
       </div>
       <div>
-        ⚡ <a href="<%= ENV.fetch('METABASE_STATIN_REPORT_URL', '') %><%= @region.name %>" target="_blank">
+        ⚡ <a href="<%= ENV.fetch('METABASE_STATIN_REPORT_URL', '') %><%= @region.slug %>" target="_blank">
           Metabase: Statin Report
         </a>
       </div>


### PR DESCRIPTION
**Story card:** [SIMPLEETH-32](https://rtsl.atlassian.net/browse/SIMPLEETH-32)

## Because

The Statins report tacks on the `name` of the facility to the report URL. This is wrong since the report expects the facility `slug`.

## This addresses

Changing `name` to `slug` for generating the Statins quicklinks

## Test instructions

Check the full generated URL for a facility
