### PR TITLE
adding partitioned reporting_overdue_patients table

### DIFF
--- a/app/models/reports/overdue_patient.rb
+++ b/app/models/reports/overdue_patient.rb
@@ -6,5 +6,9 @@ module Reports
     def self.materialized?
       true
     end
+
+    def self.partitioned?
+      true
+    end
   end
 end

--- a/db/migrate/20260515103653_create_partitioned_table_reporting_overdue_patients.rb
+++ b/db/migrate/20260515103653_create_partitioned_table_reporting_overdue_patients.rb
@@ -1,0 +1,274 @@
+class CreatePartitionedTableReportingOverduePatients < ActiveRecord::Migration[6.1]
+  def up
+    execute <<~SQL
+      CREATE TABLE IF NOT EXISTS simple_reporting.reporting_overdue_patients (
+        month_date date,
+        patient_id uuid,
+        hypertension text,
+        diabetes text,
+        htn_care_state text,
+        month double precision,
+        quarter double precision,
+        year double precision,
+        month_string text,
+        quarter_string text,
+        assigned_facility_id uuid,
+        assigned_facility_slug character varying,
+        assigned_facility_region_id uuid,
+        assigned_block_slug character varying,
+        assigned_block_region_id uuid,
+        assigned_district_slug character varying,
+        assigned_district_region_id uuid,
+        assigned_state_slug character varying,
+        assigned_state_region_id uuid,
+        assigned_organization_slug character varying,
+        assigned_organization_region_id uuid,
+        previous_appointment_id uuid,
+        previous_appointment_date timestamp without time zone,
+        previous_appointment_schedule_date date,
+        visited_at_after_appointment  timestamp without time zone,
+        called_by_user_id uuid,
+        next_called_at timestamp without time zone,
+        previous_called_at timestamp without time zone,
+        next_call_result_type character varying,
+        next_call_removed_from_overdue_list_reason character varying,
+        previous_call_result_type character varying,
+        previous_call_removed_from_overdue_list_reason character varying,
+        is_overdue text,
+        has_called text,
+        has_visited_following_call text,
+        ltfu text,
+        under_care text,
+        has_phone text,
+        removed_from_overdue_list text,
+        removed_from_overdue_list_during_the_month text
+      )
+      PARTITION BY LIST (month_date);
+    SQL
+
+    add_index "simple_reporting.reporting_overdue_patients", ["assigned_facility_region_id"], name: "overdue_patients_assigned_facility_region_id"
+    add_index "simple_reporting.reporting_overdue_patients", ["patient_id"], name: "overdue_patients_patient_id"
+
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION simple_reporting.reporting_overdue_patients_table_function(date) RETURNS SETOF simple_reporting.reporting_overdue_patients
+      LANGUAGE plpgsql
+      AS $_$
+      BEGIN
+      RETURN QUERY
+        WITH patients_with_appointments AS (
+          SELECT DISTINCT ON (rps.patient_id, rps.month_date) 
+            rps.month_date,
+            rps.patient_id,
+            rps.hypertension AS hypertension,
+            rps.diabetes AS diabetes,
+            rps.htn_care_state,
+            rps.month,
+            rps.quarter,
+            rps.year,
+            rps.month_string,
+            rps.quarter_string,
+            rps.assigned_facility_id,
+            rps.assigned_facility_slug,
+            rps.assigned_facility_region_id,
+            rps.assigned_block_slug,
+            rps.assigned_block_region_id,
+            rps.assigned_district_slug,
+            rps.assigned_district_region_id,
+            rps.assigned_state_slug,
+            rps.assigned_state_region_id,
+            rps.assigned_organization_slug,
+            rps.assigned_organization_region_id,
+            appointments.id AS previous_appointment_id,
+            appointments.device_created_at AS previous_appointment_date,
+            appointments.scheduled_date AS previous_appointment_schedule_date
+          FROM
+            reporting_patient_states rps
+          LEFT JOIN appointments ON appointments.patient_id = rps.patient_id
+            AND appointments.device_created_at < rps.month_date
+          WHERE rps.status <> 'dead'
+            AND rps.month_date = $1
+          ORDER BY
+            rps.patient_id,
+            rps.month_date,
+            appointments.device_created_at DESC
+        ),
+        patients_with_appointments_and_visits AS (
+          SELECT patients_with_appointments.*,
+            visit_id,
+            visited_at_after_appointment
+          FROM patients_with_appointments
+          LEFT JOIN lateral (
+            SELECT
+              DISTINCT ON (patient_id) id AS visit_id,
+              patient_id,
+              recorded_at AS visited_at_after_appointment
+            FROM blood_sugars
+            WHERE deleted_at IS NULL
+              AND patient_id = patients_with_appointments.patient_id
+              AND patients_with_appointments.previous_appointment_date < blood_sugars.recorded_at
+              AND blood_sugars.recorded_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+            UNION ALL (
+              SELECT id AS visit_id,
+                patient_id,
+                recorded_at AS visited_at_after_appointment
+              FROM blood_pressures
+              WHERE deleted_at IS NULL
+                AND patient_id = patients_with_appointments.patient_id
+                AND patients_with_appointments.previous_appointment_date < blood_pressures.recorded_at
+                AND blood_pressures.recorded_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+            )
+            UNION ALL (
+              SELECT id AS visit_id,
+                patient_id,
+                device_created_at AS visited_at_after_appointment
+              FROM appointments AS patients_with_appointments_visit
+              WHERE deleted_at IS NULL
+                AND patient_id = patients_with_appointments.patient_id
+                AND patients_with_appointments.previous_appointment_date < patients_with_appointments_visit.device_created_at
+                AND patients_with_appointments_visit.device_created_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+            )
+            UNION ALL (
+              SELECT id AS visit_id,
+                patient_id,
+                device_created_at AS visited_at_after_appointment
+              FROM prescription_drugs
+              WHERE deleted_at IS NULL
+                AND patient_id = patients_with_appointments.patient_id
+                AND patients_with_appointments.previous_appointment_date < prescription_drugs.device_created_at
+                AND prescription_drugs.device_created_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+            )
+            ORDER BY
+              patient_id,
+              visited_at_after_appointment
+          ) AS visits ON patients_with_appointments.patient_id = visits.patient_id
+        ),
+        patient_with_call_results AS (
+          SELECT
+            DISTINCT ON (
+              patients_with_appointments_and_visits.patient_id,
+              patients_with_appointments_and_visits.month_date
+            ) 
+            patients_with_appointments_and_visits.*,
+            previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS previous_called_at,
+            previous_call_results.result_type AS previous_call_result_type,
+            previous_call_results.remove_reason AS previous_call_removed_from_overdue_list_reason,
+            next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS next_called_at,
+            next_call_results.result_type AS next_call_result_type,
+            next_call_results.remove_reason as next_call_removed_from_overdue_list_reason,
+            next_call_results.user_id AS called_by_user_id
+          FROM
+            patients_with_appointments_and_visits
+            LEFT JOIN call_results previous_call_results ON patients_with_appointments_and_visits.patient_id = previous_call_results.patient_id
+              AND previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < patients_with_appointments_and_visits.month_date
+              AND previous_call_results.device_created_at > previous_appointment_schedule_date
+            LEFT JOIN call_results next_call_results ON patients_with_appointments_and_visits.patient_id = next_call_results.patient_id
+              AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) >= patients_with_appointments_and_visits.month_date
+              AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < patients_with_appointments_and_visits.month_date + INTERVAL '1 month'
+          ORDER BY
+            patients_with_appointments_and_visits.patient_id,
+            patients_with_appointments_and_visits.month_date,
+            next_call_results.device_created_at,
+            previous_call_results.device_created_at DESC
+        ),
+        patient_with_call_results_and_phone AS (
+          SELECT
+            DISTINCT ON (
+              patient_with_call_results.patient_id,
+              patient_with_call_results.month_date
+            ) 
+            patient_with_call_results.*,
+            patient_phone_numbers.number AS patient_phone_number
+          FROM
+            patient_with_call_results
+            LEFT JOIN patient_phone_numbers ON patient_phone_numbers.patient_id = patient_with_call_results.patient_id
+          ORDER BY
+            patient_with_call_results.patient_id,
+            patient_with_call_results.month_date
+        )
+        SELECT
+          month_date,
+          patient_id,
+          hypertension,
+          diabetes,
+          htn_care_state,
+          month,
+          quarter,
+          year,
+          month_string,
+          quarter_string,
+          assigned_facility_id,
+          assigned_facility_slug,
+          assigned_facility_region_id,
+          assigned_block_slug,
+          assigned_block_region_id,
+          assigned_district_slug,
+          assigned_district_region_id,
+          assigned_state_slug,
+          assigned_state_region_id,
+          assigned_organization_slug,
+          assigned_organization_region_id,
+          previous_appointment_id,
+          previous_appointment_date,
+          previous_appointment_schedule_date,
+          visited_at_after_appointment,
+          called_by_user_id,
+          next_called_at,
+          previous_called_at,
+          next_call_result_type,
+          next_call_removed_from_overdue_list_reason,
+          previous_call_result_type,
+          previous_call_removed_from_overdue_list_reason,
+          CASE
+            WHEN previous_appointment_id IS NULL THEN 'no'
+            WHEN (previous_appointment_schedule_date >= month_date) THEN 'no'
+            WHEN (
+              previous_appointment_schedule_date < month_date
+              and visited_at_after_appointment < month_date
+            ) THEN 'no'
+            ELSE 'yes'
+          END AS is_overdue,
+          CASE
+            WHEN next_called_at IS NULL THEN 'no'
+            ELSE 'yes'
+          END AS has_called,
+          CASE
+            WHEN visited_at_after_appointment IS NULL
+              OR next_called_at IS NULL THEN 'no'
+            WHEN visited_at_after_appointment > next_called_at + INTERVAL '15 days' THEN 'no'
+            ELSE 'yes'
+          END AS has_visited_following_call,
+          CASE
+            WHEN htn_care_state = 'lost_to_follow_up' THEN 'yes'
+            ELSE 'no'
+          END AS ltfu,
+          CASE
+            WHEN htn_care_state = 'under_care' THEN 'yes'
+            ELSE 'no'
+          END AS under_care,
+          CASE
+            WHEN patient_phone_number IS NULL THEN 'no'
+            ELSE 'yes'
+          END AS has_phone,
+          CASE
+            WHEN previous_call_result_type = 'removed_from_overdue_list' THEN 'yes'
+            ELSE 'no'
+          END AS removed_from_overdue_list,
+          CASE
+            WHEN next_call_result_type = 'removed_from_overdue_list' THEN 'yes'
+            ELSE 'no'
+          END AS removed_from_overdue_list_during_the_month
+        FROM
+          patient_with_call_results_and_phone;
+      END;
+      $_$;
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      DROP FUNCTION IF EXISTS simple_reporting.reporting_overdue_patients_table_function(date);
+    SQL
+
+    drop_table "simple_reporting.reporting_overdue_patients"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1464,6 +1464,270 @@ END;
 $_$;
 
 --
+-- Name: reporting_overdue_patients; Type: TABLE; Schema: simple_reporting; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS simple_reporting.reporting_overdue_patients (
+    month_date date,
+    patient_id uuid,
+    hypertension text,
+    diabetes text,
+    htn_care_state text,
+    month double precision,
+    quarter double precision,
+    year double precision,
+    month_string text,
+    quarter_string text,
+    assigned_facility_id uuid,
+    assigned_facility_slug character varying,
+    assigned_facility_region_id uuid,
+    assigned_block_slug character varying,
+    assigned_block_region_id uuid,
+    assigned_district_slug character varying,
+    assigned_district_region_id uuid,
+    assigned_state_slug character varying,
+    assigned_state_region_id uuid,
+    assigned_organization_slug character varying,
+    assigned_organization_region_id uuid,
+    previous_appointment_id uuid,
+    previous_appointment_date timestamp without time zone,
+    previous_appointment_schedule_date date,
+    visited_at_after_appointment  timestamp without time zone,
+    called_by_user_id uuid,
+    next_called_at timestamp without time zone,
+    previous_called_at timestamp without time zone,
+    next_call_result_type character varying,
+    next_call_removed_from_overdue_list_reason character varying,
+    previous_call_result_type character varying,
+    previous_call_removed_from_overdue_list_reason character varying,
+    is_overdue text,
+    has_called text,
+    has_visited_following_call text,
+    ltfu text,
+    under_care text,
+    has_phone text,
+    removed_from_overdue_list text,
+    removed_from_overdue_list_during_the_month text
+    )
+    PARTITION BY LIST (month_date);
+
+--
+-- Name: reporting_overdue_patients_table_function(date); Type: FUNCTION; Schema: simple_reporting; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION simple_reporting.reporting_overdue_patients_table_function(date) RETURNS SETOF simple_reporting.reporting_overdue_patients
+    LANGUAGE plpgsql
+    AS $_$
+    BEGIN
+    RETURN QUERY
+    WITH patients_with_appointments AS (
+        SELECT DISTINCT ON (rps.patient_id, rps.month_date)
+        rps.month_date,
+        rps.patient_id,
+        rps.hypertension AS hypertension,
+        rps.diabetes AS diabetes,
+        rps.htn_care_state,
+        rps.month,
+        rps.quarter,
+        rps.year,
+        rps.month_string,
+        rps.quarter_string,
+        rps.assigned_facility_id,
+        rps.assigned_facility_slug,
+        rps.assigned_facility_region_id,
+        rps.assigned_block_slug,
+        rps.assigned_block_region_id,
+        rps.assigned_district_slug,
+        rps.assigned_district_region_id,
+        rps.assigned_state_slug,
+        rps.assigned_state_region_id,
+        rps.assigned_organization_slug,
+        rps.assigned_organization_region_id,
+        appointments.id AS previous_appointment_id,
+        appointments.device_created_at AS previous_appointment_date,
+        appointments.scheduled_date AS previous_appointment_schedule_date
+        FROM
+            reporting_patient_states rps
+        LEFT JOIN appointments ON appointments.patient_id = rps.patient_id
+            AND appointments.device_created_at < rps.month_date
+        WHERE rps.status <> 'dead'
+            AND rps.month_date = $1
+        ORDER BY
+            rps.patient_id,
+            rps.month_date,
+            appointments.device_created_at DESC
+    ),
+    patients_with_appointments_and_visits AS (
+        SELECT patients_with_appointments.*,
+            visit_id,
+            visited_at_after_appointment
+        FROM patients_with_appointments
+        LEFT JOIN lateral (
+            SELECT
+                DISTINCT ON (patient_id) id AS visit_id,
+                patient_id,
+                recorded_at AS visited_at_after_appointment
+            FROM blood_sugars
+            WHERE deleted_at IS NULL
+                AND patient_id = patients_with_appointments.patient_id
+                AND patients_with_appointments.previous_appointment_date < blood_sugars.recorded_at
+                AND blood_sugars.recorded_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+            UNION ALL (
+                SELECT id AS visit_id,
+                patient_id,
+                recorded_at AS visited_at_after_appointment
+                FROM blood_pressures
+                WHERE deleted_at IS NULL
+                AND patient_id = patients_with_appointments.patient_id
+                AND patients_with_appointments.previous_appointment_date < blood_pressures.recorded_at
+                AND blood_pressures.recorded_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+            )
+            UNION ALL (
+                SELECT id AS visit_id,
+                patient_id,
+                device_created_at AS visited_at_after_appointment
+                FROM appointments AS patients_with_appointments_visit
+                WHERE deleted_at IS NULL
+                AND patient_id = patients_with_appointments.patient_id
+                AND patients_with_appointments.previous_appointment_date < patients_with_appointments_visit.device_created_at
+                AND patients_with_appointments_visit.device_created_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+            )
+            UNION ALL (
+                SELECT id AS visit_id,
+                patient_id,
+                device_created_at AS visited_at_after_appointment
+                FROM prescription_drugs
+                WHERE deleted_at IS NULL
+                AND patient_id = patients_with_appointments.patient_id
+                AND patients_with_appointments.previous_appointment_date < prescription_drugs.device_created_at
+                AND prescription_drugs.device_created_at < patients_with_appointments.month_date + INTERVAL '1 month' + INTERVAL '15 days'
+            )
+            ORDER BY
+                patient_id,
+                visited_at_after_appointment
+        ) AS visits ON patients_with_appointments.patient_id = visits.patient_id
+    ),
+    patient_with_call_results AS (
+        SELECT
+            DISTINCT ON (
+                patients_with_appointments_and_visits.patient_id,
+                patients_with_appointments_and_visits.month_date
+            )
+            patients_with_appointments_and_visits.*,
+            previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS previous_called_at,
+            previous_call_results.result_type AS previous_call_result_type,
+            previous_call_results.remove_reason AS previous_call_removed_from_overdue_list_reason,
+            next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE 'UTC' AS next_called_at,
+            next_call_results.result_type AS next_call_result_type,
+            next_call_results.remove_reason as next_call_removed_from_overdue_list_reason,
+            next_call_results.user_id AS called_by_user_id
+        FROM
+            patients_with_appointments_and_visits
+        LEFT JOIN call_results previous_call_results ON patients_with_appointments_and_visits.patient_id = previous_call_results.patient_id
+            AND previous_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < patients_with_appointments_and_visits.month_date
+            AND previous_call_results.device_created_at > previous_appointment_schedule_date
+        LEFT JOIN call_results next_call_results ON patients_with_appointments_and_visits.patient_id = next_call_results.patient_id
+            AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) >= patients_with_appointments_and_visits.month_date
+            AND next_call_results.device_created_at AT TIME ZONE 'UTC' AT TIME ZONE (SELECT current_setting('TIMEZONE')) < patients_with_appointments_and_visits.month_date + INTERVAL '1 month'
+        ORDER BY
+            patients_with_appointments_and_visits.patient_id,
+            patients_with_appointments_and_visits.month_date,
+            next_call_results.device_created_at,
+            previous_call_results.device_created_at DESC
+    ),
+    patient_with_call_results_and_phone AS (
+        SELECT
+        DISTINCT ON (
+            patient_with_call_results.patient_id,
+            patient_with_call_results.month_date
+        )
+        patient_with_call_results.*,
+        patient_phone_numbers.number AS patient_phone_number
+        FROM
+            patient_with_call_results
+            LEFT JOIN patient_phone_numbers ON patient_phone_numbers.patient_id = patient_with_call_results.patient_id
+        ORDER BY
+            patient_with_call_results.patient_id,
+            patient_with_call_results.month_date
+    )
+    SELECT
+        month_date,
+        patient_id,
+        hypertension,
+        diabetes,
+        htn_care_state,
+        month,
+        quarter,
+        year,
+        month_string,
+        quarter_string,
+        assigned_facility_id,
+        assigned_facility_slug,
+        assigned_facility_region_id,
+        assigned_block_slug,
+        assigned_block_region_id,
+        assigned_district_slug,
+        assigned_district_region_id,
+        assigned_state_slug,
+        assigned_state_region_id,
+        assigned_organization_slug,
+        assigned_organization_region_id,
+        previous_appointment_id,
+        previous_appointment_date,
+        previous_appointment_schedule_date,
+        visited_at_after_appointment,
+        called_by_user_id,
+        next_called_at,
+        previous_called_at,
+        next_call_result_type,
+        next_call_removed_from_overdue_list_reason,
+        previous_call_result_type,
+        previous_call_removed_from_overdue_list_reason,
+        CASE
+            WHEN previous_appointment_id IS NULL THEN 'no'
+            WHEN (previous_appointment_schedule_date >= month_date) THEN 'no'
+            WHEN (
+                previous_appointment_schedule_date < month_date
+                and visited_at_after_appointment < month_date
+            ) THEN 'no'
+            ELSE 'yes'
+        END AS is_overdue,
+        CASE
+            WHEN next_called_at IS NULL THEN 'no'
+            ELSE 'yes'
+        END AS has_called,
+        CASE
+            WHEN visited_at_after_appointment IS NULL
+                OR next_called_at IS NULL THEN 'no'
+            WHEN visited_at_after_appointment > next_called_at + INTERVAL '15 days' THEN 'no'
+            ELSE 'yes'
+        END AS has_visited_following_call,
+        CASE
+            WHEN htn_care_state = 'lost_to_follow_up' THEN 'yes'
+            ELSE 'no'
+        END AS ltfu,
+        CASE
+            WHEN htn_care_state = 'under_care' THEN 'yes'
+            ELSE 'no'
+        END AS under_care,
+        CASE
+            WHEN patient_phone_number IS NULL THEN 'no'
+            ELSE 'yes'
+        END AS has_phone,
+        CASE
+            WHEN previous_call_result_type = 'removed_from_overdue_list' THEN 'yes'
+            ELSE 'no'
+        END AS removed_from_overdue_list,
+        CASE
+            WHEN next_call_result_type = 'removed_from_overdue_list' THEN 'yes'
+            ELSE 'no'
+        END AS removed_from_overdue_list_during_the_month
+    FROM
+        patient_with_call_results_and_phone;
+    END;
+    $_$;
+
+--
 -- Name: accesses; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -8877,6 +9141,18 @@ CREATE INDEX index_fs_organization ON simple_reporting.reporting_facility_states
 CREATE INDEX index_fs_state ON simple_reporting.reporting_facility_states USING btree (state_region_id);
 
 --
+-- Name: overdue_patients_assigned_facility_region_id; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX overdue_patients_assigned_facility_region_id ON simple_reporting.reporting_overdue_patients USING btree (assigned_facility_region_id);
+
+--
+-- Name: overdue_patients_patient_id; Type: INDEX; Schema: simple_reporting; Owner: -
+--
+
+CREATE INDEX overdue_patients_patient_id ON simple_reporting.reporting_overdue_patients USING btree (patient_id);
+
+--
 -- Name: patient_phone_numbers fk_rails_0145dd0b05; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9447,6 +9723,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260407162829'),
 ('20260422120000'),
 ('20260507063641'),
-('20260513141718');
+('20260513141718'),
+('20260515103653');
 
 

--- a/spec/models/reports/overdue_patient_spec.rb
+++ b/spec/models/reports/overdue_patient_spec.rb
@@ -419,4 +419,10 @@ RSpec.describe Reports::OverduePatient, {type: :model, reporting_spec: true} do
       end
     end
   end
+
+  describe "#partitioned?" do
+    it "returns true" do
+      expect(described_class.partitioned?).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
**Story card:** [SIMPLEBACK-118](https://rtsl.atlassian.net/browse/SIMPLEBACK-118)

## Because

We need to move a our mat views to partitioned table

## This addresses

Creating a partitioned table reporting_overdue_patients under simple_reporting schema
Both mat view and partitioned table version will exist for a small time for monitoring in prod

## Test instructions

Suite test