### PR TITLE
For Ethiopia change the wording to visits rather than patients

### DIFF
--- a/app/components/dashboard/diabetes/registrations_and_follow_ups_by_user_component.html.erb
+++ b/app/components/dashboard/diabetes/registrations_and_follow_ups_by_user_component.html.erb
@@ -1,9 +1,8 @@
-<% follow_up_label = "Follow-up #{CountryConfig.current_country?("Ethiopia") ? "visits" : "patients"} per user" %>
 <div class="card mt-0 pr-0 pr-md-3 pb-inside-avoid">
   <%= render Dashboard::Card::TitleComponent.new(title: "Patient registrations and follow-ups") do |c| %>
     <% c.tooltip(
          { "Monthly registered patients" => t("registered_diabetes_patients_copy.monthly_registered_patients", region_name: region.name),
-           follow_up_label => t(:diabetes_follow_up_patients_copy, region_name: region.name) }) %>
+           t(:follow_up_patients_per_user_label) => t(:diabetes_follow_up_patients_copy, region_name: region.name) }) %>
   <% end %>
 
   <div class="table-responsive-md">
@@ -29,7 +28,7 @@
 
       <%= table.header("Total") %>
       <%= table.header("Monthly registered patients", colspan: 6) %>
-      <%= table.header(follow_up_label, colspan: 6) %>
+      <%= table.header(t(:follow_up_patients_per_user_label), colspan: 6) %>
 
       <%= table.sub_header("Users", sort_default: true, sort_method: :string) %>
       <%= table.sub_header("Registered patients") %>

--- a/app/components/dashboard/diabetes/registrations_and_follow_ups_by_user_component.html.erb
+++ b/app/components/dashboard/diabetes/registrations_and_follow_ups_by_user_component.html.erb
@@ -1,8 +1,9 @@
+<% follow_up_label = "Follow-up #{CountryConfig.current_country?("Ethiopia") ? "visits" : "patients"} per user" %>
 <div class="card mt-0 pr-0 pr-md-3 pb-inside-avoid">
   <%= render Dashboard::Card::TitleComponent.new(title: "Patient registrations and follow-ups") do |c| %>
     <% c.tooltip(
          { "Monthly registered patients" => t("registered_diabetes_patients_copy.monthly_registered_patients", region_name: region.name),
-           "Follow-up patients per user" => t(:diabetes_follow_up_patients_copy, region_name: region.name) }) %>
+           follow_up_label => t(:diabetes_follow_up_patients_copy, region_name: region.name) }) %>
   <% end %>
 
   <div class="table-responsive-md">
@@ -28,7 +29,7 @@
 
       <%= table.header("Total") %>
       <%= table.header("Monthly registered patients", colspan: 6) %>
-      <%= table.header("Follow-up patients per user", colspan: 6) %>
+      <%= table.header(follow_up_label, colspan: 6) %>
 
       <%= table.sub_header("Users", sort_default: true, sort_method: :string) %>
       <%= table.sub_header("Registered patients") %>

--- a/app/components/dashboard/diabetes/registrations_and_follow_ups_table_component.html.erb
+++ b/app/components/dashboard/diabetes/registrations_and_follow_ups_table_component.html.erb
@@ -1,8 +1,7 @@
-<% follow_up_label = "Follow-up #{CountryConfig.current_country?("Ethiopia") ? "visits" : "patients"}" %>
 <div class="card pr-md-3 pb-inside-avoid">
   <%= render Dashboard::Card::TitleComponent.new(title: "Diabetes patient registrations and follow-ups") do |c| %>
     <%= c.tooltip({ "Monthly registered patients" => t("registered_diabetes_patients_copy.monthly_registered_patients", region_name: region.name),
-                    follow_up_label => t(:diabetes_follow_up_patients_copy, region_name: region.name) }) %>
+                    t(:follow_up_patients_label) => t(:diabetes_follow_up_patients_copy, region_name: region.name) }) %>
   <% end %>
   <div class="table-responsive">
     <%= render Dashboard::Card::TableComponent.new(id: "diabetesRegistrationsAndFollowUpsTable") do |table| %>
@@ -24,7 +23,7 @@
 
       <%= table.header("Totals", colspan: 2) %>
       <%= table.header("Monthly registered patients", colspan: 6) %>
-      <%= table.header(follow_up_label, colspan: 6) %>
+      <%= table.header(t(:follow_up_patients_label), colspan: 6) %>
 
       <%= table.sub_header(region.child_region_type.capitalize, sort_default: true, sort_method: :string) %>
       <%= table.sub_header("Registrations") %>

--- a/app/components/dashboard/diabetes/registrations_and_follow_ups_table_component.html.erb
+++ b/app/components/dashboard/diabetes/registrations_and_follow_ups_table_component.html.erb
@@ -1,7 +1,8 @@
+<% follow_up_label = "Follow-up #{CountryConfig.current_country?("Ethiopia") ? "visits" : "patients"}" %>
 <div class="card pr-md-3 pb-inside-avoid">
   <%= render Dashboard::Card::TitleComponent.new(title: "Diabetes patient registrations and follow-ups") do |c| %>
     <%= c.tooltip({ "Monthly registered patients" => t("registered_diabetes_patients_copy.monthly_registered_patients", region_name: region.name),
-                    "Follow-up patients" => t(:diabetes_follow_up_patients_copy, region_name: region.name) }) %>
+                    follow_up_label => t(:diabetes_follow_up_patients_copy, region_name: region.name) }) %>
   <% end %>
   <div class="table-responsive">
     <%= render Dashboard::Card::TableComponent.new(id: "diabetesRegistrationsAndFollowUpsTable") do |table| %>
@@ -23,7 +24,7 @@
 
       <%= table.header("Totals", colspan: 2) %>
       <%= table.header("Monthly registered patients", colspan: 6) %>
-      <%= table.header("Follow-up patients", colspan: 6) %>
+      <%= table.header(follow_up_label, colspan: 6) %>
 
       <%= table.sub_header(region.child_region_type.capitalize, sort_default: true, sort_method: :string) %>
       <%= table.sub_header("Registrations") %>

--- a/app/components/diabetes_registrations_and_follow_ups_component.html.erb
+++ b/app/components/diabetes_registrations_and_follow_ups_component.html.erb
@@ -1,4 +1,3 @@
-<% follow_up_label = "Follow-up #{CountryConfig.current_country?("Ethiopia") ? "visits" : "patients"}" %>
 <div class="card pr-0 pr-md-3 pb-inside-avoid">
   <div class="d-flex flex-1 mb-8px">
     <h3 class="mb-16px mr-8px">
@@ -6,7 +5,7 @@
     </h3>
     <%= render "definition_tooltip",
                 definitions: { "Monthly registered patients" => t("registered_diabetes_patients_copy.monthly_registered_patients", region_name: region.name),
-                              follow_up_label => t(:diabetes_follow_up_patients_copy, region_name: region.name) } %>
+                              t(:follow_up_patients_label) => t(:diabetes_follow_up_patients_copy, region_name: region.name) } %>
   </div>
   <div class="table-responsive-md">
     <table class="analytics-table table-compact">
@@ -35,7 +34,7 @@
             Monthly registered patients
           </th>
           <th colspan="6">
-            <%= follow_up_label %>
+            <%= t(:follow_up_patients_label) %>
           </th>
         </tr>
         <tr class="sorts" data-sort-method="thead">

--- a/app/components/diabetes_registrations_and_follow_ups_component.html.erb
+++ b/app/components/diabetes_registrations_and_follow_ups_component.html.erb
@@ -1,3 +1,4 @@
+<% follow_up_label = "Follow-up #{CountryConfig.current_country?("Ethiopia") ? "visits" : "patients"}" %>
 <div class="card pr-0 pr-md-3 pb-inside-avoid">
   <div class="d-flex flex-1 mb-8px">
     <h3 class="mb-16px mr-8px">
@@ -5,7 +6,7 @@
     </h3>
     <%= render "definition_tooltip",
                 definitions: { "Monthly registered patients" => t("registered_diabetes_patients_copy.monthly_registered_patients", region_name: region.name),
-                              "Follow-up patients" => t(:diabetes_follow_up_patients_copy, region_name: region.name) } %>
+                              follow_up_label => t(:diabetes_follow_up_patients_copy, region_name: region.name) } %>
   </div>
   <div class="table-responsive-md">
     <table class="analytics-table table-compact">
@@ -34,7 +35,7 @@
             Monthly registered patients
           </th>
           <th colspan="6">
-            Follow-up patients
+            <%= follow_up_label %>
           </th>
         </tr>
         <tr class="sorts" data-sort-method="thead">

--- a/app/components/registrations_and_follow_ups_component.html.erb
+++ b/app/components/registrations_and_follow_ups_component.html.erb
@@ -1,3 +1,4 @@
+<% follow_up_label = "Follow-up #{CountryConfig.current_country?("Ethiopia") ? "visits" : "patients"}" %>
 <div class="card pr-0 pr-md-3 pb-inside-avoid">
   <div class="d-flex flex-1 mb-8px">
     <h3 class="mb-16px mr-8px">
@@ -5,7 +6,7 @@
     </h3>
     <%= render "definition_tooltip",
                 definitions: { "Monthly registered patients" => t("registered_patients_copy.monthly_registered_patients", region_name: region.name),
-                              "Follow-up patients" => t(:follow_up_patients_copy, region_name: region.name) } %>
+                              follow_up_label => t(:follow_up_patients_copy, region_name: region.name) } %>
   </div>
   <div class="table-responsive-md">
     <table class="analytics-table table-compact">
@@ -36,7 +37,7 @@
             Monthly registered patients
           </th>
           <th colspan="6">
-            Follow-up patients
+            <%= follow_up_label %>
           </th>
         </tr>
         <tr class="sorts" data-sort-method="thead">

--- a/app/components/registrations_and_follow_ups_component.html.erb
+++ b/app/components/registrations_and_follow_ups_component.html.erb
@@ -1,4 +1,3 @@
-<% follow_up_label = "Follow-up #{CountryConfig.current_country?("Ethiopia") ? "visits" : "patients"}" %>
 <div class="card pr-0 pr-md-3 pb-inside-avoid">
   <div class="d-flex flex-1 mb-8px">
     <h3 class="mb-16px mr-8px">
@@ -6,7 +5,7 @@
     </h3>
     <%= render "definition_tooltip",
                 definitions: { "Monthly registered patients" => t("registered_patients_copy.monthly_registered_patients", region_name: region.name),
-                              follow_up_label => t(:follow_up_patients_copy, region_name: region.name) } %>
+                              t(:follow_up_patients_label) => t(:follow_up_patients_copy, region_name: region.name) } %>
   </div>
   <div class="table-responsive-md">
     <table class="analytics-table table-compact">
@@ -37,7 +36,7 @@
             Monthly registered patients
           </th>
           <th colspan="6">
-            <%= follow_up_label %>
+            <%= t(:follow_up_patients_label) %>
           </th>
         </tr>
         <tr class="sorts" data-sort-method="thead">

--- a/app/views/reports/regions/_details_footnotes.html.erb
+++ b/app/views/reports/regions/_details_footnotes.html.erb
@@ -58,9 +58,9 @@
   <div class="mb-24px">
     <p class="mb-8px fs-16px fw-bold c-grey-dark">
       <% if @region.facility_region? %>
-        Follow-up <% if CountryConfig.current_country?("Ethiopia") %>visits<% else %>patients<% end %> per user
+        <%= t(:follow_up_patients_per_user_label) %>
       <% else %>
-        Follow-up <% if CountryConfig.current_country?("Ethiopia") %>visits<% else %>patients<% end %>
+        <%= t(:follow_up_patients_label) %>
       <% end %>
     </p>
     <div class="pl-16px">

--- a/app/views/reports/regions/_details_footnotes.html.erb
+++ b/app/views/reports/regions/_details_footnotes.html.erb
@@ -58,9 +58,9 @@
   <div class="mb-24px">
     <p class="mb-8px fs-16px fw-bold c-grey-dark">
       <% if @region.facility_region? %>
-        Follow-up patients per user
+        Follow-up <% if CountryConfig.current_country?("Ethiopia") %>visits<% else %>patients<% end %> per user
       <% else %>
-        Follow-up patients
+        Follow-up <% if CountryConfig.current_country?("Ethiopia") %>visits<% else %>patients<% end %>
       <% end %>
     </p>
     <div class="pl-16px">

--- a/app/views/reports/regions/_diabetes_footnotes.html.erb
+++ b/app/views/reports/regions/_diabetes_footnotes.html.erb
@@ -134,9 +134,9 @@
       <div class="mb-24px">
         <p class="mb-8px fs-16px fw-bold c-grey-dark">
           <% if @region.facility_region? %>
-            Follow-up patients per user
+            Follow-up <% if CountryConfig.current_country?("Ethiopia") %>visits<% else %>patients<% end %> per user 
           <% else %>
-            Follow-up patients
+            Follow-up <% if CountryConfig.current_country?("Ethiopia") %>visits<% else %>patients<% end %>
           <% end %>
         </p>
         <div class="pl-16px">

--- a/app/views/reports/regions/_diabetes_footnotes.html.erb
+++ b/app/views/reports/regions/_diabetes_footnotes.html.erb
@@ -134,9 +134,9 @@
       <div class="mb-24px">
         <p class="mb-8px fs-16px fw-bold c-grey-dark">
           <% if @region.facility_region? %>
-            Follow-up <% if CountryConfig.current_country?("Ethiopia") %>visits<% else %>patients<% end %> per user 
+            <%= t(:follow_up_patients_per_user_label) %>
           <% else %>
-            Follow-up <% if CountryConfig.current_country?("Ethiopia") %>visits<% else %>patients<% end %>
+            <%= t(:follow_up_patients_label) %>
           <% end %>
         </p>
         <div class="pl-16px">

--- a/app/views/reports/regions/_facility_details.html.erb
+++ b/app/views/reports/regions/_facility_details.html.erb
@@ -1,4 +1,3 @@
-<% follow_up_label = "Follow-up #{CountryConfig.current_country?("Ethiopia") ? "visits" : "patients"} per user" %>
 <div class="card mt-0 pr-0 pr-md-3 pb-inside-avoid">
   <div class="d-flex flex-1 mb-8px">
     <h3 class="mb-0px mr-8px">
@@ -6,7 +5,7 @@
     </h3>
     <%= render "definition_tooltip",
                 definitions: { "Monthly registered patients" => t("registered_patients_copy.monthly_registered_patients", region_name: @region.name),
-                              follow_up_label => t(:follow_up_patients_copy, region_name: @region.name) } %>
+                              t(:follow_up_patients_per_user_label) => t(:follow_up_patients_copy, region_name: @region.name) } %>
   </div>
   <div class="table-responsive-md">
     <table class="analytics-table table-compact">
@@ -36,7 +35,7 @@
           </th>
           <% unless Flipper.enabled?(:hide_facility_follow_up_patients_per_user) %>
           <th colspan="6">
-            <%= follow_up_label %>        
+            <%= t(:follow_up_patients_per_user_label) %>        
           </th>
           <% end %>
         </tr>

--- a/app/views/reports/regions/_facility_details.html.erb
+++ b/app/views/reports/regions/_facility_details.html.erb
@@ -1,3 +1,4 @@
+<% follow_up_label = "Follow-up #{CountryConfig.current_country?("Ethiopia") ? "visits" : "patients"} per user" %>
 <div class="card mt-0 pr-0 pr-md-3 pb-inside-avoid">
   <div class="d-flex flex-1 mb-8px">
     <h3 class="mb-0px mr-8px">
@@ -5,7 +6,7 @@
     </h3>
     <%= render "definition_tooltip",
                 definitions: { "Monthly registered patients" => t("registered_patients_copy.monthly_registered_patients", region_name: @region.name),
-                              "Follow-up patients per user" => t(:follow_up_patients_copy, region_name: @region.name) } %>
+                              follow_up_label => t(:follow_up_patients_copy, region_name: @region.name) } %>
   </div>
   <div class="table-responsive-md">
     <table class="analytics-table table-compact">
@@ -35,7 +36,7 @@
           </th>
           <% unless Flipper.enabled?(:hide_facility_follow_up_patients_per_user) %>
           <th colspan="6">
-            Follow-up patients per user
+            <%= follow_up_label %>        
           </th>
           <% end %>
         </tr>

--- a/app/views/reports/regions/_overview_footnotes.html.erb
+++ b/app/views/reports/regions/_overview_footnotes.html.erb
@@ -112,9 +112,9 @@
     <div class="mb-24px">
       <p class="mb-8px fs-16px fw-bold c-grey-dark">
         <% if @region.facility_region? %>
-            Follow-up <% if CountryConfig.current_country?("Ethiopia") %>visits<% else %>patients<% end %> per user 
+            <%= t(:follow_up_patients_per_user_label) %>
           <% else %>
-            Follow-up <% if CountryConfig.current_country?("Ethiopia") %>visits<% else %>patients<% end %>
+            <%= t(:follow_up_patients_label) %>
           <% end %>
       </p>
       <div class="pl-16px">

--- a/app/views/reports/regions/_overview_footnotes.html.erb
+++ b/app/views/reports/regions/_overview_footnotes.html.erb
@@ -112,10 +112,10 @@
     <div class="mb-24px">
       <p class="mb-8px fs-16px fw-bold c-grey-dark">
         <% if @region.facility_region? %>
-          Follow-up patients per user
-        <% else %>
-          Follow-up patients
-        <% end %>
+            Follow-up <% if CountryConfig.current_country?("Ethiopia") %>visits<% else %>patients<% end %> per user 
+          <% else %>
+            Follow-up <% if CountryConfig.current_country?("Ethiopia") %>visits<% else %>patients<% end %>
+          <% end %>
       </p>
       <div class="pl-16px">
         <p class="mb-8px fs-14px c-grey-dark">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -188,6 +188,8 @@ en:
   ltfu_denominator_copy: "Hypertension patients assigned to %{region_name}. Dead patients are excluded."
   diabetes_ltfu_denominator_copy: "Diabetes patients assigned to %{region_name}. Dead patients are excluded."
   follow_up_patients_copy: "Hypertension patients with a BP measure taken, a blood sugar taken, an appointment scheduled, or their medications refilled during a month in %{region_name}"
+  follow_up_patients_label: "Follow-up patients"
+  follow_up_patients_per_user_label: "Follow-up patients per user"
   diabetes_follow_up_patients_copy: "Diabetes patients with a BP measure taken, a blood sugar taken, an appointment scheduled, or their medications refilled during a month in %{region_name}"
   patients_under_care_copy: "Hypertension patients with a visit in the last 12 months."
   patients_bp_controlled_copy: "Hypertension patients with BP <140/90 at their last visit in the last 3 months (from patients enrolled more than 3 months ago)."

--- a/config/locales/en_ET.yml
+++ b/config/locales/en_ET.yml
@@ -49,3 +49,5 @@ en-ET:
         small: "Health centers"
         medium: "Primary hospitals"
         large: "General/specialized hospitals"
+  follow_up_patients_label: "Follow-up visits"
+  follow_up_patients_per_user_label: "Follow-up visits per user"


### PR DESCRIPTION
Affects:
- Comparison table title and tooltip at all levels
- Footer notes at all levels

**Story card:** [SIMPLEETH-26](https://rtsl.atlassian.net/browse/SIMPLEETH-26?search_id=ad88c9f4-2f56-4432-a83d-7c47199b3005&referrer=quick-find)

## Because

ET request the wording of the title is changed from Follow-up patients to Follow-up visits. The word patients to visits but leaving existing wording intact.

## This addresses

An issue in ET with the report being questioned.

## Test instructions

Example:

<img width="1392" height="240" alt="reg-fol" src="https://github.com/user-attachments/assets/1ca6a403-9c43-4035-97c2-33b0e36b4745" />
<img width="1425" height="282" alt="reg-fol-2" src="https://github.com/user-attachments/assets/87a4d6f8-f4de-4e9d-84ce-4209bf6c3840" />

- Ensure your instance is set to 'Ethiopia'
- Navigate to BOTH HTN and DM pages at all levels
Check the following 3 items:
- Table column title is updated to state 'visits'
- Table tooltip (item 2) states 'visits'
- Footer details shows 'visits'
**NOTE: At facility level the wording is 'Follow-up visits per user' but at all other levels its 'Follow-up visits'**

<img width="688" height="200" alt="reg-fol-footer" src="https://github.com/user-attachments/assets/59dc65e3-c434-4e3a-a4f6-3f7d0ae39017" />
<img width="226" height="215" alt="reg-fol-tooltip" src="https://github.com/user-attachments/assets/f1658332-15a2-4191-b904-6c6cc872526c" />
This tooltip is just an example so you know what to look for, but it should say 'Follow-up visits'.
