### PR TITLE
Fix /api-docs page not loading by updating ReDoc CDN URL

### DIFF
--- a/app/views/rswag/ui/home/index.html.erb
+++ b/app/views/rswag/ui/home/index.html.erb
@@ -152,7 +152,7 @@
 </nav>
 
 <redoc scroll-y-offset="body > nav"></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js"></script>
 <script>
     var apis = [
         {


### PR DESCRIPTION
The ReDoc library URL using @next tag on jsDelivr CDN returns 404,causing the Swagger documentation page to show blank content. Changed to @latest for a stable, working version.

**Story card:** [SIMPLEBACK-33](https://rtsl.atlassian.net/browse/SIMPLEBACK-33)

## Because

The /api-docs page was not loading because the ReDoc CDN URL was using the @next tag from jsDelivr, which currently returns a 404 response. As a result, the Swagger/ReDoc documentation page was displaying blank content.

## This addresses

Updated the ReDoc CDN URL from @next to @latest
Restored proper loading of the /api-docs page
Ensured a stable and working ReDoc version is used instead of an unstable preview tag

## Test instructions

Start the application locally
Open the /api-docs endpoint in the browser
Verify that the ReDoc/Swagger documentation page loads successfully
Confirm there are no 404 errors for the ReDoc CDN file in browser developer tools/network tab
Ensure API documentation content is displayed correctly