### PR TITLE
fix(transformer): nil guard

### DIFF
--- a/app/transformers/api/v3/transformer.rb
+++ b/app/transformers/api/v3/transformer.rb
@@ -17,6 +17,8 @@ class Api::V3::Transformer
     end
 
     def to_response(model)
+      return nil if model.nil?
+
       rename_attributes(model.attributes, to_response_key_mapping).as_json
     end
 

--- a/spec/transformers/api/v3/patient_transformer_spec.rb
+++ b/spec/transformers/api/v3/patient_transformer_spec.rb
@@ -41,5 +41,28 @@ RSpec.describe Api::V3::PatientTransformer do
       transformed_nested_patient = Api::V3::PatientTransformer.to_nested_response(patient)
       expect(transformed_nested_patient["registration_facility_id"]).to eq(patient.registration_facility.id)
     end
+
+    context "when the patient has no address (optional address)" do
+      it "does not raise and serializes the patient with a nil address" do
+        patient.update_columns(address_id: nil)
+        expect {
+          transformed_nested_patient = Api::V3::PatientTransformer.to_nested_response(patient)
+          expect(transformed_nested_patient["address"]).to be_nil
+        }.not_to raise_error
+      end
+    end
+
+    context "when the patient's address row has been hard-deleted (orphaned address_id)" do
+      it "does not raise and serializes the patient with a nil address" do
+        ActiveRecord::Base.connection.disable_referential_integrity do
+          Address.where(id: patient.address_id).delete_all
+        end
+        expect(patient.reload.address).to be_nil
+        expect {
+          transformed_nested_patient = Api::V3::PatientTransformer.to_nested_response(patient)
+          expect(transformed_nested_patient["address"]).to be_nil
+        }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/transformers/api/v3/transformer_spec.rb
+++ b/spec/transformers/api/v3/transformer_spec.rb
@@ -11,6 +11,12 @@ def dedupe(old_record, new_record, user)
 end
 
 RSpec.describe Api::V3::Transformer do
+  describe "#to_response" do
+    it "returns nil when the model is nil instead of raising" do
+      expect(Api::V3::Transformer.to_response(nil)).to be_nil
+    end
+  end
+
   context "redirects to deduped records if present" do
     it "doesn't do anything if the record is not deduped" do
       bp = create(:blood_pressure)


### PR DESCRIPTION
**Story card:** [SIMPLEBACK-136](https://rtsl.atlassian.net/browse/SIMPLEBACK-136)

## Because

Misaligned constraint between model and transformer causes breakage.

## This addresses

Introducing a nil guard to the transformer to uphold the `optional: true` contract in model

## Test instructions

run test suites
