### PR TITLE
remmoving space between rake task arguments

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -140,7 +140,7 @@ every 1.month, at: local("04:15 am"), roles: [:cron] do
 end
 
 every 1.month, at: local("06:00 am"), roles: [:cron] do
-  rake "reporting:refresh_partitioned_table[reporting_patient_prescriptions, 3]"
+  rake "reporting:refresh_partitioned_table[reporting_patient_prescriptions,3]"
 end
 
 every :day, at: local("05:00 am"), roles: [:cron] do


### PR DESCRIPTION
**Story card:** [SIMPLEBACK-115](https://rtsl.atlassian.net/browse/SIMPLEBACK-115)

## Because

The monthly scheduled task for populating reporting_patient_precriptions table is erroring out.

As a result of this recent months data is not populated in this.

## This addresses

Removing the space between rake task arguments, so that the task runs successfully

## Test instructions

Run `crontab -l | grep -i "prescription"`
Run the cron job entry that shows up manually - something like
`cd /home/app && RAILS_ENV=production bundle exec rake reporting:refresh_partitioned_table[reporting_patient_prescriptions,3]`
This should pass without errors, and the corresponding months should be populated in reporting_patient_prescriptions table