### PR TITLE
fix(Dr. Rai Reports): honor manual edit override and last-month edit rule

### DIFF
--- a/app/components/dashboard/dr_rai_report.rb
+++ b/app/components/dashboard/dr_rai_report.rb
@@ -58,7 +58,7 @@ class Dashboard::DrRaiReport < ApplicationComponent
 
   def action_plans_editable?
     Flipper.enabled?(:dr_rai_manual_edit) ||
-      current_period? && Date.current.month == selected_period.begin.month
+      current_period? && Date.current.month != selected_period.end.month
   end
 
   def a_month_to_next_period?

--- a/app/controllers/dr_rai/action_plans_controller.rb
+++ b/app/controllers/dr_rai/action_plans_controller.rb
@@ -57,10 +57,12 @@ class DrRai::ActionPlansController < AdminController
   # the component — but I have to guard against AI-generated code in the
   # future.
   def enforce_action_plan_edit_window
+    return if Flipper.enabled?(:dr_rai_manual_edit)
+
     target_period = Period.new(type: :quarter, value: @dr_rai_action_plan.target.period)
     current_period = Period.current.to_quarter_period
 
-    unless target_period == current_period && Date.current.month == current_period.begin.month
+    unless target_period == current_period && Date.current.month != current_period.end.month
       head :forbidden
     end
   end

--- a/spec/components/dashboard/dr_rai_report_spec.rb
+++ b/spec/components/dashboard/dr_rai_report_spec.rb
@@ -104,8 +104,16 @@ RSpec.describe Dashboard::DrRaiReport, type: :component do
       end
     end
 
-    it "is false on the first day of the current quarter's second month" do
+    it "is true on the first day of the current quarter's second month" do
       Timecop.freeze(Time.zone.parse("May 1 2024 15:12")) do
+        component = described_class.new(periods, region, default_options.merge(selected_quarter: q2_2024))
+
+        expect(component.action_plans_editable?).to be(true)
+      end
+    end
+
+    it "is false on the first day of the current quarter's last month" do
+      Timecop.freeze(Time.zone.parse("June 1 2024 15:12")) do
         component = described_class.new(periods, region, default_options.merge(selected_quarter: q2_2024))
 
         expect(component.action_plans_editable?).to be(false)
@@ -235,8 +243,18 @@ RSpec.describe Dashboard::DrRaiReport, type: :component do
       end
     end
 
-    it "hides edit controls after the current quarter's first month" do
+    it "shows edit controls during the current quarter's second month" do
       Timecop.freeze(Time.zone.parse("May 1 2024 15:12")) do
+        action_plan
+
+        render_inline(described_class.new(periods, region, default_options.merge(selected_quarter: q2_2024)))
+
+        expect(page).to have_css(".edit-action-plan")
+      end
+    end
+
+    it "hides edit controls during the current quarter's last month" do
+      Timecop.freeze(Time.zone.parse("June 1 2024 15:12")) do
         action_plan
 
         render_inline(described_class.new(periods, region, default_options.merge(selected_quarter: q2_2024)))

--- a/spec/controllers/dr_rai/action_plans_controller_spec.rb
+++ b/spec/controllers/dr_rai/action_plans_controller_spec.rb
@@ -123,8 +123,20 @@ RSpec.describe DrRai::ActionPlansController, type: :controller do
         expect(dr_rai_action_plan.reload.actions).to eq("Updated actions")
       end
 
-      it "forbids updates after the current quarter's first month" do
+      it "allows updates during the current quarter's second month" do
         Timecop.freeze(Time.zone.parse("May 1 2025 00:00")) do
+          patch :update, params: {
+            id: dr_rai_action_plan.to_param,
+            dr_rai_action_plan: {actions: "Updated actions"}
+          }
+        end
+
+        expect(response).to have_http_status(:no_content)
+        expect(dr_rai_action_plan.reload.actions).to eq("Updated actions")
+      end
+
+      it "forbids updates during the current quarter's last month" do
+        Timecop.freeze(Time.zone.parse("June 1 2025 00:00")) do
           patch :update, params: {
             id: dr_rai_action_plan.to_param,
             dr_rai_action_plan: {actions: "Updated actions"}
@@ -145,6 +157,39 @@ RSpec.describe DrRai::ActionPlansController, type: :controller do
 
         expect(response).to have_http_status(:forbidden)
         expect(dr_rai_action_plan.reload.actions).to eq("Original actions")
+      end
+    end
+
+    context "with the dr_rai_manual_edit override enabled" do
+      it "allows updates outside the business edit window" do
+        Flipper.enable(:dr_rai_manual_edit)
+
+        Timecop.freeze(Time.zone.parse("June 15 2025 00:00")) do
+          patch :update, params: {
+            id: dr_rai_action_plan.to_param,
+            dr_rai_action_plan: {actions: "Updated actions"}
+          }
+        end
+
+        expect(response).to have_http_status(:no_content)
+        expect(dr_rai_action_plan.reload.actions).to eq("Updated actions")
+      ensure
+        Flipper.disable(:dr_rai_manual_edit)
+      end
+
+      it "allows updates to an action plan targeting another quarter" do
+        Flipper.enable(:dr_rai_manual_edit)
+        dr_rai_action_plan.target.update!(period: "Q1-2025")
+
+        patch :update, params: {
+          id: dr_rai_action_plan.to_param,
+          dr_rai_action_plan: {actions: "Updated actions"}
+        }
+
+        expect(response).to have_http_status(:no_content)
+        expect(dr_rai_action_plan.reload.actions).to eq("Updated actions")
+      ensure
+        Flipper.disable(:dr_rai_manual_edit)
       end
     end
 


### PR DESCRIPTION
**Story card:** [SIMPLEBACK-92](https://rtsl.atlassian.net/browse/SIMPLEBACK-92)

## Because

The `dr_rai_manual_edit` Flipper override (added in #5834) bypassed the edit window check in the UI (`action_plans_editable?`) but was never mirrored in the controller's `enforce_action_plan_edit_window` guard. As a result, enabling the override showed the Edit button, but saving an edit outside the normal window still failed with a 403.

Separately, the edit window itself didn't match the updated requirement: action plans should only become read-only in the last month of the quarter, not become editable only in the first month.

## This addresses

- `enforce_action_plan_edit_window` now returns early when `dr_rai_manual_edit` is enabled, matching the view's behavior.
- The edit window rule changed from "editable only in month 1 of the quarter" to "editable in every month except the last month of the quarter," in both the component and the controller.

## Test instructions

- Create an action plan in the current quarter.
- With the `dr_rai_manual_edit` Flipper flag off, confirm Edit is available in months 1-2 of the quarter, hidden/forbidden in the last month.
- Enable `dr_rai_manual_edit`, confirm Edit works and saves successfully regardless of month or target quarter.
- `bundle exec rspec spec/controllers/dr_rai/action_plans_controller_spec.rb spec/components/dashboard/dr_rai_report_spec.rb` — all passing.