### PR TITLE
Add InfraScan audit workflow to GitHub Actions

### DIFF
--- a/.github/workflows/infrascan.yml
+++ b/.github/workflows/infrascan.yml
@@ -1,0 +1,32 @@
+name: InfraScan Audit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  infrascan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Reports Directory
+        run: |
+          mkdir -p infrascan-reports
+          chmod 777 infrascan-reports
+
+      - name: Run InfraScan
+        uses: soldevelo/infrascan@v1.0.6
+        with:
+          scanner: comprehensive
+          format: html
+          out: infrascan-reports/report.html
+            
+      - name: Upload InfraScan Report
+        uses: actions/upload-artifact@v4
+        if: always() # Upload report even if the scan step fails
+        with:
+          name: infrascan-report
+          path: infrascan-reports/report.html
+          retention-days: 14


### PR DESCRIPTION
## Because

Integrating an automated scanning process into the CI/CD pipeline ensures continuous security, compliance, and cost awareness for `simple-server`.

## This addresses

- Added a new GitHub Actions pipeline file at `.github/workflows/infrascan.yml`.
- Configured SolDevelo InfraScan (v1.0.6) to run a `comprehensive` scan (Cost + IaC Security + Containers) on every `push` and `pull_request`.
- Automated the output generation into a standalone interactive HTML report.
- Set up a workflow artifact upload (`infrascan-report`) that retains the audit results for 14 days, configured to run even if the scan stage finds issues (`if: always()`).

## Test instructions

- Open this Pull Request or push a commit to trigger the GitHub Actions pipeline.
- Go to the Actions tab in this repository and select the `InfraScan Audit` workflow run.
- Verify that all steps complete successfully.
- Scroll down to the Artifacts section at the bottom of the run summary, download the `infrascan-report` zip file, extract it, and open `report.html` in your browser to review the graded results.