### PR TITLE
Improve the language of the tooltip

### DIFF
--- a/app/components/dashboard/diabetes/dm_prescribed_statins_component.html.erb
+++ b/app/components/dashboard/diabetes/dm_prescribed_statins_component.html.erb
@@ -4,7 +4,7 @@
       title: "DM patients &ge;40y prescribed statins".html_safe,
       subtitle: "Diabetes patients in #{region.name} ≥40 years old that were prescribed statins at their latest visit in the last 12 months.") do |title| %>
       <%= title.tooltip({
-        "Numerator" => "Patients prescribed statins at their latest visit.",
+        "Numerator" => "Patients prescribed statins at their latest visit in the last 12 months.",
         "Denominator" => t(denominator_copy, region_name: region.name)
       }) %>
       <%= title.ltfu_toggle(id: 'DMPrescribedStatinsGraphLtfuToggle', enabled: with_ltfu) %>


### PR DESCRIPTION
The numerator for this tooltip doesnt specify that its the latest visit ‘in the past 12 months’ leading to confusion when viewing the the LTFU toggle enabled, dashboard.

**Story card:** [SIMPLEBACK-125](https://rtsl.atlassian.net/browse/SIMPLEBACK-125)

## Because

This might cause confusion over how the user interprets the way patients prescribed statins indicator is caluclated

## This addresses

More specific copy to fix this issue.

## Test instructions

Load the DM dashboard and hover the tooltip on both the standard view and the 'Include LTFU' view (enable to toggle).