### PR TITLE
feat(Action Plans): Edit Action Plans

### DIFF
--- a/app/assets/stylesheets/dr_rai.scss
+++ b/app/assets/stylesheets/dr_rai.scss
@@ -145,7 +145,7 @@ $font-condensed: "Roboto Condensed", sans-serif;
     right: 3px;
     font-size: 20px;
 
-    button {
+    > button {
       display: flex;
       align-items: center;
       justify-items: center;
@@ -592,6 +592,8 @@ $font-condensed: "Roboto Condensed", sans-serif;
 }
 
 .bs-canvas-overlay {
+  top: 0;
+  left: 0;
   opacity: 0;
   z-index: -1;
 }

--- a/app/components/dashboard/dr_rai_report.html.erb
+++ b/app/components/dashboard/dr_rai_report.html.erb
@@ -20,8 +20,24 @@
                 <i class="fa-solid fa-ellipsis"></i>
               </button>
               <div class="dropdown-menu dropdown-menu-right">
-                <a class="dropdown-item edit" href="#">Edit</a>
-                <div class="dropdown-divider"></div>
+                <% if action_plans_editable? %>
+                  <%= tag.button "Edit",
+                    type: "button",
+                    class: "dropdown-item edit edit-action-plan",
+                    data: {
+                      toggle: "canvas",
+                      target: "#dr-rai--edit-sidebar",
+                      action_plan_id: action_plan.id,
+                      indicator: action_plan.indicator.display_name,
+                      target_statement: action_plan.statement,
+                      actions: action_plan.actions
+                    },
+                    aria: {
+                      expanded: "false",
+                      controls: "dr-rai--edit-sidebar"
+                    } %>
+                  <div class="dropdown-divider"></div>
+                <% end %>
                 <%= link_to "Delete", dr_rai_action_plan_path(action_plan), method: :delete, class: "dropdown-item delete" %>
               </div>
             </div>
@@ -101,7 +117,8 @@
   <% end %>
 </div>
 <% unless is_lite_version? %>
-<div class="sidepanel bs-canvas bs-canvas-right position-fixed h-100" tabindex="-1" id="dr-rai--sidebar" data-period="<%= selected_period.value %>" data-region="<%= region.slug %>">
+<div class="bs-canvas-overlay bs-canvas-anim bg-dark position-fixed w-100 h-100"></div>
+<div class="sidepanel bs-canvas bs-canvas-right bs-canvas-anim position-fixed h-100" tabindex="-1" id="dr-rai--sidebar" data-period="<%= selected_period.value %>" data-region="<%= region.slug %>">
   <div class="header">
     <p>Create action</p>
     <button class="bs-canvas-close float-left close" aria-label="Close">
@@ -231,6 +248,41 @@
     </div>
   <% end %>
 </div>
+<% if action_plans_editable? %>
+  <div class="sidepanel bs-canvas bs-canvas-right bs-canvas-anim position-fixed h-100" tabindex="-1" id="dr-rai--edit-sidebar" role="dialog" aria-modal="true" aria-labelledby="dr-rai--edit-title" aria-hidden="true" inert>
+    <div class="header">
+      <p id="dr-rai--edit-title">Edit action</p>
+      <button class="bs-canvas-close float-left close" aria-label="Close">
+        <i class="fa-solid fa-xmark-large"></i>
+      </button>
+    </div>
+    <div class="content">
+      <h1><%= start_of(selected_period) %> - <%= end_of(selected_period) %> (<%= human_readable(selected_period) %>)</h1>
+      <div class="step-block">
+        <h2>Which indicator to improve?</h2>
+        <p class="step-statement edit-indicator-summary"></p>
+      </div>
+      <div class="step-block">
+        <h2>What is the goal?</h2>
+        <p class="step-statement edit-target-summary"></p>
+      </div>
+      <div class="step-block">
+        <h2>What action should be taken?</h2>
+        <textarea class="custom-actions-list" rows="4" placeholder="Write actions..."></textarea>
+      </div>
+      <p class="missing-input-warning edit-save-warning d-none" role="alert">Unable to save. Try again.</p>
+      <div class="action-buttons-block">
+        <button class="action-button cancel-button edit-cancel-button">Cancel</button>
+        <button class="action-button save-button edit-save-button">
+          <span class="loading-animation">
+            <i class="fa-solid fa-spinner-third fa-spin"></i>
+          </span>
+          <span class="button-text">Save</span>
+        </button>
+      </div>
+    </div>
+  </div>
+<% end %>
 <script type="text/javascript" charset="utf-8">
   jQuery(document).ready(function($) {
     var bsDefaults = { offset: false, overlay: true, width: '450px' },
@@ -238,31 +290,39 @@
         bsOverlay = $('.bs-canvas-overlay')
 
     const toHide = [], toReveal = []
+    const createPanel = $('#dr-rai--sidebar')
+    const editPanel = $('#dr-rai--edit-sidebar')
 
     // Opening the offcanvas
-    $('[data-toggle="canvas"][aria-expanded="false"]').on('click', function() {
-      var canvas = $(this).data('target'),
+    $('[data-toggle="canvas"][aria-expanded="false"]').on('click', function(e) {
+      e.preventDefault()
+      var canvas = $(this).attr('data-target'),
           opts = $.extend({}, bsDefaults, $(canvas).data()),
           prop = $(canvas).hasClass('bs-canvas-right') ? 'margin-right' : 'margin-left'
+      const opener = $(e.currentTarget).hasClass('edit-action-plan')
+        ? $(this).closest('.action-card').find('[data-toggle="dropdown"]').get(0)
+        : e.currentTarget
 
       if (opts.width === '100%') {
         opts.offset = false
       }
 
+      $(canvas).data('opener', opener)
       $(canvas).css('width', opts.width)
       if (opts.offset && bsMain.length) {
         bsMain.css(prop, opts.width)
       }
 
+      $(canvas).attr('aria-hidden', 'false').removeAttr('inert')
       $(canvas + ' .bs-canvas-close').attr('aria-expanded', "true")
       $('[data-toggle="canvas"][data-target="' + canvas + '"]').attr('aria-expanded', "true")
       if (opts.overlay && bsOverlay.length)
         bsOverlay.addClass('show')
-      return false
     })
 
     // Closing the offcanvas
-    $('.bs-canvas-close, .bs-canvas-overlay').on('click', function() {
+    $('.bs-canvas-close, .bs-canvas-overlay').on('click', function(e) {
+      e.preventDefault()
       var canvas, aria
       if ($(this).hasClass('bs-canvas-close')) {
         canvas = $(this).closest('.bs-canvas')
@@ -281,18 +341,26 @@
         }
       }
       canvas.css('width', '')
+      canvas.attr('aria-hidden', 'true').attr('inert', '')
       aria.attr('aria-expanded', "false")
       if (bsOverlay.length) {
         bsOverlay.removeClass('show')
       }
-      return false
+      canvas.trigger('canvas-closed')
+    })
+
+    $('.bs-canvas').on('canvas-closed', function() {
+      const canvas = $(this)
+      const opener = canvas.data('opener')
+      canvas.removeData('opener')
+      if (opener) opener.focus()
     })
 
     // ===================
     // BEGIN DR. RAI LOGIC
     // ===================
 
-    $('.step-block').on('step-through', (e, target, indicator) => {
+    createPanel.find('.step-block').on('step-through', (e, target, indicator) => {
       const targets = ['.active', '.inactive']
       const goalInputBlock = $(e.currentTarget).find('.goal-input-block')
       if (goalInputBlock.length > 0 && goalInputBlock.find('input').val() === '') {
@@ -320,7 +388,7 @@
           $(e.currentTarget).find('.step-statement').text($(e.currentTarget).find('.activity-promise').text())
           $('#dr-rai--sidebar').data('statement', $(e.currentTarget).find('.step-statement').text())
         }
-        $('.action-buttons-block .save-button').removeClass('invisible')
+        createPanel.find('.action-buttons-block .save-button').removeClass('invisible')
       } else {
         if (target.ui !== undefined) {
           $('#step-3').data('target-type', target.type)
@@ -348,7 +416,7 @@
       }
     })
 
-    $('.goal-input-block input').on('blur keyup', (e) => {
+    createPanel.find('.goal-input-block input').on('blur keyup', (e) => {
       $('.missing-input-warning').addClass('d-none')
     })
 
@@ -380,9 +448,9 @@
       $('#dr-rai--sidebar').data('target-value', targetValue)
     })
 
-    $('.action-buttons-block .save-button').on('click', (e) => {
-      $('.action-buttons-block .save-button').prop('disabled', true)
-      $(".save-button .button-text").text("Creating...");
+    createPanel.find('.action-buttons-block .save-button').on('click', (e) => {
+      createPanel.find('.action-buttons-block .save-button').prop('disabled', true)
+      createPanel.find(".save-button .button-text").text("Creating...");
       $.ajax({
         url: `/dr_rai/action_plans`,
         type: 'POST',
@@ -390,7 +458,7 @@
           'dr_rai_action_plan': {
             'indicator_id': $('#dr-rai--sidebar').data('indicator-id'),
             'period': $('#dr-rai--sidebar').data('period'),
-            'actions': $('.custom-actions-list').val(),
+            'actions': createPanel.find('.custom-actions-list').val(),
             'region_slug': $('#dr-rai--sidebar').data('region'),
             'statement': $('#dr-rai--sidebar').data('statement'),
             'target_type': $('#dr-rai--sidebar').data('target-type'),
@@ -404,14 +472,14 @@
           window.location.reload()
         },
         error: (xhr) => {
-          $('.action-buttons-block .save-button').prop('disabled', false)
-          $(".save-button .button-text").text("Create");
+          createPanel.find('.action-buttons-block .save-button').prop('disabled', false)
+          createPanel.find(".save-button .button-text").text("Create");
         }
       });
 
     })
 
-    $('.step-block .next-button, .advancer').on('click', (e) => {
+    createPanel.find('.step-block .next-button, .advancer').on('click', (e) => {
       $('#dr-rai--sidebar').data('indicator-id', $(e.currentTarget).data('indicator-id'))
       $('#dr-rai--sidebar').data('target-type', $(e.currentTarget).data('target-type'))
       $(e.currentTarget)
@@ -433,7 +501,7 @@
         ])
     })
 
-    $('.link-button.advancer').on('click', (e) => {
+    createPanel.find('.link-button.advancer').on('click', (e) => {
       $(e.currentTarget)
         .closest(".active")
         .siblings('.inactive')
@@ -442,7 +510,7 @@
         .text($(e.currentTarget).text())
     })
 
-    $('.cancel-button').on('click', (e) => {
+    createPanel.find('.cancel-button').on('click', (e) => {
       // Clear "state"
       $('#dr-rai--sidebar').removeData([
         'indicator-id',
@@ -455,14 +523,112 @@
       // Reset UI
       toHide.forEach((el) => el.addClass('d-none'))
       toReveal.forEach((el) => el.removeClass('d-none'))
-      $('.action-buttons-block .save-button').addClass('invisible')
-      $('.sidepanel input').val('')
+      createPanel.find('.action-buttons-block .save-button').addClass('invisible')
+      createPanel.find('input').val('')
       $('.active .activity-promise').addClass('d-none')
-      $('.sidepanel textarea').val('')
+      createPanel.find('textarea').val('')
 
       // Close the offcanvas
-      $('.bs-canvas-close').trigger('click')
+      createPanel.find('.bs-canvas-close').trigger('click')
 
+    })
+
+    const editFocusableSelector = [
+      'a[href]',
+      'button:not([disabled])',
+      'textarea:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])'
+    ].join(',')
+
+    const resetEditError = () => {
+      editPanel.find('.edit-save-warning').addClass('d-none')
+    }
+
+    const clearEditPanel = () => {
+      editPanel.removeData('action-plan-id')
+      editPanel.removeData('open')
+      editPanel.find('.edit-indicator-summary, .edit-target-summary').text('')
+      editPanel.find('.custom-actions-list').val('')
+      editPanel.find('.edit-save-button').prop('disabled', false)
+      editPanel.find('.edit-save-button .button-text').text('Save')
+      resetEditError()
+    }
+
+    $('.edit-action-plan').on('click', (e) => {
+      const editControl = $(e.currentTarget)
+      editPanel.data('open', true)
+      editPanel.data('action-plan-id', editControl.attr('data-action-plan-id'))
+      editPanel.find('.edit-indicator-summary').text(editControl.attr('data-indicator'))
+      editPanel.find('.edit-target-summary').text(editControl.attr('data-target-statement'))
+      editPanel.find('.custom-actions-list').val(editControl.attr('data-actions'))
+      resetEditError()
+      window.setTimeout(() => editPanel.find('.custom-actions-list').trigger('focus'), 0)
+    })
+
+    editPanel.find('.edit-cancel-button').on('click', () => {
+      editPanel.find('.bs-canvas-close').trigger('click')
+    })
+
+    editPanel.on('canvas-closed', clearEditPanel)
+
+    editPanel.on('keydown', (e) => {
+      if (!editPanel.data('open')) return
+
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        editPanel.find('.bs-canvas-close').trigger('click')
+        return
+      }
+
+      if (e.key !== 'Tab') return
+
+      const focusableElements = editPanel.find(editFocusableSelector).filter(':visible')
+      const firstFocusable = focusableElements.first().get(0)
+      const lastFocusable = focusableElements.last().get(0)
+
+      if (!firstFocusable) {
+        e.preventDefault()
+        editPanel.trigger('focus')
+      } else if (e.shiftKey && document.activeElement === firstFocusable) {
+        e.preventDefault()
+        lastFocusable.focus()
+      } else if (!e.shiftKey && document.activeElement === lastFocusable) {
+        e.preventDefault()
+        firstFocusable.focus()
+      } else if (!editPanel.get(0).contains(document.activeElement)) {
+        e.preventDefault()
+        firstFocusable.focus()
+      }
+    })
+
+    editPanel.find('.edit-save-button').on('click', () => {
+      const saveButton = editPanel.find('.edit-save-button')
+      resetEditError()
+      saveButton.prop('disabled', true)
+      saveButton.find('.button-text').text('Saving...')
+
+      $.ajax({
+        url: `/dr_rai/action_plans/${editPanel.data('action-plan-id')}`,
+        type: 'PATCH',
+        data: {
+          'dr_rai_action_plan': {
+            'actions': editPanel.find('.custom-actions-list').val()
+          }
+        },
+        headers: {
+          'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
+        },
+        success: () => {
+          window.location.reload()
+        },
+        error: () => {
+          saveButton.prop('disabled', false)
+          saveButton.find('.button-text').text('Save')
+          editPanel.find('.edit-save-warning').removeClass('d-none')
+        }
+      })
     })
 
     // show action delete overlay, takes several seconds to process

--- a/app/components/dashboard/dr_rai_report.html.erb
+++ b/app/components/dashboard/dr_rai_report.html.erb
@@ -20,8 +20,8 @@
                 <i class="fa-solid fa-ellipsis"></i>
               </button>
               <div class="dropdown-menu dropdown-menu-right">
-                <%# <a class="dropdown-item edit" href="#">Edit</a> %>
-                <%# <div class="dropdown-divider"></div> %>
+                <a class="dropdown-item edit" href="#">Edit</a>
+                <div class="dropdown-divider"></div>
                 <%= link_to "Delete", dr_rai_action_plan_path(action_plan), method: :delete, class: "dropdown-item delete" %>
               </div>
             </div>

--- a/app/components/dashboard/dr_rai_report.rb
+++ b/app/components/dashboard/dr_rai_report.rb
@@ -56,6 +56,10 @@ class Dashboard::DrRaiReport < ApplicationComponent
     selected_period == current_period
   end
 
+  def action_plans_editable?
+    current_period? && Date.current.month == selected_period.begin.month
+  end
+
   def a_month_to_next_period?
     next_month_period == current_period.next
   end

--- a/app/controllers/dr_rai/action_plans_controller.rb
+++ b/app/controllers/dr_rai/action_plans_controller.rb
@@ -1,7 +1,9 @@
 class DrRai::ActionPlansController < AdminController
   before_action :authorize_user
   before_action :hydrate_plan, only: [:create]
-  before_action :set_dr_rai_action_plan, only: %i[destroy]
+  before_action :set_dr_rai_action_plan, only: %i[update destroy]
+  before_action :authorize_edit_action_plans, only: [:update]
+  before_action :enforce_action_plan_edit_window, only: [:update]
 
   # POST /dr_rai/action_plans or /dr_rai/action_plans.json
   def create
@@ -22,6 +24,15 @@ class DrRai::ActionPlansController < AdminController
     end
   end
 
+  # PATCH/PUT /dr_rai/action_plans/1 or /dr_rai/action_plans/1.json
+  def update
+    if @dr_rai_action_plan.update(dr_rai_action_plan_update_params)
+      head :no_content
+    else
+      render json: @dr_rai_action_plan.errors, status: :unprocessable_entity
+    end
+  end
+
   # DELETE /dr_rai/action_plans/1 or /dr_rai/action_plans/1.json
   def destroy
     @dr_rai_action_plan.discard
@@ -33,6 +44,26 @@ class DrRai::ActionPlansController < AdminController
   end
 
   private
+
+  def authorize_edit_action_plans
+    authorize {
+      current_admin
+        .accessible_facility_regions(:view_reports)
+        .find(@dr_rai_action_plan.region_id)
+    }
+  end
+
+  # So… this one… may not be necessary — especially because the guard exists in
+  # the component — but I have to guard against AI-generated code in the
+  # future.
+  def enforce_action_plan_edit_window
+    target_period = Period.new(type: :quarter, value: @dr_rai_action_plan.target.period)
+    current_period = Period.current.to_quarter_period
+
+    unless target_period == current_period && Date.current.month == current_period.begin.month
+      head :forbidden
+    end
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_dr_rai_action_plan
@@ -50,6 +81,10 @@ class DrRai::ActionPlansController < AdminController
       :target_type,
       :target_value
     )
+  end
+
+  def dr_rai_action_plan_update_params
+    params.require(:dr_rai_action_plan).permit(:actions)
   end
 
   def authorize_user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   namespace :dr_rai do
-    resources :action_plans, only: [:create, :destroy]
+    resources :action_plans, only: [:create, :update, :destroy]
   end
   resources :home
 

--- a/spec/components/dashboard/dr_rai_report_spec.rb
+++ b/spec/components/dashboard/dr_rai_report_spec.rb
@@ -95,6 +95,157 @@ RSpec.describe Dashboard::DrRaiReport, type: :component do
     end
   end
 
+  describe "#action_plans_editable?" do
+    it "is true on the last day of the current quarter's first month" do
+      Timecop.freeze(Time.zone.parse("April 30 2024 15:12")) do
+        component = described_class.new(periods, region, default_options.merge(selected_quarter: q2_2024))
+
+        expect(component.action_plans_editable?).to be(true)
+      end
+    end
+
+    it "is false on the first day of the current quarter's second month" do
+      Timecop.freeze(Time.zone.parse("May 1 2024 15:12")) do
+        component = described_class.new(periods, region, default_options.merge(selected_quarter: q2_2024))
+
+        expect(component.action_plans_editable?).to be(false)
+      end
+    end
+
+    it "is false when another quarter is selected" do
+      Timecop.freeze(Time.zone.parse("April 15 2024 15:12")) do
+        component = described_class.new(periods, region, default_options.merge(selected_quarter: q1_2024))
+
+        expect(component.action_plans_editable?).to be(false)
+      end
+    end
+  end
+
+  describe "editing action plans" do
+    let(:indicator) { create(:indicator, :contact_overdue_patients) }
+    let(:action_plan) do
+      create(
+        :action_plan,
+        region: Region.find_by!(slug: region),
+        statement: "Call 20 overdue patients",
+        actions: "Call patients marked \"high-risk\" & follow up",
+        dr_rai_indicator: indicator,
+        dr_rai_target: create(:target, :percentage, period: q2_2024, indicator: indicator)
+      )
+    end
+
+    it "renders eligible action plans with safely escaped edit data" do
+      Timecop.freeze(Time.zone.parse("April 15 2024 15:12")) do
+        action_plan
+
+        render_inline(described_class.new(periods, region, default_options.merge(selected_quarter: q2_2024)))
+
+        edit_control = page.find(".edit-action-plan")
+        expect(edit_control["data-action-plan-id"]).to eq(action_plan.id.to_s)
+        expect(edit_control["data-target"]).to eq("#dr-rai--edit-sidebar")
+        expect(edit_control["data-indicator"]).to eq("Contact overdue patients")
+        expect(edit_control["data-target-statement"]).to eq("Call 20 overdue patients")
+        expect(edit_control["data-actions"]).to eq("Call patients marked \"high-risk\" & follow up")
+        expect(edit_control["data-target-statement"]).not_to include("&quot;")
+        expect(edit_control["data-actions"]).not_to include("&amp;")
+      end
+    end
+
+    it "preserves strings that jQuery data attributes would coerce" do
+      Timecop.freeze(Time.zone.parse("April 15 2024 15:12")) do
+        action_plan.update!(statement: "null", actions: "{\"enabled\":true}")
+
+        render_inline(described_class.new(periods, region, default_options.merge(selected_quarter: q2_2024)))
+
+        edit_control = page.find(".edit-action-plan")
+        expect(edit_control["data-target-statement"]).to eq("null")
+        expect(edit_control["data-actions"]).to eq("{\"enabled\":true}")
+        expect(page.native.to_html).to include("editControl.attr('data-indicator')")
+        expect(page.native.to_html).to include("editControl.attr('data-target-statement')")
+        expect(page.native.to_html).to include("editControl.attr('data-actions')")
+      end
+    end
+
+    it "renders a dedicated edit side panel congruent with the creation panel" do
+      Timecop.freeze(Time.zone.parse("April 15 2024 15:12")) do
+        action_plan
+
+        render_inline(described_class.new(periods, region, default_options.merge(selected_quarter: q2_2024)))
+
+        panel = page.find("#dr-rai--edit-sidebar.sidepanel.bs-canvas.bs-canvas-right.bs-canvas-anim")
+        expect(panel).to have_css(".header", text: "Edit action")
+        expect(panel).to have_css(".content > h1", text: "Apr-1 - Jun-30 (Q2 2024)")
+        expect(panel).to have_css(".step-block .edit-indicator-summary")
+        expect(panel).to have_css(".step-block .edit-target-summary")
+        expect(panel).to have_css("textarea.custom-actions-list")
+        expect(panel).to have_css(".action-buttons-block .cancel-button", text: "Cancel")
+        expect(panel).to have_css(".action-buttons-block .save-button .loading-animation")
+        expect(panel).to have_css(".action-buttons-block .save-button .button-text", text: "Save")
+      end
+    end
+
+    it "renders the edit panel as an accessible labelled modal with an error message" do
+      Timecop.freeze(Time.zone.parse("April 15 2024 15:12")) do
+        action_plan
+
+        render_inline(described_class.new(periods, region, default_options.merge(selected_quarter: q2_2024)))
+
+        panel = page.find("#dr-rai--edit-sidebar")
+        expect(panel["role"]).to eq("dialog")
+        expect(panel["aria-modal"]).to eq("true")
+        expect(panel["aria-labelledby"]).to eq("dr-rai--edit-title")
+        expect(panel["aria-hidden"]).to eq("true")
+        expect(panel["inert"]).to eq("")
+        expect(panel).to have_css(".header > p#dr-rai--edit-title", text: "Edit action")
+        expect(panel).to have_css(".missing-input-warning.edit-save-warning.d-none", text: "Unable to save. Try again.")
+      end
+    end
+
+    it "removes and restores the edit panel accessibility guards when toggled" do
+      Timecop.freeze(Time.zone.parse("April 15 2024 15:12")) do
+        action_plan
+
+        render_inline(described_class.new(periods, region, default_options.merge(selected_quarter: q2_2024)))
+
+        markup = page.native.to_html
+        expect(markup).to include("$(canvas).attr('aria-hidden', 'false').removeAttr('inert')")
+        expect(markup).to include("canvas.attr('aria-hidden', 'true').attr('inert', '')")
+      end
+    end
+
+    it "restores focus to the visible action-card toggle after editing and to the opener after creating" do
+      Timecop.freeze(Time.zone.parse("April 15 2024 15:12")) do
+        action_plan
+
+        render_inline(described_class.new(periods, region, default_options.merge(selected_quarter: q2_2024)))
+
+        markup = page.native.to_html
+        expect(markup).to include("$(this).closest('.action-card').find('[data-toggle=\"dropdown\"]').get(0)")
+        expect(markup).to include(": e.currentTarget")
+        expect(markup).to include("$(canvas).data('opener', opener)")
+        expect(markup).to include("opener.focus()")
+      end
+    end
+
+    it "renders a fixed overlay for the offcanvas panels" do
+      Timecop.freeze(Time.zone.parse("April 15 2024 15:12")) do
+        render_inline(described_class.new(periods, region, default_options.merge(selected_quarter: q2_2024)))
+
+        expect(page).to have_css(".bs-canvas-overlay.position-fixed.w-100.h-100", visible: :all)
+      end
+    end
+
+    it "hides edit controls after the current quarter's first month" do
+      Timecop.freeze(Time.zone.parse("May 1 2024 15:12")) do
+        action_plan
+
+        render_inline(described_class.new(periods, region, default_options.merge(selected_quarter: q2_2024)))
+
+        expect(page).not_to have_css(".edit-action-plan")
+      end
+    end
+  end
+
   describe "stale periods" do
     it "does not allow adding new actions" do
       rai_options = default_options.merge(selected_quarter: q1_2024)

--- a/spec/controllers/dr_rai/action_plans_controller_spec.rb
+++ b/spec/controllers/dr_rai/action_plans_controller_spec.rb
@@ -70,6 +70,139 @@ RSpec.describe DrRai::ActionPlansController, type: :controller do
     end
   end
 
+  describe "PATCH /update" do
+    let(:dr_rai_action_plan) {
+      create(:action_plan,
+        region: facility_1.region,
+        dr_rai_indicator: indicator,
+        dr_rai_target: create(:target, :percentage, period: "Q2-2025", indicator: indicator),
+        statement: "Original statement",
+        actions: "Original actions")
+    }
+
+    around do |example|
+      Timecop.freeze(Time.zone.parse("April 30 2025 15:12")) { example.run }
+    end
+
+    context "authorization" do
+      it "allows an admin with report access to the action plan facility to update it" do
+        admin = create(:admin, :viewer_reports_only, :with_access, resource: facility_1)
+        sign_in admin.email_authentication
+
+        patch :update, params: {
+          id: dr_rai_action_plan.to_param,
+          dr_rai_action_plan: {actions: "Updated actions"}
+        }
+
+        expect(dr_rai_action_plan.reload.actions).to eq("Updated actions")
+      end
+
+      it "does not allow an admin without report access to the action plan facility to update it" do
+        inaccessible_facility = create(:facility)
+        admin = create(:admin, :viewer_reports_only, :with_access, resource: inaccessible_facility)
+        sign_in admin.email_authentication
+
+        patch :update, params: {
+          id: dr_rai_action_plan.to_param,
+          dr_rai_action_plan: {actions: "Updated actions"}
+        }
+
+        expect(dr_rai_action_plan.reload.actions).to eq("Original actions")
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
+      end
+    end
+
+    context "within the business edit window" do
+      it "allows updates on the last day of the current quarter's first month" do
+        patch :update, params: {
+          id: dr_rai_action_plan.to_param,
+          dr_rai_action_plan: {actions: "Updated actions"}
+        }
+
+        expect(response).to have_http_status(:no_content)
+        expect(dr_rai_action_plan.reload.actions).to eq("Updated actions")
+      end
+
+      it "forbids updates after the current quarter's first month" do
+        Timecop.freeze(Time.zone.parse("May 1 2025 00:00")) do
+          patch :update, params: {
+            id: dr_rai_action_plan.to_param,
+            dr_rai_action_plan: {actions: "Updated actions"}
+          }
+        end
+
+        expect(response).to have_http_status(:forbidden)
+        expect(dr_rai_action_plan.reload.actions).to eq("Original actions")
+      end
+
+      it "forbids updates to an action plan targeting another quarter" do
+        dr_rai_action_plan.target.update!(period: "Q1-2025")
+
+        patch :update, params: {
+          id: dr_rai_action_plan.to_param,
+          dr_rai_action_plan: {actions: "Updated actions"}
+        }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(dr_rai_action_plan.reload.actions).to eq("Original actions")
+      end
+    end
+
+    it "updates the action plan actions" do
+      patch :update, params: {
+        id: dr_rai_action_plan.to_param,
+        dr_rai_action_plan: {actions: "Updated actions"}
+      }
+
+      expect(dr_rai_action_plan.reload.actions).to eq("Updated actions")
+    end
+
+    it "does not update the indicator, target, or statement" do
+      original_indicator = dr_rai_action_plan.dr_rai_indicator
+      original_target = dr_rai_action_plan.dr_rai_target
+      other_indicator = create(:indicator, type: "DrRai::TitrationIndicator")
+      other_target = create(:target, :percentage, indicator: other_indicator)
+
+      patch :update, params: {
+        id: dr_rai_action_plan.to_param,
+        dr_rai_action_plan: {
+          actions: "Updated actions",
+          dr_rai_indicator_id: other_indicator.id,
+          dr_rai_target_id: other_target.id,
+          statement: "Updated statement"
+        }
+      }
+
+      dr_rai_action_plan.reload
+      expect(dr_rai_action_plan.dr_rai_indicator_id).to eq(original_indicator.id)
+      expect(dr_rai_action_plan.dr_rai_target_id).to eq(original_target.id)
+      expect(dr_rai_action_plan.statement).to eq("Original statement")
+    end
+
+    it "returns no content so the AJAX client can reload the report" do
+      patch :update, params: {
+        id: dr_rai_action_plan.to_param,
+        dr_rai_action_plan: {actions: "Updated actions"}
+      }
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "returns JSON errors when the update fails validation" do
+      dr_rai_action_plan.errors.add(:actions, "is invalid")
+      allow(DrRai::ActionPlan).to receive(:find).and_return(dr_rai_action_plan)
+      allow(dr_rai_action_plan).to receive(:update).and_return(false)
+
+      patch :update, params: {
+        id: dr_rai_action_plan.to_param,
+        dr_rai_action_plan: {actions: "Invalid actions"}
+      }, format: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body).to eq("actions" => ["is invalid"])
+    end
+  end
+
   describe "DELETE /destroy" do
     it "destroys the requested dr_rai_action_plan" do
       dr_rai_action_plan = create :action_plan, region: region, dr_rai_indicator: contact_overdue_patients_indicator

--- a/spec/routing/dr_rai/action_plans_routing_spec.rb
+++ b/spec/routing/dr_rai/action_plans_routing_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe DrRai::ActionPlansController, type: :routing do
       expect(post: "/dr_rai/action_plans").to route_to("dr_rai/action_plans#create")
     end
 
+    it "routes to #update" do
+      expect(patch: "/dr_rai/action_plans/1").to route_to("dr_rai/action_plans#update", id: "1")
+    end
+
     it "routes to #destroy" do
       expect(delete: "/dr_rai/action_plans/1").to route_to("dr_rai/action_plans#destroy", id: "1")
     end


### PR DESCRIPTION

**Story card:** [SIMPLEBACK-92](https://rtsl.atlassian.net/browse/SIMPLEBACK-92)

## Because

Users want the ability to edit action plans

## This addresses

- Unhiding the Edit button
- Allowing edits to the text within the edit window
- The edit window is one month into the quarter

## Test instructions

- Create an action plan 
- Edit it 
